### PR TITLE
fix(workflows): surface subagent diagnostics and history

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/@quintinshaw/pi-dynamic-workflows?color=cb3837&logo=npm)](https://www.npmjs.com/package/@quintinshaw/pi-dynamic-workflows)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 [![for Pi](https://img.shields.io/badge/for-Pi-7c3aed)](https://pi.dev)
-[![tests](https://img.shields.io/badge/tests-641%20passing-success)](#development)
+[![tests](https://img.shields.io/badge/tests-650%20passing-success)](#development)
 
 > **Claude Code–style dynamic workflows for [Pi](https://pi.dev).**
 > Turn one prompt into a fleet of subagents that fan out in parallel, cross-check each other, and hand back a single synthesized answer.
@@ -73,7 +73,7 @@ return await agent('Synthesize and double-check these findings:\n' + findings.jo
 - **Git worktree isolation** — `isolation: "worktree"` gives an agent its own branch, so parallel agents can edit the same files without clobbering each other.
 - **Real token & cost accounting** — read from each subagent's session, not estimated. `budget` gates on the real total and `/workflows` shows the dollar cost.
 - **Background by default** — the turn ends right away, a live "Workflows running" panel tracks runs, and each result is delivered back so the conversation auto-continues when it finishes.
-- **Interactive `/workflows` TUI** — drill runs → phases → agents → detail; pause, stop, restart, and save runs from the keyboard.
+- **Interactive `/workflows` TUI** — drill runs → phases → agents → detail; inspect per-agent failures and compact subagent history; pause, stop, restart, and save runs from the keyboard.
 - **Quality patterns built in** — `verify()`, `judgePanel()`, `loopUntilDry()`, and `completenessCheck()` for adversarial review, best-of-N, and exhaustive discovery.
 - **Ultracode** — `/ultracode` is a standing opt-in that auto-arms an exhaustive multi-agent workflow for every substantive message, the way Claude Code's ultracode does. `/effort high` is the lighter tier.
 - **Bundled `/deep-research` + `/adversarial-review`** — real web search, source cross-checking, and cited reports.
@@ -111,7 +111,7 @@ The same model — on Pi, plus the production pieces a real run needs:
 /adversarial-review <task>  findings vetted by skeptical reviewers
 ```
 
-In the navigator: `↑/↓` select · `enter`/`→` open · `esc`/`←` back · `p` pause · `x` stop · `r` restart · `s` save · `q` quit. Each agent shows the model it ran on.
+In the navigator: `↑/↓` select · `enter`/`→` open · `esc`/`←` back · `p` pause · `x` stop · `r` restart · `s` save · `q` quit. Each agent shows the model it ran on; the detail view shows its prompt, result, error diagnostics, and compact message/tool history.
 
 ## Reference
 
@@ -119,7 +119,7 @@ The full guide — every global, agent option, `agentType` definitions, structur
 
 | Global | What it does |
 | --- | --- |
-| `agent(prompt, opts)` | Spawn an isolated subagent. Returns its final text, or a validated object with `opts.schema`. |
+| `agent(prompt, opts)` | Spawn an isolated subagent. Returns its final text, or a validated object with `opts.schema`; recoverable failures return `null` with diagnostics in `/workflows`. |
 | `parallel(thunks)` | Run `() => agent(...)` thunks concurrently; results in input order. |
 | `pipeline(items, ...stages)` | Fan items through sequential stages `(prev, original, index)`. |
 | `phase(title, { budget? })` | Group agents in the live view; optional per-phase token sub-budget. |
@@ -143,7 +143,7 @@ Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()
 
 ```bash
 npm install
-npm test     # biome + tsc + 641 unit tests
+npm test     # biome + tsc + 650 unit tests
 ```
 
 Every feature is also verified end-to-end against a real Pi subagent session before release.

--- a/src/agent-history.ts
+++ b/src/agent-history.ts
@@ -1,0 +1,133 @@
+export type AgentHistoryRole = "user" | "assistant" | "tool";
+
+export type AgentHistoryKind = "text" | "toolCall" | "toolResult" | "error";
+
+export interface AgentHistoryEntry {
+  role: AgentHistoryRole;
+  kind: AgentHistoryKind;
+  text: string;
+  toolName?: string;
+  isError?: boolean;
+  timestamp?: number;
+}
+
+export interface AgentHistoryOptions {
+  maxEntries?: number;
+  maxTextChars?: number;
+  maxTotalChars?: number;
+}
+
+const DEFAULT_MAX_ENTRIES = 40;
+const DEFAULT_MAX_TEXT_CHARS = 2000;
+const DEFAULT_MAX_TOTAL_CHARS = 20000;
+
+export function compactAgentHistory(messages: unknown[], options: AgentHistoryOptions = {}): AgentHistoryEntry[] {
+  const maxEntries = positiveInt(options.maxEntries, DEFAULT_MAX_ENTRIES);
+  const maxTextChars = positiveInt(options.maxTextChars, DEFAULT_MAX_TEXT_CHARS);
+  const maxTotalChars = positiveInt(options.maxTotalChars, DEFAULT_MAX_TOTAL_CHARS);
+  const entries: AgentHistoryEntry[] = [];
+
+  for (const raw of messages) {
+    const message = asRecord(raw);
+    if (!message) continue;
+    const role = message.role;
+    const timestamp = typeof message.timestamp === "number" ? message.timestamp : undefined;
+
+    if (role === "user") {
+      const text = textFromContent(message.content);
+      if (text.trim()) entries.push({ role: "user", kind: "text", text, timestamp });
+      continue;
+    }
+
+    if (role === "assistant") {
+      for (const part of Array.isArray(message.content) ? message.content : []) {
+        const block = asRecord(part);
+        if (!block || typeof block.type !== "string") continue;
+        if (block.type === "text" && typeof block.text === "string" && block.text.trim()) {
+          entries.push({ role: "assistant", kind: "text", text: block.text, timestamp });
+        } else if (block.type === "toolCall" && typeof block.name === "string") {
+          entries.push({
+            role: "assistant",
+            kind: "toolCall",
+            toolName: block.name,
+            text: stringifyCompact(block.arguments ?? {}),
+            timestamp,
+          });
+        }
+      }
+      if (typeof message.errorMessage === "string" && message.errorMessage.trim()) {
+        entries.push({ role: "assistant", kind: "error", text: message.errorMessage, isError: true, timestamp });
+      }
+      continue;
+    }
+
+    if (role === "toolResult") {
+      const toolName = typeof message.toolName === "string" ? message.toolName : undefined;
+      const text = textFromContent(message.content) || "(no text output)";
+      entries.push({
+        role: "tool",
+        kind: message.isError ? "error" : "toolResult",
+        toolName,
+        text,
+        isError: Boolean(message.isError),
+        timestamp,
+      });
+    }
+  }
+
+  return fitEntries(entries, maxEntries, maxTextChars, maxTotalChars);
+}
+
+function fitEntries(
+  entries: AgentHistoryEntry[],
+  maxEntries: number,
+  maxTextChars: number,
+  maxTotalChars: number,
+): AgentHistoryEntry[] {
+  const fitted: AgentHistoryEntry[] = [];
+  let total = 0;
+
+  for (const entry of entries.slice(-maxEntries).reverse()) {
+    const remaining = maxTotalChars - total;
+    if (remaining <= 0) break;
+    const text = truncateText(entry.text, Math.min(maxTextChars, remaining));
+    fitted.unshift({ ...entry, text });
+    total += text.length;
+  }
+
+  return fitted;
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      const block = asRecord(part);
+      return block?.type === "text" && typeof block.text === "string" ? block.text : "";
+    })
+    .filter(Boolean)
+    .join("");
+}
+
+function stringifyCompact(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  if (maxChars <= 20) return text.slice(0, maxChars);
+  return `${text.slice(0, maxChars - 20)}... [truncated]`;
+}
+
+function positiveInt(value: number | undefined, fallback: number): number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -13,6 +13,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { Static, TSchema } from "typebox";
 import { Check, Convert } from "typebox/value";
+import { type AgentHistoryEntry, compactAgentHistory } from "./agent-history.js";
 import { applyToolPolicy } from "./agent-registry.js";
 import { WorkflowError, WorkflowErrorCode } from "./errors.js";
 import { loadModelTierConfig, type ModelTierConfig, resolveTierModel } from "./model-tier-config.js";
@@ -223,6 +224,8 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
   onModelResolved?: (modelId: string) => void;
   /** Called when `model`/`tier`/phase resolved to a spec that wasn't found (fell back to session default). */
   onModelFallback?: (requestedSpec: string) => void;
+  /** Called with a compact snapshot of this subagent's message/tool history. */
+  onHistory?: (history: AgentHistoryEntry[]) => void;
   /** Run this agent in a different working directory (e.g. an isolated worktree). */
   cwd?: string;
   /**
@@ -344,12 +347,25 @@ export class WorkflowAgent {
     });
 
     let removeAbortListener: (() => void) | undefined;
+    let removeHistoryListener: (() => void) | undefined;
+    let lastHistoryEmit = 0;
+    const emitHistory = () => options.onHistory?.(compactAgentHistory(session.messages));
+    const maybeEmitHistory = () => {
+      if (!options.onHistory) return;
+      const now = Date.now();
+      if (now - lastHistoryEmit < 250) return;
+      lastHistoryEmit = now;
+      emitHistory();
+    };
     try {
       if (options.signal?.aborted) throw new Error("Subagent was aborted");
       if (options.signal) {
         const onAbort = () => void session.abort();
         options.signal.addEventListener("abort", onAbort, { once: true });
         removeAbortListener = () => options.signal?.removeEventListener("abort", onAbort);
+      }
+      if (options.onHistory) {
+        removeHistoryListener = session.subscribe(() => maybeEmitHistory());
       }
 
       await session.prompt(this.buildPrompt(prompt, options as AgentRunOptions<any>, Boolean(options.schema)));
@@ -371,6 +387,12 @@ export class WorkflowAgent {
       return text as AgentRunResult<TSchemaDef>;
     } finally {
       removeAbortListener?.();
+      removeHistoryListener?.();
+      try {
+        emitHistory();
+      } catch {
+        // History is diagnostic only; never let it mask the real result/error.
+      }
       // Read real usage before disposing — dispose tears down the session state.
       if (options.onUsage) {
         try {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -361,7 +361,14 @@ export class WorkflowAgent {
         )) as AgentRunResult<TSchemaDef>;
       }
 
-      return this.lastAssistantText(session.messages) as AgentRunResult<TSchemaDef>;
+      const text = this.lastAssistantText(session.messages);
+      if (!text.trim()) {
+        throw new WorkflowError("Subagent produced no assistant output", WorkflowErrorCode.AGENT_EMPTY_OUTPUT, {
+          recoverable: true,
+          agentLabel: options.label,
+        });
+      }
+      return text as AgentRunResult<TSchemaDef>;
     } finally {
       removeAbortListener?.();
       // Read real usage before disposing — dispose tears down the session state.

--- a/src/display.ts
+++ b/src/display.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { AgentHistoryEntry } from "./agent-history.js";
 import type { WorkflowErrorCode } from "./errors.js";
 import type { WorkflowMeta } from "./workflow.js";
 
@@ -14,6 +15,7 @@ export interface WorkflowAgentSnapshot {
   error?: string;
   errorCode?: WorkflowErrorCode;
   recoverable?: boolean;
+  history?: AgentHistoryEntry[];
   /** Tokens used by this agent. */
   tokens?: number;
   /** The model this agent ran on (provider/id), when known. */

--- a/src/display.ts
+++ b/src/display.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { WorkflowErrorCode } from "./errors.js";
 import type { WorkflowMeta } from "./workflow.js";
 
 export type WorkflowAgentStatus = "queued" | "running" | "done" | "error" | "skipped";
@@ -11,6 +12,8 @@ export interface WorkflowAgentSnapshot {
   status: WorkflowAgentStatus;
   resultPreview?: string;
   error?: string;
+  errorCode?: WorkflowErrorCode;
+  recoverable?: boolean;
   /** Tokens used by this agent. */
   tokens?: number;
   /** The model this agent ran on (provider/id), when known. */

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -15,6 +15,8 @@ export enum WorkflowErrorCode {
   SCRIPT_VALIDATION_ERROR = "SCRIPT_VALIDATION_ERROR",
   /** A schema agent never produced valid structured_output (after repair + extraction). */
   SCHEMA_NONCOMPLIANCE = "SCHEMA_NONCOMPLIANCE",
+  /** A non-schema agent completed without any assistant text output. */
+  AGENT_EMPTY_OUTPUT = "AGENT_EMPTY_OUTPUT",
   /** Agent execution failed. */
   AGENT_EXECUTION_ERROR = "AGENT_EXECUTION_ERROR",
   /** Run state persistence failed. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export type { AdversarialReviewConfig } from "./adversarial-review.js";
 export { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
 export type { AgentRunOptions, AgentRunResult, WorkflowAgentOptions } from "./agent.js";
 export { listAvailableModelSpecs, WorkflowAgent } from "./agent.js";
+export type { AgentHistoryEntry, AgentHistoryKind, AgentHistoryRole } from "./agent-history.js";
+export { compactAgentHistory } from "./agent-history.js";
 export type { AgentDefinition, AgentRegistry } from "./agent-registry.js";
 export { applyToolPolicy, listAgentTypes, loadAgentRegistry, resolveAgentType } from "./agent-registry.js";
 export { registerBuiltinWorkflows } from "./builtin-commands.js";

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -4,6 +4,7 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import type { AgentHistoryEntry } from "./agent-history.js";
 import { WORKFLOW_RUNS_DIR } from "./config.js";
 import type { WorkflowErrorCode } from "./errors.js";
 
@@ -19,6 +20,7 @@ export interface PersistedAgentState {
   error?: string;
   errorCode?: WorkflowErrorCode;
   recoverable?: boolean;
+  history?: AgentHistoryEntry[];
   startedAt?: string;
   endedAt?: string;
   /** The model this agent ran on (provider/id), when known. */

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -5,6 +5,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { WORKFLOW_RUNS_DIR } from "./config.js";
+import type { WorkflowErrorCode } from "./errors.js";
 
 export type RunStatus = "pending" | "running" | "paused" | "completed" | "failed" | "aborted";
 
@@ -16,6 +17,8 @@ export interface PersistedAgentState {
   status: "queued" | "running" | "done" | "error" | "skipped";
   result?: unknown;
   error?: string;
+  errorCode?: WorkflowErrorCode;
+  recoverable?: boolean;
   startedAt?: string;
   endedAt?: string;
   /** The model this agent ran on (provider/id), when known. */

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -312,6 +312,9 @@ export class WorkflowManager extends EventEmitter {
           if (agent) {
             agent.status = event.result === null ? "error" : "done";
             agent.resultPreview = preview(event.result);
+            agent.error = event.error;
+            agent.errorCode = event.errorCode;
+            agent.recoverable = event.recoverable;
             agent.tokens = event.tokens;
             if (event.model) agent.model = event.model;
           }

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -321,6 +321,16 @@ export class WorkflowManager extends EventEmitter {
           this.emit("agentEnd", { runId: managed.runId, ...event });
           progress();
         },
+        onAgentHistory: (event) => {
+          const agent = [...managed.snapshot.agents]
+            .reverse()
+            .find((a) => a.label === event.label && a.status === "running");
+          if (agent) {
+            agent.history = event.history;
+          }
+          this.emit("agentHistory", { runId: managed.runId, ...event });
+          progress();
+        },
         onTokenUsage: (usage) => {
           managed.snapshot.tokenUsage = usage;
           this.emit("tokenUsage", { runId: managed.runId, usage });

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -190,6 +190,7 @@ function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
       error: a.error,
       errorCode: a.errorCode,
       recoverable: a.recoverable,
+      history: a.history,
       model: a.model,
     })),
     agentCount: p.agents.length,
@@ -410,6 +411,12 @@ export function renderNavigator(
       body.push(...wrap(a.prompt ?? "", width));
       body.push("", dim("Result:"));
       body.push(...wrap(a.resultPreview ?? "(none)", width));
+      if (a.history?.length) {
+        body.push("", dim("History:"));
+        for (const entry of a.history) {
+          body.push(...wrap(`${historyLabel(entry)}: ${entry.text}`, width));
+        }
+      }
       pushScrollable(body);
     }
   } else if (state.kind === "savedDetail" && state.savedName) {
@@ -431,6 +438,13 @@ export function renderNavigator(
   lines.push("");
   lines.push(footerHint(state, model, theme));
   return lines;
+}
+
+function historyLabel(entry: NonNullable<WorkflowAgentSnapshot["history"]>[number]): string {
+  if (entry.kind === "toolCall") return entry.toolName ? `assistant tool ${entry.toolName}` : "assistant tool";
+  if (entry.role === "tool") return entry.toolName ? `tool ${entry.toolName}` : "tool";
+  if (entry.kind === "error") return `${entry.role} error`;
+  return entry.role;
 }
 
 function footerHint(state: NavigatorState, model: NavigatorModel, theme: ThemeLike): string {

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -188,6 +188,8 @@ function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
       resultPreview:
         a.result == null ? undefined : String(typeof a.result === "string" ? a.result : JSON.stringify(a.result)),
       error: a.error,
+      errorCode: a.errorCode,
+      recoverable: a.recoverable,
       model: a.model,
     })),
     agentCount: p.agents.length,
@@ -403,6 +405,7 @@ export function renderNavigator(
       body.push(dim("Status: ") + (a.status ?? ""));
       if (a.model) body.push(dim("Model: ") + (shortModel(a.model) ?? ""));
       if (a.error) body.push(dim("Error: ") + a.error);
+      if (a.errorCode) body.push(`${dim("Error code: ")}${a.errorCode}${a.recoverable ? " (recoverable)" : ""}`);
       body.push("", dim("Prompt:"));
       body.push(...wrap(a.prompt ?? "", width));
       body.push("", dim("Result:"));

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -5,6 +5,7 @@ import { parse } from "acorn";
 import type { TSchema } from "typebox";
 import type { AgentUsage } from "./agent.js";
 import { WorkflowAgent, type WorkflowAgentOptions } from "./agent.js";
+import type { AgentHistoryEntry } from "./agent-history.js";
 import {
   type AgentDefinition,
   type AgentRegistry,
@@ -105,6 +106,7 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
     errorCode?: WorkflowErrorCode;
     recoverable?: boolean;
   }) => void;
+  onAgentHistory?: (event: { label: string; phase?: string; history: AgentHistoryEntry[] }) => void;
   onTokenUsage?: (usage: {
     input: number;
     output: number;
@@ -465,6 +467,9 @@ export async function runWorkflow<T = unknown>(
             },
             onUsage: (u: AgentUsage) => {
               usage = u;
+            },
+            onHistory: (history: AgentHistoryEntry[]) => {
+              options.onAgentHistory?.({ label, phase: assignedPhase, history });
             },
           } as any),
           timeout,

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -101,6 +101,9 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
     tokens?: number;
     worktree?: string;
     model?: string;
+    error?: string;
+    errorCode?: WorkflowErrorCode;
+    recoverable?: boolean;
   }) => void;
   onTokenUsage?: (usage: {
     input: number;
@@ -398,14 +401,15 @@ export async function runWorkflow<T = unknown>(
     // downstream results served from the journal.
     const cached = options.resumeJournal?.get(callIndex);
     const hashMatches = cached != null && cached.hash === callHash;
-    if (hashMatches && callIndex < state.firstMiss) {
+    const cachedEmptyOutput = hashMatches && isEmptyTextAgentResult(cached.result, agentOptions.schema);
+    if (hashMatches && !cachedEmptyOutput && callIndex < state.firstMiss) {
       options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
       options.onAgentEnd?.({ label, phase: assignedPhase, result: cached.result, tokens: 0, model: displayModel });
       return cached.result;
     }
     // A genuine miss (no journal entry, or the hash changed) marks where the
     // unchanged prefix ends; this call and every later one then run live.
-    if (!hashMatches) state.firstMiss = Math.min(state.firstMiss, callIndex);
+    if (!hashMatches || cachedEmptyOutput) state.firstMiss = Math.min(state.firstMiss, callIndex);
 
     return limiter(async () => {
       const timeout = agentOptions.timeoutMs ?? agentTimeoutMs;
@@ -468,6 +472,12 @@ export async function runWorkflow<T = unknown>(
         );
 
         throwIfAborted();
+        if (isEmptyTextAgentResult(result, agentOptions.schema)) {
+          throw new WorkflowError("Subagent produced no assistant output", WorkflowErrorCode.AGENT_EMPTY_OUTPUT, {
+            recoverable: true,
+            agentLabel: label,
+          });
+        }
 
         const tokens = recordTokens(result);
         options.onAgentJournal?.({ index: callIndex, hash: callHash, result });
@@ -479,7 +489,17 @@ export async function runWorkflow<T = unknown>(
         const workflowError = wrapError(error, { agentLabel: label });
         logger.error(`agent ${label} failed: ${workflowError.message}`);
         const tokens = recordTokens(null);
-        options.onAgentEnd?.({ label, phase: assignedPhase, result: null, tokens, worktree: runCwd });
+        options.onAgentEnd?.({
+          label,
+          phase: assignedPhase,
+          result: null,
+          tokens,
+          worktree: runCwd,
+          model: displayModel,
+          error: workflowError.message,
+          errorCode: workflowError.code,
+          recoverable: workflowError.recoverable,
+        });
 
         // Return null for recoverable errors
         if (workflowError.recoverable) {
@@ -1018,6 +1038,10 @@ function buildAgentInstructions(
   if (options.isolation) lines.push(`Requested isolation: ${options.isolation}`);
   // Note: options.model is applied for real via the session, not injected as prose.
   return lines.length ? lines.join("\n\n") : undefined;
+}
+
+function isEmptyTextAgentResult(result: unknown, schema: TSchema | undefined): boolean {
+  return schema === undefined && typeof result === "string" && result.trim().length === 0;
 }
 
 function estimateTokens(value: unknown): number {

--- a/tests/agent-history.test.ts
+++ b/tests/agent-history.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { compactAgentHistory } from "../src/agent-history.js";
+
+test("compactAgentHistory captures user, assistant, tool call, and tool result entries", () => {
+  const history = compactAgentHistory([
+    { role: "user", content: "inspect repo", timestamp: 1 },
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "I will inspect it." },
+        { type: "toolCall", name: "read", arguments: { file: "README.md" } },
+      ],
+      timestamp: 2,
+    },
+    {
+      role: "toolResult",
+      toolName: "read",
+      content: [{ type: "text", text: "README content" }],
+      isError: false,
+      timestamp: 3,
+    },
+  ]);
+
+  assert.deepEqual(
+    history.map((entry) => [entry.role, entry.kind, entry.toolName, entry.text]),
+    [
+      ["user", "text", undefined, "inspect repo"],
+      ["assistant", "text", undefined, "I will inspect it."],
+      ["assistant", "toolCall", "read", '{"file":"README.md"}'],
+      ["tool", "toolResult", "read", "README content"],
+    ],
+  );
+});
+
+test("compactAgentHistory records assistant and tool errors", () => {
+  const history = compactAgentHistory([
+    {
+      role: "assistant",
+      content: [],
+      errorMessage: "model failed",
+      timestamp: 1,
+    },
+    {
+      role: "toolResult",
+      toolName: "bash",
+      content: [{ type: "text", text: "exit 1" }],
+      isError: true,
+      timestamp: 2,
+    },
+  ]);
+
+  assert.equal(history[0].kind, "error");
+  assert.equal(history[0].text, "model failed");
+  assert.equal(history[1].kind, "error");
+  assert.equal(history[1].toolName, "bash");
+  assert.equal(history[1].isError, true);
+});
+
+test("compactAgentHistory truncates text and keeps the latest entries", () => {
+  const history = compactAgentHistory(
+    [
+      { role: "user", content: "old" },
+      { role: "assistant", content: [{ type: "text", text: "middle" }] },
+      { role: "assistant", content: [{ type: "text", text: "Z".repeat(100) }] },
+    ],
+    { maxEntries: 2, maxTextChars: 30, maxTotalChars: 60 },
+  );
+
+  assert.equal(history.length, 2);
+  assert.equal(history[0].text, "middle");
+  assert.match(history[1].text, /truncated/);
+  assert.ok(history[1].text.length <= 30);
+});

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -305,6 +305,31 @@ test("agent() in workflow fires onAgentStart and onAgentEnd callbacks", async ()
   assert.deepEqual(events, ["start:greeter", "end:greeter"]);
 });
 
+test("agent() in workflow forwards compact subagent history snapshots", async () => {
+  const historyRunner = {
+    async run(_prompt: string, options: any) {
+      options.onHistory?.([{ role: "assistant", kind: "text", text: "working" }]);
+      return "done";
+    },
+  };
+  const histories: Array<{ label: string; history: Array<{ text: string }> }> = [];
+
+  await runWorkflow(
+    `export const meta = { name: 'test', description: 't' }
+     await agent('hello', { label: 'greeter' })
+     return 1`,
+    {
+      agent: historyRunner,
+      persistLogs: false,
+      onAgentHistory: (event) => histories.push(event),
+    },
+  );
+
+  assert.equal(histories.length, 1);
+  assert.equal(histories[0].label, "greeter");
+  assert.equal(histories[0].history[0].text, "working");
+});
+
 test("agent() in workflow fires onAgentStart with phase info", async () => {
   const rec = new CallRecordingAgent();
   const starts: Array<{ label: string; phase?: string }> = [];

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { AgentRunOptions, AgentUsage } from "../src/agent.js";
 import { listAvailableModelSpecs, resolveAgentModelSpec, WorkflowAgent } from "../src/agent.js";
+import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import type { ModelTierConfig } from "../src/model-tier-config.js";
 import { runWorkflow } from "../src/workflow.js";
 
@@ -340,13 +341,82 @@ test("agent() in workflow returns null for recoverable errors", async () => {
       throw new Error("recoverable agent error");
     },
   };
+  let end:
+    | {
+        result: unknown;
+        error?: string;
+        errorCode?: WorkflowErrorCode;
+        recoverable?: boolean;
+      }
+    | undefined;
   const result = await runWorkflow<unknown>(
     `export const meta = { name: 'test', description: 't' }
      const r = await agent('failing task', { label: 'f' })
      return r`,
-    { agent: failer, persistLogs: false },
+    { agent: failer, persistLogs: false, onAgentEnd: (e) => (end = e) },
   );
   assert.equal(result.result, null);
+  assert.equal(end?.result, null);
+  assert.equal(end?.error, "recoverable agent error");
+  assert.equal(end?.errorCode, WorkflowErrorCode.AGENT_EXECUTION_ERROR);
+  assert.equal(end?.recoverable, true);
+});
+
+test("agent() in workflow treats empty text output as a recoverable failure", async () => {
+  const rec = new CallRecordingAgent();
+  rec.result = "   ";
+  let end:
+    | {
+        result: unknown;
+        error?: string;
+        errorCode?: WorkflowErrorCode;
+        recoverable?: boolean;
+      }
+    | undefined;
+  const result = await runWorkflow<unknown>(
+    `export const meta = { name: 'test', description: 't' }
+     const r = await agent('empty task', { label: 'empty' })
+     return r`,
+    { agent: rec, persistLogs: false, onAgentEnd: (e) => (end = e) },
+  );
+
+  assert.equal(result.result, null);
+  assert.equal(end?.result, null);
+  assert.equal(end?.error, "Subagent produced no assistant output");
+  assert.equal(end?.errorCode, WorkflowErrorCode.AGENT_EMPTY_OUTPUT);
+  assert.equal(end?.recoverable, true);
+});
+
+test("agent() in workflow reports non-recoverable errors before throwing", async () => {
+  const failer = {
+    async run() {
+      throw new WorkflowError("schema failed", WorkflowErrorCode.SCHEMA_NONCOMPLIANCE, { recoverable: false });
+    },
+  };
+  let end:
+    | {
+        result: unknown;
+        error?: string;
+        errorCode?: WorkflowErrorCode;
+        recoverable?: boolean;
+      }
+    | undefined;
+
+  await assert.rejects(
+    () =>
+      runWorkflow<unknown>(
+        `export const meta = { name: 'test', description: 't' }
+         await agent('schema task', { label: 'schema' })
+         return 1`,
+        { agent: failer, persistLogs: false, onAgentEnd: (e) => (end = e) },
+      ),
+    (err) => err instanceof WorkflowError && err.code === WorkflowErrorCode.SCHEMA_NONCOMPLIANCE,
+  );
+
+  assert.equal(end?.result, null);
+  assert.equal(end?.error, "schema failed");
+  assert.equal(end?.errorCode, WorkflowErrorCode.SCHEMA_NONCOMPLIANCE);
+  assert.equal(end?.recoverable, false);
 });
 
 test("agent() in workflow fires onTokenUsage after run", async () => {

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -142,6 +142,28 @@ test(
 );
 
 test(
+  "runSync stores compact subagent history for /workflows detail",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(_prompt: string, options: { onHistory?: (history: unknown[]) => void }) {
+          options.onHistory?.([{ role: "assistant", kind: "text", text: "inspecting files" }]);
+          return "ok";
+        },
+      },
+    });
+
+    await manager.runSync(oneAgentScript);
+
+    const run = manager.listRuns().find((r) => r.workflowName === "tracked_demo");
+    const agent = run?.agents[0];
+    assert.equal(agent?.history?.length, 1);
+    assert.equal(agent?.history?.[0]?.text, "inspecting files");
+  }),
+);
+
+test(
   "startInBackground returns immediately with runId and promise",
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({ cwd, agent: fakeAgent() });

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -119,6 +119,29 @@ return { a, b }`;
 );
 
 test(
+  "runSync persists recoverable agent error details for /workflows",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          throw new Error("agent exploded");
+        },
+      },
+    });
+
+    await manager.runSync(oneAgentScript);
+
+    const run = manager.listRuns().find((r) => r.workflowName === "tracked_demo");
+    const agent = run?.agents[0];
+    assert.equal(agent?.status, "error");
+    assert.equal(agent?.error, "agent exploded");
+    assert.equal(agent?.errorCode, WorkflowErrorCode.AGENT_EXECUTION_ERROR);
+    assert.equal(agent?.recoverable, true);
+  }),
+);
+
+test(
   "startInBackground returns immediately with runId and promise",
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({ cwd, agent: fakeAgent() });

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -77,6 +77,10 @@ function errorDetailManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
         error: "Subagent produced no assistant output",
         errorCode: WorkflowErrorCode.AGENT_EMPTY_OUTPUT,
         recoverable: true,
+        history: [
+          { role: "assistant", kind: "toolCall", toolName: "read", text: '{"file":"README.md"}' },
+          { role: "tool", kind: "toolResult", toolName: "read", text: "README content" },
+        ],
       },
     ],
     agentCount: 1,
