### PR TITLE
fix(workflow-editor): add keyword trigger toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/@quintinshaw/pi-dynamic-workflows?color=cb3837&logo=npm)](https://www.npmjs.com/package/@quintinshaw/pi-dynamic-workflows)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 [![for Pi](https://img.shields.io/badge/for-Pi-7c3aed)](https://pi.dev)
-[![tests](https://img.shields.io/badge/tests-631%20passing-success)](#development)
+[![tests](https://img.shields.io/badge/tests-640%20passing-success)](#development)
 
 > **Claude Code–style dynamic workflows for [Pi](https://pi.dev).**
 > Turn one prompt into a fleet of subagents that fan out in parallel, cross-check each other, and hand back a single synthesized answer.
@@ -32,7 +32,7 @@ Ask in plain language:
 Run a workflow to audit every route under src/routes/ for missing auth checks.
 ```
 
-Pi writes the script and runs it in the background — your turn ends immediately and a live panel tracks progress while you keep working. Or just type the word **workflows** in any message to force one:
+Pi writes the script and runs it in the background — your turn ends immediately and a live panel tracks progress while you keep working. Or just type the word **workflows** in any message to force one. If you only want to discuss workflows without triggering one, run `/workflows-trigger off`, check the current state with `/workflows-trigger status`, and turn it back on with `/workflows-trigger on`.
 
 ![Workflows mode in the input box](https://raw.githubusercontent.com/QuintinShaw/pi-dynamic-workflows/main/docs/media/workflows-mode.jpg)
 
@@ -99,6 +99,8 @@ The same model — on Pi, plus the production pieces a real run needs:
 /workflows status <id>      watch a run live; print its result when it finishes
 /workflows save <name>      save the latest run's script as a reusable /<name> command
 /workflows pause|resume|stop|rm <id>
+/workflows-trigger off|on|status
+                            disable, restore, or inspect keyword-triggered workflows mode
 /workflows-models           map the small / medium / big tiers to real models
 /ultracode [off]            ultracode: auto-arm an exhaustive workflow for every substantive message
 /effort off|high|ultra      finer control over the standing opt-in (high = thorough, ultra = ultracode)
@@ -139,7 +141,7 @@ Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()
 
 ```bash
 npm install
-npm test     # biome + tsc + 631 unit tests
+npm test     # biome + tsc + 640 unit tests
 ```
 
 Every feature is also verified end-to-end against a real Pi subagent session before release.

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export {
   hasTrigger,
   installWorkflowEditor,
   RAINBOW,
+  registerWorkflowTriggerCommand,
   tokenizeAnsi,
   WorkflowEditor,
   type WorkflowModeState,

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -16,7 +16,12 @@
  * inherited untouched.
  */
 
-import { CustomEditor, type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import {
+  CustomEditor,
+  type ExtensionAPI,
+  type ExtensionCommandContext,
+  type ExtensionUIContext,
+} from "@earendil-works/pi-coding-agent";
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import { type EffortState, effortDirective, isSubstantive } from "./effort-command.js";
 
@@ -47,6 +52,8 @@ export function endsWithTrigger(textBeforeCursor: string): boolean {
 /** Shared, mutable view of whether "workflows mode" is currently armed. */
 export interface WorkflowModeState {
   active: boolean;
+  keywordTriggerEnabled: boolean;
+  suppressedKeywordText?: string;
 }
 
 interface AnsiToken {
@@ -159,13 +166,14 @@ export class WorkflowEditor extends CustomEditor {
 
   /** Highlighted/armed: a trigger is present and the user hasn't toggled it off. */
   isActive(): boolean {
-    return !this.disabled && hasTrigger(this.getText());
+    return this.modeState.keywordTriggerEnabled && !this.disabled && hasTrigger(this.getText());
   }
 
   override handleInput(data: string): void {
     // First Backspace right after a trigger word disarms (non-destructive).
     if (isBackspace(data) && this.isActive() && this.cursorAfterTrigger()) {
       this.disabled = true;
+      this.modeState.suppressedKeywordText = this.getText().trim();
       this.syncState();
       this.tui.requestRender();
       return;
@@ -175,8 +183,16 @@ export class WorkflowEditor extends CustomEditor {
     const after = this.getText();
     if (after !== before) {
       const now = hasTrigger(after);
+      const normalizedAfter = after.trim();
+      const suppressionCleared =
+        this.modeState.suppressedKeywordText !== undefined &&
+        normalizedAfter !== "" &&
+        normalizedAfter !== this.modeState.suppressedKeywordText;
+      if (suppressionCleared) {
+        this.modeState.suppressedKeywordText = undefined;
+      }
       // A freshly typed trigger re-arms a previously disabled box.
-      if (now && !this.wasTriggered) this.disabled = false;
+      if (now && (!this.wasTriggered || suppressionCleared)) this.disabled = false;
       this.wasTriggered = now;
     }
     this.syncState();
@@ -255,14 +271,45 @@ export function buildForcedWorkflowPrompt(text: string, extraDirective?: string)
 /** The exact name of the workflow tool that workflows mode forces. */
 export const WORKFLOW_TOOL_NAME = "workflow";
 
+export function registerWorkflowTriggerCommand(pi: ExtensionAPI, state: WorkflowModeState): void {
+  pi.registerCommand?.("workflows-trigger", {
+    description: "Keyword workflow trigger: on | off | status",
+    async handler(args: string, _ctx: ExtensionCommandContext) {
+      const arg = args.trim().toLowerCase();
+      const say = (content: string) => pi.sendMessage({ customType: "workflows-trigger", content, display: true });
+      if (arg === "on") {
+        state.keywordTriggerEnabled = true;
+        state.suppressedKeywordText = undefined;
+        await say(
+          "Workflows keyword trigger on — mentioning workflow/workflows in an interactive message will auto-arm workflows mode.",
+        );
+        return;
+      }
+      if (arg === "off") {
+        state.keywordTriggerEnabled = false;
+        state.active = false;
+        state.suppressedKeywordText = undefined;
+        await say(
+          "Workflows keyword trigger off — messages can mention workflow/workflows without forcing the workflow tool. Use /workflows-trigger on to restore.",
+        );
+        return;
+      }
+      await say(
+        `Workflows keyword trigger is ${state.keywordTriggerEnabled ? "on" : "off"}. Usage: /workflows-trigger on | off | status`,
+      );
+    },
+  });
+}
+
 export function installWorkflowEditor(
   pi: ExtensionAPI,
   ui: ExtensionUIContext,
   effort?: EffortState,
 ): WorkflowModeState {
-  const state: WorkflowModeState = { active: false };
+  const state: WorkflowModeState = { active: false, keywordTriggerEnabled: true };
 
   ui.setEditorComponent((tui, theme, keybindings) => new WorkflowEditor(tui, theme, keybindings, state));
+  registerWorkflowTriggerCommand(pi, state);
 
   // Active tools saved while a turn is restricted to `workflow`; restored on turn_end.
   let savedTools: string[] | undefined;
@@ -282,7 +329,10 @@ export function installWorkflowEditor(
     if (event.source !== "interactive" || !event.text) return { action: "continue" } as const;
     // Arm either when the user typed the "workflow(s)" trigger, or when standing
     // effort mode is on and the message is a substantive request.
-    const triggered = hasTrigger(event.text);
+    const normalizedText = event.text.trim();
+    const suppressed = state.suppressedKeywordText === normalizedText;
+    if (suppressed) state.suppressedKeywordText = undefined;
+    const triggered = state.keywordTriggerEnabled && !suppressed && hasTrigger(event.text);
     const byEffort = !triggered && !!effort && effort.level !== "off" && isSubstantive(event.text);
     if (!triggered && !byEffort) return { action: "continue" } as const;
     try {

--- a/tests/workflow-editor.test.ts
+++ b/tests/workflow-editor.test.ts
@@ -311,14 +311,20 @@ describe("WorkflowEditor", () => {
     KB = core.KeybindingsManager as unknown as KBManagerClass;
   });
 
-  function createEditor(stateOverrides?: Partial<{ active: boolean }>): {
+  function createEditor(
+    stateOverrides?: Partial<{ active: boolean; keywordTriggerEnabled: boolean; suppressedKeywordText?: string }>,
+  ): {
     editor: InstanceType<Awaited<ReturnType<typeof load>>["WorkflowEditor"]>;
-    state: { active: boolean };
+    state: { active: boolean; keywordTriggerEnabled: boolean; suppressedKeywordText?: string };
   } {
     const tui = createMockTui();
     const theme = makeTheme();
     const kb = new KB();
-    const state: { active: boolean } = { active: false, ...stateOverrides };
+    const state: { active: boolean; keywordTriggerEnabled: boolean; suppressedKeywordText?: string } = {
+      active: false,
+      keywordTriggerEnabled: true,
+      ...stateOverrides,
+    };
     const editor = new mod.WorkflowEditor(tui, theme, kb, state);
     return { editor, state };
   }
@@ -327,6 +333,7 @@ describe("WorkflowEditor", () => {
     const { editor, state } = createEditor();
     assert.ok(editor instanceof mod.WorkflowEditor);
     assert.equal(state.active, false);
+    assert.equal(state.keywordTriggerEnabled, true);
   });
 
   it("render() returns an array of strings", () => {
@@ -345,6 +352,15 @@ describe("WorkflowEditor", () => {
     assert.equal(editor.isActive(), true, "should be active after typing trigger");
   });
 
+  it("isActive() returns false when the keyword trigger is disabled", () => {
+    const { editor, state } = createEditor({ keywordTriggerEnabled: false });
+    editor.setText("run a workflow test");
+    assert.equal(editor.isActive(), false, "keyword trigger off should suppress workflow mode");
+
+    state.keywordTriggerEnabled = true;
+    assert.equal(editor.isActive(), true, "re-enabling the keyword trigger should re-arm matching text");
+  });
+
   it("isActive() returns false after backspace disarms trigger", () => {
     const { editor } = createEditor();
     editor.setText("workflow");
@@ -353,6 +369,49 @@ describe("WorkflowEditor", () => {
     // Backspace (DEL = \x7f) when cursor is right after "workflow" should disarm
     editor.handleInput("\x7f");
     assert.equal(editor.isActive(), false, "should be inactive after backspace disarm");
+  });
+
+  it("backspace disarm records the exact text to suppress on submit", () => {
+    const { editor, state } = createEditor();
+    editor.setText("please discuss workflows");
+    assert.equal(editor.isActive(), true, "active after typing trigger");
+
+    editor.handleInput("\x7f");
+    assert.equal(editor.isActive(), false, "should be inactive after backspace disarm");
+    assert.equal(state.suppressedKeywordText, "please discuss workflows");
+
+    editor.handleInput("!");
+    assert.equal(state.suppressedKeywordText, undefined, "editing after disarm should clear one-shot suppression");
+    assert.equal(editor.isActive(), true, "a changed trigger text should re-arm");
+  });
+
+  it("re-arms changed trigger text after an interactively typed trigger was disarmed", () => {
+    const { editor, state } = createEditor();
+    editor.handleInput("please discuss workflows");
+    assert.equal(editor.isActive(), true, "active after typing trigger");
+
+    editor.handleInput("\x7f");
+    assert.equal(editor.isActive(), false, "backspace should disarm the current text");
+    assert.equal(state.suppressedKeywordText, "please discuss workflows");
+
+    editor.handleInput(" workflow");
+    assert.equal(state.suppressedKeywordText, undefined, "changed trigger text should clear one-shot suppression");
+    assert.equal(editor.isActive(), true, "changed trigger text should visually re-arm");
+  });
+
+  it("submit after backspace disarm preserves suppression for the input hook", () => {
+    const { editor, state } = createEditor();
+    editor.setText("please discuss workflows");
+    editor.handleInput("\x7f");
+
+    let submittedText: string | undefined;
+    editor.onSubmit = (text: string) => {
+      submittedText = text;
+    };
+    editor.handleInput("\r");
+
+    assert.equal(submittedText, "please discuss workflows");
+    assert.equal(state.suppressedKeywordText, "please discuss workflows");
   });
 
   it("handleInput calls onSubmit when Enter is pressed", () => {
@@ -429,6 +488,42 @@ describe("installWorkflowEditor", () => {
     assert.equal(typeof setFactory, "function", "the argument should be a factory function");
   });
 
+  it("registers /workflows-trigger and toggles the keyword trigger", async () => {
+    const mod = await load();
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+    const sent: Array<{ content?: string }> = [];
+    const pi = {
+      on: () => {},
+      registerCommand: (name: string, command: { handler: (args: string, ctx: unknown) => Promise<void> }) => {
+        commands.set(name, command);
+      },
+      sendMessage: (message: { content?: string }) => {
+        sent.push(message);
+      },
+      getActiveTools: () => [],
+      setActiveTools: () => {},
+    } as unknown as ExtensionAPI;
+
+    const ui = {
+      setEditorComponent: () => {},
+    } as unknown as ExtensionUIContext;
+
+    const state = mod.installWorkflowEditor(pi, ui);
+    assert.equal(state.keywordTriggerEnabled, true, "keyword trigger should default on");
+
+    const command = commands.get("workflows-trigger");
+    assert.ok(command, "should register /workflows-trigger");
+
+    await command.handler("off", {});
+    assert.equal(state.keywordTriggerEnabled, false);
+    assert.equal(state.active, false);
+    assert.match(sent.at(-1)?.content ?? "", /keyword trigger off/i);
+
+    await command.handler("on", {});
+    assert.equal(state.keywordTriggerEnabled, true);
+    assert.match(sent.at(-1)?.content ?? "", /keyword trigger on/i);
+  });
+
   it("saves active tools and adds WORKFLOW_TOOL_NAME on triggered input", async () => {
     const mod = await load();
     let savedTools: string[] = [];
@@ -488,6 +583,149 @@ describe("installWorkflowEditor", () => {
     );
     assert.ok(resultTrigger.text?.includes("run a workflow test"), "transformed text should include original prompt");
     assert.ok(savedTools.includes("workflow"), `saved tools (${savedTools.join(", ")}) should include "workflow"`);
+  });
+
+  it("does not transform keyword-triggered input when /workflows-trigger is off", async () => {
+    const mod = await load();
+    const captured: Array<{ event: string; handler: (...args: unknown[]) => unknown }> = [];
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+    let setActiveToolsCalls = 0;
+    const pi = {
+      on: (event: string, handler: (...args: unknown[]) => unknown) => {
+        captured.push({ event, handler });
+      },
+      registerCommand: (name: string, command: { handler: (args: string, ctx: unknown) => Promise<void> }) => {
+        commands.set(name, command);
+      },
+      sendMessage: () => {},
+      getActiveTools: () => ["bash", "read"],
+      setActiveTools: () => {
+        setActiveToolsCalls++;
+      },
+    } as unknown as ExtensionAPI;
+
+    const ui = {
+      setEditorComponent: () => {},
+    } as unknown as ExtensionUIContext;
+
+    mod.installWorkflowEditor(pi, ui);
+    await commands.get("workflows-trigger")?.handler("off", {});
+
+    const inputHandler = captured.find((h) => h.event === "input")?.handler;
+    assert.ok(inputHandler, "input handler should be registered");
+    const result = inputHandler({
+      source: "interactive",
+      text: "Please discuss workflows as a normal topic.",
+    });
+
+    assert.deepEqual(result, { action: "continue" });
+    assert.equal(setActiveToolsCalls, 0);
+  });
+
+  it("does not transform one-shot backspace-suppressed keyword input", async () => {
+    const mod = await load();
+    const captured: Array<{ event: string; handler: (...args: unknown[]) => unknown }> = [];
+    let setActiveToolsCalls = 0;
+    const pi = {
+      on: (event: string, handler: (...args: unknown[]) => unknown) => {
+        captured.push({ event, handler });
+      },
+      registerCommand: () => {},
+      sendMessage: () => {},
+      getActiveTools: () => ["bash", "read"],
+      setActiveTools: () => {
+        setActiveToolsCalls++;
+      },
+    } as unknown as ExtensionAPI;
+
+    const ui = {
+      setEditorComponent: () => {},
+    } as unknown as ExtensionUIContext;
+
+    const state = mod.installWorkflowEditor(pi, ui);
+    state.suppressedKeywordText = "Please discuss workflows as a normal topic.";
+
+    const inputHandler = captured.find((h) => h.event === "input")?.handler;
+    assert.ok(inputHandler, "input handler should be registered");
+    const result = inputHandler({
+      source: "interactive",
+      text: "Please discuss workflows as a normal topic.",
+    });
+
+    assert.deepEqual(result, { action: "continue" });
+    assert.equal(setActiveToolsCalls, 0);
+    assert.equal(state.suppressedKeywordText, undefined, "suppression should be consumed after one submit");
+  });
+
+  it("transforms the same keyword input later when it was not just suppressed", async () => {
+    const mod = await load();
+    const captured: Array<{ event: string; handler: (...args: unknown[]) => unknown }> = [];
+    const pi = {
+      on: (event: string, handler: (...args: unknown[]) => unknown) => {
+        captured.push({ event, handler });
+      },
+      registerCommand: () => {},
+      sendMessage: () => {},
+      getActiveTools: () => ["bash", "read"],
+      setActiveTools: () => {},
+    } as unknown as ExtensionAPI;
+
+    const ui = {
+      setEditorComponent: () => {},
+    } as unknown as ExtensionUIContext;
+
+    mod.installWorkflowEditor(pi, ui);
+
+    const text = "Please discuss workflows as a normal topic.";
+    const inputHandler = captured.find((h) => h.event === "input")?.handler;
+    assert.ok(inputHandler, "input handler should be registered");
+    const result = inputHandler({ source: "interactive", text });
+
+    assert.deepEqual(result, {
+      action: "transform",
+      text: mod.buildForcedWorkflowPrompt(text),
+    });
+  });
+
+  it("still transforms effort-armed input when the keyword trigger is off", async () => {
+    const mod = await load();
+    const { createEffortState, effortDirective } = await import("../src/effort-command.js");
+    const captured: Array<{ event: string; handler: (...args: unknown[]) => unknown }> = [];
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+    const effort = createEffortState();
+    effort.level = "high";
+    let tools: string[] = [];
+    const pi = {
+      on: (event: string, handler: (...args: unknown[]) => unknown) => {
+        captured.push({ event, handler });
+      },
+      registerCommand: (name: string, command: { handler: (args: string, ctx: unknown) => Promise<void> }) => {
+        commands.set(name, command);
+      },
+      sendMessage: () => {},
+      getActiveTools: () => ["bash", "read"],
+      setActiveTools: (next: string[]) => {
+        tools = next;
+      },
+    } as unknown as ExtensionAPI;
+
+    const ui = {
+      setEditorComponent: () => {},
+    } as unknown as ExtensionUIContext;
+
+    mod.installWorkflowEditor(pi, ui, effort);
+    await commands.get("workflows-trigger")?.handler("off", {});
+
+    const text = "Please discuss workflows as a normal topic.";
+    const inputHandler = captured.find((h) => h.event === "input")?.handler;
+    assert.ok(inputHandler, "input handler should be registered");
+    const result = inputHandler({ source: "interactive", text });
+
+    assert.deepEqual(result, {
+      action: "transform",
+      text: mod.buildForcedWorkflowPrompt(text, effortDirective("high")),
+    });
+    assert.ok(tools.includes(mod.WORKFLOW_TOOL_NAME), "effort mode should still add the workflow tool");
   });
 
   it("restores original tools on turn_end after a triggered turn", async () => {


### PR DESCRIPTION
## Summary
- Add `/workflows-trigger on|off|status` to control keyword-triggered workflows mode
- Preserve Backspace-after-trigger as a one-shot per-message disarm
- Re-arm the editor when changed trigger text should submit as a workflow again
- Document the new trigger toggle in README

## Tests
- `node --import tsx --test tests/workflow-editor.test.ts`
- Backspace/re-arm smoke test with the real `WorkflowEditor` and input hook
- `npm test`

Closes #7

Thanks for reporting this.