### PR TITLE
fix: bound workflow fan-out and isolate Windows test home

### DIFF
--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -26,6 +26,8 @@ export default function extension(pi: ExtensionAPI) {
     cwd,
     loadSavedWorkflow: (name) => storage.load(name)?.script,
     defaultAgentTimeoutMs: settings.defaultAgentTimeoutMs ?? null,
+    concurrency: settings.defaultConcurrency,
+    defaultAgentRetries: settings.defaultAgentRetries,
   });
 
   const workflowTool = createWorkflowTool({ cwd, manager, storage });

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,9 @@ export const DEFAULT_AGENT_TIMEOUT_MS = null;
 /** Maximum concurrent agents (matches Claude Code limit). */
 export const MAX_CONCURRENCY = 16;
 
+/** Maximum automatic retry attempts after a recoverable agent failure. */
+export const MAX_AGENT_RETRIES = 3;
+
 /** Default token budget if none specified. */
 export const DEFAULT_TOKEN_BUDGET = null;
 

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -54,6 +54,10 @@ export interface ExecOptions {
   onProgress?: (snapshot: WorkflowSnapshot) => void;
   /** Hard token budget for this run; once spent reaches it, agent() throws. */
   tokenBudget?: number | null;
+  /** Max concurrent agents for this execution. */
+  concurrency?: number;
+  /** Retry attempts after recoverable agent failures for this execution. */
+  agentRetries?: number;
   /** Resolve a checkpoint() question with a human reply (only for UI-bearing runs). */
   confirm?: (promptText: string, options: unknown) => Promise<unknown>;
 }
