### PR TITLE
fix(task-panel): respect terminal width

### DIFF
--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
-import type { Component, TUI } from "@earendil-works/pi-tui";
+import { type Component, type TUI, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { ManagedRun, WorkflowManager } from "./workflow-manager.js";
 import type { WorkflowStorage } from "./workflow-saved.js";
 
@@ -35,6 +35,13 @@ function summarizeResult(result: unknown): string {
   }
   const json = JSON.stringify(result, null, 2);
   return json.length > 400 ? `${json.slice(0, 400)}\n…(truncated)` : json;
+}
+
+function fitLine(line: string, width?: number): string {
+  if (typeof width !== "number" || !Number.isFinite(width)) return line;
+  const maxWidth = Math.max(0, Math.floor(width));
+  if (visibleWidth(line) <= maxWidth) return line;
+  return truncateToWidth(line, maxWidth);
 }
 
 export function deliverText(run: ManagedRun): string {
@@ -99,7 +106,7 @@ export function installResultDelivery(pi: ExtensionAPI, manager: WorkflowManager
   });
 }
 
-export function renderPanel(manager: WorkflowManager, theme: Theme): string[] {
+export function renderPanel(manager: WorkflowManager, theme: Theme, width?: number): string[] {
   const all = manager.listRuns();
   const active = all.filter((r) => r.status === "running" || r.status === "paused");
   if (!active.length) return [];
@@ -120,7 +127,7 @@ export function renderPanel(manager: WorkflowManager, theme: Theme): string[] {
       ? `  /workflows — open navigator (${finished} finished kept in history)`
       : "  /workflows — open navigator",
   );
-  return [theme.bold(`Workflows running (${active.length}):`), ...rows, hint];
+  return [theme.bold(`Workflows running (${active.length}):`), ...rows, hint].map((line) => fitLine(line, width));
 }
 
 /**
@@ -142,7 +149,7 @@ export function installTaskPanel(
       // Purely informational: it lists running runs and re-renders on events. To
       // open the navigator, the user runs /workflows (the panel takes no input).
       const comp: Component & { dispose?(): void } = {
-        render: () => renderPanel(manager, theme),
+        render: (width: number) => renderPanel(manager, theme, width),
         invalidate: () => {},
         dispose: () => {
           for (const ev of RUN_EVENTS) manager.off(ev, onEvent);

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { before, describe, it } from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
 
 type TaskPanelModule = {
   installResultDelivery: (pi: ExtensionAPI, manager: unknown) => void;
@@ -279,6 +280,45 @@ describe("installTaskPanel", () => {
     assert.equal(registeredName, "workflow-tasks");
     assert.equal(registeredPlacement, "belowEditor");
   });
+
+  it("passes the render width through to the task panel", () => {
+    const manager = new EventEmitter() as ReturnType<typeof EventEmitter> & {
+      getRun: (...args: unknown[]) => unknown;
+      listRuns: () => unknown[];
+    };
+    manager.getRun = () => undefined;
+    manager.listRuns = () => [
+      {
+        runId: "a",
+        workflowName: "handle_gh_issues_11_12_with_a_long_suffix",
+        status: "running",
+        agents: [{ status: "done" }, { status: "running" }],
+        logs: [],
+      },
+    ];
+
+    let factory:
+      | ((
+          tui: { requestRender(): void },
+          theme: { fg(color: string, text: string): string; bold(text: string): string },
+        ) => { render(width: number): string[] })
+      | undefined;
+    const ui = {
+      setWidget: (_name: string, registeredFactory: typeof factory) => {
+        factory = registeredFactory;
+      },
+    };
+    const theme = { fg: (_c: string, t: string) => t, bold: (t: string) => t };
+
+    mod.installTaskPanel(null, manager, ui);
+    const component = factory?.({ requestRender: () => {} }, theme);
+    const lines = component?.render(24) ?? [];
+
+    assert.ok(lines.length > 0, "panel should render active runs");
+    for (const line of lines) {
+      assert.ok(visibleWidth(line) <= 24, `line exceeds width: ${visibleWidth(line)} > 24`);
+    }
+  });
 });
 
 describe("renderPanel", () => {
@@ -312,5 +352,42 @@ describe("renderPanel", () => {
       getRun: () => undefined,
     };
     assert.deepEqual(renderPanel(manager as never, theme as never), []);
+  });
+
+  it("truncates every rendered line to the requested visible width", async () => {
+    const { renderPanel } = await import("../src/task-panel.js");
+    const ansiTheme = {
+      fg: (_c: string, t: string) => `\x1b[2m${t}\x1b[22m`,
+      bold: (t: string) => `\x1b[1m${t}\x1b[22m`,
+    };
+    const manager = {
+      listRuns: () => [
+        {
+          runId: "a",
+          workflowName: "handle_gh_issues_11_12_中文_🙂_very_long_workflow_name",
+          status: "running",
+          agents: [{ status: "done" }, { status: "running" }],
+          logs: [],
+        },
+        { runId: "b", workflowName: "old", status: "completed", agents: [], logs: [] },
+      ],
+      getRun: () => ({
+        snapshot: {
+          currentPhase: "Issue implementation phase with a very long suffix",
+          agents: [{ status: "done" }, { status: "running" }],
+        },
+      }),
+    };
+
+    const lines = renderPanel(manager as never, ansiTheme as never, 42);
+
+    assert.ok(lines.length > 0, "panel should render active runs");
+    assert.ok(
+      lines.some((line) => line.includes("...")),
+      "at least one line should be truncated",
+    );
+    for (const line of lines) {
+      assert.ok(visibleWidth(line) <= 42, `line exceeds width: ${visibleWidth(line)} > 42`);
+    }
   });
 });


### PR DESCRIPTION
Fixes #5.

## Summary
- Pass the TUI render width into the workflow task panel.
- Truncate every rendered task-panel line with Pi TUI's `visibleWidth` / `truncateToWidth`.
- Cover narrow terminals, ANSI styling, wide characters, emoji, long workflow names, and long phase names.

## Root Cause
The `workflow-tasks` widget ignored the `width` passed to `Component.render(width)`, so long workflow/phase status rows could exceed the terminal width and trigger Pi TUI's rendered-line invariant.

## Validation
- `npm test` -> 631 tests passed
- Real Pi smoke in a 42-column PTY:
  - command loaded the local extension from `./extensions/workflow.ts`
  - workflow: `handle_gh_issues_11_12`
  - phase: `Issue implementation`
  - live panel rendered as `◆ handle_gh_issues_11_12  0/1 agents ...`
  - workflow completed successfully with `{ "ok": true, "result": "OK" }`
