### PR TITLE
docs: document concurrency/agentRetries config and add CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Thanks for contributing to pi-dynamic-workflows. This project values small, well-tested changes that keep the workflow runtime predictable. A few conventions keep review fast.
+
+## Before you open a PR
+
+```bash
+npm install
+npm test     # biome check + tsc build + unit tests — must pass
+```
+
+`npm test` runs exactly what CI runs. If it's green locally it should be green in CI. CI runs on every PR to `main`; for fork PRs a maintainer approves the first run.
+
+## What a good PR looks like
+
+- **One concern per PR.** Keep a bug fix, a feature, and a refactor in separate PRs. A mixed PR (e.g. a test-infra fix *and* a new runtime feature) is harder to review and to revert; split it if you can.
+- **Conventional Commits.** Use `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, etc. The type drives versioning, so it matters: anything that adds or changes public API (new tool params, new settings, new exported options) is a `feat:`, not a `fix:`, even if it's small. Maintainers squash-merge, so the PR title becomes the commit — make it accurate.
+- **Backward compatible by default.** New options should be optional with conservative defaults (off unless configured).
+
+## When you add user-facing config
+
+If you add a `workflow` tool parameter or a `~/.pi/workflows/settings.json` setting, document it in `README.md` in the same place the existing ones live (the agent-options table and the settings paragraph). Undocumented config is treated as incomplete.
+
+## When you change runtime behavior
+
+Fake-agent unit tests are necessary but not sufficient. Any change to how agents actually run — retries, timeouts, model routing, token accounting, concurrency, resume — must also be verified **end-to-end against a real Pi subagent session** (real `createAgentSession` → real model), because the real SDK path behaves differently than a mock. If you don't have a real-provider environment, say so in the PR and a maintainer will run it before merge.
+
+A throwaway harness for this should live in the repo root (not `/tmp`, whose symlink breaks relative imports), import from `./src`, and be deleted before commit — don't commit harnesses.
+
+## Style
+
+Formatting and linting are handled by Biome (`npm run format`, `npm run lint`). Match the existing code; don't reformat files you aren't otherwise changing.

--- a/README.md
+++ b/README.md
@@ -144,8 +144,11 @@ The full guide — every global, agent option, `agentType` definitions, structur
 | `isolation: "worktree"` | Run in a throwaway git worktree for conflict-free parallel edits. |
 | `schema` | JSON Schema → the subagent returns a validated object. |
 | `label` / `phase` / `timeoutMs` | Display label / phase override / optional per-agent hard timeout. Omit `timeoutMs` for no hard timeout. |
+| `retries` | Retry attempts after a recoverable failure (timeout, connection failure, empty output) for this agent. Overrides the run-level `agentRetries`. Default `0`. |
 
 By default, workflows do not set a run-wide token budget or per-agent hard timeout. Use the `workflow` tool's `tokenBudget` / `agentTimeoutMs`, per-phase budgets, or per-agent `timeoutMs` only when you want an explicit cap. A global fallback timeout can also be set in `~/.pi/workflows/settings.json` as `{ "defaultAgentTimeoutMs": 600000 }`; set it to `null` or omit it for no default hard timeout.
+
+For larger or flakier fan-outs, the `workflow` tool also accepts `concurrency` (max agents running at once, clamped to the runtime maximum of `16`) and `agentRetries` (retry attempts after a recoverable agent failure such as a timeout, connection failure, or empty output). Both can be defaulted in `~/.pi/workflows/settings.json` as `{ "defaultConcurrency": 4, "defaultAgentRetries": 2 }`; a per-run tool value overrides the default, and a per-agent `retries` overrides `agentRetries`. Retries default to `0` (off) unless configured or passed, and only recoverable failures retry — nonrecoverable errors still abort the run.
 
 The live "Workflows running" panel is configured in the same `~/.pi/workflows/settings.json`: `"progressPanelMode"` is `"compact"` (default, one line per run) or `"detailed"` (per-phase/per-agent rows with tokens, cost, and a live tok/s rate), and `"progressPanelMaxAgents"` (default `8`, range `1`–`1000`) caps how many agents each phase shows in detailed mode before a `… N earlier agents` line. Toggle them live with `/workflows-progress compact|detailed` and `/workflows-progress-max <N>` — changes take effect on the next render without a restart.
 
@@ -155,7 +158,7 @@ Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()
 
 ```bash
 npm install
-npm test     # biome + tsc + 679 unit tests
+npm test     # biome + tsc + unit tests
 ```
 
 Every feature is also verified end-to-end against a real Pi subagent session before release.


### PR DESCRIPTION
Follow-up docs for #22 (bounded fan-out + recoverable retries), plus a CONTRIBUTING guide.

## README
- Add a `retries` row to the agent-options table (per-agent override of run-level `agentRetries`).
- Document the `workflow` tool's `concurrency` and `agentRetries` params, and the `defaultConcurrency` / `defaultAgentRetries` settings in `~/.pi/workflows/settings.json`. Notes that retries default to 0 and only recoverable failures retry.
- Drop the hardcoded unit-test count in the Development section (was stale).

## CONTRIBUTING.md (new)
Codifies the conventions surfaced while reviewing #22: one concern per PR, Conventional Commits (new public API is `feat:`, not `fix:`), new user-facing config must be documented in the README, and runtime-behavior changes must be validated end-to-end against a real Pi subagent session (not just fake-agent unit tests).

## Validation
- `npm run check` clean (biome).
- The retry behavior described here was verified against a real provider: an expired-auth model produced a real `AGENT_EMPTY_OUTPUT`, retried exactly twice (3 attempts), then exhausted to `null`; a working deepseek control succeeded first try with no retry.

No code changes.