### PR TITLE
fix(workflow): make default agent timeout unbounded

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/@quintinshaw/pi-dynamic-workflows?color=cb3837&logo=npm)](https://www.npmjs.com/package/@quintinshaw/pi-dynamic-workflows)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 [![for Pi](https://img.shields.io/badge/for-Pi-7c3aed)](https://pi.dev)
-[![tests](https://img.shields.io/badge/tests-658%20passing-success)](#development)
+[![tests](https://img.shields.io/badge/tests-665%20passing-success)](#development)
 
 > **Claude Code–style dynamic workflows for [Pi](https://pi.dev).**
 > Turn one prompt into a fleet of subagents that fan out in parallel, cross-check each other, and hand back a single synthesized answer.
@@ -71,7 +71,7 @@ return await agent('Synthesize and double-check these findings:\n' + findings.jo
 - **Real model routing** — `small` / `medium` / `big` tiers (or an exact `model`) per agent. It actually switches the subagent's model — cheap work on a light one, hard synthesis on a big one.
 - **Journaled resume** — an interrupted run replays finished agents from a journal (no re-run, no tokens) and runs only what's left or what you changed.
 - **Git worktree isolation** — `isolation: "worktree"` gives an agent its own branch, so parallel agents can edit the same files without clobbering each other.
-- **Real token & cost accounting** — read from each subagent's session, not estimated. `budget` gates on the real total and `/workflows` shows the dollar cost.
+- **Real token & cost accounting** — read from each subagent's session, not estimated. Runs have no default token cap; `tokenBudget`, phase budgets, and `budget` let you add explicit gates when you want them.
 - **Background by default** — the turn ends right away, a live "Workflows running" panel tracks runs, and each result is delivered back so the conversation auto-continues when it finishes.
 - **Interactive `/workflows` TUI** — drill runs → phases → agents → detail; inspect per-agent failures and compact subagent history; pause, stop, restart, and save runs from the keyboard.
 - **Quality patterns built in** — `verify()`, `judgePanel()`, `loopUntilDry()`, and `completenessCheck()` for adversarial review, best-of-N, and exhaustive discovery.
@@ -135,7 +135,9 @@ The full guide — every global, agent option, `agentType` definitions, structur
 | `agentType` | A named definition (`.pi/agents/<name>.md`) binding tools + model + role prompt. |
 | `isolation: "worktree"` | Run in a throwaway git worktree for conflict-free parallel edits. |
 | `schema` | JSON Schema → the subagent returns a validated object. |
-| `label` / `phase` / `timeoutMs` | Display label / phase override / per-agent timeout. |
+| `label` / `phase` / `timeoutMs` | Display label / phase override / optional per-agent hard timeout. Omit `timeoutMs` for no hard timeout. |
+
+By default, workflows do not set a run-wide token budget or per-agent hard timeout. Use the `workflow` tool's `tokenBudget` / `agentTimeoutMs`, per-phase budgets, or per-agent `timeoutMs` only when you want an explicit cap. A global fallback timeout can also be set in `~/.pi/workflows/settings.json` as `{ "defaultAgentTimeoutMs": 600000 }`; set it to `null` or omit it for no default hard timeout.
 
 Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()`, and `require`/`import`/`fs`/network are unavailable, so runs stay reproducible — which is what makes resume reliable.
 
@@ -143,7 +145,7 @@ Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()
 
 ```bash
 npm install
-npm test     # biome + tsc + 658 unit tests
+npm test     # biome + tsc + 665 unit tests
 ```
 
 Every feature is also verified end-to-end against a real Pi subagent session before release.

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -6,6 +6,7 @@ import {
   installResultDelivery,
   installTaskPanel,
   installWorkflowEditor,
+  loadWorkflowSettings,
   registerAllSavedWorkflows,
   registerBuiltinWorkflows,
   registerEffortCommand,
@@ -19,7 +20,12 @@ export default function extension(pi: ExtensionAPI) {
   // so background runs started by the tool are reachable from the command.
   const cwd = process.cwd();
   const storage = createWorkflowStorage(cwd);
-  const manager = new WorkflowManager({ cwd, loadSavedWorkflow: (name) => storage.load(name)?.script });
+  const settings = loadWorkflowSettings();
+  const manager = new WorkflowManager({
+    cwd,
+    loadSavedWorkflow: (name) => storage.load(name)?.script,
+    defaultAgentTimeoutMs: settings.defaultAgentTimeoutMs ?? null,
+  });
 
   const workflowTool = createWorkflowTool({ cwd, manager, storage });
   pi.registerTool(workflowTool);

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,8 +5,8 @@
 /** Maximum number of agents allowed per workflow run. */
 export const MAX_AGENTS_PER_RUN = 1000;
 
-/** Default timeout for a single agent in milliseconds (5 minutes). */
-export const DEFAULT_AGENT_TIMEOUT_MS = 5 * 60 * 1000;
+/** Default timeout for a single agent in milliseconds. null means no hard timeout. */
+export const DEFAULT_AGENT_TIMEOUT_MS = null;
 
 /** Maximum concurrent agents (matches Claude Code limit). */
 export const MAX_CONCURRENCY = 16;

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,13 +89,12 @@ export {
   tokenizeAnsi,
   WorkflowEditor,
   type WorkflowModeState,
-  type WorkflowSettingsStore,
 } from "./workflow-editor.js";
 export type { ManagedRun, WorkflowManagerOptions } from "./workflow-manager.js";
 export { WorkflowManager } from "./workflow-manager.js";
 export type { SavedWorkflow, WorkflowStorage } from "./workflow-saved.js";
 export { createWorkflowStorage } from "./workflow-saved.js";
-export type { WorkflowSettings } from "./workflow-settings.js";
+export type { WorkflowSettings, WorkflowSettingsStore } from "./workflow-settings.js";
 export { getWorkflowSettingsPath, loadWorkflowSettings, saveWorkflowSettings } from "./workflow-settings.js";
 export type { WorkflowToolInput, WorkflowToolOptions } from "./workflow-tool.js";
 export { backgroundStartedText, createWorkflowTool } from "./workflow-tool.js";

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -24,7 +24,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import { type EffortState, effortDirective, isSubstantive } from "./effort-command.js";
-import { loadWorkflowSettings, saveWorkflowSettings, type WorkflowSettings } from "./workflow-settings.js";
+import { loadWorkflowSettings, saveWorkflowSettings, type WorkflowSettingsStore } from "./workflow-settings.js";
 
 // A trigger is `workflow`/`workflows` (substring, case-insensitive) that is NOT
 // immediately preceded by `/` — so a slash command like `/workflows` or `/workflow`
@@ -55,11 +55,6 @@ export interface WorkflowModeState {
   active: boolean;
   keywordTriggerEnabled: boolean;
   suppressedKeywordText?: string;
-}
-
-export interface WorkflowSettingsStore {
-  load(): WorkflowSettings;
-  save(settings: WorkflowSettings): void;
 }
 
 export interface InstallWorkflowEditorOptions {

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -46,8 +46,8 @@ export interface ExecOptions {
   resumeJournal?: Map<number, JournalEntry>;
   /** Cap on total agents for this run. */
   maxAgents?: number;
-  /** Per-agent timeout in milliseconds. */
-  agentTimeoutMs?: number;
+  /** Per-agent timeout in milliseconds. null/omitted means no hard timeout. */
+  agentTimeoutMs?: number | null;
   /** Host signal (e.g. tool/Esc) that should abort this run when fired. */
   externalSignal?: AbortSignal;
   /** Called with the live snapshot on every progress event. */
@@ -69,6 +69,8 @@ export interface WorkflowManagerOptions {
   mainModel?: string;
   /** The pi session id to tag runs with (see setSessionId). */
   sessionId?: string;
+  /** Default per-agent timeout when a run does not pass agentTimeoutMs. null means no hard timeout. */
+  defaultAgentTimeoutMs?: number | null;
 }
 
 export class WorkflowManager extends EventEmitter {
@@ -82,6 +84,7 @@ export class WorkflowManager extends EventEmitter {
   private mainModel?: string;
   /** The current pi session id; runs are stamped with it and listRuns() filters by it. */
   private sessionId?: string;
+  private defaultAgentTimeoutMs: number | null;
 
   constructor(options: WorkflowManagerOptions = {}) {
     super();
@@ -91,6 +94,7 @@ export class WorkflowManager extends EventEmitter {
     this.agent = options.agent;
     this.mainModel = options.mainModel;
     this.sessionId = options.sessionId;
+    this.defaultAgentTimeoutMs = options.defaultAgentTimeoutMs ?? null;
     this.persistence = createRunPersistence(this.cwd);
     this.recoverStaleRuns();
   }
@@ -253,6 +257,7 @@ export class WorkflowManager extends EventEmitter {
     exec: ExecOptions = {},
   ): Promise<WorkflowRunResult> {
     const { resumeJournal, maxAgents, agentTimeoutMs, externalSignal, onProgress, tokenBudget, confirm } = exec;
+    const resolvedAgentTimeoutMs = agentTimeoutMs !== undefined ? agentTimeoutMs : this.defaultAgentTimeoutMs;
     const progress = () => onProgress?.(managed.snapshot);
     // Let a host abort (e.g. Esc during a blocking tool call) cancel this run.
     if (externalSignal) {
@@ -268,7 +273,7 @@ export class WorkflowManager extends EventEmitter {
         signal: managed.controller.signal,
         concurrency: this.concurrency,
         maxAgents,
-        agentTimeoutMs,
+        agentTimeoutMs: resolvedAgentTimeoutMs,
         tokenBudget,
         confirm,
         loadSavedWorkflow: this.loadSavedWorkflow,

--- a/src/workflow-settings.ts
+++ b/src/workflow-settings.ts
@@ -12,6 +12,12 @@ import { WORKFLOW_SETTINGS_FILE } from "./config.js";
 
 export interface WorkflowSettings {
   keywordTriggerEnabled?: boolean;
+  defaultAgentTimeoutMs?: number | null;
+}
+
+export interface WorkflowSettingsStore {
+  load(): WorkflowSettings;
+  save(settings: WorkflowSettings): void;
 }
 
 /** Path to the user-level workflow settings JSON file (~/.pi/workflows/settings.json). */
@@ -43,7 +49,20 @@ export function saveWorkflowSettings(settings: WorkflowSettings, settingsPath?: 
 function normalizeSettings(value: unknown): WorkflowSettings {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   const raw = value as Record<string, unknown>;
-  return typeof raw.keywordTriggerEnabled === "boolean" ? { keywordTriggerEnabled: raw.keywordTriggerEnabled } : {};
+  const settings: WorkflowSettings = {};
+  if (typeof raw.keywordTriggerEnabled === "boolean") {
+    settings.keywordTriggerEnabled = raw.keywordTriggerEnabled;
+  }
+  if (raw.defaultAgentTimeoutMs === null) {
+    settings.defaultAgentTimeoutMs = null;
+  } else if (
+    typeof raw.defaultAgentTimeoutMs === "number" &&
+    Number.isFinite(raw.defaultAgentTimeoutMs) &&
+    raw.defaultAgentTimeoutMs > 0
+  ) {
+    settings.defaultAgentTimeoutMs = raw.defaultAgentTimeoutMs;
+  }
+  return settings;
 }
 
 function readObject(path: string): Record<string, unknown> {

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -14,6 +14,7 @@ import { WorkflowError, WorkflowErrorCode } from "./errors.js";
 import { parseWorkflowScript, type WorkflowRunResult } from "./workflow.js";
 import { WorkflowManager } from "./workflow-manager.js";
 import { createWorkflowStorage, type WorkflowStorage } from "./workflow-saved.js";
+import { loadWorkflowSettings } from "./workflow-settings.js";
 
 /**
  * Model routing guideline for workflow authors.
@@ -82,7 +83,8 @@ const workflowToolSchema = Type.Object({
   ),
   agentTimeoutMs: Type.Optional(
     Type.Number({
-      description: "Timeout per agent in milliseconds. Default: 300000 (5 minutes).",
+      description:
+        "Timeout per agent in milliseconds. Omit for no hard timeout by default. Set only when the user asks to bound time.",
     }),
   ),
   tokenBudget: Type.Optional(
@@ -109,6 +111,8 @@ export interface WorkflowToolOptions {
   manager?: WorkflowManager;
   /** Shared saved-workflow storage. */
   storage?: WorkflowStorage;
+  /** Default per-agent timeout for runs created by this tool. null means no hard timeout. */
+  defaultAgentTimeoutMs?: number | null;
 }
 
 export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefinition<typeof workflowToolSchema, any> {
@@ -119,6 +123,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       cwd: options.cwd,
       concurrency: options.concurrency,
       loadSavedWorkflow: (name: string) => storage.load(name)?.script,
+      defaultAgentTimeoutMs: resolveDefaultAgentTimeoutMs(options.defaultAgentTimeoutMs),
     });
 
   return defineTool({
@@ -138,6 +143,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       "For workflow, available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), args, cwd, process.cwd(), and budget. Every workflow must call agent() at least once; do not use workflow only to declare phases or return a static object.",
       "For workflow, prefer the built-in quality helpers when they fit (each is built on agent()/parallel() and returns plain data): verify(item, {reviewers, threshold, lens}) for adversarial fact-checking; judgePanel(attempts, {judges, rubric}) to score N candidates and return the best; loopUntilDry({round, key, consecutiveEmpty}) to keep finding until rounds stop yielding new items; completenessCheck(args, results) as a final 'what's missing' critic.",
       "For workflow, when meta.phases declares more than one phase, call phase('Exact Title') at the start of each phase's work (or set opts.phase on each agent) so every agent groups under the correct phase; never declare a phase you don't switch into — a declared phase with no agents shows as 0/0 and any agent you forgot to move stays in the previous phase.",
+      "For workflow, do not set tokenBudget or agentTimeoutMs unless the user explicitly asks to cap spend or time; the defaults are unbounded.",
       "For workflow, to bound spend: pass tokenBudget for a hard run-wide cap; carve a per-phase ceiling with phase('Name', {budget: N}) (that phase throws at its sub-budget without touching the run total — wrap its work in try/catch so later phases proceed); use retry(thunk, {attempts, until}) for bounded retry, and gate(thunk, validator, {attempts}) when a validator's feedback should steer the next attempt. To degrade gracefully, branch on budget.remaining() to skip optional rounds or choose a lighter tier.",
       "For workflow, prefer it for decomposable work: repository inspection, independent research/checks, multi-perspective review, or fan-out/fan-in synthesis. Do not use it for a single quick file read/edit or when ordinary tools are enough.",
       "For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.",
@@ -289,6 +295,11 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       return new Text(clean || theme.fg("muted", "workflow"), 0, 0);
     },
   });
+}
+
+function resolveDefaultAgentTimeoutMs(explicit: number | null | undefined): number | null {
+  if (explicit !== undefined) return explicit;
+  return loadWorkflowSettings().defaultAgentTimeoutMs ?? null;
 }
 
 /**

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -70,8 +70,8 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   signal?: AbortSignal;
   /** Maximum number of agents allowed in this run. Default: 1000 */
   maxAgents?: number;
-  /** Timeout per agent in milliseconds. Default: 5 minutes */
-  agentTimeoutMs?: number;
+  /** Timeout per agent in milliseconds. null/omitted means no hard timeout. */
+  agentTimeoutMs?: number | null;
   /** Whether to persist logs to disk. Default: true */
   persistLogs?: boolean;
   /** Run ID for persistence. Auto-generated if not provided. */
@@ -162,8 +162,8 @@ export interface AgentOptions<TSchemaDef extends TSchema | undefined = TSchema |
    * and falls back to default tools/model (with the name as a prose hint).
    */
   agentType?: string;
-  /** Override timeout for this specific agent. */
-  timeoutMs?: number;
+  /** Override timeout for this specific agent. null means no hard timeout. */
+  timeoutMs?: number | null;
 }
 
 /** Options for a human checkpoint() — a deterministic, journaled, replayable gate. */
@@ -248,7 +248,7 @@ export async function runWorkflow<T = unknown>(
   // Per-phase model routing from meta.phases[].model, with meta.model as the default.
   const routingConfig = parseModelRoutingFromMeta(meta.phases, meta.model);
   const maxAgents = options.maxAgents ?? MAX_AGENTS_PER_RUN;
-  const agentTimeoutMs = options.agentTimeoutMs ?? DEFAULT_AGENT_TIMEOUT_MS;
+  const agentTimeoutMs = options.agentTimeoutMs !== undefined ? options.agentTimeoutMs : DEFAULT_AGENT_TIMEOUT_MS;
   const runId = options.runId ?? `run-${started.toString(36)}`;
   const baseCwd = options.cwd ?? process.cwd();
   // Snapshot the agentType registry ONCE per run so two agent() calls can't
@@ -414,7 +414,7 @@ export async function runWorkflow<T = unknown>(
     if (!hashMatches || cachedEmptyOutput) state.firstMiss = Math.min(state.firstMiss, callIndex);
 
     return limiter(async () => {
-      const timeout = agentOptions.timeoutMs ?? agentTimeoutMs;
+      const timeout = agentOptions.timeoutMs !== undefined ? agentOptions.timeoutMs : agentTimeoutMs;
 
       options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
 
@@ -473,7 +473,7 @@ export async function runWorkflow<T = unknown>(
             },
           } as any),
           timeout,
-          `Agent "${label}" timed out after ${timeout}ms`,
+          label,
         );
 
         throwIfAborted();
@@ -1056,12 +1056,20 @@ function estimateTokens(value: unknown): number {
 /**
  * Run a promise with a timeout.
  */
-async function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+async function withTimeout<T>(promise: Promise<T>, ms: number | null, label: string): Promise<T> {
+  if (ms === null) return promise;
+
   let timeoutId: NodeJS.Timeout | undefined;
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
-      reject(new WorkflowError(message, WorkflowErrorCode.AGENT_TIMEOUT, { recoverable: true }));
+      reject(
+        new WorkflowError(
+          `Agent "${label}" timed out after ${ms}ms; raise or omit timeoutMs/agentTimeoutMs to allow longer runs`,
+          WorkflowErrorCode.AGENT_TIMEOUT,
+          { recoverable: true },
+        ),
+      );
     }, ms);
   });
 

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -499,20 +499,63 @@ test("agent() accumulates usage across multiple agents", async () => {
 test("agent() with timeout should handle gracefully (timeout returns null)", async () => {
   const slow = {
     async run() {
-      await new Promise((r) => setTimeout(r, 20000));
+      await new Promise((r) => setTimeout(r, 50));
       return "slow";
     },
   };
+  let errorMessage = "";
   const result = await runWorkflow<unknown>(
     `export const meta = { name: 'test', description: 't' }
      let val = null
      try { val = await agent('slow', { label: 's', timeoutMs: 5 }) } catch (e) { val = 'error:' + (e && e.message || e) }
      return { val }`,
-    { agent: slow, persistLogs: false },
+    {
+      agent: slow,
+      persistLogs: false,
+      onAgentEnd: (event) => {
+        if (event.error) errorMessage = event.error;
+      },
+    },
   );
   const r = result.result as { val: unknown };
   // agent() catches timeout internally (recoverable) and returns null
   assert.equal(r.val, null, "timeout agent should return null (recoverable)");
+  assert.match(errorMessage, /timed out after 5ms/);
+  assert.match(errorMessage, /raise or omit timeoutMs\/agentTimeoutMs/);
+});
+
+test("agent() default timeout is unbounded", async () => {
+  const slow = {
+    async run() {
+      await new Promise((r) => setTimeout(r, 25));
+      return "slow";
+    },
+  };
+  const result = await runWorkflow<{ val: string }>(
+    `export const meta = { name: 'test', description: 't' }
+     const val = await agent('slow', { label: 's' })
+     return { val }`,
+    { agent: slow, persistLogs: false },
+  );
+
+  assert.equal(result.result.val, "slow");
+});
+
+test("agent() timeoutMs null overrides a run-level timeout", async () => {
+  const slow = {
+    async run() {
+      await new Promise((r) => setTimeout(r, 25));
+      return "slow";
+    },
+  };
+  const result = await runWorkflow<{ val: string }>(
+    `export const meta = { name: 'test', description: 't' }
+     const val = await agent('slow', { label: 's', timeoutMs: null })
+     return { val }`,
+    { agent: slow, agentTimeoutMs: 5, persistLogs: false },
+  );
+
+  assert.equal(result.result.val, "slow");
 });
 
 test("agent() with parallel invokes all agents", async () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -137,7 +137,7 @@ describe("config", () => {
     const c = await loadConfig();
     assert.equal(c.MAX_AGENTS_PER_RUN, 1000);
     assert.equal(c.MAX_CONCURRENCY, 16);
-    assert.equal(c.DEFAULT_AGENT_TIMEOUT_MS, 5 * 60 * 1000);
+    assert.equal(c.DEFAULT_AGENT_TIMEOUT_MS, null);
     assert.equal(c.WORKFLOW_RUNS_DIR, ".pi/workflows/runs");
     assert.equal(c.WORKFLOW_SAVED_DIR, ".pi/workflows/saved");
     assert.equal(c.WORKFLOW_SETTINGS_FILE, ".pi/workflows/settings.json");

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -44,6 +44,23 @@ function deferredAgent() {
   };
 }
 
+function delayedAgent(delayMs: number, result: unknown = "slow") {
+  return {
+    async run(_prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      options?.onUsage?.({
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+        cost: 0,
+      });
+      return result;
+    },
+  };
+}
+
 const oneAgentScript = `export const meta = { name: 'tracked_demo', description: 'one agent' }
 phase('Work')
 const a = await agent('do it', { label: 'a' })
@@ -85,6 +102,34 @@ test(
     assert.equal(runs[0].workflowName, "tracked_demo");
     assert.equal(runs[0].status, "completed");
     assert.equal(runs[0].tokenUsage?.total, 140, "token usage is persisted for the navigator");
+  }),
+);
+
+test(
+  "manager defaultAgentTimeoutMs applies when run options omit agentTimeoutMs",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: delayedAgent(25), defaultAgentTimeoutMs: 5 });
+
+    const result = await manager.runSync(oneAgentScript);
+
+    assert.equal((result.result as { a: unknown }).a, null);
+    const agent = manager.listRuns()[0]?.agents[0];
+    assert.equal(agent?.status, "error");
+    assert.match(agent?.error ?? "", /timed out after 5ms/);
+    assert.match(agent?.error ?? "", /raise or omit timeoutMs\/agentTimeoutMs/);
+  }),
+);
+
+test(
+  "run option agentTimeoutMs overrides manager defaultAgentTimeoutMs",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: delayedAgent(25), defaultAgentTimeoutMs: 5 });
+
+    const result = await manager.runSync(oneAgentScript, undefined, { agentTimeoutMs: null });
+
+    assert.equal((result.result as { a: unknown }).a, "slow");
+    const agent = manager.listRuns()[0]?.agents[0];
+    assert.equal(agent?.status, "done");
   }),
 );
 