@@ -464,6 +468,9 @@ test("renderNavigator shows agent error diagnostics in detail view", () => {
   assert.match(text, /Subagent produced no assistant output/);
   assert.match(text, /Error code:/);
   assert.match(text, /AGENT_EMPTY_OUTPUT \(recoverable\)/);
+  assert.match(text, /History:/);
+  assert.match(text, /assistant tool read: \{"file":"README.md"\}/);
+  assert.match(text, /tool read: README content/);
 });
 
 test("renderNavigator shows model info in agent rows", () => {

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { WorkflowSnapshot } from "../src/display.js";
+import { WorkflowErrorCode } from "../src/errors.js";
 import type { PersistedRunState } from "../src/run-persistence.js";
 import type { ManagedRun, WorkflowManager } from "../src/workflow-manager.js";
 import type { SavedWorkflow } from "../src/workflow-saved.js";
@@ -56,6 +57,40 @@ function fakeManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
     ],
     getRun: (id: string) =>
       id === "run-1" ? ({ runId: "run-1", status: "running", snapshot } as unknown as ManagedRun) : undefined,
+  };
+}
+
+function errorDetailManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
+  const snapshot: WorkflowSnapshot = {
+    name: "wf",
+    phases: ["P"],
+    currentPhase: "P",
+    logs: [],
+    agents: [
+      {
+        id: 1,
+        label: "empty",
+        phase: "P",
+        prompt: "do it",
+        status: "error",
+        resultPreview: "(none)",
+        error: "Subagent produced no assistant output",
+        errorCode: WorkflowErrorCode.AGENT_EMPTY_OUTPUT,
+        recoverable: true,
+      },
+    ],
+    agentCount: 1,
+    runningCount: 0,
+    doneCount: 0,
+    errorCount: 1,
+  };
+  return {
+    listRuns: () =>
+      [
+        { runId: "r-error", workflowName: "wf", status: "completed", phases: ["P"], agents: snapshot.agents, logs: [] },
+      ] as unknown as PersistedRunState[],
+    getRun: (id: string) =>
+      id === "r-error" ? ({ runId: "r-error", status: "completed", snapshot } as unknown as ManagedRun) : undefined,
   };
 }
 
