### PR TITLE
fix(workflow): store project state under workflow home

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/@quintinshaw/pi-dynamic-workflows?color=cb3837&logo=npm)](https://www.npmjs.com/package/@quintinshaw/pi-dynamic-workflows)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 [![for Pi](https://img.shields.io/badge/for-Pi-7c3aed)](https://pi.dev)
-[![tests](https://img.shields.io/badge/tests-665%20passing-success)](#development)
+[![tests](https://img.shields.io/badge/tests-679%20passing-success)](#development)
 
 > **Claude Code–style dynamic workflows for [Pi](https://pi.dev).**
 > Turn one prompt into a fleet of subagents that fan out in parallel, cross-check each other, and hand back a single synthesized answer.
@@ -113,6 +113,10 @@ The same model — on Pi, plus the production pieces a real run needs:
 
 In the navigator: `↑/↓` select · `enter`/`→` open · `esc`/`←` back · `p` pause · `x` stop · `r` restart · `s` save · `q` quit. Each agent shows the model it ran on; the detail view shows its prompt, result, error diagnostics, and compact message/tool history.
 
+## Storage
+
+Workflow state is stored under `~/.pi/workflows` so projects do not accumulate extension-owned `.pi/workflows` directories. Global settings and model tiers live at `~/.pi/workflows/settings.json` and `~/.pi/workflows/model-tiers.json`; project-scoped run history, resume journals, locks, and saved workflow overrides live under `~/.pi/workflows/projects/<project>/`. Older project-local `.pi/workflows/runs` and `.pi/workflows/saved` data is still read as a fallback, but new writes go to the user-level workflow store.
+
 ## Reference
 
 The full guide — every global, agent option, `agentType` definitions, structured output, and determinism — lives on the **[website](https://quintinshaw.github.io/pi-dynamic-workflows/)**. The essentials:
@@ -145,7 +149,7 @@ Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()
 
 ```bash
 npm install
-npm test     # biome + tsc + 665 unit tests
+npm test     # biome + tsc + 679 unit tests
 ```
 
 Every feature is also verified end-to-end against a real Pi subagent session before release.

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -12,6 +12,7 @@ import {
   registerEffortCommand,
   registerWorkflowCommands,
   registerWorkflowModelsCommand,
+  saveWorkflowSettingsForCwd,
   WorkflowManager,
 } from "../src/index.js";
 
@@ -20,7 +21,7 @@ export default function extension(pi: ExtensionAPI) {
   // so background runs started by the tool are reachable from the command.
   const cwd = process.cwd();
   const storage = createWorkflowStorage(cwd);
-  const settings = loadWorkflowSettings();
+  const settings = loadWorkflowSettings({ cwd });
   const manager = new WorkflowManager({
     cwd,
     loadSavedWorkflow: (name) => storage.load(name)?.script,
@@ -63,7 +64,12 @@ export default function extension(pi: ExtensionAPI) {
     // Live "workflows running" panel below the input (focus + enter to open).
     installTaskPanel(pi, manager, ctx.ui, { storage, cwd });
     if (!editorInstalled) {
-      installWorkflowEditor(pi, ctx.ui, effort);
+      installWorkflowEditor(pi, ctx.ui, effort, {
+        settingsStore: {
+          load: () => loadWorkflowSettings({ cwd }),
+          save: (nextSettings) => saveWorkflowSettingsForCwd(nextSettings, cwd),
+        },
+      });
       editorInstalled = true;
     }
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,10 +14,10 @@ export const MAX_CONCURRENCY = 16;
 /** Default token budget if none specified. */
 export const DEFAULT_TOKEN_BUDGET = null;
 
-/** Directory for persisting workflow run state. */
+/** Legacy project-relative directory for persisted workflow run state. New writes use workflowProjectPaths(). */
 export const WORKFLOW_RUNS_DIR = ".pi/workflows/runs";
 
-/** Directory for saved workflow commands. */
+/** Legacy project-relative directory for saved workflow commands. New writes use workflowProjectPaths(). */
 export const WORKFLOW_SAVED_DIR = ".pi/workflows/saved";
 
 /** User-level saved workflows directory. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,10 +92,25 @@ export {
 } from "./workflow-editor.js";
 export type { ManagedRun, WorkflowManagerOptions } from "./workflow-manager.js";
 export { WorkflowManager } from "./workflow-manager.js";
+export type { WorkflowProjectPaths } from "./workflow-paths.js";
+export {
+  WORKFLOW_HOME_RELATIVE_DIR,
+  WORKFLOW_PROJECTS_SUBDIR,
+  workflowHomeDir,
+  workflowProjectKey,
+  workflowProjectPaths,
+  workflowUserSavedDir,
+} from "./workflow-paths.js";
 export type { SavedWorkflow, WorkflowStorage } from "./workflow-saved.js";
-export { createWorkflowStorage } from "./workflow-saved.js";
-export type { WorkflowSettings, WorkflowSettingsStore } from "./workflow-settings.js";
-export { getWorkflowSettingsPath, loadWorkflowSettings, saveWorkflowSettings } from "./workflow-settings.js";
+export { assertSafeSavedWorkflowName, createWorkflowStorage, isSafeSavedWorkflowName } from "./workflow-saved.js";
+export type { WorkflowSettings, WorkflowSettingsOptions, WorkflowSettingsStore } from "./workflow-settings.js";
+export {
+  getWorkflowProjectSettingsPath,
+  getWorkflowSettingsPath,
+  loadWorkflowSettings,
+  saveWorkflowSettings,
+  saveWorkflowSettingsForCwd,
+} from "./workflow-settings.js";
 export type { WorkflowToolInput, WorkflowToolOptions } from "./workflow-tool.js";
 export { backgroundStartedText, createWorkflowTool } from "./workflow-tool.js";
 export {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,7 +4,7 @@
 
 import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { WORKFLOW_RUNS_DIR } from "./config.js";
+import { workflowProjectPaths } from "./workflow-paths.js";
 
 export interface WorkflowLogger {
   log(message: string): void;
@@ -30,6 +30,7 @@ export function createWorkflowLogger(options: WorkflowLoggerOptions = {}): Workf
   const persistLogs = options.persist ?? true;
   const cwd = options.cwd ?? process.cwd();
   const runId = options.runId ?? `run-${Date.now()}`;
+  const runsDir = workflowProjectPaths(cwd).runsDir;
   let logFile: string | null = null;
 
   const write = (level: string, message: string) => {
@@ -63,7 +64,6 @@ export function createWorkflowLogger(options: WorkflowLoggerOptions = {}): Workf
     persist() {
       if (!persistLogs) return null;
       try {
-        const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
         mkdirSync(runsDir, { recursive: true });
         logFile = join(runsDir, `${runId}.log`);
         writeFileSync(logFile, `${logs.join("\n")}\n`);
@@ -77,7 +77,6 @@ export function createWorkflowLogger(options: WorkflowLoggerOptions = {}): Workf
   // Initialize log file if persisting
   if (persistLogs) {
     try {
-      const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
       mkdirSync(runsDir, { recursive: true });
       logFile = join(runsDir, `${runId}.log`);
     } catch {

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -3,10 +3,10 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import type { AgentHistoryEntry } from "./agent-history.js";
-import { WORKFLOW_RUNS_DIR } from "./config.js";
 import type { WorkflowErrorCode } from "./errors.js";
+import { workflowProjectPaths } from "./workflow-paths.js";
 
 export type RunStatus = "pending" | "running" | "paused" | "completed" | "failed" | "aborted";
 
@@ -113,7 +113,9 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
   const _unlinkSync = fsOverride?.unlinkSync ?? unlinkSync;
   const _writeFileSync = fsOverride?.writeFileSync ?? writeFileSync;
 
-  const runsDir = resolve(cwd, WORKFLOW_RUNS_DIR);
+  const paths = workflowProjectPaths(cwd);
+  const runsDir = paths.runsDir;
+  const legacyRunsDir = paths.legacyRunsDir;
 
   const ensureDir = () => {
     if (!_existsSync(runsDir)) {
@@ -121,8 +123,13 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     }
   };
 
-  const runPath = (runId: string) => join(runsDir, `${runId}.json`);
-  const lockPath = (runId: string) => join(runsDir, `${runId}.lock`);
+  const runPath = (dir: string, runId: string) => join(dir, `${runId}.json`);
+  const primaryRunPath = (runId: string) => runPath(runsDir, runId);
+  const legacyRunPath = (runId: string) => runPath(legacyRunsDir, runId);
+  const lockPath = (dir: string, runId: string) => join(dir, `${runId}.lock`);
+  const primaryLockPath = (runId: string) => lockPath(runsDir, runId);
+  const legacyLockPath = (runId: string) => lockPath(legacyRunsDir, runId);
+  const candidateRunPaths = (runId: string) => [primaryRunPath(runId), legacyRunPath(runId)];
 
   const pidIsAlive = (pid: number): boolean => {
     if (!Number.isInteger(pid) || pid <= 0) return false;
@@ -135,19 +142,33 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     }
   };
 
-  const readLock = (runId: string): LockFile | null => {
+  const readLockAt = (path: string): LockFile | null => {
     try {
-      return JSON.parse(_readFileSync(lockPath(runId), "utf-8")) as LockFile;
+      return JSON.parse(_readFileSync(path, "utf-8")) as LockFile;
     } catch {
       return null;
     }
+  };
+
+  const readLock = (runId: string): LockFile | null => readLockAt(primaryLockPath(runId));
+
+  const removeStaleLegacyLock = (runId: string): boolean => {
+    const lock = legacyLockPath(runId);
+    const existing = readLockAt(lock);
+    if (existing?.runId === runId && pidIsAlive(existing.pid)) return false;
+    try {
+      if (_existsSync(lock)) _unlinkSync(lock);
+    } catch {
+      return false;
+    }
+    return true;
   };
 
   return {
     save(state: PersistedRunState) {
       ensureDir();
       state.updatedAt = new Date().toISOString();
-      const path = runPath(state.runId);
+      const path = primaryRunPath(state.runId);
       const json = JSON.stringify(state, null, 2);
       // Atomic write: a crash mid-write can't corrupt the live file (tmp+rename is
       // atomic on the same filesystem). A .bak from the previous good save is the
@@ -162,63 +183,74 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     },
 
     load(runId: string): PersistedRunState | null {
-      const path = runPath(runId);
       // Try the primary, then the .bak — so a corrupt primary doesn't lose the run.
-      for (const candidate of [path, `${path}.bak`]) {
-        try {
-          if (!_existsSync(candidate)) continue;
-          return JSON.parse(_readFileSync(candidate, "utf-8")) as PersistedRunState;
-        } catch {
-          // primary corrupt -> fall through to .bak
+      for (const path of candidateRunPaths(runId)) {
+        for (const candidate of [path, `${path}.bak`]) {
+          try {
+            if (!_existsSync(candidate)) continue;
+            return JSON.parse(_readFileSync(candidate, "utf-8")) as PersistedRunState;
+          } catch {
+            // corrupt candidate -> fall through to the next candidate
+          }
         }
       }
       return null;
     },
 
     list(): PersistedRunState[] {
-      ensureDir();
-      try {
-        const files = _readdirSync(runsDir).filter((f) => f.endsWith(".json"));
-        const runs: PersistedRunState[] = [];
-        for (const file of files) {
-          try {
-            const state = JSON.parse(_readFileSync(join(runsDir, file), "utf-8")) as PersistedRunState;
-            runs.push(state);
-          } catch {
-            // Skip corrupted files
+      const byRunId = new Map<string, PersistedRunState>();
+      for (const dir of [runsDir, legacyRunsDir]) {
+        try {
+          if (!_existsSync(dir)) continue;
+          const files = _readdirSync(dir).filter((f) => f.endsWith(".json"));
+          for (const file of files) {
+            try {
+              const state = JSON.parse(_readFileSync(join(dir, file), "utf-8")) as PersistedRunState;
+              if (!byRunId.has(state.runId)) byRunId.set(state.runId, state);
+            } catch {
+              // Skip corrupted files
+            }
           }
+        } catch {
+          // Skip unreadable directories; another storage location may still work.
         }
-        return runs.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
-      } catch {
-        return [];
       }
+      return [...byRunId.values()].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
     },
 
     delete(runId: string): boolean {
+      let deleted = false;
       try {
-        const path = runPath(runId);
-        // Best-effort cleanup of the sidecar files alongside the primary.
-        for (const sidecar of [`${path}.bak`, `${path}.tmp`, lockPath(runId)]) {
+        for (const path of candidateRunPaths(runId)) {
+          const dir = path === primaryRunPath(runId) ? runsDir : legacyRunsDir;
+          // Best-effort cleanup of the sidecar files alongside the primary.
+          for (const sidecar of [`${path}.bak`, `${path}.tmp`, lockPath(dir, runId)]) {
+            try {
+              if (_existsSync(sidecar)) _unlinkSync(sidecar);
+            } catch {
+              // ignore sidecar cleanup failures
+            }
+          }
           try {
-            if (_existsSync(sidecar)) _unlinkSync(sidecar);
+            if (_existsSync(path)) {
+              _unlinkSync(path);
+              deleted = true;
+            }
           } catch {
-            // ignore sidecar cleanup failures
+            // ignore per-file cleanup failures
           }
         }
-        if (_existsSync(path)) {
-          _unlinkSync(path);
-          return true;
-        }
-        return false;
+        return deleted;
       } catch {
-        return false;
+        return deleted;
       }
     },
 
     acquireRunLease(runId: string): RunLease | null {
       ensureDir();
-      const path = runPath(runId);
-      const lock = lockPath(runId);
+      const path = primaryRunPath(runId);
+      const lock = primaryLockPath(runId);
+      if (!removeStaleLegacyLock(runId)) return null;
       for (let attempt = 0; attempt < 2; attempt++) {
         const token = `${process.pid}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
         const payload: LockFile = {
@@ -251,7 +283,7 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     releaseRunLease(lease: RunLease): void {
       try {
         const existing = readLock(lease.runId);
-        if (existing?.token === lease.token) _unlinkSync(lockPath(lease.runId));
+        if (existing?.token === lease.token) _unlinkSync(primaryLockPath(lease.runId));
       } catch {
         // Best-effort cleanup only.
       }

--- a/src/workflow-commands.ts
+++ b/src/workflow-commands.ts
@@ -210,12 +210,18 @@ export function registerWorkflowCommands(
             ctx.ui.notify(runIdArg ? `No run ${runIdArg} with a script` : "No saved run to save", "error");
             return;
           }
-          const saved = storage.save({
-            name,
-            description: run.workflowName,
-            script: run.script,
-            location: "project",
-          });
+          let saved: ReturnType<WorkflowStorage["save"]>;
+          try {
+            saved = storage.save({
+              name,
+              description: run.workflowName,
+              script: run.script,
+              location: "project",
+            });
+          } catch (error) {
+            ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+            return;
+          }
           registerSavedWorkflow(pi, opts.cwd ?? process.cwd(), saved, undefined, () =>
             storage.list().some((w) => w.name === saved.name),
           );

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -393,7 +393,7 @@ export class WorkflowManager extends EventEmitter {
         runId: managed.runId,
         workflowName: managed.snapshot.name,
         // Persist the real script + journal so the run can be resumed. Runs live
-        // under .pi/workflows/runs/ — protect via directory permissions, not blanking.
+        // in workflow run storage — protect via directory permissions, not blanking.
         script: managed.script,
         args: managed.args,
         sessionId: this.sessionId,

--- a/src/workflow-paths.ts
+++ b/src/workflow-paths.ts
@@ -1,0 +1,63 @@
+/**
+ * Filesystem layout for pi-dynamic-workflows state.
+ *
+ * New writes live under the user's workflow home so projects do not get
+ * scattered `.pi/workflows` directories. Project-scoped state is still isolated
+ * by a stable cwd-derived namespace.
+ */
+
+import { createHash } from "node:crypto";
+import { homedir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { USER_WORKFLOW_SAVED_DIR, WORKFLOW_RUNS_DIR, WORKFLOW_SAVED_DIR } from "./config.js";
+
+export const WORKFLOW_HOME_RELATIVE_DIR = ".pi/workflows";
+export const WORKFLOW_PROJECTS_SUBDIR = "projects";
+
+export interface WorkflowProjectPaths {
+  key: string;
+  rootDir: string;
+  runsDir: string;
+  savedDir: string;
+  settingsPath: string;
+  legacyRunsDir: string;
+  legacySavedDir: string;
+}
+
+export function workflowHomeDir(): string {
+  return join(homedir(), WORKFLOW_HOME_RELATIVE_DIR);
+}
+
+export function workflowUserSavedDir(): string {
+  return USER_WORKFLOW_SAVED_DIR.replace("~", homedir());
+}
+
+export function workflowProjectKey(cwd: string): string {
+  const projectPath = resolve(cwd);
+  const slug = sanitizePathSegment(basename(projectPath) || "project");
+  const hash = createHash("sha256").update(projectPath).digest("hex").slice(0, 12);
+  return `${slug}-${hash}`;
+}
+
+export function workflowProjectPaths(cwd: string): WorkflowProjectPaths {
+  const key = workflowProjectKey(cwd);
+  const rootDir = join(workflowHomeDir(), WORKFLOW_PROJECTS_SUBDIR, key);
+  return {
+    key,
+    rootDir,
+    runsDir: join(rootDir, "runs"),
+    savedDir: join(rootDir, "saved"),
+    settingsPath: join(rootDir, "settings.json"),
+    legacyRunsDir: resolve(cwd, WORKFLOW_RUNS_DIR),
+    legacySavedDir: resolve(cwd, WORKFLOW_SAVED_DIR),
+  };
+}
+
+function sanitizePathSegment(value: string): string {
+  const sanitized = value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  return sanitized || "project";
+}

--- a/src/workflow-saved.ts
+++ b/src/workflow-saved.ts
@@ -4,7 +4,7 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { USER_WORKFLOW_SAVED_DIR, WORKFLOW_SAVED_DIR } from "./config.js";
+import { workflowProjectPaths, workflowUserSavedDir } from "./workflow-paths.js";
 
 export interface SavedWorkflow {
   /** Command name (filename without extension). */
@@ -34,9 +34,28 @@ export interface WorkflowStorage {
   delete(name: string, location?: "project" | "user"): boolean;
 }
 
+export function isSafeSavedWorkflowName(name: string): boolean {
+  return (
+    name.length > 0 &&
+    name.length <= 128 &&
+    name.trim() === name &&
+    name !== "." &&
+    name !== ".." &&
+    !/[/\\\0]/.test(name)
+  );
+}
+
+export function assertSafeSavedWorkflowName(name: string): void {
+  if (!isSafeSavedWorkflowName(name)) {
+    throw new Error("Saved workflow name must be a non-empty path-safe name without slashes.");
+  }
+}
+
 export function createWorkflowStorage(cwd: string): WorkflowStorage {
-  const projectDir = join(cwd, WORKFLOW_SAVED_DIR);
-  const userDir = USER_WORKFLOW_SAVED_DIR.replace("~", process.env.HOME ?? "");
+  const paths = workflowProjectPaths(cwd);
+  const projectDir = paths.savedDir;
+  const legacyProjectDir = paths.legacySavedDir;
+  const userDir = workflowUserSavedDir();
 
   const ensureDir = (dir: string) => {
     if (!existsSync(dir)) {
@@ -45,14 +64,22 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
   };
 
   const workflowPath = (name: string, location: "project" | "user") => {
+    assertSafeSavedWorkflowName(name);
     const dir = location === "project" ? projectDir : userDir;
     return join(dir, `${name}.json`);
+  };
+  const legacyProjectWorkflowPath = (name: string) => {
+    assertSafeSavedWorkflowName(name);
+    return join(legacyProjectDir, `${name}.json`);
   };
 
   const loadFromFile = (path: string, location: "project" | "user"): SavedWorkflow | null => {
     try {
       if (!existsSync(path)) return null;
       const data = JSON.parse(readFileSync(path, "utf-8"));
+      if (!data || typeof data !== "object" || !isSafeSavedWorkflowName((data as { name?: string }).name ?? "")) {
+        return null;
+      }
       return {
         ...data,
         location,
@@ -65,6 +92,7 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
 
   return {
     save(workflow, location = "project") {
+      assertSafeSavedWorkflowName(workflow.name);
       const dir = location === "project" ? projectDir : userDir;
       ensureDir(dir);
 
@@ -81,10 +109,14 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
     },
 
     load(name: string): SavedWorkflow | null {
+      if (!isSafeSavedWorkflowName(name)) return null;
       // Project takes precedence over user
       const projectPath = workflowPath(name, "project");
       const project = loadFromFile(projectPath, "project");
       if (project) return project;
+
+      const legacyProject = loadFromFile(legacyProjectWorkflowPath(name), "project");
+      if (legacyProject) return legacyProject;
 
       const userPath = workflowPath(name, "user");
       return loadFromFile(userPath, "user");
@@ -93,26 +125,28 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
     list(): SavedWorkflow[] {
       const workflows: SavedWorkflow[] = [];
 
-      // Load project workflows
-      if (existsSync(projectDir)) {
-        for (const file of readdirSync(projectDir).filter((f) => f.endsWith(".json"))) {
-          const wf = loadFromFile(join(projectDir, file), "project");
-          if (wf) workflows.push(wf);
+      const seen = new Set<string>();
+      const addDir = (dir: string, location: "project" | "user") => {
+        if (!existsSync(dir)) return;
+        for (const file of readdirSync(dir).filter((f) => f.endsWith(".json"))) {
+          const wf = loadFromFile(join(dir, file), location);
+          if (wf && !seen.has(wf.name)) {
+            seen.add(wf.name);
+            workflows.push(wf);
+          }
         }
-      }
+      };
 
-      // Load user workflows
-      if (existsSync(userDir)) {
-        for (const file of readdirSync(userDir).filter((f) => f.endsWith(".json"))) {
-          const wf = loadFromFile(join(userDir, file), "user");
-          if (wf) workflows.push(wf);
-        }
-      }
+      // Priority order mirrors load(): project > legacy project > user.
+      addDir(projectDir, "project");
+      addDir(legacyProjectDir, "project");
+      addDir(userDir, "user");
 
       return workflows.sort((a, b) => a.name.localeCompare(b.name));
     },
 
     delete(name: string, location?: "project" | "user"): boolean {
+      if (!isSafeSavedWorkflowName(name)) return false;
       const locations = location ? [location] : (["project", "user"] as const);
       let deleted = false;
 
@@ -121,6 +155,13 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
         if (existsSync(path)) {
           unlinkSync(path);
           deleted = true;
+        }
+        if (loc === "project") {
+          const legacyPath = legacyProjectWorkflowPath(name);
+          if (existsSync(legacyPath)) {
+            unlinkSync(legacyPath);
+            deleted = true;
+          }
         }
       }
 

--- a/src/workflow-settings.ts
+++ b/src/workflow-settings.ts
@@ -6,9 +6,8 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { WORKFLOW_SETTINGS_FILE } from "./config.js";
+import { workflowHomeDir, workflowProjectPaths } from "./workflow-paths.js";
 
 export interface WorkflowSettings {
   keywordTriggerEnabled?: boolean;
@@ -20,30 +19,76 @@ export interface WorkflowSettingsStore {
   save(settings: WorkflowSettings): void;
 }
 
+export interface WorkflowSettingsOptions {
+  /** Explicit settings path, primarily for tests and migrations. */
+  settingsPath?: string;
+  /** Project cwd whose project-level settings should override global settings. */
+  cwd?: string;
+  /** Explicit project settings path, primarily for tests. */
+  projectSettingsPath?: string;
+  /** Save destination when using saveWorkflowSettings with cwd. Default: global. */
+  scope?: "global" | "project";
+}
+
 /** Path to the user-level workflow settings JSON file (~/.pi/workflows/settings.json). */
 export function getWorkflowSettingsPath(): string {
-  return join(homedir(), WORKFLOW_SETTINGS_FILE);
+  return join(workflowHomeDir(), "settings.json");
+}
+
+/** Path to this project's optional workflow settings override. */
+export function getWorkflowProjectSettingsPath(cwd: string): string {
+  return workflowProjectPaths(cwd).settingsPath;
 }
 
 /** Load settings from disk. Missing, corrupt, or invalid files resolve to {}. */
-export function loadWorkflowSettings(settingsPath?: string): WorkflowSettings {
-  const path = settingsPath ?? getWorkflowSettingsPath();
+export function loadWorkflowSettings(settingsPathOrOptions?: string | WorkflowSettingsOptions): WorkflowSettings {
+  const options = normalizeOptions(settingsPathOrOptions);
+  const globalSettings = readSettings(options.settingsPath ?? getWorkflowSettingsPath());
+  const projectPath =
+    options.projectSettingsPath ?? (options.cwd ? getWorkflowProjectSettingsPath(options.cwd) : undefined);
+  if (!projectPath) return globalSettings;
+  return { ...globalSettings, ...readSettings(projectPath) };
+}
+
+/** Merge known settings into the user-level settings file. */
+export function saveWorkflowSettings(
+  settings: WorkflowSettings,
+  settingsPathOrOptions?: string | WorkflowSettingsOptions,
+): void {
+  const options = normalizeOptions(settingsPathOrOptions);
+  const projectPath =
+    options.projectSettingsPath ?? (options.cwd ? getWorkflowProjectSettingsPath(options.cwd) : undefined);
+  const path =
+    options.scope === "project" && projectPath ? projectPath : (options.settingsPath ?? getWorkflowSettingsPath());
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+  const existing = readObject(path);
+  writeFileSync(path, `${JSON.stringify({ ...existing, ...normalizeSettings(settings) }, null, 2)}\n`, "utf-8");
+}
+
+/** Save a global preference and update an existing project override if one is present. */
+export function saveWorkflowSettingsForCwd(settings: WorkflowSettings, cwd: string): void {
+  saveWorkflowSettings(settings);
+  const projectPath = getWorkflowProjectSettingsPath(cwd);
+  if (existsSync(projectPath)) {
+    saveWorkflowSettings(settings, { projectSettingsPath: projectPath, scope: "project" });
+  }
+}
+
+function normalizeOptions(settingsPathOrOptions?: string | WorkflowSettingsOptions): WorkflowSettingsOptions {
+  return typeof settingsPathOrOptions === "string"
+    ? { settingsPath: settingsPathOrOptions }
+    : (settingsPathOrOptions ?? {});
+}
+
+function readSettings(path: string): WorkflowSettings {
   if (!existsSync(path)) return {};
   try {
     return normalizeSettings(JSON.parse(readFileSync(path, "utf-8")));
   } catch {
     return {};
   }
-}
-
-/** Merge known settings into the user-level settings file. */
-export function saveWorkflowSettings(settings: WorkflowSettings, settingsPath?: string): void {
-  const path = settingsPath ?? getWorkflowSettingsPath();
-  const dir = dirname(path);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-
-  const existing = readObject(path);
-  writeFileSync(path, `${JSON.stringify({ ...existing, ...normalizeSettings(settings) }, null, 2)}\n`, "utf-8");
 }
 
 function normalizeSettings(value: unknown): WorkflowSettings {

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -123,7 +123,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       cwd: options.cwd,
       concurrency: options.concurrency,
       loadSavedWorkflow: (name: string) => storage.load(name)?.script,
-      defaultAgentTimeoutMs: resolveDefaultAgentTimeoutMs(options.defaultAgentTimeoutMs),
+      defaultAgentTimeoutMs: resolveDefaultAgentTimeoutMs(options.defaultAgentTimeoutMs, options.cwd ?? process.cwd()),
     });
 
   return defineTool({
@@ -297,9 +297,9 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
   });
 }
 
-function resolveDefaultAgentTimeoutMs(explicit: number | null | undefined): number | null {
+function resolveDefaultAgentTimeoutMs(explicit: number | null | undefined, cwd: string): number | null {
   if (explicit !== undefined) return explicit;
-  return loadWorkflowSettings().defaultAgentTimeoutMs ?? null;
+  return loadWorkflowSettings({ cwd }).defaultAgentTimeoutMs ?? null;
 }
 
 /**

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -637,12 +637,18 @@ export function openWorkflowNavigator(
             } else {
               const storage = opts.storage;
               const name = run.workflowName || "workflow";
-              const saved = storage.save({
-                name,
-                description: run.workflowName,
-                script: run.script,
-                location: "project",
-              });
+              let saved: ReturnType<WorkflowStorage["save"]>;
+              try {
+                saved = storage.save({
+                  name,
+                  description: run.workflowName,
+                  script: run.script,
+                  location: "project",
+                });
+              } catch (error) {
+                ui.notify(error instanceof Error ? error.message : String(error), "error");
+                break;
+              }
               registerSavedWorkflow(pi, opts.cwd ?? process.cwd(), saved, undefined, () =>
                 storage.list().some((w) => w.name === saved.name),
               );

--- a/tests/run-persistence.test.ts
+++ b/tests/run-persistence.test.ts
@@ -1,19 +1,25 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { WORKFLOW_RUNS_DIR } from "../src/config.js";
 import { createRunPersistence, generateRunId, type PersistedRunState } from "../src/run-persistence.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
+import { workflowProjectPaths } from "../src/workflow-paths.js";
 
 function withTempCwd(fn: (cwd: string) => Promise<void>) {
   return async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-dw-rp-"));
+    const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
+    const origHome = process.env.HOME;
+    process.env.HOME = fakeHome;
     try {
       await fn(cwd);
     } finally {
+      process.env.HOME = origHome;
       rmSync(cwd, { recursive: true, force: true });
+      rmSync(fakeHome, { recursive: true, force: true });
     }
   };
 }
@@ -22,7 +28,7 @@ test(
   "createRunPersistence creates runs directory on first save",
   withTempCwd(async (cwd) => {
     const rp = createRunPersistence(cwd);
-    const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
+    const runsDir = workflowProjectPaths(cwd).runsDir;
     assert.equal(existsSync(runsDir), false, "dir should not exist yet");
     rp.save({
       runId: "test-1",
@@ -37,6 +43,7 @@ test(
     });
     assert.ok(existsSync(runsDir), "dir should be created");
     assert.ok(existsSync(join(runsDir, "test-1.json")), "run file should exist");
+    assert.equal(existsSync(join(cwd, WORKFLOW_RUNS_DIR)), false, "legacy project runs dir should not be created");
   }),
 );
 
@@ -112,12 +119,42 @@ test(
 );
 
 test(
+  "createRunPersistence reads legacy project run files",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    const legacyRunsDir = join(cwd, WORKFLOW_RUNS_DIR);
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    mkdirSync(legacyRunsDir, { recursive: true });
+    writeFileSync(
+      join(legacyRunsDir, "legacy-run.json"),
+      JSON.stringify({
+        runId: "legacy-run",
+        workflowName: "legacy",
+        script: "export const meta = { name: 'legacy', description: 'legacy' }",
+        status: "completed",
+        phases: [],
+        agents: [],
+        logs: [],
+        startedAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      }),
+    );
+
+    assert.equal(rp.load("legacy-run")?.workflowName, "legacy");
+    assert.equal(
+      rp.list().some((run) => run.runId === "legacy-run"),
+      true,
+    );
+  }),
+);
+
+test(
   "createRunPersistence list returns runs sorted by updatedAt descending",
   withTempCwd(async (cwd) => {
     const rp = createRunPersistence(cwd);
     // Save with explicit updatedAt values to guarantee order
     // (save() overwrites updatedAt, so we need to write files directly)
-    const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
+    const runsDir = workflowProjectPaths(cwd).runsDir;
     const { mkdirSync, writeFileSync } = await import("node:fs");
     mkdirSync(runsDir, { recursive: true });
     const makeFile = (runId: string, date: string) => {
@@ -154,6 +191,7 @@ test(
     const rp = createRunPersistence(cwd);
     const runs = rp.list();
     assert.deepEqual(runs, []);
+    assert.equal(existsSync(workflowProjectPaths(cwd).runsDir), false, "list should not create the runs dir");
   }),
 );
 
@@ -174,7 +212,7 @@ test(
       updatedAt: "2024-01-01T00:00:00.000Z",
     });
     // Write a corrupted file
-    const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
+    const runsDir = workflowProjectPaths(cwd).runsDir;
     const { writeFileSync } = await import("node:fs");
     writeFileSync(join(runsDir, "corrupted.json"), "not valid json{{{");
     writeFileSync(join(runsDir, "empty.json"), "");
@@ -200,10 +238,37 @@ test(
       startedAt: "2024-01-01T00:00:00.000Z",
       updatedAt: "2024-01-01T00:00:00.000Z",
     });
-    assert.ok(existsSync(join(cwd, WORKFLOW_RUNS_DIR, "delete-me.json")), "existsSync() should succeed");
+    assert.ok(existsSync(join(workflowProjectPaths(cwd).runsDir, "delete-me.json")), "existsSync() should succeed");
     const deleted = rp.delete("delete-me");
     assert.equal(deleted, true);
     assert.equal(rp.load("delete-me"), null);
+  }),
+);
+
+test(
+  "createRunPersistence delete removes legacy project run files",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    const legacyRunsDir = join(cwd, WORKFLOW_RUNS_DIR);
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    mkdirSync(legacyRunsDir, { recursive: true });
+    writeFileSync(
+      join(legacyRunsDir, "delete-legacy.json"),
+      JSON.stringify({
+        runId: "delete-legacy",
+        workflowName: "legacy",
+        script: "export const meta = { name: 'legacy', description: 'legacy' }",
+        status: "completed",
+        phases: [],
+        agents: [],
+        logs: [],
+        startedAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      }),
+    );
+
+    assert.equal(rp.delete("delete-legacy"), true);
+    assert.equal(existsSync(join(legacyRunsDir, "delete-legacy.json")), false);
   }),
 );
 
@@ -220,7 +285,7 @@ test(
   "createRunPersistence getRunsDir returns the runs directory path",
   withTempCwd(async (cwd) => {
     const rp = createRunPersistence(cwd);
-    assert.equal(rp.getRunsDir(), join(cwd, WORKFLOW_RUNS_DIR));
+    assert.equal(rp.getRunsDir(), workflowProjectPaths(cwd).runsDir);
   }),
 );
 
@@ -438,7 +503,7 @@ test(
       agents: [],
       logs: [],
     } as PersistedRunState);
-    const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
+    const runsDir = workflowProjectPaths(cwd).runsDir;
     assert.ok(existsSync(join(runsDir, "r1.json")), "primary written");
     assert.ok(existsSync(join(runsDir, "r1.json.bak")), ".bak written");
     assert.equal(existsSync(join(runsDir, "r1.json.tmp")), false, "no leftover .tmp");
@@ -458,7 +523,7 @@ test(
       logs: [],
     } as PersistedRunState);
     // Corrupt the primary; the .bak from the good save should still load.
-    writeFileSync(join(cwd, WORKFLOW_RUNS_DIR, "r1.json"), "{ truncated", "utf-8");
+    writeFileSync(join(workflowProjectPaths(cwd).runsDir, "r1.json"), "{ truncated", "utf-8");
     const loaded = rp.load("r1");
     assert.equal(loaded?.runId, "r1", "load falls back to the intact .bak");
   }),
@@ -477,7 +542,7 @@ test(
       logs: [],
     } as PersistedRunState);
     rp.delete("r1");
-    const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
+    const runsDir = workflowProjectPaths(cwd).runsDir;
     assert.equal(existsSync(join(runsDir, "r1.json")), false);
     assert.equal(existsSync(join(runsDir, "r1.json.bak")), false, ".bak cleaned up");
   }),
@@ -509,16 +574,70 @@ test(
     const rp = createRunPersistence(cwd);
     const lease = rp.acquireRunLease("lease-1");
     assert.ok(lease, "first acquire should succeed");
-    assert.equal(existsSync(join(cwd, WORKFLOW_RUNS_DIR, "lease-1.lock")), true, "lock file is created");
+    assert.equal(existsSync(join(workflowProjectPaths(cwd).runsDir, "lease-1.lock")), true, "lock file is created");
 
     const second = rp.acquireRunLease("lease-1");
     assert.equal(second, null, "second acquire should be refused while owner pid is alive");
 
     rp.releaseRunLease({ ...lease, token: "wrong-token" });
-    assert.equal(existsSync(join(cwd, WORKFLOW_RUNS_DIR, "lease-1.lock")), true, "wrong token does not release");
+    assert.equal(
+      existsSync(join(workflowProjectPaths(cwd).runsDir, "lease-1.lock")),
+      true,
+      "wrong token does not release",
+    );
 
     rp.releaseRunLease(lease);
-    assert.equal(existsSync(join(cwd, WORKFLOW_RUNS_DIR, "lease-1.lock")), false, "owner token releases");
+    assert.equal(existsSync(join(workflowProjectPaths(cwd).runsDir, "lease-1.lock")), false, "owner token releases");
+  }),
+);
+
+test(
+  "run lease refuses while a legacy project lock owner is alive",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    const legacyRunsDir = join(cwd, WORKFLOW_RUNS_DIR);
+    mkdirSync(legacyRunsDir, { recursive: true });
+    writeFileSync(
+      join(legacyRunsDir, "legacy-live.lock"),
+      JSON.stringify({
+        runId: "legacy-live",
+        runPath: join(legacyRunsDir, "legacy-live.json"),
+        pid: process.pid,
+        startedAt: "2024-01-01T00:00:00.000Z",
+        token: "legacy-owner",
+      }),
+      "utf-8",
+    );
+
+    assert.equal(rp.acquireRunLease("legacy-live"), null);
+    assert.equal(existsSync(join(workflowProjectPaths(cwd).runsDir, "legacy-live.lock")), false);
+  }),
+);
+
+test(
+  "run lease removes a stale legacy project lock before acquiring the new lock",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    const legacyRunsDir = join(cwd, WORKFLOW_RUNS_DIR);
+    const primaryRunsDir = workflowProjectPaths(cwd).runsDir;
+    mkdirSync(legacyRunsDir, { recursive: true });
+    writeFileSync(
+      join(legacyRunsDir, "legacy-stale.lock"),
+      JSON.stringify({
+        runId: "legacy-stale",
+        runPath: join(legacyRunsDir, "legacy-stale.json"),
+        pid: 2147483647,
+        startedAt: "2024-01-01T00:00:00.000Z",
+        token: "legacy-stale",
+      }),
+      "utf-8",
+    );
+
+    const lease = rp.acquireRunLease("legacy-stale");
+    assert.ok(lease, "dead-pid legacy lock should not block the new owner");
+    assert.equal(existsSync(join(legacyRunsDir, "legacy-stale.lock")), false);
+    assert.equal(existsSync(join(primaryRunsDir, "legacy-stale.lock")), true);
+    rp.releaseRunLease(lease);
   }),
 );
 
@@ -526,7 +645,7 @@ test(
   "run lease steals a stale lock whose pid is dead",
   withTempCwd(async (cwd) => {
     const rp = createRunPersistence(cwd);
-    const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
+    const runsDir = workflowProjectPaths(cwd).runsDir;
     rp.save({
       runId: "stale-lock",
       workflowName: "w",
@@ -571,7 +690,7 @@ test(
     const lease = rp.acquireRunLease("delete-lock");
     assert.ok(lease, "lease exists before delete");
     rp.delete("delete-lock");
-    assert.equal(existsSync(join(cwd, WORKFLOW_RUNS_DIR, "delete-lock.lock")), false, "lock cleaned up");
+    assert.equal(existsSync(join(workflowProjectPaths(cwd).runsDir, "delete-lock.lock")), false, "lock cleaned up");
   }),
 );
 
@@ -591,6 +710,46 @@ test(
     // A fresh manager (the previous process died) should recover the orphan.
     new WorkflowManager({ cwd });
     assert.equal(rp.load("stale")?.status, "paused", "stale running -> paused (journal preserved for resume)");
+  }),
+);
+
+test(
+  "WorkflowManager does not recover a legacy running run while its legacy lock owner is alive",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    const legacyRunsDir = join(cwd, WORKFLOW_RUNS_DIR);
+    mkdirSync(legacyRunsDir, { recursive: true });
+    writeFileSync(
+      join(legacyRunsDir, "legacy-live.json"),
+      JSON.stringify({
+        runId: "legacy-live",
+        workflowName: "w",
+        status: "running",
+        script: "export const meta = { name: 'w', description: 'd' }\nawait agent('x',{label:'x'})\nreturn 1",
+        phases: [],
+        agents: [],
+        logs: [],
+        startedAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      }),
+      "utf-8",
+    );
+    writeFileSync(
+      join(legacyRunsDir, "legacy-live.lock"),
+      JSON.stringify({
+        runId: "legacy-live",
+        runPath: join(legacyRunsDir, "legacy-live.json"),
+        pid: process.pid,
+        startedAt: "2024-01-01T00:00:00.000Z",
+        token: "legacy-owner",
+      }),
+      "utf-8",
+    );
+
+    new WorkflowManager({ cwd });
+
+    assert.equal(rp.load("legacy-live")?.status, "running");
+    assert.equal(existsSync(join(workflowProjectPaths(cwd).runsDir, "legacy-live.json")), false);
   }),
 );
 

--- a/tests/workflow-manager-abort.test.ts
+++ b/tests/workflow-manager-abort.test.ts
@@ -51,14 +51,19 @@ phase('Work')
 const a = await agent('do it', { label: 'a' })
 return { a }`;
 
-/** Run each manager test in its own temp cwd so .pi/workflows/runs is isolated. */
+/** Run each manager test with isolated cwd and HOME so workflow state is isolated. */
 function withTempCwd(fn: (cwd: string) => Promise<void>) {
   return async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-dw-abort-"));
+    const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
+    const origHome = process.env.HOME;
+    process.env.HOME = fakeHome;
     try {
       await fn(cwd);
     } finally {
+      process.env.HOME = origHome;
       rmSync(cwd, { recursive: true, force: true });
+      rmSync(fakeHome, { recursive: true, force: true });
     }
   };
 }

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -66,14 +66,19 @@ phase('Work')
 const a = await agent('do it', { label: 'a' })
 return { a }`;
 
-/** Run each manager test in its own temp cwd so .pi/workflows/runs is isolated. */
+/** Run each manager test with isolated cwd and HOME so workflow state is isolated. */
 function withTempCwd(fn: (cwd: string) => Promise<void>) {
   return async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-dw-mgr-"));
+    const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
+    const origHome = process.env.HOME;
+    process.env.HOME = fakeHome;
     try {
       await fn(cwd);
     } finally {
+      process.env.HOME = origHome;
       rmSync(cwd, { recursive: true, force: true });
+      rmSync(fakeHome, { recursive: true, force: true });
     }
   };
 }

--- a/tests/workflow-paths.test.ts
+++ b/tests/workflow-paths.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, normalize } from "node:path";
+import { describe, it } from "node:test";
+import {
+  WORKFLOW_HOME_RELATIVE_DIR,
+  WORKFLOW_PROJECTS_SUBDIR,
+  workflowHomeDir,
+  workflowProjectKey,
+  workflowProjectPaths,
+  workflowUserSavedDir,
+} from "../src/workflow-paths.js";
+
+function withIsolatedHome(fn: (home: string, cwd: string) => void): void {
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-project-"));
+  const origHome = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    fn(home, cwd);
+  } finally {
+    process.env.HOME = origHome;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+describe("workflow paths", () => {
+  it("resolves workflow home under the user home", () => {
+    withIsolatedHome((home) => {
+      assert.equal(workflowHomeDir(), join(home, WORKFLOW_HOME_RELATIVE_DIR));
+      assert.equal(workflowUserSavedDir(), join(home, WORKFLOW_HOME_RELATIVE_DIR, "saved"));
+    });
+  });
+
+  it("creates stable project namespaces from cwd", () => {
+    withIsolatedHome((_home, cwd) => {
+      const key = workflowProjectKey(cwd);
+      assert.equal(key, workflowProjectKey(cwd));
+      assert.match(key, /^[a-z0-9._-]+-[a-f0-9]{12}$/);
+      assert.ok(key.startsWith(basename(cwd).toLowerCase()));
+    });
+  });
+
+  it("keeps new project storage under workflow home and legacy paths under cwd", () => {
+    withIsolatedHome((home, cwd) => {
+      const paths = workflowProjectPaths(cwd);
+      assert.ok(paths.rootDir.startsWith(join(home, WORKFLOW_HOME_RELATIVE_DIR, WORKFLOW_PROJECTS_SUBDIR)));
+      assert.equal(paths.runsDir, join(paths.rootDir, "runs"));
+      assert.equal(paths.savedDir, join(paths.rootDir, "saved"));
+      assert.equal(paths.settingsPath, join(paths.rootDir, "settings.json"));
+      assert.equal(paths.legacyRunsDir, normalize(join(cwd, ".pi/workflows/runs")));
+      assert.equal(paths.legacySavedDir, normalize(join(cwd, ".pi/workflows/saved")));
+    });
+  });
+});

--- a/tests/workflow-saved.test.ts
+++ b/tests/workflow-saved.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
 import test from "node:test";
 import { WORKFLOW_SAVED_DIR } from "../src/config.js";
+import { workflowProjectPaths } from "../src/workflow-paths.js";
 import { createWorkflowStorage } from "../src/workflow-saved.js";
 
 /**
@@ -40,9 +41,10 @@ test(
     assert.equal(saved.location, "project");
     assert.ok(saved.path.endsWith("test-wf.json"), "should end with test-wf.json");
     assert.ok(saved.savedAt, "should have savedAt timestamp");
-    const dir = join(cwd, WORKFLOW_SAVED_DIR);
+    const dir = workflowProjectPaths(cwd).savedDir;
     assert.ok(existsSync(dir), "project saved dir should exist");
     assert.ok(existsSync(join(dir, "test-wf.json")), "file should exist");
+    assert.equal(existsSync(join(cwd, WORKFLOW_SAVED_DIR)), false, "legacy project saved dir should not be created");
   }),
 );
 
@@ -111,6 +113,39 @@ test(
     assert.ok(loaded, "should load successfully");
     assert.equal(loaded?.script, "user script");
     assert.equal(loaded?.location, "user");
+  }),
+);
+
+test(
+  "createWorkflowStorage load reads legacy project workflows before user workflows",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    const legacyProjectDir = join(cwd, WORKFLOW_SAVED_DIR);
+    mkdirSync(legacyProjectDir, { recursive: true });
+    writeFileSync(
+      join(legacyProjectDir, "shared.json"),
+      JSON.stringify({
+        name: "shared",
+        description: "Legacy project version",
+        script: "legacy project script",
+        location: "project",
+        savedAt: "2024-01-01T00:00:00.000Z",
+        path: join(legacyProjectDir, "shared.json"),
+      }),
+      "utf-8",
+    );
+    storage.save(
+      {
+        name: "shared",
+        description: "User version",
+        script: "user script",
+      },
+      "user",
+    );
+
+    const loaded = storage.load("shared");
+    assert.equal(loaded?.script, "legacy project script");
+    assert.equal(loaded?.location, "project");
   }),
 );
 
@@ -200,6 +235,17 @@ test(
 );
 
 test(
+  "createWorkflowStorage rejects path-unsafe workflow names",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    assert.throws(() => storage.save({ name: "../escape", description: "bad", script: "bad" }), /path-safe name/);
+    assert.equal(storage.load("../escape"), null);
+    assert.equal(storage.delete("../escape"), false);
+    assert.equal(existsSync(join(workflowProjectPaths(cwd).rootDir, "escape.json")), false);
+  }),
+);
+
+test(
   "createWorkflowStorage file contents are valid JSON with expected fields",
   withIsolatedHome(async (cwd) => {
     const storage = createWorkflowStorage(cwd);
@@ -208,7 +254,7 @@ test(
       description: "desc",
       script: "export const meta = { name: 'c', description: 'c' }",
     });
-    const filePath = join(cwd, WORKFLOW_SAVED_DIR, "check-json.json");
+    const filePath = join(workflowProjectPaths(cwd).savedDir, "check-json.json");
     const raw = JSON.parse(readFileSync(filePath, "utf-8"));
     assert.equal(raw.name, "check-json");
     assert.equal(raw.description, "desc");
@@ -222,8 +268,7 @@ test(
   "createWorkflowStorage handles corrupted files gracefully",
   withIsolatedHome(async (cwd) => {
     const storage = createWorkflowStorage(cwd);
-    const { mkdirSync, writeFileSync } = await import("node:fs");
-    const projectDir = join(cwd, WORKFLOW_SAVED_DIR);
+    const projectDir = workflowProjectPaths(cwd).savedDir;
     mkdirSync(projectDir, { recursive: true });
     writeFileSync(join(projectDir, "corrupted.json"), "not valid json{{{");
 
@@ -232,5 +277,28 @@ test(
     const list = storage.list();
     assert.ok(Array.isArray(list), "list should be an array");
     assert.equal(list.length, 0); // only corrupted file
+  }),
+);
+
+test(
+  "createWorkflowStorage skips legacy files with unsafe workflow names",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    const projectDir = workflowProjectPaths(cwd).savedDir;
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, "unsafe.json"),
+      JSON.stringify({
+        name: "../unsafe",
+        description: "unsafe",
+        script: "unsafe",
+        location: "project",
+        savedAt: "2024-01-01T00:00:00.000Z",
+        path: join(projectDir, "unsafe.json"),
+      }),
+      "utf-8",
+    );
+
+    assert.deepEqual(storage.list(), []);
   }),
 );

--- a/tests/workflow-settings.test.ts
+++ b/tests/workflow-settings.test.ts
@@ -4,7 +4,13 @@ import { tmpdir } from "node:os";
 import { dirname, join, normalize } from "node:path";
 import { describe, it } from "node:test";
 import { WORKFLOW_SETTINGS_FILE } from "../src/config.js";
-import { getWorkflowSettingsPath, loadWorkflowSettings, saveWorkflowSettings } from "../src/workflow-settings.js";
+import {
+  getWorkflowProjectSettingsPath,
+  getWorkflowSettingsPath,
+  loadWorkflowSettings,
+  saveWorkflowSettings,
+  saveWorkflowSettingsForCwd,
+} from "../src/workflow-settings.js";
 
 function withSettingsPath(fn: (settingsPath: string) => void): void {
   const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-settings-"));
@@ -43,6 +49,71 @@ describe("workflow settings", () => {
       saveWorkflowSettings({ defaultAgentTimeoutMs: null }, settingsPath);
       assert.deepEqual(loadWorkflowSettings(settingsPath), { defaultAgentTimeoutMs: null });
     });
+  });
+
+  it("merges project settings over global settings when cwd is provided", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-project-settings-"));
+    const cwd = join(dir, "project");
+    const fakeHome = join(dir, "home");
+    const origHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    const globalPath = getWorkflowSettingsPath();
+    const projectPath = getWorkflowProjectSettingsPath(cwd);
+    try {
+      saveWorkflowSettings({ keywordTriggerEnabled: true, defaultAgentTimeoutMs: 600000 }, globalPath);
+      saveWorkflowSettings({ keywordTriggerEnabled: false }, { cwd, settingsPath: globalPath, scope: "project" });
+
+      assert.deepEqual(loadWorkflowSettings(globalPath), {
+        keywordTriggerEnabled: true,
+        defaultAgentTimeoutMs: 600000,
+      });
+      assert.deepEqual(loadWorkflowSettings({ cwd, settingsPath: globalPath, projectSettingsPath: projectPath }), {
+        keywordTriggerEnabled: false,
+        defaultAgentTimeoutMs: 600000,
+      });
+    } finally {
+      process.env.HOME = origHome;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("saves cwd preferences globally without creating a project override", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-project-settings-"));
+    const cwd = join(dir, "project");
+    const fakeHome = join(dir, "home");
+    const origHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    try {
+      saveWorkflowSettingsForCwd({ keywordTriggerEnabled: false }, cwd);
+
+      assert.deepEqual(loadWorkflowSettings({ cwd }), { keywordTriggerEnabled: false });
+      assert.equal(existsSync(getWorkflowProjectSettingsPath(cwd)), false);
+    } finally {
+      process.env.HOME = origHome;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("saves cwd preferences into an existing project override", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-project-settings-"));
+    const cwd = join(dir, "project");
+    const fakeHome = join(dir, "home");
+    const origHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+    try {
+      saveWorkflowSettings({ keywordTriggerEnabled: false }, { cwd, scope: "project" });
+
+      saveWorkflowSettingsForCwd({ keywordTriggerEnabled: true }, cwd);
+
+      assert.deepEqual(loadWorkflowSettings(), { keywordTriggerEnabled: true });
+      assert.deepEqual(loadWorkflowSettings({ cwd }), { keywordTriggerEnabled: true });
+      assert.deepEqual(loadWorkflowSettings({ projectSettingsPath: getWorkflowProjectSettingsPath(cwd) }), {
+        keywordTriggerEnabled: true,
+      });
+    } finally {
+      process.env.HOME = origHome;
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("preserves unknown settings when saving known settings", () => {


### PR DESCRIPTION
## Summary
- move project-scoped workflow runs, logs, locks, and saved workflow overrides under `~/.pi/workflows/projects/<project>/`
- keep global settings/model tiers and global saved workflows under `~/.pi/workflows`
- read legacy `<cwd>/.pi/workflows/runs` and `<cwd>/.pi/workflows/saved` as fallback so old history is not lost
- preserve project isolation with cwd-derived project namespaces
- add project settings override support while keeping `/workflows-trigger` global by default
- reject path-unsafe saved workflow names to keep saved workflows inside the workflow store

Fixes #18

## Review follow-up
Addressed independent subagent review findings before opening this PR:
- legacy run locks are respected during acquisition/recovery so old live processes are not double-owned
- existing project settings overrides are updated when `/workflows-trigger` saves a global preference
- saved workflow names are validated as safe path segments

## Validation
- `npm run check`
- `npm run build`
- targeted storage/settings tests — 58 passing
- `npm test` — 679 passing
- storage smoke verified run JSON/log writes under `~/.pi/workflows/projects/<project>/runs` without creating `<cwd>/.pi/workflows`