--- a/tests/workflow-settings.test.ts
+++ b/tests/workflow-settings.test.ts
@@ -35,6 +35,16 @@ describe("workflow settings", () => {
     });
   });
 
+  it("saves and loads default agent timeout preference", () => {
+    withSettingsPath((settingsPath) => {
+      saveWorkflowSettings({ defaultAgentTimeoutMs: 600000 }, settingsPath);
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { defaultAgentTimeoutMs: 600000 });
+
+      saveWorkflowSettings({ defaultAgentTimeoutMs: null }, settingsPath);
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { defaultAgentTimeoutMs: null });
+    });
+  });
+
   it("preserves unknown settings when saving known settings", () => {
     withSettingsPath((settingsPath) => {
       saveWorkflowSettings({ keywordTriggerEnabled: true }, settingsPath);
@@ -57,6 +67,12 @@ describe("workflow settings", () => {
       assert.deepEqual(loadWorkflowSettings(settingsPath), {});
 
       writeFileSync(settingsPath, JSON.stringify({ keywordTriggerEnabled: "off" }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+
+      writeFileSync(settingsPath, JSON.stringify({ defaultAgentTimeoutMs: 0 }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+
+      writeFileSync(settingsPath, JSON.stringify({ defaultAgentTimeoutMs: -1 }), "utf-8");
       assert.deepEqual(loadWorkflowSettings(settingsPath), {});
     });
   });

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -64,6 +64,21 @@ test("createWorkflowTool promptGuidelines mention model routing", () => {
   assert.ok(all.includes("small") || all.includes("medium") || all.includes("big"), "should mention tier names");
 });
 
+test("createWorkflowTool promptGuidelines keep budget and timeout unbounded by default", () => {
+  const tool = createWorkflowTool();
+  const all = tool.promptGuidelines.join(" ");
+  assert.match(all, /do not set tokenBudget or agentTimeoutMs/i);
+  assert.match(all, /defaults are unbounded/i);
+});
+
+test("createWorkflowTool schema describes unbounded default timeout", () => {
+  const tool = createWorkflowTool();
+  const parameters = tool.parameters as { properties?: Record<string, { description?: string }> };
+  const description = parameters.properties?.agentTimeoutMs?.description ?? "";
+  assert.match(description, /Omit for no hard timeout/i);
+  assert.match(description, /only when the user asks/i);
+});
+
 // ─── modelRoutingGuideline ──────────────────────────────────────────────────────
 
 test("modelRoutingGuideline mentions all three tier names", () => {


### PR DESCRIPTION
## Summary
- remove the 5-minute default hard timeout for workflow subagents
- keep explicit `timeoutMs` / `agentTimeoutMs` caps working, with a self-correcting timeout error message
- add optional `defaultAgentTimeoutMs` support in `~/.pi/workflows/settings.json`
- update workflow prompt guidance, tool schema, README, and tests for unbounded defaults

Fixes #14

## Validation
- `npx tsx --test tests/agent.test.ts tests/workflow-manager.test.ts tests/workflow-settings.test.ts tests/workflow-tool.test.ts tests/utils.test.ts` — 178 passing
- `npm run build`
- `npm test` — 665 passing
- real Pi `openai-codex` smoke: short workflow returned `{"result":"pi-workflow-smoke-ok"}`
- real Pi `openai-codex` long workflow: completed after 354s and returned `pi-workflow-timeout-ok`, proving it passes the old 300s default timeout