### PR TITLE
feat(task-panel): configurable detailed progress panel with live token/s (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ return await agent('Synthesize and double-check these findings:\n' + findings.jo
 - **Journaled resume** — an interrupted run replays finished agents from a journal (no re-run, no tokens) and runs only what's left or what you changed.
 - **Git worktree isolation** — `isolation: "worktree"` gives an agent its own branch, so parallel agents can edit the same files without clobbering each other.
 - **Real token & cost accounting** — read from each subagent's session, not estimated. Runs have no default token cap; `tokenBudget`, phase budgets, and `budget` let you add explicit gates when you want them.
-- **Background by default** — the turn ends right away, a live "Workflows running" panel tracks runs, and each result is delivered back so the conversation auto-continues when it finishes.
+- **Background by default** — the turn ends right away, a live "Workflows running" panel tracks runs, and each result is delivered back so the conversation auto-continues when it finishes. The panel is compact by default; `/workflows-progress detailed` expands it inline to per-phase/per-agent rows with tokens, cost, and a live tok/s rate (so a stalled agent shows as 0 tok/s) — no need to open `/workflows`.
 - **Interactive `/workflows` TUI** — drill runs → phases → agents → detail; inspect per-agent failures and compact subagent history; pause, stop, restart, and save runs from the keyboard.
 - **Quality patterns built in** — `verify()`, `judgePanel()`, `loopUntilDry()`, and `completenessCheck()` for adversarial review, best-of-N, and exhaustive discovery.
 - **Ultracode** — `/ultracode` is a standing opt-in that auto-arms an exhaustive multi-agent workflow for every substantive message, the way Claude Code's ultracode does. `/effort high` is the lighter tier.
@@ -103,6 +103,10 @@ The same model — on Pi, plus the production pieces a real run needs:
 /workflows pause|resume|stop|rm <id>
 /workflows-trigger off|on|status
                             persistently disable, restore, or inspect keyword-triggered workflows mode
+/workflows-progress compact|detailed|status
+                            switch the live panel between the compact one-liner and the detailed
+                            per-phase/per-agent view (with tokens, cost, and a live tok/s rate)
+/workflows-progress-max <N> cap agents shown per phase in detailed mode (1-1000, default 8)
 /workflows-models           map the small / medium / big tiers to real models
 /ultracode [off]            ultracode: auto-arm an exhaustive workflow for every substantive message
 /effort off|high|ultra      finer control over the standing opt-in (high = thorough, ultra = ultracode)
@@ -142,6 +146,8 @@ The full guide — every global, agent option, `agentType` definitions, structur
 | `label` / `phase` / `timeoutMs` | Display label / phase override / optional per-agent hard timeout. Omit `timeoutMs` for no hard timeout. |
 
 By default, workflows do not set a run-wide token budget or per-agent hard timeout. Use the `workflow` tool's `tokenBudget` / `agentTimeoutMs`, per-phase budgets, or per-agent `timeoutMs` only when you want an explicit cap. A global fallback timeout can also be set in `~/.pi/workflows/settings.json` as `{ "defaultAgentTimeoutMs": 600000 }`; set it to `null` or omit it for no default hard timeout.
+
+The live "Workflows running" panel is configured in the same `~/.pi/workflows/settings.json`: `"progressPanelMode"` is `"compact"` (default, one line per run) or `"detailed"` (per-phase/per-agent rows with tokens, cost, and a live tok/s rate), and `"progressPanelMaxAgents"` (default `8`, range `1`–`1000`) caps how many agents each phase shows in detailed mode before a `… N earlier agents` line. Toggle them live with `/workflows-progress compact|detailed` and `/workflows-progress-max <N>` — changes take effect on the next render without a restart.
 
 Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()`, and `require`/`import`/`fs`/network are unavailable, so runs stay reproducible — which is what makes resume reliable.
 

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -62,7 +62,9 @@ export default function extension(pi: ExtensionAPI) {
     // Deliver a background run's result into the conversation when it finishes.
     installResultDelivery(pi, manager);
     // Live "workflows running" panel below the input (focus + enter to open).
-    installTaskPanel(pi, manager, ctx.ui, { storage, cwd });
+    // Pass a live settings loader so /workflows-progress (compact|detailed) takes
+    // effect without a restart.
+    installTaskPanel(pi, manager, ctx.ui, { storage, cwd, loadSettings: () => loadWorkflowSettings({ cwd }) });
     if (!editorInstalled) {
       installWorkflowEditor(pi, ctx.ui, effort, {
         settingsStore: {

--- a/src/display.ts
+++ b/src/display.ts
@@ -246,7 +246,7 @@ function statusLine(snapshot: WorkflowSnapshot, completed: boolean): string {
   return `workflow ${snapshot.name}: ${snapshot.doneCount}/${snapshot.agentCount} done`;
 }
 
-function statusIcon(status: WorkflowAgentStatus): string {
+export function statusIcon(status: WorkflowAgentStatus): string {
   switch (status) {
     case "queued":
       return "○";
@@ -265,7 +265,7 @@ function unique(values: string[]): string[] {
   return [...new Set(values)];
 }
 
-function shorten(value: string, max: number): string {
+export function shorten(value: string, max: number): string {
   const text = value.replace(/\s+/g, " ").trim();
   return text.length > max ? `${text.slice(0, max - 1)}…` : text;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ export {
   type InstallWorkflowEditorOptions,
   installWorkflowEditor,
   RAINBOW,
+  registerWorkflowProgressCommands,
   registerWorkflowTriggerCommand,
   tokenizeAnsi,
   WorkflowEditor,

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -8,14 +8,39 @@
 
 import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
 import { type Component, type TUI, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { shorten, statusIcon, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
 import type { ManagedRun, WorkflowManager } from "./workflow-manager.js";
 import type { WorkflowStorage } from "./workflow-saved.js";
+import type { WorkflowSettings } from "./workflow-settings.js";
+import { shortModel } from "./workflow-ui.js";
 
-const RUN_EVENTS = ["agentStart", "agentEnd", "phase", "log", "complete", "error", "stopped", "paused", "resumed"];
+// `tokenUsage` is included so the detailed panel's live token/s counter refreshes
+// as tokens accrue (not only on agent start/end). It is harmless in compact mode —
+// it redraws identical content.
+const RUN_EVENTS = [
+  "agentStart",
+  "agentEnd",
+  "phase",
+  "log",
+  "tokenUsage",
+  "complete",
+  "error",
+  "stopped",
+  "paused",
+  "resumed",
+];
+/** Events after which a run is gone and its token-rate samples can be dropped. */
+const RUN_END_EVENTS = ["complete", "error", "stopped"] as const;
 
 export interface TaskPanelOptions {
   storage?: WorkflowStorage;
   cwd?: string;
+  /**
+   * Live settings loader. When provided, the panel reads it fresh (with a short
+   * TTL cache) on each render so `/workflows-progress` takes effect without a
+   * restart. Omitted in tests / minimal hosts → always compact.
+   */
+  loadSettings?: () => WorkflowSettings;
 }
 
 /**
@@ -130,29 +155,232 @@ export function renderPanel(manager: WorkflowManager, theme: Theme, width?: numb
   return [theme.bold(`Workflows running (${active.length}):`), ...rows, hint].map((line) => fitLine(line, width));
 }
 
+// ─── Detailed mode: live token rate ────────────────────────────────────────────
+
+/** Rolling window for the token/s rate. Older samples age out so a stall decays to 0. */
+const RATE_WINDOW_MS = 10_000;
+/** Per-run (timestamp, cumulative total) samples, keyed by the persisted runId so
+ *  the rolling rate survives pause→resume. Cleared when a run ends. */
+const tokenSamples = new Map<string, Array<{ ts: number; total: number }>>();
+
+/** Record a token-total sample for `runId` at time `now` (ms). */
+export function sampleTokens(runId: string, total: number, now: number): void {
+  const samples = tokenSamples.get(runId) ?? [];
+  const last = samples[samples.length - 1];
+  // Collapse repeat renders within the same instant (e.g. width recalcs).
+  if (last && last.ts === now && last.total === total) return;
+  samples.push({ ts: now, total });
+  // Drop samples beyond the rolling window, always keeping ≥2 so a rate is computable.
+  while (samples.length > 2 && now - samples[0].ts > RATE_WINDOW_MS) samples.shift();
+  tokenSamples.set(runId, samples);
+}
+
+/** Tokens/second over the rolling window; 0 when too few samples or totals plateau. */
+export function tokensPerSecond(runId: string): number {
+  const samples = tokenSamples.get(runId);
+  if (!samples || samples.length < 2) return 0;
+  const oldest = samples[0];
+  const newest = samples[samples.length - 1];
+  const elapsedMs = newest.ts - oldest.ts;
+  if (elapsedMs <= 0) return 0;
+  const delta = newest.total - oldest.total;
+  if (delta <= 0) return 0;
+  return (delta / elapsedMs) * 1000;
+}
+
+/** Forget a run's samples (call when it finishes) so the map can't grow unbounded. */
+export function clearTokenSamples(runId: string): void {
+  tokenSamples.delete(runId);
+}
+
+/** Compact token count for the space-constrained panel: 980, 12.4K, 1.3M. */
+function fmtTokensShort(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "";
+  if (n < 1000) return `${Math.round(n)}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+/** Normalize the configured per-phase agent cap to a sane integer (default 8). */
+export function clampMaxAgents(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return 8;
+  return Math.min(1000, Math.floor(value));
+}
+
+/** Per-phase + per-agent body for one run in detailed mode (mirrors renderWorkflowLines). */
+function renderRunBody(
+  snap: WorkflowSnapshot,
+  agents: WorkflowAgentSnapshot[],
+  maxAgents: number,
+  theme: Theme,
+): string[] {
+  const dim = (t: string) => theme.fg("dim", t);
+  const lines: string[] = [];
+  // Group agents by phase, declared order first then discovery order (as the navigator does).
+  const order = snap.phases.length ? [...snap.phases] : [];
+  const byPhase = new Map<string, WorkflowAgentSnapshot[]>();
+  for (const a of agents) {
+    const key = a.phase ?? "(no phase)";
+    if (!byPhase.has(key)) byPhase.set(key, []);
+    byPhase.get(key)?.push(a);
+    if (!order.includes(key)) order.push(key);
+  }
+  for (const title of order) {
+    const phaseAgents = byPhase.get(title) ?? [];
+    if (!phaseAgents.length) continue;
+    const done = phaseAgents.filter((a) => a.status === "done").length;
+    const running = phaseAgents.filter((a) => a.status === "running").length;
+    const errors = phaseAgents.filter((a) => a.status === "error").length;
+    const skipped = phaseAgents.filter((a) => a.status === "skipped").length;
+    const complete = done + errors + skipped === phaseAgents.length;
+    const marker = running > 0 || (!complete && snap.currentPhase === title) ? "▶" : complete ? "✓" : " ";
+    const phaseTokens = phaseAgents.reduce((n, a) => n + (a.tokens ?? 0), 0);
+    const phaseMeta = [
+      `${done}/${phaseAgents.length} agents`,
+      running ? `${running} running` : "",
+      errors ? `${errors} errors` : "",
+      phaseTokens > 0 ? `${fmtTokensShort(phaseTokens)} tok` : "",
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    lines.push(theme.fg("accent", `  ${marker} ${title}`) + dim(`  ${phaseMeta}`));
+
+    const visible = phaseAgents.slice(-maxAgents);
+    for (const a of visible) {
+      const tok = a.tokens ? dim(` ${fmtTokensShort(a.tokens)} tok`) : "";
+      const mdl = shortModel(a.model);
+      const model = mdl ? dim(` · ${mdl}`) : "";
+      lines.push(`    [${a.id}] ${statusIcon(a.status)} ${shorten(a.label, 40)}${tok}${model}`);
+    }
+    if (phaseAgents.length > visible.length) {
+      lines.push(dim(`    … ${phaseAgents.length - visible.length} earlier agents`));
+    }
+  }
+  return lines;
+}
+
+/**
+ * Detailed variant of {@link renderPanel}: per-run header with aggregate tokens,
+ * cost, and a live token/s rate, followed by per-phase progress and per-agent rows
+ * (capped at `maxAgents` per phase). `now` is injected for testability.
+ */
+export function renderPanelDetailed(
+  manager: WorkflowManager,
+  theme: Theme,
+  width: number | undefined,
+  maxAgents: number,
+  now: number,
+): string[] {
+  const all = manager.listRuns();
+  const active = all.filter((r) => r.status === "running" || r.status === "paused");
+  if (!active.length) return [];
+  const dim = (t: string) => theme.fg("dim", t);
+  const out: string[] = [theme.bold(`Workflows running (${active.length}):`)];
+
+  for (const r of active) {
+    const live = manager.getRun(r.runId);
+    const snap = live?.snapshot;
+    const agents = (snap?.agents ?? r.agents) as WorkflowAgentSnapshot[];
+    const done = agents.filter((a) => a.status === "done").length;
+    const icon = r.status === "paused" ? "⏸" : "◆";
+    const usage = snap?.tokenUsage ?? r.tokenUsage;
+    // The run-level tokenUsage aggregate is only finalized when the run ends, so
+    // it reads 0 for the whole live run. Per-agent `tokens` update on each agent
+    // completion, so sum those for a live total (and keep the header consistent
+    // with the per-phase subtotals). Note: tokens land at agent-completion
+    // granularity, so the rate reflects completion throughput — it decays to 0
+    // during a single long-running agent or a stall (which is the intended signal).
+    const total = agents.reduce((n, a) => n + (a.tokens ?? 0), 0);
+    // Sample the running total and derive the rolling token/s. Paused runs don't
+    // accrue tokens, so their rate is suppressed (a stalled rate would mislead).
+    sampleTokens(r.runId, total, now);
+    const rate = r.status === "running" ? tokensPerSecond(r.runId) : 0;
+    const meta = [
+      `${done}/${agents.length} agents`,
+      snap?.currentPhase || "",
+      total > 0 ? `${fmtTokensShort(total)} tok` : "",
+      // 2 decimals for ≥1¢, 4 for sub-cent so a real cost never shows as "$0.00".
+      // (cost is only known once the run finalizes its usage.)
+      usage?.cost ? `$${usage.cost.toFixed(usage.cost >= 0.01 ? 2 : 4)}` : "",
+      rate > 0 ? `${Math.round(rate)} tok/s` : "",
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    out.push(`  ${icon} ${theme.bold(r.workflowName)}  ${dim(meta)}`);
+    if (snap) out.push(...renderRunBody(snap, agents, maxAgents, theme));
+  }
+
+  const finished = all.filter((r) => r.status !== "running" && r.status !== "paused").length;
+  out.push(
+    dim(
+      finished > 0
+        ? `  /workflows — open navigator (${finished} finished kept in history)`
+        : "  /workflows — open navigator",
+    ),
+  );
+  return out.map((line) => fitLine(line, width));
+}
+
 /**
  * Install the live "workflows running" panel below the editor. Re-rendered on
  * every manager event. Informational only — the user opens the navigator with
- * /workflows. (`_pi`/`_opts` are kept for signature stability.)
+ * /workflows. (`_pi` is kept for signature stability.)
  */
 export function installTaskPanel(
   _pi: ExtensionAPI,
   manager: WorkflowManager,
   ui: ExtensionUIContext,
-  _opts: TaskPanelOptions = {},
+  opts: TaskPanelOptions = {},
 ): void {
+  // Live-read settings with a ~1s TTL: a render-path disk read every frame would
+  // be wasteful, but re-reading at most once a second still makes
+  // /workflows-progress take effect "immediately" (no restart).
+  let cached: WorkflowSettings = {};
+  let cachedAt = Number.NEGATIVE_INFINITY;
+  const settings = (): WorkflowSettings => {
+    if (!opts.loadSettings) return cached;
+    const now = Date.now();
+    if (now - cachedAt > 1000) {
+      try {
+        cached = opts.loadSettings() ?? {};
+      } catch {
+        cached = {};
+      }
+      cachedAt = now;
+    }
+    return cached;
+  };
+  const hasActiveRun = () => manager.listRuns().some((r) => r.status === "running" || r.status === "paused");
+
   ui.setWidget(
     "workflow-tasks",
     (tui: TUI, theme: Theme) => {
       const onEvent = () => tui.requestRender();
       for (const ev of RUN_EVENTS) manager.on(ev, onEvent);
+      const onRunEnd = ({ runId }: { runId: string }) => clearTokenSamples(runId);
+      for (const ev of RUN_END_EVENTS) manager.on(ev, onRunEnd);
+      // In detailed mode, force a redraw every 2s while a run is active so the
+      // token/s rate keeps updating between sparse token events — and decays to 0
+      // when an agent stalls. Gated + unref'd so it costs nothing when idle.
+      const timer = setInterval(() => {
+        if (settings().progressPanelMode === "detailed" && hasActiveRun()) tui.requestRender();
+      }, 2000);
+      (timer as { unref?: () => void }).unref?.();
       // Purely informational: it lists running runs and re-renders on events. To
       // open the navigator, the user runs /workflows (the panel takes no input).
       const comp: Component & { dispose?(): void } = {
-        render: (width: number) => renderPanel(manager, theme, width),
+        render: (width: number) => {
+          const s = settings();
+          if (s.progressPanelMode === "detailed") {
+            return renderPanelDetailed(manager, theme, width, clampMaxAgents(s.progressPanelMaxAgents), Date.now());
+          }
+          return renderPanel(manager, theme, width);
+        },
         invalidate: () => {},
         dispose: () => {
+          clearInterval(timer);
           for (const ev of RUN_EVENTS) manager.off(ev, onEvent);
+          for (const ev of RUN_END_EVENTS) manager.off(ev, onRunEnd);
         },
       };
       return comp;

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -24,7 +24,12 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import { type EffortState, effortDirective, isSubstantive } from "./effort-command.js";
-import { loadWorkflowSettings, saveWorkflowSettings, type WorkflowSettingsStore } from "./workflow-settings.js";
+import {
+  loadWorkflowSettings,
+  saveWorkflowSettings,
+  type WorkflowSettings,
+  type WorkflowSettingsStore,
+} from "./workflow-settings.js";
 
 // A trigger is `workflow`/`workflows` (substring, case-insensitive) that is NOT
 // immediately preceded by `/` — so a slash command like `/workflows` or `/workflow`
@@ -316,6 +321,64 @@ export function registerWorkflowTriggerCommand(
   });
 }
 
+/**
+ * Register the bottom progress-panel preference commands:
+ *  - `/workflows-progress compact|detailed|status` — switch (or report) the panel mode.
+ *  - `/workflows-progress-max <1-1000>` — cap agents shown per phase in detailed mode.
+ * Both persist via `settingsStore` and take effect on the next live run (the panel
+ * live-reads its settings), so no session restart is needed.
+ */
+export function registerWorkflowProgressCommands(
+  pi: ExtensionAPI,
+  settingsStore: WorkflowSettingsStore = DEFAULT_SETTINGS_STORE,
+): void {
+  pi.registerCommand?.("workflows-progress", {
+    description: "Bottom progress panel: compact | detailed | status",
+    async handler(args: string, _ctx: ExtensionCommandContext) {
+      const arg = args.trim().toLowerCase();
+      const say = (content: string) => pi.sendMessage({ customType: "workflows-progress", content, display: true });
+      if (arg === "compact" || arg === "detailed") {
+        const saved = persistProgressSettings(settingsStore, { progressPanelMode: arg });
+        await say(
+          saved
+            ? `Workflow progress panel set to ${arg} — takes effect on the next render of a live run (no restart needed).`
+            : `Workflow progress panel set to ${arg} for this session, but the preference could not be saved.`,
+        );
+        return;
+      }
+      await say(
+        `Workflow progress panel is ${loadProgressMode(settingsStore)}. Usage: /workflows-progress compact | detailed | status`,
+      );
+    },
+  });
+
+  pi.registerCommand?.("workflows-progress-max", {
+    description: "Max agents shown per phase in detailed progress mode (1-1000)",
+    async handler(args: string, _ctx: ExtensionCommandContext) {
+      const arg = args.trim();
+      const say = (content: string) => pi.sendMessage({ customType: "workflows-progress", content, display: true });
+      if (!arg) {
+        await say(
+          `Detailed progress shows up to ${loadProgressMaxAgents(settingsStore)} agents per phase. Usage: /workflows-progress-max <1-1000>`,
+        );
+        return;
+      }
+      const n = Number.parseInt(arg, 10);
+      if (!Number.isFinite(n) || n < 1) {
+        await say(`Invalid value "${arg}". Usage: /workflows-progress-max <1-1000> (a whole number ≥ 1).`);
+        return;
+      }
+      const clamped = Math.min(1000, n);
+      const saved = persistProgressSettings(settingsStore, { progressPanelMaxAgents: clamped });
+      await say(
+        saved
+          ? `Detailed progress now shows up to ${clamped} agents per phase.`
+          : `Set to ${clamped} for this session, but the preference could not be saved.`,
+      );
+    },
+  });
+}
+
 export function installWorkflowEditor(
   pi: ExtensionAPI,
   ui: ExtensionUIContext,
@@ -332,6 +395,7 @@ export function installWorkflowEditor(
     ui.setEditorComponent((tui, theme, keybindings) => new WorkflowEditor(tui, theme, keybindings, state));
   }
   registerWorkflowTriggerCommand(pi, state, settingsStore);
+  registerWorkflowProgressCommands(pi, settingsStore);
 
   // Active tools saved while a turn is restricted to `workflow`; restored on turn_end.
   let savedTools: string[] | undefined;
@@ -407,5 +471,30 @@ function persistKeywordTrigger(settingsStore: WorkflowSettingsStore, enabled: bo
     return true;
   } catch {
     return false;
+  }
+}
+
+function persistProgressSettings(settingsStore: WorkflowSettingsStore, settings: WorkflowSettings): boolean {
+  try {
+    settingsStore.save(settings);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function loadProgressMode(settingsStore: WorkflowSettingsStore): "compact" | "detailed" {
+  try {
+    return settingsStore.load().progressPanelMode ?? "compact";
+  } catch {
+    return "compact";
+  }
+}
+
+function loadProgressMaxAgents(settingsStore: WorkflowSettingsStore): number {
+  try {
+    return settingsStore.load().progressPanelMaxAgents ?? 8;
+  } catch {
+    return 8;
   }
 }

--- a/src/workflow-settings.ts
+++ b/src/workflow-settings.ts
@@ -12,6 +12,10 @@ import { workflowHomeDir, workflowProjectPaths } from "./workflow-paths.js";
 export interface WorkflowSettings {
   keywordTriggerEnabled?: boolean;
   defaultAgentTimeoutMs?: number | null;
+  /** Bottom task-panel display mode: "compact" (default, one line per run) | "detailed". */
+  progressPanelMode?: "compact" | "detailed";
+  /** Max agents shown per phase in detailed progress mode (default 8). */
+  progressPanelMaxAgents?: number;
 }
 
 export interface WorkflowSettingsStore {
@@ -106,6 +110,16 @@ function normalizeSettings(value: unknown): WorkflowSettings {
     raw.defaultAgentTimeoutMs > 0
   ) {
     settings.defaultAgentTimeoutMs = raw.defaultAgentTimeoutMs;
+  }
+  if (raw.progressPanelMode === "compact" || raw.progressPanelMode === "detailed") {
+    settings.progressPanelMode = raw.progressPanelMode;
+  }
+  if (
+    typeof raw.progressPanelMaxAgents === "number" &&
+    Number.isFinite(raw.progressPanelMaxAgents) &&
+    raw.progressPanelMaxAgents >= 1
+  ) {
+    settings.progressPanelMaxAgents = Math.min(1000, Math.floor(raw.progressPanelMaxAgents));
   }
   return settings;
 }

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -77,7 +77,7 @@ interface AgentRow {
 }
 
 /** Short, human-friendly model label: drop the provider prefix for display. */
-function shortModel(model: string | undefined): string | undefined {
+export function shortModel(model: string | undefined): string | undefined {
   if (!model) return undefined;
   const slash = model.indexOf("/");
   return slash > 0 ? model.slice(slash + 1) : model;

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -391,3 +391,214 @@ describe("renderPanel", () => {
     }
   });
 });
+
+// ─── token/s rolling-window math ────────────────────────────────────────────────
+
+describe("token rate", () => {
+  it("returns 0 with fewer than two samples and after clearing", async () => {
+    const { sampleTokens, tokensPerSecond, clearTokenSamples } = await import("../src/task-panel.js");
+    clearTokenSamples("rate-a");
+    assert.equal(tokensPerSecond("rate-a"), 0);
+    sampleTokens("rate-a", 100, 1000);
+    assert.equal(tokensPerSecond("rate-a"), 0);
+    sampleTokens("rate-a", 1100, 2000);
+    assert.equal(tokensPerSecond("rate-a"), 1000, "1000 tokens over 1s = 1000 tok/s");
+    clearTokenSamples("rate-a");
+    assert.equal(tokensPerSecond("rate-a"), 0, "cleared samples reset the rate");
+  });
+
+  it("computes the rate over the oldest-to-newest window", async () => {
+    const { sampleTokens, tokensPerSecond, clearTokenSamples } = await import("../src/task-panel.js");
+    clearTokenSamples("rate-b");
+    sampleTokens("rate-b", 0, 1000);
+    sampleTokens("rate-b", 1000, 2000);
+    sampleTokens("rate-b", 1500, 3000);
+    // (1500 - 0) tokens over (3000 - 1000) ms = 750 tok/s
+    assert.equal(tokensPerSecond("rate-b"), 750);
+  });
+
+  it("decays to 0 when the total plateaus (stall detection)", async () => {
+    const { sampleTokens, tokensPerSecond, clearTokenSamples } = await import("../src/task-panel.js");
+    clearTokenSamples("rate-c");
+    sampleTokens("rate-c", 0, 0);
+    sampleTokens("rate-c", 1000, 1000);
+    assert.equal(tokensPerSecond("rate-c"), 1000);
+    // A stall: same total sampled > 10s later ages out the growth window → 0 tok/s.
+    sampleTokens("rate-c", 1000, 12000);
+    assert.equal(tokensPerSecond("rate-c"), 0, "stalled agent shows 0 tok/s");
+  });
+});
+
+// ─── detailed progress panel ─────────────────────────────────────────────────────
+
+describe("renderPanelDetailed", () => {
+  const theme = { fg: (_c: string, t: string) => t, bold: (t: string) => t };
+
+  // `blueTokens` drives the first agent's live token count; the run aggregate and
+  // token/s are summed from per-agent tokens (the run-level tokenUsage aggregate is
+  // not live — see renderPanelDetailed), so growing blueTokens grows the rate.
+  function detailedManager(blueTokens: number, status = "running") {
+    const snapshot = {
+      name: "auth_audit",
+      phases: ["Scan", "Review"],
+      currentPhase: "Scan",
+      logs: [],
+      agents: [
+        {
+          id: 1,
+          label: "discover_routes",
+          status: "done",
+          phase: "Scan",
+          tokens: blueTokens,
+          model: "anthropic/claude-haiku-4-5",
+        },
+        { id: 2, label: "audit_auth", status: "running", phase: "Scan", tokens: 1800 },
+        { id: 3, label: "scan_middleware", status: "queued", phase: "Scan" },
+        { id: 4, label: "cross_check", status: "queued", phase: "Review" },
+      ],
+      // Only `cost` is read from the run-level aggregate (it lands when the run ends).
+      tokenUsage: { total: 0, input: 0, output: 0, cost: 0.02 },
+    };
+    return {
+      listRuns: () => [
+        { runId: "r1", workflowName: "auth_audit", status, agents: snapshot.agents, tokenUsage: snapshot.tokenUsage },
+      ],
+      getRun: (id: string) => (id === "r1" ? { snapshot, status } : undefined),
+    };
+  }
+
+  it("renders aggregate tokens, cost, phases, and per-agent rows", async () => {
+    const { renderPanelDetailed, clearTokenSamples } = await import("../src/task-panel.js");
+    clearTokenSamples("r1");
+    // discover_routes 2100 + audit_auth 1800 = 3900 → "3.9K tok" aggregate.
+    const lines = renderPanelDetailed(detailedManager(2100) as never, theme as never, undefined, 8, 1000);
+    const text = lines.join("\n");
+
+    assert.ok(/auth_audit/.test(text), "shows the run name");
+    assert.ok(/1\/4 agents/.test(text), "shows done/total agents");
+    assert.ok(/3\.9K tok/.test(text), "shows aggregate tokens summed from per-agent tokens");
+    assert.ok(/\$0\.02/.test(text), "shows cost");
+    // Phase headers
+    assert.ok(
+      lines.some((l) => l.includes("▶ Scan") && /1\/3 agents/.test(l) && /3\.9K tok/.test(l)),
+      "Scan phase header with subtotal",
+    );
+    assert.ok(
+      lines.some((l) => l.includes("Review") && /0\/1 agents/.test(l)),
+      "Review phase header",
+    );
+    // Agent rows: status icons + label + tokens + model
+    assert.ok(
+      lines.some((l) => l.includes("[1] ✓ discover_routes") && /2\.1K tok/.test(l) && /claude-haiku-4-5/.test(l)),
+      "done agent row with model",
+    );
+    assert.ok(
+      lines.some((l) => l.includes("[2] ● audit_auth") && /1\.8K tok/.test(l)),
+      "running agent row",
+    );
+    assert.ok(
+      lines.some((l) => l.includes("[3] ○ scan_middleware")),
+      "queued agent row",
+    );
+  });
+
+  it("shows a live token/s after two growing samples", async () => {
+    const { renderPanelDetailed, clearTokenSamples } = await import("../src/task-panel.js");
+    clearTokenSamples("r1");
+    // aggregate goes 3900 → 5900 over 1s = 2000 tok/s
+    renderPanelDetailed(detailedManager(2100) as never, theme as never, undefined, 8, 1000);
+    const lines = renderPanelDetailed(detailedManager(4100) as never, theme as never, undefined, 8, 2000);
+    assert.ok(
+      lines.some((l) => /2000 tok\/s/.test(l)),
+      `expected a tok/s readout, got:\n${lines.join("\n")}`,
+    );
+  });
+
+  it("caps agents per phase and reports the overflow", async () => {
+    const { renderPanelDetailed, clearTokenSamples } = await import("../src/task-panel.js");
+    clearTokenSamples("r1");
+    const lines = renderPanelDetailed(detailedManager(12400) as never, theme as never, undefined, 2, 1000);
+    const text = lines.join("\n");
+    // Scan has 3 agents, cap 2 → most recent 2 shown + "… 1 earlier agents"
+    assert.ok(/… 1 earlier agents/.test(text), "overflow line present");
+    assert.ok(!/discover_routes/.test(text), "oldest agent hidden when capped");
+    assert.ok(/audit_auth/.test(text) && /scan_middleware/.test(text), "most recent agents shown");
+  });
+
+  it("suppresses tok/s for paused runs", async () => {
+    const { renderPanelDetailed, clearTokenSamples } = await import("../src/task-panel.js");
+    clearTokenSamples("r1");
+    renderPanelDetailed(detailedManager(1000, "paused") as never, theme as never, undefined, 8, 1000);
+    const lines = renderPanelDetailed(detailedManager(3000, "paused") as never, theme as never, undefined, 8, 2000);
+    assert.ok(!lines.some((l) => /tok\/s/.test(l)), "paused run shows no token rate");
+  });
+});
+
+// ─── mode selection in installTaskPanel ───────────────────────────────────────────
+
+describe("installTaskPanel mode selection", () => {
+  const theme = { fg: (_c: string, t: string) => t, bold: (t: string) => t };
+
+  function activeManager() {
+    const manager = new EventEmitter() as ReturnType<typeof EventEmitter> & {
+      getRun: (id: string) => unknown;
+      listRuns: () => unknown[];
+    };
+    const snapshot = {
+      name: "wf",
+      phases: ["P1"],
+      currentPhase: "P1",
+      logs: [],
+      agents: [{ id: 1, label: "a", status: "running", phase: "P1", tokens: 500 }],
+      tokenUsage: { total: 500, input: 250, output: 250 },
+    };
+    manager.listRuns = () => [
+      { runId: "r1", workflowName: "wf", status: "running", agents: snapshot.agents, tokenUsage: snapshot.tokenUsage },
+    ];
+    manager.getRun = (id: string) => (id === "r1" ? { snapshot, status: "running" } : undefined);
+    return manager;
+  }
+
+  function captureRender(loadSettings?: () => Record<string, unknown>) {
+    const manager = activeManager();
+    let factory:
+      | ((tui: { requestRender(): void }, theme: unknown) => { render(w: number): string[]; dispose?(): void })
+      | undefined;
+    const ui = {
+      setWidget: (_n: string, f: typeof factory) => {
+        factory = f;
+      },
+    };
+    mod.installTaskPanel(null, manager as never, ui as never, { loadSettings } as never);
+    const comp = factory?.({ requestRender: () => {} }, theme);
+    const lines = comp?.render(120) ?? [];
+    comp?.dispose?.();
+    return lines;
+  }
+
+  it("uses compact rendering when no loadSettings is provided", () => {
+    const lines = captureRender();
+    assert.ok(
+      lines.some((l) => /1 agents/.test(l)),
+      "compact one-liner",
+    );
+    assert.ok(!lines.some((l) => /▶ P1/.test(l)), "no per-phase detail in compact");
+  });
+
+  it("uses compact rendering when the mode is compact", () => {
+    const lines = captureRender(() => ({ progressPanelMode: "compact" }));
+    assert.ok(!lines.some((l) => /▶ P1/.test(l)), "no per-phase detail in compact");
+  });
+
+  it("uses detailed rendering when the mode is detailed", () => {
+    const lines = captureRender(() => ({ progressPanelMode: "detailed" }));
+    assert.ok(
+      lines.some((l) => /▶ P1/.test(l)),
+      "per-phase detail in detailed mode",
+    );
+    assert.ok(
+      lines.some((l) => /\[1\] ● a/.test(l)),
+      "per-agent row in detailed mode",
+    );
+  });
+});

--- a/tests/workflow-editor.test.ts
+++ b/tests/workflow-editor.test.ts
@@ -970,3 +970,71 @@ describe("installWorkflowEditor", () => {
     assert.deepEqual(result, { action: "continue" }, "non-interactive source should return continue");
   });
 });
+
+describe("registerWorkflowProgressCommands", () => {
+  function setup() {
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+    const sent: Array<{ content?: string }> = [];
+    let settings: Record<string, unknown> = {};
+    const pi = {
+      registerCommand: (name: string, command: { handler: (args: string, ctx: unknown) => Promise<void> }) => {
+        commands.set(name, command);
+      },
+      sendMessage: (message: { content?: string }) => {
+        sent.push(message);
+      },
+    } as unknown as ExtensionAPI;
+    const settingsStore = {
+      load: () => ({ ...settings }),
+      save: (next: Record<string, unknown>) => {
+        settings = { ...settings, ...next };
+      },
+    };
+    return { commands, sent, settingsStore, getSettings: () => settings, pi };
+  }
+
+  it("persists a valid mode and reports the current one on status", async () => {
+    const mod = await load();
+    const { commands, sent, settingsStore, getSettings, pi } = setup();
+    mod.registerWorkflowProgressCommands(pi, settingsStore);
+
+    const cmd = commands.get("workflows-progress");
+    assert.ok(cmd, "registers /workflows-progress");
+
+    await cmd.handler("detailed", {});
+    assert.deepEqual(getSettings(), { progressPanelMode: "detailed" });
+    assert.match(sent.at(-1)?.content ?? "", /detailed/i);
+
+    await cmd.handler("status", {});
+    assert.match(sent.at(-1)?.content ?? "", /panel is detailed/i);
+  });
+
+  it("ignores an invalid mode without persisting", async () => {
+    const mod = await load();
+    const { commands, sent, settingsStore, getSettings, pi } = setup();
+    mod.registerWorkflowProgressCommands(pi, settingsStore);
+
+    await commands.get("workflows-progress")?.handler("verbose", {});
+    assert.deepEqual(getSettings(), {}, "invalid mode is not saved");
+    assert.match(sent.at(-1)?.content ?? "", /Usage:/);
+  });
+
+  it("clamps and persists the per-phase agent cap, rejecting non-numbers", async () => {
+    const mod = await load();
+    const { commands, sent, settingsStore, getSettings, pi } = setup();
+    mod.registerWorkflowProgressCommands(pi, settingsStore);
+
+    const cmd = commands.get("workflows-progress-max");
+    assert.ok(cmd, "registers /workflows-progress-max");
+
+    await cmd.handler("5000", {});
+    assert.deepEqual(getSettings(), { progressPanelMaxAgents: 1000 }, "clamps to 1000");
+
+    await cmd.handler("abc", {});
+    assert.match(sent.at(-1)?.content ?? "", /Invalid value/);
+    assert.deepEqual(getSettings(), { progressPanelMaxAgents: 1000 }, "invalid value does not overwrite");
+
+    await cmd.handler("0", {});
+    assert.match(sent.at(-1)?.content ?? "", /Invalid value/);
+  });
+});

--- a/tests/workflow-settings.test.ts
+++ b/tests/workflow-settings.test.ts
@@ -131,6 +131,42 @@ describe("workflow settings", () => {
     });
   });
 
+  it("saves and loads the progress panel mode", () => {
+    withSettingsPath((settingsPath) => {
+      saveWorkflowSettings({ progressPanelMode: "detailed" }, settingsPath);
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { progressPanelMode: "detailed" });
+
+      saveWorkflowSettings({ progressPanelMode: "compact" }, settingsPath);
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { progressPanelMode: "compact" });
+    });
+  });
+
+  it("rejects an invalid progress panel mode", () => {
+    withSettingsPath((settingsPath) => {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+      writeFileSync(settingsPath, JSON.stringify({ progressPanelMode: "verbose" }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+    });
+  });
+
+  it("clamps and floors progressPanelMaxAgents into [1, 1000]", () => {
+    withSettingsPath((settingsPath) => {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+
+      writeFileSync(settingsPath, JSON.stringify({ progressPanelMaxAgents: 12.7 }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { progressPanelMaxAgents: 12 });
+
+      writeFileSync(settingsPath, JSON.stringify({ progressPanelMaxAgents: 5000 }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { progressPanelMaxAgents: 1000 });
+
+      writeFileSync(settingsPath, JSON.stringify({ progressPanelMaxAgents: 0 }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+
+      writeFileSync(settingsPath, JSON.stringify({ progressPanelMaxAgents: "8" }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+    });
+  });
+
   it("ignores corrupt or invalid settings", () => {
     withSettingsPath((settingsPath) => {
       mkdirSync(dirname(settingsPath), { recursive: true });


### PR DESCRIPTION
Closes #20.

## What

Adds a **`detailed`** mode to the always-visible "Workflows running" panel, alongside the existing compact one-liner. A simple toggle switches between them; **compact mode is byte-for-byte unchanged**.

```
Workflows running (1):
  ◆ auth_audit  2/3 agents · Review · 31.7K tok · 4434 tok/s
  ✓ Scan  2/2 agents · 31.7K tok
    [1] ✓ scan_blue 15.8K tok · deepseek-v4-flash
    [2] ✓ scan_red 15.9K tok · deepseek-v4-flash
  ▶ Review  0/1 agents · 1 running
    [3] ● review_warm · deepseek-v4-flash
  /workflows — open navigator
```

Detailed mode shows, without opening `/workflows`:
- Run header — aggregate tokens, cost (when finalized), and a **live tok/s rate** (0 tok/s = stalled agent)
- Per-phase progress — marker (`▶`/`✓`) + done/total + error count + token subtotal
- Per-agent rows — `[id]` + status icon + label + tokens + model, capped at `progressPanelMaxAgents` per phase with a `… N earlier agents` overflow line

## Config

Two new keys in `~/.pi/workflows/settings.json`, live-read each render (1s TTL) so toggles apply **without a restart**:
- `progressPanelMode`: `"compact"` (default) | `"detailed"`
- `progressPanelMaxAgents`: `1`–`1000` (default `8`)

Two new commands:
- `/workflows-progress compact|detailed|status`
- `/workflows-progress-max <N>`

## Notable: token/s data source

The issue suggested deriving tok/s from `WorkflowSnapshot.tokenUsage.total` deltas. **Real-pi testing showed that aggregate is only finalized at run-end and reads 0 for the entire live run.** Per-agent `agent.tokens` *is* live (set on each agent completion), so the live aggregate and tok/s are summed from per-agent tokens instead — which also keeps the run header consistent with the per-phase subtotals. (A fake unit test that hand-set `tokenUsage.total` would never have caught this.)

Reuses `statusIcon`/`shorten` (`display.ts`) and `shortModel` (`workflow-ui.ts`) via new exports — no duplicated formatting.

## Tests

- **16 new unit tests**: settings normalize/clamp, token-rate math (ramp → 750 tok/s, stall → 0), detailed layout, per-phase overflow, compact/detailed mode selection, command validation/clamping.
- Full suite: **695 pass / 0 fail**, biome clean, build clean.
- **Real-pi end-to-end** (real `WorkflowManager` + real `deepseek-v4-flash`, no fake runner): verified the detailed panel renders real phases/agents/tokens/model and a live positive tok/s (observed `31.7K tok · 4434 tok/s`, decaying with the rolling window).

## Files

`src/task-panel.ts` (renderer + token-rate + mode wiring), `src/workflow-settings.ts` (keys + normalize), `src/workflow-editor.ts` (commands), `extensions/workflow.ts` (live loader), `src/display.ts` / `src/workflow-ui.ts` / `src/index.ts` (exports), `README.md`, + 3 test files.

> Note: no version bump in this PR — left for the release step.