@@ -415,6 +450,20 @@ test("renderNavigator shows agent detail view", () => {
   assert.match(text, /Model:/);
   assert.match(text, /model/); // shortModel strips provider prefix
   assert.match(text, /j\/k scroll/); // detail view footer
+});
+
+test("renderNavigator shows agent error diagnostics in detail view", () => {
+  const model = new NavigatorModel(errorDetailManager());
+  const state = new NavigatorState();
+  state.drill(model);
+  state.drill(model);
+  state.drill(model);
+
+  const text = renderNavigator(state, model, 80).join("\n");
+  assert.match(text, /Error:/);
+  assert.match(text, /Subagent produced no assistant output/);
+  assert.match(text, /Error code:/);
+  assert.match(text, /AGENT_EMPTY_OUTPUT \(recoverable\)/);
 });
 
 test("renderNavigator shows model info in agent rows", () => {


### PR DESCRIPTION
## Summary
- Treat blank non-schema subagent output as a recoverable `AGENT_EMPTY_OUTPUT` failure instead of a successful empty string.
- Propagate `error`, `errorCode`, and `recoverable` metadata through workflow events, live snapshots, persisted runs, and the `/workflows` agent detail view.
- Capture compact subagent message/tool history via `session.subscribe()`, throttle live updates, persist final snapshots, and render history in `/workflows` detail.

## Root Cause
Recoverable subagent failures intentionally returned `null`, but the structured failure metadata was only logged and never attached to the agent snapshot. A second path silently returned `""` when a subagent completed without assistant text, which made the run appear successful while downstream consumers dropped the empty value. Subagent sessions were also in-memory and disposed without any compact history for debugging.

## Testing
- `npm test` (650 passing)
- Manual empty-output smoke through built `dist/index.js`: verified `result: null`, `errorCode: "AGENT_EMPTY_OUTPUT"`, and compact history emission.

Closes #4
