### PR TITLE
fix(workflow-editor): persist keyword trigger preference (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/@quintinshaw/pi-dynamic-workflows?color=cb3837&logo=npm)](https://www.npmjs.com/package/@quintinshaw/pi-dynamic-workflows)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 [![for Pi](https://img.shields.io/badge/for-Pi-7c3aed)](https://pi.dev)
-[![tests](https://img.shields.io/badge/tests-651%20passing-success)](#development)
+[![tests](https://img.shields.io/badge/tests-658%20passing-success)](#development)
 
 > **Claude Code–style dynamic workflows for [Pi](https://pi.dev).**
 > Turn one prompt into a fleet of subagents that fan out in parallel, cross-check each other, and hand back a single synthesized answer.
@@ -32,11 +32,11 @@ Ask in plain language:
 Run a workflow to audit every route under src/routes/ for missing auth checks.
 ```
 
-Pi writes the script and runs it in the background — your turn ends immediately and a live panel tracks progress while you keep working. Or just type the word **workflows** in any message to force one. If you only want to discuss workflows without triggering one, run `/workflows-trigger off`, check the current state with `/workflows-trigger status`, and turn it back on with `/workflows-trigger on`.
+Pi writes the script and runs it in the background — your turn ends immediately and a live panel tracks progress while you keep working. Or just type the word **workflows** in any message to force one. If you only want to discuss workflows without triggering one, run `/workflows-trigger off`; the preference is saved for new sessions in `~/.pi/workflows/settings.json`. Check the current state with `/workflows-trigger status`, and turn it back on with `/workflows-trigger on`.
 
 ![Workflows mode in the input box](https://raw.githubusercontent.com/QuintinShaw/pi-dynamic-workflows/main/docs/media/workflows-mode.jpg)
 
-If another Pi extension has already installed a custom editor component, pi-dynamic-workflows leaves it in place and keeps the submit-time workflow trigger active. In that compatibility mode, the animated keyword highlight and Backspace one-shot disarm affordance are skipped because the existing editor remains responsible for rendering and input handling; use `/workflows-trigger off` when you need to discuss workflow/workflows without auto-triggering. Editor composition is load-order dependent: whichever extension installs a visual editor last owns the editor surface, while pi-dynamic-workflows still keeps its submit-time hook registered.
+If another Pi extension has already installed a custom editor component, pi-dynamic-workflows leaves it in place and keeps the submit-time workflow trigger active. In that compatibility mode, the animated keyword highlight and Backspace one-shot disarm affordance are skipped because the existing editor remains responsible for rendering and input handling; use `/workflows-trigger off` when you need to discuss workflow/workflows without auto-triggering, including in future sessions. Editor composition is load-order dependent: whichever extension installs a visual editor last owns the editor surface, while pi-dynamic-workflows still keeps its submit-time hook registered.
 
 ## What a workflow looks like
 
@@ -102,7 +102,7 @@ The same model — on Pi, plus the production pieces a real run needs:
 /workflows save <name>      save the latest run's script as a reusable /<name> command
 /workflows pause|resume|stop|rm <id>
 /workflows-trigger off|on|status
-                            disable, restore, or inspect keyword-triggered workflows mode
+                            persistently disable, restore, or inspect keyword-triggered workflows mode
 /workflows-models           map the small / medium / big tiers to real models
 /ultracode [off]            ultracode: auto-arm an exhaustive workflow for every substantive message
 /effort off|high|ultra      finer control over the standing opt-in (high = thorough, ultra = ultracode)
@@ -143,7 +143,7 @@ Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()
 
 ```bash
 npm install
-npm test     # biome + tsc + 651 unit tests
+npm test     # biome + tsc + 658 unit tests
 ```
 
 Every feature is also verified end-to-end against a real Pi subagent session before release.

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,9 @@ export const USER_WORKFLOW_SAVED_DIR = "~/.pi/workflows/saved";
 /** User-level model tiers config file, relative to the home directory. */
 export const MODEL_TIERS_FILE = ".pi/workflows/model-tiers.json";
 
+/** User-level workflow extension settings file, relative to the home directory. */
+export const WORKFLOW_SETTINGS_FILE = ".pi/workflows/settings.json";
+
 /**
  * Named workflow subagent definitions directory. Resolved both project-relative
  * (cwd/.pi/agents) and home-relative (~/.pi/agents); project entries win on name

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,17 +82,21 @@ export {
   colorizeWorkflow,
   endsWithTrigger,
   hasTrigger,
+  type InstallWorkflowEditorOptions,
   installWorkflowEditor,
   RAINBOW,
   registerWorkflowTriggerCommand,
   tokenizeAnsi,
   WorkflowEditor,
   type WorkflowModeState,
+  type WorkflowSettingsStore,
 } from "./workflow-editor.js";
 export type { ManagedRun, WorkflowManagerOptions } from "./workflow-manager.js";
 export { WorkflowManager } from "./workflow-manager.js";
 export type { SavedWorkflow, WorkflowStorage } from "./workflow-saved.js";
 export { createWorkflowStorage } from "./workflow-saved.js";
+export type { WorkflowSettings } from "./workflow-settings.js";
+export { getWorkflowSettingsPath, loadWorkflowSettings, saveWorkflowSettings } from "./workflow-settings.js";
 export type { WorkflowToolInput, WorkflowToolOptions } from "./workflow-tool.js";
 export { backgroundStartedText, createWorkflowTool } from "./workflow-tool.js";
 export {

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -24,6 +24,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import { type EffortState, effortDirective, isSubstantive } from "./effort-command.js";
+import { loadWorkflowSettings, saveWorkflowSettings, type WorkflowSettings } from "./workflow-settings.js";
 
 // A trigger is `workflow`/`workflows` (substring, case-insensitive) that is NOT
 // immediately preceded by `/` — so a slash command like `/workflows` or `/workflow`
@@ -54,6 +55,15 @@ export interface WorkflowModeState {
   active: boolean;
   keywordTriggerEnabled: boolean;
   suppressedKeywordText?: string;
+}
+
+export interface WorkflowSettingsStore {
+  load(): WorkflowSettings;
+  save(settings: WorkflowSettings): void;
+}
+
+export interface InstallWorkflowEditorOptions {
+  settingsStore?: WorkflowSettingsStore;
 }
 
 interface AnsiToken {
@@ -271,7 +281,11 @@ export function buildForcedWorkflowPrompt(text: string, extraDirective?: string)
 /** The exact name of the workflow tool that workflows mode forces. */
 export const WORKFLOW_TOOL_NAME = "workflow";
 
-export function registerWorkflowTriggerCommand(pi: ExtensionAPI, state: WorkflowModeState): void {
+export function registerWorkflowTriggerCommand(
+  pi: ExtensionAPI,
+  state: WorkflowModeState,
+  settingsStore: WorkflowSettingsStore = DEFAULT_SETTINGS_STORE,
+): void {
   pi.registerCommand?.("workflows-trigger", {
     description: "Keyword workflow trigger: on | off | status",
     async handler(args: string, _ctx: ExtensionCommandContext) {
@@ -280,8 +294,11 @@ export function registerWorkflowTriggerCommand(pi: ExtensionAPI, state: Workflow
       if (arg === "on") {
         state.keywordTriggerEnabled = true;
         state.suppressedKeywordText = undefined;
+        const saved = persistKeywordTrigger(settingsStore, true);
         await say(
-          "Workflows keyword trigger on — mentioning workflow/workflows in an interactive message will auto-arm workflows mode.",
+          saved
+            ? "Workflows keyword trigger on — mentioning workflow/workflows in an interactive message will auto-arm workflows mode. Saved for new sessions."
+            : "Workflows keyword trigger on for this session, but the preference could not be saved.",
         );
         return;
       }
@@ -289,13 +306,16 @@ export function registerWorkflowTriggerCommand(pi: ExtensionAPI, state: Workflow
         state.keywordTriggerEnabled = false;
         state.active = false;
         state.suppressedKeywordText = undefined;
+        const saved = persistKeywordTrigger(settingsStore, false);
         await say(
-          "Workflows keyword trigger off — messages can mention workflow/workflows without forcing the workflow tool. Use /workflows-trigger on to restore.",
+          saved
+            ? "Workflows keyword trigger off — messages can mention workflow/workflows without forcing the workflow tool. Saved for new sessions. Use /workflows-trigger on to restore."
+            : "Workflows keyword trigger off for this session, but the preference could not be saved. Use /workflows-trigger on to restore.",
         );
         return;
       }
       await say(
-        `Workflows keyword trigger is ${state.keywordTriggerEnabled ? "on" : "off"}. Usage: /workflows-trigger on | off | status`,
+        `Workflows keyword trigger is ${state.keywordTriggerEnabled ? "on" : "off"}. Changes are saved for new sessions. Usage: /workflows-trigger on | off | status`,
       );
     },
   });
@@ -305,13 +325,18 @@ export function installWorkflowEditor(
   pi: ExtensionAPI,
   ui: ExtensionUIContext,
   effort?: EffortState,
+  options: InstallWorkflowEditorOptions = {},
 ): WorkflowModeState {
-  const state: WorkflowModeState = { active: false, keywordTriggerEnabled: true };
+  const settingsStore = options.settingsStore ?? DEFAULT_SETTINGS_STORE;
+  const state: WorkflowModeState = {
+    active: false,
+    keywordTriggerEnabled: loadInitialKeywordTrigger(settingsStore),
+  };
 
   if (!ui.getEditorComponent?.()) {
     ui.setEditorComponent((tui, theme, keybindings) => new WorkflowEditor(tui, theme, keybindings, state));
   }
-  registerWorkflowTriggerCommand(pi, state);
+  registerWorkflowTriggerCommand(pi, state, settingsStore);
 
   // Active tools saved while a turn is restricted to `workflow`; restored on turn_end.
   let savedTools: string[] | undefined;
@@ -366,4 +391,26 @@ export function installWorkflowEditor(
   });
 
   return state;
+}
+
+const DEFAULT_SETTINGS_STORE: WorkflowSettingsStore = {
+  load: loadWorkflowSettings,
+  save: saveWorkflowSettings,
+};
+
+function loadInitialKeywordTrigger(settingsStore: WorkflowSettingsStore): boolean {
+  try {
+    return settingsStore.load().keywordTriggerEnabled ?? true;
+  } catch {
+    return true;
+  }
+}
+
+function persistKeywordTrigger(settingsStore: WorkflowSettingsStore, enabled: boolean): boolean {
+  try {
+    settingsStore.save({ keywordTriggerEnabled: enabled });
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/workflow-settings.ts
+++ b/src/workflow-settings.ts
@@ -1,0 +1,57 @@
+/**
+ * User-level settings for pi-dynamic-workflows.
+ *
+ * Stored separately from Pi's own settings.json so extension preferences remain
+ * stable without depending on host-internal config shape.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { WORKFLOW_SETTINGS_FILE } from "./config.js";
+
+export interface WorkflowSettings {
+  keywordTriggerEnabled?: boolean;
+}
+
+/** Path to the user-level workflow settings JSON file (~/.pi/workflows/settings.json). */
+export function getWorkflowSettingsPath(): string {
+  return join(homedir(), WORKFLOW_SETTINGS_FILE);
+}
+
+/** Load settings from disk. Missing, corrupt, or invalid files resolve to {}. */
+export function loadWorkflowSettings(settingsPath?: string): WorkflowSettings {
+  const path = settingsPath ?? getWorkflowSettingsPath();
+  if (!existsSync(path)) return {};
+  try {
+    return normalizeSettings(JSON.parse(readFileSync(path, "utf-8")));
+  } catch {
+    return {};
+  }
+}
+
+/** Merge known settings into the user-level settings file. */
+export function saveWorkflowSettings(settings: WorkflowSettings, settingsPath?: string): void {
+  const path = settingsPath ?? getWorkflowSettingsPath();
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+  const existing = readObject(path);
+  writeFileSync(path, `${JSON.stringify({ ...existing, ...normalizeSettings(settings) }, null, 2)}\n`, "utf-8");
+}
+
+function normalizeSettings(value: unknown): WorkflowSettings {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const raw = value as Record<string, unknown>;
+  return typeof raw.keywordTriggerEnabled === "boolean" ? { keywordTriggerEnabled: raw.keywordTriggerEnabled } : {};
+}
+
+function readObject(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -140,6 +140,7 @@ describe("config", () => {
     assert.equal(c.DEFAULT_AGENT_TIMEOUT_MS, 5 * 60 * 1000);
     assert.equal(c.WORKFLOW_RUNS_DIR, ".pi/workflows/runs");
     assert.equal(c.WORKFLOW_SAVED_DIR, ".pi/workflows/saved");
+    assert.equal(c.WORKFLOW_SETTINGS_FILE, ".pi/workflows/settings.json");
     assert.equal(c.USER_WORKFLOW_SAVED_DIR, "~/.pi/workflows/saved");
     assert.equal(c.DEFAULT_TOKEN_BUDGET, null);
   });

--- a/tests/workflow-editor.test.ts
+++ b/tests/workflow-editor.test.ts
@@ -60,6 +60,35 @@ async function load() {
   return import("../src/workflow-editor.js");
 }
 
+function testSettingsOptions(keywordTriggerEnabled = true) {
+  return {
+    settingsStore: {
+      load: () => ({ keywordTriggerEnabled }),
+      save: () => {},
+    },
+  };
+}
+
+function memorySettingsOptions(keywordTriggerEnabled = true) {
+  let settings = { keywordTriggerEnabled };
+  const saved: Array<{ keywordTriggerEnabled?: boolean }> = [];
+  return {
+    options: {
+      settingsStore: {
+        load: () => ({ ...settings }),
+        save: (next: { keywordTriggerEnabled?: boolean }) => {
+          settings = { ...settings, ...next };
+          saved.push(next);
+        },
+      },
+    },
+    get settings() {
+      return settings;
+    },
+    saved,
+  };
+}
+
 describe("hasTrigger", () => {
   it('returns true for "workflow"', async () => {
     const { hasTrigger } = await load();
@@ -460,7 +489,7 @@ describe("installWorkflowEditor", () => {
       setEditorComponent: (_factory: unknown) => {},
     } as unknown as ExtensionUIContext;
 
-    mod.installWorkflowEditor(pi, ui);
+    mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions());
 
     const events = registered.map((r) => r.event);
     assert.ok(events.includes("input"), 'should register "input" hook');
@@ -482,7 +511,7 @@ describe("installWorkflowEditor", () => {
       },
     } as unknown as ExtensionUIContext;
 
-    mod.installWorkflowEditor(pi, ui);
+    mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions());
 
     assert.notEqual(setFactory, undefined, "setEditorComponent should have been called");
     assert.equal(typeof setFactory, "function", "the argument should be a factory function");
@@ -511,7 +540,7 @@ describe("installWorkflowEditor", () => {
       },
     } as unknown as ExtensionUIContext;
 
-    mod.installWorkflowEditor(pi, ui);
+    mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions());
 
     assert.equal(setEditorCalls, 0, "existing custom editor should not be overwritten");
 
@@ -526,6 +555,81 @@ describe("installWorkflowEditor", () => {
   });
 
   it("registers /workflows-trigger and toggles the keyword trigger", async () => {
+    const mod = await load();
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+    const sent: Array<{ content?: string }> = [];
+    const store = memorySettingsOptions();
+    const pi = {
+      on: () => {},
+      registerCommand: (name: string, command: { handler: (args: string, ctx: unknown) => Promise<void> }) => {
+        commands.set(name, command);
+      },
+      sendMessage: (message: { content?: string }) => {
+        sent.push(message);
+      },
+      getActiveTools: () => [],
+      setActiveTools: () => {},
+    } as unknown as ExtensionAPI;
+
+    const ui = {
+      setEditorComponent: () => {},
+    } as unknown as ExtensionUIContext;
+
+    const state = mod.installWorkflowEditor(pi, ui, undefined, store.options);
+    assert.equal(state.keywordTriggerEnabled, true, "keyword trigger should default on");
+
+    const command = commands.get("workflows-trigger");
+    assert.ok(command, "should register /workflows-trigger");
+
+    await command.handler("off", {});
+    assert.equal(state.keywordTriggerEnabled, false);
+    assert.equal(state.active, false);
+    assert.deepEqual(store.settings, { keywordTriggerEnabled: false });
+    assert.match(sent.at(-1)?.content ?? "", /keyword trigger off/i);
+    assert.match(sent.at(-1)?.content ?? "", /saved for new sessions/i);
+
+    await command.handler("on", {});
+    assert.equal(state.keywordTriggerEnabled, true);
+    assert.deepEqual(store.settings, { keywordTriggerEnabled: true });
+    assert.match(sent.at(-1)?.content ?? "", /keyword trigger on/i);
+    assert.match(sent.at(-1)?.content ?? "", /saved for new sessions/i);
+  });
+
+  it("loads the persisted keyword trigger preference on install", async () => {
+    const mod = await load();
+    const captured: Array<{ event: string; handler: (...args: unknown[]) => unknown }> = [];
+    let setActiveToolsCalls = 0;
+    const pi = {
+      on: (event: string, handler: (...args: unknown[]) => unknown) => {
+        captured.push({ event, handler });
+      },
+      registerCommand: () => {},
+      sendMessage: () => {},
+      getActiveTools: () => ["bash", "read"],
+      setActiveTools: () => {
+        setActiveToolsCalls++;
+      },
+    } as unknown as ExtensionAPI;
+
+    const ui = {
+      setEditorComponent: () => {},
+    } as unknown as ExtensionUIContext;
+
+    const state = mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions(false));
+    assert.equal(state.keywordTriggerEnabled, false, "persisted off should apply to new sessions");
+
+    const inputHandler = captured.find((h) => h.event === "input")?.handler;
+    assert.ok(inputHandler, "input handler should be registered");
+    const result = inputHandler({
+      source: "interactive",
+      text: "Please discuss workflows as a normal topic.",
+    });
+
+    assert.deepEqual(result, { action: "continue" });
+    assert.equal(setActiveToolsCalls, 0);
+  });
+
+  it("keeps session trigger state when saving the preference fails", async () => {
     const mod = await load();
     const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
     const sent: Array<{ content?: string }> = [];
@@ -545,20 +649,27 @@ describe("installWorkflowEditor", () => {
       setEditorComponent: () => {},
     } as unknown as ExtensionUIContext;
 
-    const state = mod.installWorkflowEditor(pi, ui);
-    assert.equal(state.keywordTriggerEnabled, true, "keyword trigger should default on");
-
+    const state = mod.installWorkflowEditor(pi, ui, undefined, {
+      settingsStore: {
+        load: () => ({ keywordTriggerEnabled: true }),
+        save: () => {
+          throw new Error("write failed");
+        },
+      },
+    });
     const command = commands.get("workflows-trigger");
     assert.ok(command, "should register /workflows-trigger");
 
     await command.handler("off", {});
+
     assert.equal(state.keywordTriggerEnabled, false);
     assert.equal(state.active, false);
-    assert.match(sent.at(-1)?.content ?? "", /keyword trigger off/i);
+    assert.match(sent.at(-1)?.content ?? "", /could not be saved/i);
 
     await command.handler("on", {});
+
     assert.equal(state.keywordTriggerEnabled, true);
-    assert.match(sent.at(-1)?.content ?? "", /keyword trigger on/i);
+    assert.match(sent.at(-1)?.content ?? "", /could not be saved/i);
   });
 
   it("saves active tools and adds WORKFLOW_TOOL_NAME on triggered input", async () => {
@@ -576,7 +687,7 @@ describe("installWorkflowEditor", () => {
       setEditorComponent: () => {},
     } as unknown as ExtensionUIContext;
 
-    mod.installWorkflowEditor(pi, ui);
+    mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions());
 
     // Simulate the "input" event — find the registered handler
     // We need to actually invoke the handler the install sets up.
@@ -598,7 +709,7 @@ describe("installWorkflowEditor", () => {
     } as unknown as ExtensionUIContext;
 
     savedTools = [];
-    mod.installWorkflowEditor(pi2, ui2);
+    mod.installWorkflowEditor(pi2, ui2, undefined, testSettingsOptions());
 
     const inputHandler = captured.find((c) => c.event === "input")?.handler as
       | ((event: { source?: string; text?: string }) => { action: string; text?: string })
@@ -645,7 +756,7 @@ describe("installWorkflowEditor", () => {
       setEditorComponent: () => {},
     } as unknown as ExtensionUIContext;
 
-    mod.installWorkflowEditor(pi, ui);
+    mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions());
     await commands.get("workflows-trigger")?.handler("off", {});
 
     const inputHandler = captured.find((h) => h.event === "input")?.handler;
@@ -679,7 +790,7 @@ describe("installWorkflowEditor", () => {
       setEditorComponent: () => {},
     } as unknown as ExtensionUIContext;
 
-    const state = mod.installWorkflowEditor(pi, ui);
+    const state = mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions());
     state.suppressedKeywordText = "Please discuss workflows as a normal topic.";
 
     const inputHandler = captured.find((h) => h.event === "input")?.handler;
@@ -711,7 +822,7 @@ describe("installWorkflowEditor", () => {
       setEditorComponent: () => {},
     } as unknown as ExtensionUIContext;
 
-    mod.installWorkflowEditor(pi, ui);
+    mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions());
 
     const text = "Please discuss workflows as a normal topic.";
     const inputHandler = captured.find((h) => h.event === "input")?.handler;
@@ -750,7 +861,7 @@ describe("installWorkflowEditor", () => {
       setEditorComponent: () => {},
     } as unknown as ExtensionUIContext;
 
-    mod.installWorkflowEditor(pi, ui, effort);
+    mod.installWorkflowEditor(pi, ui, effort, testSettingsOptions());
     await commands.get("workflows-trigger")?.handler("off", {});
 
     const text = "Please discuss workflows as a normal topic.";
@@ -784,7 +895,7 @@ describe("installWorkflowEditor", () => {
       setEditorComponent: () => {},
     } as unknown as ExtensionUIContext;
 
-    mod.installWorkflowEditor(pi, ui);
+    mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions());
 
     const inputHandler = captured.find((c) => c.event === "input")?.handler;
     const turnEndHandler = captured.find((c) => c.event === "turn_end")?.handler;
@@ -822,7 +933,7 @@ describe("installWorkflowEditor", () => {
       setEditorComponent: () => {},
     } as unknown as ExtensionUIContext;
 
-    mod.installWorkflowEditor(pi, ui);
+    mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions());
 
     const inputHandler = captured.find((c) => c.event === "input")?.handler;
     assert.notEqual(inputHandler, undefined);
@@ -847,7 +958,7 @@ describe("installWorkflowEditor", () => {
       setEditorComponent: () => {},
     } as unknown as ExtensionUIContext;
 
-    mod.installWorkflowEditor(pi, ui);
+    mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions());
 
     const inputHandler = captured.find((c) => c.event === "input")?.handler as
       | ((event: { source?: string; text?: string }) => { action: string })

--- a/tests/workflow-settings.test.ts
+++ b/tests/workflow-settings.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, normalize } from "node:path";
+import { describe, it } from "node:test";
+import { WORKFLOW_SETTINGS_FILE } from "../src/config.js";
+import { getWorkflowSettingsPath, loadWorkflowSettings, saveWorkflowSettings } from "../src/workflow-settings.js";
+
+function withSettingsPath(fn: (settingsPath: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-settings-"));
+  try {
+    fn(join(dir, "nested", "settings.json"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("workflow settings", () => {
+  it("resolves the user-level settings path", () => {
+    assert.ok(getWorkflowSettingsPath().endsWith(normalize(WORKFLOW_SETTINGS_FILE)));
+  });
+
+  it("returns empty settings when the file is missing", () => {
+    withSettingsPath((settingsPath) => {
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+    });
+  });
+
+  it("saves and loads keyword trigger preference", () => {
+    withSettingsPath((settingsPath) => {
+      saveWorkflowSettings({ keywordTriggerEnabled: false }, settingsPath);
+
+      assert.ok(existsSync(settingsPath), "settings file should be created");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { keywordTriggerEnabled: false });
+    });
+  });
+
+  it("preserves unknown settings when saving known settings", () => {
+    withSettingsPath((settingsPath) => {
+      saveWorkflowSettings({ keywordTriggerEnabled: true }, settingsPath);
+      const current = JSON.parse(readFileSync(settingsPath, "utf-8"));
+      writeFileSync(settingsPath, `${JSON.stringify({ ...current, theme: "dark" }, null, 2)}\n`, "utf-8");
+
+      saveWorkflowSettings({ keywordTriggerEnabled: false }, settingsPath);
+
+      assert.deepEqual(JSON.parse(readFileSync(settingsPath, "utf-8")), {
+        keywordTriggerEnabled: false,
+        theme: "dark",
+      });
+    });
+  });
+
+  it("ignores corrupt or invalid settings", () => {
+    withSettingsPath((settingsPath) => {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+      writeFileSync(settingsPath, "{not json", "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+
+      writeFileSync(settingsPath, JSON.stringify({ keywordTriggerEnabled: "off" }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+    });
+  });
+});

--- a/tests/workflow-tools-available.test.ts
+++ b/tests/workflow-tools-available.test.ts
@@ -64,6 +64,15 @@ function createMockPi(initialTools: string[] = [...DEFAULT_PI_TOOLS]): MockPi {
   };
 }
 
+function testSettingsOptions(keywordTriggerEnabled = true) {
+  return {
+    settingsStore: {
+      load: () => ({ keywordTriggerEnabled }),
+      save: () => {},
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Test: installWorkflowEditor keeps default tools available
 // ---------------------------------------------------------------------------
@@ -78,7 +87,12 @@ describe("installWorkflowEditor - tool availability", () => {
       setEditorComponent: mock.fn(),
     };
 
-    installWorkflowEditor(mockPi as unknown as ExtensionAPI, ui as unknown as ExtensionUIContext);
+    installWorkflowEditor(
+      mockPi as unknown as ExtensionAPI,
+      ui as unknown as ExtensionUIContext,
+      undefined,
+      testSettingsOptions(),
+    );
 
     // Simulate user submitting a message with "workflow" keyword
     const inputHandlers = mockPi.handlers.input;
@@ -134,7 +148,12 @@ describe("installWorkflowEditor - tool availability", () => {
       setEditorComponent: mock.fn(),
     };
 
-    installWorkflowEditor(mockPi as unknown as ExtensionAPI, ui as unknown as ExtensionUIContext);
+    installWorkflowEditor(
+      mockPi as unknown as ExtensionAPI,
+      ui as unknown as ExtensionUIContext,
+      undefined,
+      testSettingsOptions(),
+    );
 
     // Trigger input with "workflows"
     const inputHandlers = mockPi.handlers.input;
@@ -170,7 +189,12 @@ describe("installWorkflowEditor - tool availability", () => {
       setEditorComponent: mock.fn(),
     };
 
-    installWorkflowEditor(mockPi as unknown as ExtensionAPI, ui as unknown as ExtensionUIContext);
+    installWorkflowEditor(
+      mockPi as unknown as ExtensionAPI,
+      ui as unknown as ExtensionUIContext,
+      undefined,
+      testSettingsOptions(),
+    );
 
     // Simulate user submitting a slash command
     const inputHandlers = mockPi.handlers.input;
@@ -195,7 +219,12 @@ describe("installWorkflowEditor - tool availability", () => {
       setEditorComponent: mock.fn(),
     };
 
-    installWorkflowEditor(mockPi as unknown as ExtensionAPI, ui as unknown as ExtensionUIContext);
+    installWorkflowEditor(
+      mockPi as unknown as ExtensionAPI,
+      ui as unknown as ExtensionUIContext,
+      undefined,
+      testSettingsOptions(),
+    );
 
     const inputHandlers = mockPi.handlers.input;
     const result = inputHandlers[0]({
@@ -216,7 +245,12 @@ describe("installWorkflowEditor - tool availability", () => {
       setEditorComponent: mock.fn(),
     };
 
-    installWorkflowEditor(mockPi as unknown as ExtensionAPI, ui as unknown as ExtensionUIContext);
+    installWorkflowEditor(
+      mockPi as unknown as ExtensionAPI,
+      ui as unknown as ExtensionUIContext,
+      undefined,
+      testSettingsOptions(),
+    );
 
     const inputHandlers = mockPi.handlers.input;
     const result = inputHandlers[0]({
@@ -239,7 +273,12 @@ describe("installWorkflowEditor - tool availability", () => {
       setEditorComponent: mock.fn(),
     };
 
-    installWorkflowEditor(mockPi as unknown as ExtensionAPI, ui as unknown as ExtensionUIContext);
+    installWorkflowEditor(
+      mockPi as unknown as ExtensionAPI,
+      ui as unknown as ExtensionUIContext,
+      undefined,
+      testSettingsOptions(),
+    );
 
     const inputHandlers = mockPi.handlers.input;
     assert.doesNotThrow(() => {
@@ -262,7 +301,12 @@ describe("installWorkflowEditor - tool availability", () => {
       setEditorComponent: mock.fn(),
     };
 
-    installWorkflowEditor(mockPi as unknown as ExtensionAPI, ui as unknown as ExtensionUIContext);
+    installWorkflowEditor(
+      mockPi as unknown as ExtensionAPI,
+      ui as unknown as ExtensionUIContext,
+      undefined,
+      testSettingsOptions(),
+    );
 
     const inputHandlers = mockPi.handlers.input;
     // Should not throw — the catch block handles it
@@ -285,7 +329,12 @@ describe("installWorkflowEditor - tool availability", () => {
       setEditorComponent: mock.fn(),
     };
 
-    installWorkflowEditor(mockPi as unknown as ExtensionAPI, ui as unknown as ExtensionUIContext);
+    installWorkflowEditor(
+      mockPi as unknown as ExtensionAPI,
+      ui as unknown as ExtensionUIContext,
+      undefined,
+      testSettingsOptions(),
+    );
 
     // First trigger
     const inputHandlers = mockPi.handlers.input;
@@ -319,7 +368,12 @@ describe("installWorkflowEditor - tool availability", () => {
     for (const keyword of ["workflow", "workflows", "WORKFLOW", "WorkFlows"]) {
       const mockPi = createMockPi();
       const ui = { setEditorComponent: mock.fn() };
-      installWorkflowEditor(mockPi as unknown as ExtensionAPI, ui as unknown as ExtensionUIContext);
+      installWorkflowEditor(
+        mockPi as unknown as ExtensionAPI,
+        ui as unknown as ExtensionUIContext,
+        undefined,
+        testSettingsOptions(),
+      );
 
       mockPi.setActiveTools.mock.resetCalls();
 
@@ -343,7 +397,12 @@ describe("installWorkflowEditor - tool availability", () => {
     const setEditorComponent = mock.fn();
     const ui = { setEditorComponent };
 
-    const state = installWorkflowEditor(mockPi as unknown as ExtensionAPI, ui as unknown as ExtensionUIContext);
+    const state = installWorkflowEditor(
+      mockPi as unknown as ExtensionAPI,
+      ui as unknown as ExtensionUIContext,
+      undefined,
+      testSettingsOptions(),
+    );
 
     assert.equal(setEditorComponent.mock.callCount(), 1);
     assert.ok(state, "should return a WorkflowModeState");
@@ -359,6 +418,8 @@ describe("installWorkflowEditor - tool availability", () => {
     const state: WorkflowModeState = installWorkflowEditor(
       mockPi as unknown as ExtensionAPI,
       ui as unknown as ExtensionUIContext,
+      undefined,
+      testSettingsOptions(),
     );
 
     assert.equal(typeof state.active, "boolean");


### PR DESCRIPTION
## Summary
- persist `/workflows-trigger off|on` in `~/.pi/workflows/settings.json` so the keyword trigger preference survives new sessions
- load the saved preference during editor installation while defaulting to enabled when settings are missing, invalid, or unreadable
- keep explicit workflow entry points unaffected: `/workflows`, the `workflow` tool, `/effort`, and `/ultracode` still work
- document the persistent behavior and add focused coverage for settings load/save and trigger command behavior

Fixes #15

## Validation
- `npx tsx --test tests/workflow-editor.test.ts tests/workflow-settings.test.ts`
- `npm test` (658 passing)