### PR TITLE
fix(workflow-editor): preserve existing custom editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/@quintinshaw/pi-dynamic-workflows?color=cb3837&logo=npm)](https://www.npmjs.com/package/@quintinshaw/pi-dynamic-workflows)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 [![for Pi](https://img.shields.io/badge/for-Pi-7c3aed)](https://pi.dev)
-[![tests](https://img.shields.io/badge/tests-640%20passing-success)](#development)
+[![tests](https://img.shields.io/badge/tests-641%20passing-success)](#development)
 
 > **Claude Code–style dynamic workflows for [Pi](https://pi.dev).**
 > Turn one prompt into a fleet of subagents that fan out in parallel, cross-check each other, and hand back a single synthesized answer.
@@ -35,6 +35,8 @@ Run a workflow to audit every route under src/routes/ for missing auth checks.
 Pi writes the script and runs it in the background — your turn ends immediately and a live panel tracks progress while you keep working. Or just type the word **workflows** in any message to force one. If you only want to discuss workflows without triggering one, run `/workflows-trigger off`, check the current state with `/workflows-trigger status`, and turn it back on with `/workflows-trigger on`.
 
 ![Workflows mode in the input box](https://raw.githubusercontent.com/QuintinShaw/pi-dynamic-workflows/main/docs/media/workflows-mode.jpg)
+
+If another Pi extension has already installed a custom editor component, pi-dynamic-workflows leaves it in place and keeps the submit-time workflow trigger active. In that compatibility mode, the animated keyword highlight and Backspace one-shot disarm affordance are skipped because the existing editor remains responsible for rendering and input handling; use `/workflows-trigger off` when you need to discuss workflow/workflows without auto-triggering. Editor composition is load-order dependent: whichever extension installs a visual editor last owns the editor surface, while pi-dynamic-workflows still keeps its submit-time hook registered.
 
 ## What a workflow looks like
 
@@ -141,7 +143,7 @@ Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()
 
 ```bash
 npm install
-npm test     # biome + tsc + 640 unit tests
+npm test     # biome + tsc + 641 unit tests
 ```
 
 Every feature is also verified end-to-end against a real Pi subagent session before release.

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -308,7 +308,9 @@ export function installWorkflowEditor(
 ): WorkflowModeState {
   const state: WorkflowModeState = { active: false, keywordTriggerEnabled: true };
 
-  ui.setEditorComponent((tui, theme, keybindings) => new WorkflowEditor(tui, theme, keybindings, state));
+  if (!ui.getEditorComponent?.()) {
+    ui.setEditorComponent((tui, theme, keybindings) => new WorkflowEditor(tui, theme, keybindings, state));
+  }
   registerWorkflowTriggerCommand(pi, state);
 
   // Active tools saved while a turn is restricted to `workflow`; restored on turn_end.

--- a/tests/workflow-editor.test.ts
+++ b/tests/workflow-editor.test.ts
@@ -488,6 +488,43 @@ describe("installWorkflowEditor", () => {
     assert.equal(typeof setFactory, "function", "the argument should be a factory function");
   });
 
+  it("does not replace an existing custom editor component", async () => {
+    const mod = await load();
+    const captured: Array<{ event: string; handler: (...args: unknown[]) => unknown }> = [];
+    let setEditorCalls = 0;
+    let setActiveToolsCalls = 0;
+    const existingEditorFactory = () => ({ kind: "existing-editor" });
+    const pi = {
+      on: (event: string, handler: (...args: unknown[]) => unknown) => {
+        captured.push({ event, handler });
+      },
+      getActiveTools: () => ["bash", "read"],
+      setActiveTools: () => {
+        setActiveToolsCalls++;
+      },
+    } as unknown as ExtensionAPI;
+
+    const ui = {
+      getEditorComponent: () => existingEditorFactory,
+      setEditorComponent: () => {
+        setEditorCalls++;
+      },
+    } as unknown as ExtensionUIContext;
+
+    mod.installWorkflowEditor(pi, ui);
+
+    assert.equal(setEditorCalls, 0, "existing custom editor should not be overwritten");
+
+    const inputHandler = captured.find((h) => h.event === "input")?.handler;
+    assert.ok(inputHandler, "input handler should still be registered");
+    const result = inputHandler({
+      source: "interactive",
+      text: "Please run this workflow.",
+    });
+    assert.equal((result as { action?: string }).action, "transform");
+    assert.equal(setActiveToolsCalls, 1, "workflow trigger should still add the workflow tool");
+  });
+
   it("registers /workflows-trigger and toggles the keyword trigger", async () => {
     const mod = await load();
     const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();


### PR DESCRIPTION
## Summary
- Avoid replacing an existing custom editor component during workflow editor installation
- Keep workflow input hooks and `/workflows-trigger` registered even when the visual editor is skipped
- Document compatibility-mode behavior and load-order limits in README

## Tests
- `node --import tsx --test tests/workflow-editor.test.ts`
- `npm test`

Closes #6

Thanks for reporting this.