### PR TITLE
fix: truncate task panel lines to terminal width

### DIFF
--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -111,6 +111,7 @@ export function renderPanel(manager: WorkflowManager, theme: Theme, width?: numb
     const icon = r.status === "paused" ? "⏸" : "◆";
     const phase = live?.snapshot.currentPhase ? ` · ${live.snapshot.currentPhase}` : "";
     const line = `  ${icon} ${r.workflowName}  ${done}/${agents.length} agents${phase}`;
+    // Truncate line to fit terminal width
     if (line.length > maxWidth) {
       return line.slice(0, maxWidth - 1) + "…";
     }
@@ -119,12 +120,12 @@ export function renderPanel(manager: WorkflowManager, theme: Theme, width?: numb
   // Finished runs leave this live panel but are kept in the navigator. Tell the
   // user so a completed run doesn't look like it vanished.
   const finished = all.filter((r) => r.status !== "running" && r.status !== "paused").length;
-  const hint = theme.fg(
-    "dim",
-    finished > 0
-      ? `  /workflows — open navigator (${finished} finished kept in history)`
-      : "  /workflows — open navigator",
-  );
+  const hintText = finished > 0
+    ? `  /workflows — open navigator (${finished} finished kept in history)`
+    : "  /workflows — open navigator";
+  // Truncate hint text before applying color (theme.fg adds ANSI codes)
+  const truncatedHint = hintText.length > maxWidth ? hintText.slice(0, maxWidth - 1) + "…" : hintText;
+  const hint = theme.fg("dim", truncatedHint);
   return [theme.bold(`Workflows running (${active.length}):`), ...rows, hint];
 }
 

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -99,17 +99,22 @@ export function installResultDelivery(pi: ExtensionAPI, manager: WorkflowManager
   });
 }
 
-export function renderPanel(manager: WorkflowManager, theme: Theme): string[] {
+export function renderPanel(manager: WorkflowManager, theme: Theme, width?: number): string[] {
   const all = manager.listRuns();
   const active = all.filter((r) => r.status === "running" || r.status === "paused");
   if (!active.length) return [];
+  const maxWidth = width || 80;
   const rows = active.map((r) => {
     const live = manager.getRun(r.runId);
     const agents = live?.snapshot.agents ?? r.agents;
     const done = agents.filter((a) => a.status === "done").length;
     const icon = r.status === "paused" ? "⏸" : "◆";
     const phase = live?.snapshot.currentPhase ? ` · ${live.snapshot.currentPhase}` : "";
-    return `  ${icon} ${r.workflowName}  ${done}/${agents.length} agents${phase}`;
+    const line = `  ${icon} ${r.workflowName}  ${done}/${agents.length} agents${phase}`;
+    if (line.length > maxWidth) {
+      return line.slice(0, maxWidth - 1) + "…";
+    }
+    return line;
   });
   // Finished runs leave this live panel but are kept in the navigator. Tell the
   // user so a completed run doesn't look like it vanished.
@@ -142,7 +147,7 @@ export function installTaskPanel(
       // Purely informational: it lists running runs and re-renders on events. To
       // open the navigator, the user runs /workflows (the panel takes no input).
       const comp: Component & { dispose?(): void } = {
-        render: () => renderPanel(manager, theme),
+        render: (width: number) => renderPanel(manager, theme, width),
         invalidate: () => {},
         dispose: () => {
           for (const ev of RUN_EVENTS) manager.off(ev, onEvent);


### PR DESCRIPTION
## Fix: Truncate task panel lines to terminal width

### Problem
When a workflow has a long name or phase name, the task panel renders a line exceeding the terminal width, causing pi-tui to crash with:

```
Error: Rendered line 440 exceeds terminal width (69 > 45).
```

### Root Cause
`renderPanel()` builds status lines without respecting the terminal width:

```typescript
return `  ${icon} ${r.workflowName}  ${done}/${agents.length} agents${phase}`;
```

When `workflowName` + `phase` is long, the line overflows.

### Fix
1. Pass `width` from the `Component.render()` callback to `renderPanel()`
2. Truncate lines that exceed `maxWidth`

The lines in `rows` are intentionally plain text (no ANSI codes), so `string.length` is sufficient for width calculation.