@@ -71,6 +75,8 @@ export interface WorkflowManagerOptions {
   sessionId?: string;
   /** Default per-agent timeout when a run does not pass agentTimeoutMs. null means no hard timeout. */
   defaultAgentTimeoutMs?: number | null;
+  /** Default retry attempts after recoverable agent failures. */
+  defaultAgentRetries?: number;
 }
 
 export class WorkflowManager extends EventEmitter {
@@ -85,6 +91,7 @@ export class WorkflowManager extends EventEmitter {
   /** The current pi session id; runs are stamped with it and listRuns() filters by it. */
   private sessionId?: string;
   private defaultAgentTimeoutMs: number | null;
+  private defaultAgentRetries: number;
 
   constructor(options: WorkflowManagerOptions = {}) {
     super();
@@ -95,6 +102,7 @@ export class WorkflowManager extends EventEmitter {
     this.mainModel = options.mainModel;
     this.sessionId = options.sessionId;
     this.defaultAgentTimeoutMs = options.defaultAgentTimeoutMs ?? null;
+    this.defaultAgentRetries = options.defaultAgentRetries ?? 0;
     this.persistence = createRunPersistence(this.cwd);
     this.recoverStaleRuns();
   }
@@ -256,8 +264,20 @@ export class WorkflowManager extends EventEmitter {
     args?: unknown,
     exec: ExecOptions = {},
   ): Promise<WorkflowRunResult> {
-    const { resumeJournal, maxAgents, agentTimeoutMs, externalSignal, onProgress, tokenBudget, confirm } = exec;
+    const {
+      resumeJournal,
+      maxAgents,
+      agentTimeoutMs,
+      externalSignal,
+      onProgress,
+      tokenBudget,
+      concurrency,
+      agentRetries,
+      confirm,
+    } = exec;
     const resolvedAgentTimeoutMs = agentTimeoutMs !== undefined ? agentTimeoutMs : this.defaultAgentTimeoutMs;
+    const resolvedConcurrency = concurrency ?? this.concurrency;
+    const resolvedAgentRetries = agentRetries ?? this.defaultAgentRetries;
     const progress = () => onProgress?.(managed.snapshot);
     // Let a host abort (e.g. Esc during a blocking tool call) cancel this run.
     if (externalSignal) {
@@ -271,7 +291,8 @@ export class WorkflowManager extends EventEmitter {
         agent: this.agent,
         mainModel: this.mainModel,
         signal: managed.controller.signal,
-        concurrency: this.concurrency,
+        concurrency: resolvedConcurrency,
+        agentRetries: resolvedAgentRetries,
         maxAgents,
         agentTimeoutMs: resolvedAgentTimeoutMs,
         tokenBudget,

--- a/src/workflow-paths.ts
+++ b/src/workflow-paths.ts
@@ -9,7 +9,7 @@
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { basename, join, resolve } from "node:path";
-import { USER_WORKFLOW_SAVED_DIR, WORKFLOW_RUNS_DIR, WORKFLOW_SAVED_DIR } from "./config.js";
+import { WORKFLOW_RUNS_DIR, WORKFLOW_SAVED_DIR } from "./config.js";
 
 export const WORKFLOW_HOME_RELATIVE_DIR = ".pi/workflows";
 export const WORKFLOW_PROJECTS_SUBDIR = "projects";
@@ -29,7 +29,7 @@ export function workflowHomeDir(): string {
 }
 
 export function workflowUserSavedDir(): string {
-  return USER_WORKFLOW_SAVED_DIR.replace("~", homedir());
+  return join(workflowHomeDir(), "saved");
 }
 
 export function workflowProjectKey(cwd: string): string {

--- a/src/workflow-settings.ts
+++ b/src/workflow-settings.ts
@@ -7,11 +7,16 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { MAX_AGENT_RETRIES, MAX_CONCURRENCY } from "./config.js";
 import { workflowHomeDir, workflowProjectPaths } from "./workflow-paths.js";
 
 export interface WorkflowSettings {
   keywordTriggerEnabled?: boolean;
   defaultAgentTimeoutMs?: number | null;
+  /** Default max concurrent agents per run. Clamped to the runtime maximum. */
+  defaultConcurrency?: number;
+  /** Default retry attempts after recoverable agent failures. */
+  defaultAgentRetries?: number;
   /** Bottom task-panel display mode: "compact" (default, one line per run) | "detailed". */
   progressPanelMode?: "compact" | "detailed";
   /** Max agents shown per phase in detailed progress mode (default 8). */
@@ -111,6 +116,10 @@ function normalizeSettings(value: unknown): WorkflowSettings {
   ) {
     settings.defaultAgentTimeoutMs = raw.defaultAgentTimeoutMs;
   }
+  const defaultConcurrency = normalizeInteger(raw.defaultConcurrency, 1, MAX_CONCURRENCY);
+  if (defaultConcurrency !== undefined) settings.defaultConcurrency = defaultConcurrency;
+  const defaultAgentRetries = normalizeInteger(raw.defaultAgentRetries, 0, MAX_AGENT_RETRIES);
+  if (defaultAgentRetries !== undefined) settings.defaultAgentRetries = defaultAgentRetries;
   if (raw.progressPanelMode === "compact" || raw.progressPanelMode === "detailed") {
     settings.progressPanelMode = raw.progressPanelMode;
   }
@@ -122,6 +131,11 @@ function normalizeSettings(value: unknown): WorkflowSettings {
     settings.progressPanelMaxAgents = Math.min(1000, Math.floor(raw.progressPanelMaxAgents));
   }
   return settings;
+}
+
+function normalizeInteger(value: unknown, min: number, max: number): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < min) return undefined;
+  return Math.min(max, Math.floor(value));
 }
 
 function readObject(path: string): Record<string, unknown> {

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -81,6 +81,18 @@ const workflowToolSchema = Type.Object({
       description: "Maximum number of agents allowed in this run. Default: 1000.",
     }),
   ),
+  concurrency: Type.Optional(
+    Type.Number({
+      description:
+        "Maximum concurrent agents for this run. Clamped to the runtime maximum. Use when provider/transport stability matters.",
+    }),
+  ),
+  agentRetries: Type.Optional(
+    Type.Number({
+      description:
+        "Retry attempts for recoverable agent failures such as timeout, connection failure, or empty assistant output. Default 0 unless configured.",
+    }),
+  ),
   agentTimeoutMs: Type.Optional(
     Type.Number({
       description:
@@ -100,6 +112,8 @@ export type WorkflowToolInput = {
   args?: unknown;
   background?: boolean;
   maxAgents?: number;
+  concurrency?: number;
+  agentRetries?: number;
   agentTimeoutMs?: number;
   tokenBudget?: number;
 };
@@ -113,17 +127,24 @@ export interface WorkflowToolOptions {
   storage?: WorkflowStorage;
   /** Default per-agent timeout for runs created by this tool. null means no hard timeout. */
   defaultAgentTimeoutMs?: number | null;
+  /** Default max concurrent agents when no tool-level concurrency is passed. */
+  defaultConcurrency?: number;
+  /** Default retry attempts after recoverable agent failures. */
+  defaultAgentRetries?: number;
 }
 
 export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefinition<typeof workflowToolSchema, any> {
   const storage = options.storage ?? createWorkflowStorage(options.cwd ?? process.cwd());
+  const cwd = options.cwd ?? process.cwd();
+  const defaults = resolveWorkflowToolDefaults(options, cwd);
   const manager =
     options.manager ??
     new WorkflowManager({
       cwd: options.cwd,
-      concurrency: options.concurrency,
+      concurrency: defaults.concurrency,
       loadSavedWorkflow: (name: string) => storage.load(name)?.script,
-      defaultAgentTimeoutMs: resolveDefaultAgentTimeoutMs(options.defaultAgentTimeoutMs, options.cwd ?? process.cwd()),
+      defaultAgentTimeoutMs: defaults.agentTimeoutMs,
+      defaultAgentRetries: defaults.agentRetries,
     });
 
   return defineTool({
@@ -149,6 +170,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       "For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.",
       "For workflow, pipeline(items, ...stages) runs each item through stages sequentially, while different items may run concurrently. Each stage receives (previousValue, originalItem, index).",
       "For workflow, every agent() call should include a unique short label option, 2-5 words, such as { label: 'repo inventory' } or { label: 'source modules' }; unique labels make live status and error reporting readable.",
+      "For workflow, use low concurrency and agentRetries for unstable provider/transport fan-out runs; retries apply only to recoverable agent failures and still require explicit null handling after exhaustion.",
       "For workflow, failed agent(), parallel(), or pipeline() branches return null and log the failure unless the workflow is aborted. Check for nulls before synthesizing conclusions.",
       "For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.",
       "For workflow, if agent() needs machine-readable output, pass a plain JSON Schema via opts.schema; agent() will return the validated object. Use JSON Schema syntax, not TypeScript or TypeBox constructors.",
@@ -184,6 +206,8 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       if (params.background ?? true) {
         const { runId } = manager.startInBackground(script, params.args, {
           maxAgents: params.maxAgents,
+          concurrency: params.concurrency,
+          agentRetries: params.agentRetries,
           agentTimeoutMs: params.agentTimeoutMs,
           tokenBudget: params.tokenBudget,
         });
@@ -209,6 +233,8 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       try {
         result = await manager.runSync(script, params.args, {
           maxAgents: params.maxAgents,
+          concurrency: params.concurrency,
+          agentRetries: params.agentRetries,
           agentTimeoutMs: params.agentTimeoutMs,
           tokenBudget: params.tokenBudget,
           confirm,
@@ -297,9 +323,19 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
   });
 }
 
-function resolveDefaultAgentTimeoutMs(explicit: number | null | undefined, cwd: string): number | null {
-  if (explicit !== undefined) return explicit;
-  return loadWorkflowSettings({ cwd }).defaultAgentTimeoutMs ?? null;
+function resolveWorkflowToolDefaults(
+  options: WorkflowToolOptions,
+  cwd: string,
+): { agentTimeoutMs: number | null; concurrency?: number; agentRetries: number } {
+  const settings = loadWorkflowSettings({ cwd });
+  return {
+    agentTimeoutMs:
+      options.defaultAgentTimeoutMs !== undefined
+        ? options.defaultAgentTimeoutMs
+        : (settings.defaultAgentTimeoutMs ?? null),
+    concurrency: options.defaultConcurrency ?? options.concurrency ?? settings.defaultConcurrency,
+    agentRetries: options.defaultAgentRetries ?? settings.defaultAgentRetries ?? 0,
+  };
 }
 
 /**

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -13,7 +13,7 @@ import {
   loadAgentRegistry,
   resolveAgentType,
 } from "./agent-registry.js";
-import { DEFAULT_AGENT_TIMEOUT_MS, MAX_AGENTS_PER_RUN, MAX_CONCURRENCY } from "./config.js";
+import { DEFAULT_AGENT_TIMEOUT_MS, MAX_AGENT_RETRIES, MAX_AGENTS_PER_RUN, MAX_CONCURRENCY } from "./config.js";
 import { WorkflowError, WorkflowErrorCode, wrapError } from "./errors.js";
 import { createWorkflowLogger } from "./logger.js";
 import { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.js";
@@ -66,6 +66,8 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
    */
   agentRegistry?: AgentRegistry;
   concurrency?: number;
+  /** Retry attempts after a recoverable agent failure. Default 0. */
+  agentRetries?: number;
   tokenBudget?: number | null;
   signal?: AbortSignal;
   /** Maximum number of agents allowed in this run. Default: 1000 */
@@ -164,6 +166,8 @@ export interface AgentOptions<TSchemaDef extends TSchema | undefined = TSchema |
   agentType?: string;
   /** Override timeout for this specific agent. null means no hard timeout. */
   timeoutMs?: number | null;
+  /** Retry attempts after a recoverable failure for this specific agent. */
+  retries?: number;
 }
 
 /** Options for a human checkpoint() — a deterministic, journaled, replayable gate. */
@@ -277,9 +281,8 @@ export async function runWorkflow<T = unknown>(
   };
 
   const agentRunner = options.agent ?? new WorkflowAgent(options);
-  const concurrency = Math.max(
-    1,
-    Math.min(options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2), MAX_CONCURRENCY),
+  const concurrency = normalizeConcurrency(
+    options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2),
   );
   // Global caps + budget are shared with any nested workflow() so they hold across nesting.
   const shared: SharedRuntime = options.sharedRuntime ?? {
@@ -415,6 +418,8 @@ export async function runWorkflow<T = unknown>(
 
     return limiter(async () => {
       const timeout = agentOptions.timeoutMs !== undefined ? agentOptions.timeoutMs : agentTimeoutMs;
+      const retryAttempts = normalizeAgentRetries(agentOptions.retries ?? options.agentRetries ?? 0);
+      const maxAttempts = retryAttempts + 1;
 
       options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
 
@@ -427,7 +432,8 @@ export async function runWorkflow<T = unknown>(
       const runCwd = worktree?.isolated ? worktree.cwd : undefined;
 
       // Captured from the subagent's real session usage; falls back to an
-      // estimate when the provider reports no usage (total === 0).
+      // estimate when the provider reports no usage (total === 0). Usage is reset
+      // per retry attempt so a failed attempt does not double-count the next one.
       let usage: AgentUsage | undefined;
       const recordTokens = (result: unknown): number => {
         const tokens = usage && usage.total > 0 ? usage.total : estimateTokens(result) + estimateTokens(prompt);
@@ -444,73 +450,96 @@ export async function runWorkflow<T = unknown>(
       };
 
       try {
-        throwIfAborted();
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+          usage = undefined;
+          try {
+            throwIfAborted();
 
-        // Run agent with timeout
-        const result = await withTimeout(
-          agentRunner.run(prompt, {
-            label,
-            schema: agentOptions.schema,
-            signal: options.signal,
-            instructions: buildAgentInstructions(assignedPhase, agentOptions, agentDef),
-            model: modelSpec,
-            tier: agentOptions.tier,
-            toolNames: agentDef?.tools,
-            disallowedToolNames: agentDef?.disallowedTools,
-            cwd: runCwd,
-            onModelResolved: (id: string) => {
-              displayModel = id;
-            },
-            onModelFallback: (spec: string) => {
-              // Make the silent degrade visible in /workflows, not just console.
-              log(`${label}: model "${spec}" unavailable — using the session default`);
-            },
-            onUsage: (u: AgentUsage) => {
-              usage = u;
-            },
-            onHistory: (history: AgentHistoryEntry[]) => {
-              options.onAgentHistory?.({ label, phase: assignedPhase, history });
-            },
-          } as any),
-          timeout,
-          label,
-        );
+            // Run agent with timeout
+            const result = await withTimeout(
+              agentRunner.run(prompt, {
+                label,
+                schema: agentOptions.schema,
+                signal: options.signal,
+                instructions: buildAgentInstructions(assignedPhase, agentOptions, agentDef),
+                model: modelSpec,
+                tier: agentOptions.tier,
+                toolNames: agentDef?.tools,
+                disallowedToolNames: agentDef?.disallowedTools,
+                cwd: runCwd,
+                onModelResolved: (id: string) => {
+                  displayModel = id;
+                },
+                onModelFallback: (spec: string) => {
+                  // Make the silent degrade visible in /workflows, not just console.
+                  log(`${label}: model "${spec}" unavailable — using the session default`);
+                },
+                onUsage: (u: AgentUsage) => {
+                  usage = u;
+                },
+                onHistory: (history: AgentHistoryEntry[]) => {
+                  options.onAgentHistory?.({ label, phase: assignedPhase, history });
+                },
+              } as any),
+              timeout,
+              label,
+            );
 
-        throwIfAborted();
-        if (isEmptyTextAgentResult(result, agentOptions.schema)) {
-          throw new WorkflowError("Subagent produced no assistant output", WorkflowErrorCode.AGENT_EMPTY_OUTPUT, {
-            recoverable: true,
-            agentLabel: label,
-          });
+            throwIfAborted();
+            if (isEmptyTextAgentResult(result, agentOptions.schema)) {
+              throw new WorkflowError("Subagent produced no assistant output", WorkflowErrorCode.AGENT_EMPTY_OUTPUT, {
+                recoverable: true,
+                agentLabel: label,
+              });
+            }
+
+            const tokens = recordTokens(result);
+            options.onAgentJournal?.({ index: callIndex, hash: callHash, result });
+            options.onAgentEnd?.({
+              label,
+              phase: assignedPhase,
+              result,
+              tokens,
+              worktree: runCwd,
+              model: displayModel,
+            });
+            return result;
+          } catch (error) {
+            if (options.signal?.aborted) throw error;
+
+            const workflowError = wrapError(error, { agentLabel: label });
+            logger.error(`agent ${label} attempt ${attempt}/${maxAttempts} failed: ${workflowError.message}`);
+            const tokens = recordTokens(null);
+
+            if (workflowError.recoverable && attempt < maxAttempts) {
+              log(
+                `agent "${label}" attempt ${attempt}/${maxAttempts} failed: ${workflowError.code} ${workflowError.message}; retrying`,
+              );
+              continue;
+            }
+
+            options.onAgentEnd?.({
+              label,
+              phase: assignedPhase,
+              result: null,
+              tokens,
+              worktree: runCwd,
+              model: displayModel,
+              error: workflowError.message,
+              errorCode: workflowError.code,
+              recoverable: workflowError.recoverable,
+            });
+
+            if (workflowError.recoverable) {
+              log(
+                `agent "${label}" exhausted ${maxAttempts} attempt${maxAttempts === 1 ? "" : "s"}: ${workflowError.code} ${workflowError.message}`,
+              );
+              return null;
+            }
+            throw workflowError;
+          }
         }
-
-        const tokens = recordTokens(result);
-        options.onAgentJournal?.({ index: callIndex, hash: callHash, result });
-        options.onAgentEnd?.({ label, phase: assignedPhase, result, tokens, worktree: runCwd, model: displayModel });
-        return result;
-      } catch (error) {
-        if (options.signal?.aborted) throw error;
-
-        const workflowError = wrapError(error, { agentLabel: label });
-        logger.error(`agent ${label} failed: ${workflowError.message}`);
-        const tokens = recordTokens(null);
-        options.onAgentEnd?.({
-          label,
-          phase: assignedPhase,
-          result: null,
-          tokens,
-          worktree: runCwd,
-          model: displayModel,
-          error: workflowError.message,
-          errorCode: workflowError.code,
-          recoverable: workflowError.recoverable,
-        });
-
-        // Return null for recoverable errors
-        if (workflowError.recoverable) {
-          return null;
-        }
-        throw workflowError;
+        return null;
       } finally {
         // Always tear down the worktree, even on timeout/abort.
         if (worktree?.isolated) await removeWorktree(worktree);
@@ -1051,6 +1080,16 @@ function isEmptyTextAgentResult(result: unknown, schema: TSchema | undefined): b
 
 function estimateTokens(value: unknown): number {
   return Math.ceil(JSON.stringify(value ?? "").length / 4);
+}
+
+function normalizeConcurrency(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return 1;
+  return Math.min(MAX_CONCURRENCY, Math.floor(value));
+}
+
+function normalizeAgentRetries(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return 0;
+  return Math.min(MAX_AGENT_RETRIES, Math.floor(value));
 }
 
 /**

--- a/tests/helpers/fake-home.ts
+++ b/tests/helpers/fake-home.ts
@@ -1,0 +1,59 @@
+import { parse } from "node:path";
+
+const HOME_ENV_KEYS = ["HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH"] as const;
+type HomeEnvKey = (typeof HOME_ENV_KEYS)[number];
+
+/**
+ * Temporarily point Node's os.homedir() at a fake home directory.
+ *
+ * On Windows, os.homedir() prefers USERPROFILE over HOME. Tests that only set
+ * HOME can still write into the real user profile, so set both and restore the
+ * complete Windows home env tuple afterwards.
+ */
+export function withFakeHome<T>(home: string, fn: () => T): T {
+  const restore = installFakeHome(home);
+  try {
+    return fn();
+  } finally {
+    restore();
+  }
+}
+
+/** Async variant of withFakeHome(). */
+export async function withFakeHomeAsync<T>(home: string, fn: () => Promise<T>): Promise<T> {
+  const restore = installFakeHome(home);
+  try {
+    return await fn();
+  } finally {
+    restore();
+  }
+}
+
+function installFakeHome(home: string): () => void {
+  const original = new Map<HomeEnvKey, string | undefined>();
+  for (const key of HOME_ENV_KEYS) original.set(key, process.env[key]);
+
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+
+  if (process.platform === "win32") {
+    const parsed = parse(home);
+    const drive = parsed.root.replace(/[\\/]$/, "");
+    if (drive) {
+      process.env.HOMEDRIVE = drive;
+      const homePath = home.slice(drive.length);
+      process.env.HOMEPATH = homePath || "\\";
+    }
+  }
+
+  return () => {
+    for (const key of HOME_ENV_KEYS) {
+      const value = original.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+}

--- a/tests/run-persistence.test.ts
+++ b/tests/run-persistence.test.ts
@@ -7,17 +7,15 @@ import { WORKFLOW_RUNS_DIR } from "../src/config.js";
 import { createRunPersistence, generateRunId, type PersistedRunState } from "../src/run-persistence.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
 import { workflowProjectPaths } from "../src/workflow-paths.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 function withTempCwd(fn: (cwd: string) => Promise<void>) {
   return async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-dw-rp-"));
     const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
-    const origHome = process.env.HOME;
-    process.env.HOME = fakeHome;
     try {
-      await fn(cwd);
+      await withFakeHomeAsync(fakeHome, () => fn(cwd));
     } finally {
-      process.env.HOME = origHome;
       rmSync(cwd, { recursive: true, force: true });
       rmSync(fakeHome, { recursive: true, force: true });
     }

--- a/tests/saved-commands.test.ts
+++ b/tests/saved-commands.test.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
 import { makeCommandRegistryPi, makeNotifyCtx } from "./helpers/mock-pi.js";
 
 async function load() {
@@ -138,10 +142,15 @@ describe("registerSavedWorkflow", () => {
       name: "run-inline",
       script: "export const meta = { name: 't', description: 't' };\nreturn { report: 'done' };",
     };
-    registerSavedWorkflow(pi, "/cwd", wf); // no manager
+    const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
+    try {
+      registerSavedWorkflow(pi, "/cwd", wf); // no manager
 
-    const { ctx } = makeNotifyCtx();
-    await commands[0].handler("", ctx);
+      const { ctx } = makeNotifyCtx();
+      await withFakeHomeAsync(fakeHome, () => commands[0].handler("", ctx));
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
 
     // The inline fallback ran to completion and delivered the report — proving it
     // did not crash on the missing manager and actually executed runWorkflow().

--- a/tests/workflow-manager-abort.test.ts
+++ b/tests/workflow-manager-abort.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -56,12 +57,9 @@ function withTempCwd(fn: (cwd: string) => Promise<void>) {
   return async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-dw-abort-"));
     const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
-    const origHome = process.env.HOME;
-    process.env.HOME = fakeHome;
     try {
-      await fn(cwd);
+      await withFakeHomeAsync(fakeHome, () => fn(cwd));
     } finally {
-      process.env.HOME = origHome;
       rmSync(cwd, { recursive: true, force: true });
       rmSync(fakeHome, { recursive: true, force: true });
     }

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 /** Agent runner that reports fixed usage so token accounting is exercised. */
 function fakeAgent(usage: Partial<AgentUsage> = {}, result: unknown = "ok") {
@@ -71,12 +72,9 @@ function withTempCwd(fn: (cwd: string) => Promise<void>) {
   return async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-dw-mgr-"));
     const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
-    const origHome = process.env.HOME;
-    process.env.HOME = fakeHome;
     try {
-      await fn(cwd);
+      await withFakeHomeAsync(fakeHome, () => fn(cwd));
     } finally {
-      process.env.HOME = origHome;
       rmSync(cwd, { recursive: true, force: true });
       rmSync(fakeHome, { recursive: true, force: true });
     }
@@ -135,6 +133,62 @@ test(
     assert.equal((result.result as { a: unknown }).a, "slow");
     const agent = manager.listRuns()[0]?.agents[0];
     assert.equal(agent?.status, "done");
+  }),
+);
+
+test(
+  "manager forwards exec concurrency and agentRetries to runtime",
+  withTempCwd(async (cwd) => {
+    let active = 0;
+    let maxActive = 0;
+    const callsByPrompt = new Map<string, number>();
+    const manager = new WorkflowManager({
+      cwd,
+      concurrency: 8,
+      defaultAgentRetries: 0,
+      agent: {
+        async run(prompt: string) {
+          active++;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          active--;
+          const calls = (callsByPrompt.get(prompt) ?? 0) + 1;
+          callsByPrompt.set(prompt, calls);
+          return calls === 1 ? "" : `ok:${prompt}`;
+        },
+      },
+    });
+    const script = `export const meta = { name: 'forwarding', description: 'manager controls' }
+const xs = await parallel(['a','b'].map((p) => () => agent(p, { label: p })))
+return xs`;
+
+    const result = await manager.runSync(script, undefined, { concurrency: 1, agentRetries: 1 });
+
+    assert.deepEqual(result.result, ["ok:a", "ok:b"]);
+    assert.equal(maxActive, 1, "exec concurrency should override the manager default");
+    assert.deepEqual([...callsByPrompt.values()], [2, 2], "exec agentRetries should be forwarded");
+  }),
+);
+
+test(
+  "manager defaultAgentRetries applies when run options omit agentRetries",
+  withTempCwd(async (cwd) => {
+    let calls = 0;
+    const manager = new WorkflowManager({
+      cwd,
+      defaultAgentRetries: 1,
+      agent: {
+        async run() {
+          calls++;
+          return calls === 1 ? "" : "ok";
+        },
+      },
+    });
+
+    const result = await manager.runSync(oneAgentScript);
+
+    assert.equal((result.result as { a: unknown }).a, "ok");
+    assert.equal(calls, 2);
   }),
 );
 

--- a/tests/workflow-paths.test.ts
+++ b/tests/workflow-paths.test.ts
@@ -11,16 +11,14 @@ import {
   workflowProjectPaths,
   workflowUserSavedDir,
 } from "../src/workflow-paths.js";
+import { withFakeHome } from "./helpers/fake-home.js";
 
 function withIsolatedHome(fn: (home: string, cwd: string) => void): void {
   const home = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
   const cwd = mkdtempSync(join(tmpdir(), "pi-dw-project-"));
-  const origHome = process.env.HOME;
-  process.env.HOME = home;
   try {
-    fn(home, cwd);
+    withFakeHome(home, () => fn(home, cwd));
   } finally {
-    process.env.HOME = origHome;
     rmSync(home, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });
   }

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
+import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { type JournalEntry, runWorkflow } from "../src/workflow.js";
 
 /** Agent runner that counts real invocations and echoes a per-call result. */
@@ -39,6 +40,151 @@ const twoAgentScript = `export const meta = { name: 'usage_demo', description: '
 const a = await agent('first', { label: 'a' })
 const b = await agent('second', { label: 'b' })
 return { a, b }`;
+
+function createDeferred<T = void>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+test("runWorkflow concurrency caps parallel agents", async () => {
+  let active = 0;
+  let maxActive = 0;
+  const release = createDeferred<void>();
+  const started: Array<string> = [];
+  const runner = {
+    async run(prompt: string) {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      started.push(prompt);
+      await release.promise;
+      active--;
+      return `ok:${prompt}`;
+    },
+  };
+  const script = `export const meta = { name: 'concurrency_cap', description: 'cap parallelism' }
+const xs = await parallel(['a','b','c','d'].map((p) => () => agent(p, { label: p })))
+return xs`;
+
+  const run = runWorkflow(script, { agent: runner, concurrency: 2, persistLogs: false });
+  while (started.length < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(started.length, 2, "only the first two agents should start before the gate opens");
+  release.resolve();
+  const result = await run;
+
+  assert.equal(maxActive, 2);
+  assert.deepEqual(result.result, ["ok:a", "ok:b", "ok:c", "ok:d"]);
+  assert.equal(result.agentCount, 4);
+});
+
+test("runWorkflow retries recoverable empty output then succeeds", async () => {
+  let calls = 0;
+  const journal: JournalEntry[] = [];
+  const result = await runWorkflow(
+    `export const meta = { name: 'retry_success', description: 'retry success' }
+const a = await agent('work', { label: 'a' })
+return a`,
+    {
+      agent: {
+        async run() {
+          calls++;
+          return calls === 1 ? "" : "ok";
+        },
+      },
+      agentRetries: 1,
+      persistLogs: false,
+      onAgentJournal: (entry) => journal.push(entry),
+    },
+  );
+
+  assert.equal(result.result, "ok");
+  assert.equal(calls, 2);
+  assert.equal(result.agentCount, 1, "retries should not allocate extra logical agent slots");
+  assert.equal(journal.length, 1, "only the final success is journaled");
+});
+
+test("runWorkflow returns null when recoverable retries are exhausted", async () => {
+  let calls = 0;
+  const logs: string[] = [];
+  const journal: JournalEntry[] = [];
+  const result = await runWorkflow(
+    `export const meta = { name: 'retry_exhausted', description: 'retry exhausted' }
+const a = await agent('work', { label: 'a' })
+return a`,
+    {
+      agent: {
+        async run() {
+          calls++;
+          return "";
+        },
+      },
+      agentRetries: 1,
+      persistLogs: false,
+      onLog: (message) => logs.push(message),
+      onAgentJournal: (entry) => journal.push(entry),
+    },
+  );
+
+  assert.equal(result.result, null);
+  assert.equal(calls, 2);
+  assert.equal(result.agentCount, 1);
+  assert.equal(journal.length, 0, "failed/null recoverable results are not journaled");
+  assert.ok(
+    logs.some((message) => /retrying/i.test(message)),
+    "logs should mention retrying",
+  );
+  assert.ok(
+    logs.some((message) => /exhausted/i.test(message)),
+    "logs should mention exhaustion",
+  );
+});
+
+test("runWorkflow does not retry nonrecoverable errors", async () => {
+  let calls = 0;
+  await assert.rejects(
+    runWorkflow(
+      `export const meta = { name: 'no_retry_nonrecoverable', description: 'nonrecoverable' }
+const a = await agent('work', { label: 'a' })
+return a`,
+      {
+        agent: {
+          async run() {
+            calls++;
+            throw new WorkflowError("hard stop", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, { recoverable: false });
+          },
+        },
+        agentRetries: 2,
+        persistLogs: false,
+      },
+    ),
+    (error: unknown) => error instanceof WorkflowError && error.code === WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+  );
+  assert.equal(calls, 1);
+});
+
+test("per-agent retries override run-level retries", async () => {
+  let calls = 0;
+  const result = await runWorkflow(
+    `export const meta = { name: 'agent_retry_override', description: 'override' }
+const a = await agent('work', { label: 'a', retries: 1 })
+return a`,
+    {
+      agent: {
+        async run() {
+          calls++;
+          return calls === 1 ? "" : "ok";
+        },
+      },
+      agentRetries: 0,
+      persistLogs: false,
+    },
+  );
+
+  assert.equal(result.result, "ok");
+  assert.equal(calls, 2);
+});
 
 test("runWorkflow accumulates real per-agent usage (incl. cost + cache tokens)", async () => {
   const result = await runWorkflow(twoAgentScript, {

--- a/tests/workflow-saved.test.ts
+++ b/tests/workflow-saved.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import { WORKFLOW_SAVED_DIR } from "../src/config.js";
 import { workflowProjectPaths } from "../src/workflow-paths.js";
 import { createWorkflowStorage } from "../src/workflow-saved.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 /**
  * Run tests with HOME overridden to a temp directory so the user-level
@@ -14,14 +15,10 @@ import { createWorkflowStorage } from "../src/workflow-saved.js";
 function withIsolatedHome(fn: (cwd: string) => Promise<void>) {
   return async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-dw-ws-"));
-    const origHome = process.env.HOME;
-    // Create a fake home with .pi/workflows/saved subdir
     const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
-    process.env.HOME = fakeHome;
     try {
-      await fn(cwd);
+      await withFakeHomeAsync(fakeHome, () => fn(cwd));
     } finally {
-      process.env.HOME = origHome;
       rmSync(cwd, { recursive: true, force: true });
       rmSync(fakeHome, { recursive: true, force: true });
     }

--- a/tests/workflow-settings.test.ts
+++ b/tests/workflow-settings.test.ts
@@ -11,6 +11,7 @@ import {
   saveWorkflowSettings,
   saveWorkflowSettingsForCwd,
 } from "../src/workflow-settings.js";
+import { withFakeHome } from "./helpers/fake-home.js";
 
 function withSettingsPath(fn: (settingsPath: string) => void): void {
   const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-settings-"));
@@ -51,28 +52,42 @@ describe("workflow settings", () => {
     });
   });
 
+  it("normalizes default concurrency and agent retries", () => {
+    withSettingsPath((settingsPath) => {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+
+      writeFileSync(settingsPath, JSON.stringify({ defaultConcurrency: 4.9, defaultAgentRetries: 2.8 }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { defaultConcurrency: 4, defaultAgentRetries: 2 });
+
+      writeFileSync(settingsPath, JSON.stringify({ defaultConcurrency: 99, defaultAgentRetries: 99 }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { defaultConcurrency: 16, defaultAgentRetries: 3 });
+
+      writeFileSync(settingsPath, JSON.stringify({ defaultConcurrency: 0, defaultAgentRetries: -1 }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+    });
+  });
+
   it("merges project settings over global settings when cwd is provided", () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-project-settings-"));
     const cwd = join(dir, "project");
     const fakeHome = join(dir, "home");
-    const origHome = process.env.HOME;
-    process.env.HOME = fakeHome;
-    const globalPath = getWorkflowSettingsPath();
-    const projectPath = getWorkflowProjectSettingsPath(cwd);
     try {
-      saveWorkflowSettings({ keywordTriggerEnabled: true, defaultAgentTimeoutMs: 600000 }, globalPath);
-      saveWorkflowSettings({ keywordTriggerEnabled: false }, { cwd, settingsPath: globalPath, scope: "project" });
+      withFakeHome(fakeHome, () => {
+        const globalPath = getWorkflowSettingsPath();
+        const projectPath = getWorkflowProjectSettingsPath(cwd);
+        saveWorkflowSettings({ keywordTriggerEnabled: true, defaultAgentTimeoutMs: 600000 }, globalPath);
+        saveWorkflowSettings({ keywordTriggerEnabled: false }, { cwd, settingsPath: globalPath, scope: "project" });
 
-      assert.deepEqual(loadWorkflowSettings(globalPath), {
-        keywordTriggerEnabled: true,
-        defaultAgentTimeoutMs: 600000,
-      });
-      assert.deepEqual(loadWorkflowSettings({ cwd, settingsPath: globalPath, projectSettingsPath: projectPath }), {
-        keywordTriggerEnabled: false,
-        defaultAgentTimeoutMs: 600000,
+        assert.deepEqual(loadWorkflowSettings(globalPath), {
+          keywordTriggerEnabled: true,
+          defaultAgentTimeoutMs: 600000,
+        });
+        assert.deepEqual(loadWorkflowSettings({ cwd, settingsPath: globalPath, projectSettingsPath: projectPath }), {
+          keywordTriggerEnabled: false,
+          defaultAgentTimeoutMs: 600000,
+        });
       });
     } finally {
-      process.env.HOME = origHome;
       rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -81,15 +96,14 @@ describe("workflow settings", () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-project-settings-"));
     const cwd = join(dir, "project");
     const fakeHome = join(dir, "home");
-    const origHome = process.env.HOME;
-    process.env.HOME = fakeHome;
     try {
-      saveWorkflowSettingsForCwd({ keywordTriggerEnabled: false }, cwd);
+      withFakeHome(fakeHome, () => {
+        saveWorkflowSettingsForCwd({ keywordTriggerEnabled: false }, cwd);
 
-      assert.deepEqual(loadWorkflowSettings({ cwd }), { keywordTriggerEnabled: false });
-      assert.equal(existsSync(getWorkflowProjectSettingsPath(cwd)), false);
+        assert.deepEqual(loadWorkflowSettings({ cwd }), { keywordTriggerEnabled: false });
+        assert.equal(existsSync(getWorkflowProjectSettingsPath(cwd)), false);
+      });
     } finally {
-      process.env.HOME = origHome;
       rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -98,20 +112,19 @@ describe("workflow settings", () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-project-settings-"));
     const cwd = join(dir, "project");
     const fakeHome = join(dir, "home");
-    const origHome = process.env.HOME;
-    process.env.HOME = fakeHome;
     try {
-      saveWorkflowSettings({ keywordTriggerEnabled: false }, { cwd, scope: "project" });
+      withFakeHome(fakeHome, () => {
+        saveWorkflowSettings({ keywordTriggerEnabled: false }, { cwd, scope: "project" });
 
-      saveWorkflowSettingsForCwd({ keywordTriggerEnabled: true }, cwd);
+        saveWorkflowSettingsForCwd({ keywordTriggerEnabled: true }, cwd);
 
-      assert.deepEqual(loadWorkflowSettings(), { keywordTriggerEnabled: true });
-      assert.deepEqual(loadWorkflowSettings({ cwd }), { keywordTriggerEnabled: true });
-      assert.deepEqual(loadWorkflowSettings({ projectSettingsPath: getWorkflowProjectSettingsPath(cwd) }), {
-        keywordTriggerEnabled: true,
+        assert.deepEqual(loadWorkflowSettings(), { keywordTriggerEnabled: true });
+        assert.deepEqual(loadWorkflowSettings({ cwd }), { keywordTriggerEnabled: true });
+        assert.deepEqual(loadWorkflowSettings({ projectSettingsPath: getWorkflowProjectSettingsPath(cwd) }), {
+          keywordTriggerEnabled: true,
+        });
       });
     } finally {
-      process.env.HOME = origHome;
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -79,6 +79,23 @@ test("createWorkflowTool schema describes unbounded default timeout", () => {
   assert.match(description, /only when the user asks/i);
 });
 
+test("createWorkflowTool schema exposes concurrency and agentRetries", () => {
+  const tool = createWorkflowTool();
+  const parameters = tool.parameters as { properties?: Record<string, { description?: string }> };
+
+  assert.match(parameters.properties?.concurrency?.description ?? "", /Maximum concurrent agents/i);
+  assert.match(parameters.properties?.agentRetries?.description ?? "", /Retry attempts/i);
+});
+
+test("createWorkflowTool promptGuidelines mention retry and concurrency controls", () => {
+  const tool = createWorkflowTool();
+  const all = tool.promptGuidelines.join(" ");
+
+  assert.match(all, /low concurrency/i);
+  assert.match(all, /agentRetries/i);
+  assert.match(all, /null handling/i);
+});
+
 // ─── modelRoutingGuideline ──────────────────────────────────────────────────────
 
 test("modelRoutingGuideline mentions all three tier names", () => {
@@ -172,14 +189,24 @@ test("createWorkflowTool prepareArguments strips javascript fences", () => {
 test("createWorkflowTool prepareArguments passes through args", () => {
   const tool = createWorkflowTool();
   if (tool.prepareArguments) {
-    const prepare = tool.prepareArguments as (args: unknown) => { script: string; args?: unknown; maxAgents?: number };
+    const prepare = tool.prepareArguments as (args: unknown) => {
+      script: string;
+      args?: unknown;
+      maxAgents?: number;
+      concurrency?: number;
+      agentRetries?: number;
+    };
     const result = prepare({
       script: "export const meta = { name: 't', description: 't' }",
       args: { question: "test" },
       maxAgents: 5,
+      concurrency: 2,
+      agentRetries: 1,
     });
     assert.equal(result.script, "export const meta = { name: 't', description: 't' }");
     assert.deepEqual(result.args, { question: "test" });
     assert.equal(result.maxAgents, 5);
+    assert.equal(result.concurrency, 2);
+    assert.equal(result.agentRetries, 1);
   }
 });


### PR DESCRIPTION
# PR draft: Add bounded workflow fan-out controls, recoverable retries, and Windows-safe tests

## Summary

This PR hardens `pi-dynamic-workflows` for larger fan-out runs and Windows development environments.

It adds:

- Per-run `concurrency` control for workflow execution.
- Per-run and per-agent retry controls for recoverable agent failures.
- Settings defaults for concurrency and retry attempts.
- Persisted recoverable error details for `/workflows` visibility.
- Windows-safe fake-home test isolation so tests do not write to the real user profile.

## Motivation

Large workflow fan-outs can surface provider/transport instability as empty assistant output, timeouts, or connection failures. Previously those failures could be hard to diagnose and there was no practical per-run way to reduce concurrency or retry recoverable failures.

On Windows, tests that set only `process.env.HOME` can still write to the real home directory because Node `os.homedir()` prefers `USERPROFILE`. This can cause tests to write artifacts into the real `~/.pi/workflows` directory.

## Changes

### Runtime

- Add `MAX_AGENT_RETRIES` in `src/config.ts`.
- Add `WorkflowRunOptions.agentRetries` and `AgentOptions.retries` in `src/workflow.ts`.
- Clamp concurrency and retry values.
- Retry recoverable agent failures up to the configured attempt limit.
- Preserve nonrecoverable failure behavior: nonrecoverable errors still abort/throw.
- Persist exhausted recoverable failure details via `onAgentEnd()`.

### Manager/tool/settings

- Add `ExecOptions.concurrency` and `ExecOptions.agentRetries`.
- Add manager-level `defaultAgentRetries`.
- Expose `concurrency` and `agentRetries` on the workflow tool schema.
- Add `defaultConcurrency` and `defaultAgentRetries` to workflow settings.
- Apply settings defaults both when `createWorkflowTool()` creates a manager and when `extensions/workflow.ts` creates the shared manager.

### Windows tests

- Add `tests/helpers/fake-home.ts` to set/restore `HOME`, `USERPROFILE`, `HOMEDRIVE`, and `HOMEPATH`.
- Wrap persistence/storage/manager/saved-command tests in fake home isolation.
- Fix `workflowUserSavedDir()` to use `join(workflowHomeDir(), "saved")`.

## Validation

Passed locally:

```bash
npm run build
npx biome check extensions/workflow.ts src/config.ts src/workflow.ts src/workflow-manager.ts src/workflow-settings.ts src/workflow-tool.ts src/workflow-paths.ts tests/helpers/fake-home.ts tests/workflow-runtime.test.ts tests/workflow-manager.test.ts tests/workflow-settings.test.ts tests/workflow-tool.test.ts tests/workflow-paths.test.ts tests/run-persistence.test.ts tests/workflow-saved.test.ts tests/workflow-manager-abort.test.ts tests/saved-commands.test.ts
npx tsc --ignoreConfig --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --esModuleInterop --skipLibCheck extensions/workflow.ts
npm run test:unit
```

Unit tests:

```text
705/705 pass
```

Additional guard:

```text
real-home writes after test cutoff: count=0
```

`npm test` still fails in this checkout because `biome check .` reports pre-existing whole-repo CRLF/formatter differences outside the files changed by this PR. This PR intentionally avoids whole-repo formatting churn.

## Notes for maintainers

- Retry attempts are intentionally logical-agent preserving: a retry does not allocate a new logical agent slot or journal failed attempts as successful outputs.
- Failed retry attempts contribute to global token usage if usage is reported; the final agent row reflects the final result/error event.
- Defaults remain conservative: retries default to 0 unless configured or explicitly passed.
