### PR TITLE
feat: checkpoint workflows on provider usage limit instead of failing

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -15,7 +15,7 @@ import type { Static, TSchema } from "typebox";
 import { Check, Convert } from "typebox/value";
 import { type AgentHistoryEntry, compactAgentHistory } from "./agent-history.js";
 import { applyToolPolicy } from "./agent-registry.js";
-import { WorkflowError, WorkflowErrorCode } from "./errors.js";
+import { classifyProviderLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import { loadModelTierConfig, type ModelTierConfig, resolveTierModel } from "./model-tier-config.js";
 import { createStructuredOutputTool, type StructuredOutputCapture } from "./structured-output.js";
 
@@ -60,6 +60,40 @@ export function extractValidated<T>(text: string, schema: TSchema): T | undefine
     // typebox can throw on exotic schemas; treat as no match.
   }
   return undefined;
+}
+
+/**
+ * The last assistant message's terminal metadata (stopReason/errorMessage). The pi
+ * SDK does NOT throw provider usage/quota limits — it records them as an assistant
+ * message with stopReason "error" and an errorMessage. This is the only place that
+ * metadata is observable to the workflow layer.
+ */
+export function lastAssistantError(messages: unknown[]): { stopReason?: string; errorMessage?: string } | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i] as Partial<AssistantMessage> | undefined;
+    if (message?.role !== "assistant") continue;
+    return { stopReason: message.stopReason, errorMessage: message.errorMessage };
+  }
+  return undefined;
+}
+
+/**
+ * If the subagent's turn ended in a provider usage/quota/rate-limit error, throw a
+ * PROVIDER_USAGE_LIMIT WorkflowError carrying the real provider message + reset hint.
+ * Gated on stopReason === "error" so a successful turn whose text merely mentions
+ * "rate limit" is never misclassified. recoverable:false so the run checkpoints
+ * (paused) rather than being retried into the same wall or collapsed to a silent null.
+ */
+export function throwIfProviderLimit(messages: unknown[], label?: string): void {
+  const err = lastAssistantError(messages);
+  if (err?.stopReason !== "error") return;
+  const { matched, resetHint } = classifyProviderLimit(err.errorMessage);
+  if (!matched) return;
+  throw new WorkflowError(
+    err.errorMessage ?? "Provider usage/quota limit reached",
+    WorkflowErrorCode.PROVIDER_USAGE_LIMIT,
+    { recoverable: false, agentLabel: label, resetHint },
+  );
 }
 
 /** Minimal session surface resolveStructuredOutput needs (real session or a test double). */
@@ -108,6 +142,10 @@ export async function resolveStructuredOutput<T>(
     );
     return extracted;
   }
+
+  // A repair re-prompt can itself hit the provider limit. Surface that as the real
+  // (recoverable) cause instead of the misleading non-recoverable SCHEMA_NONCOMPLIANCE.
+  throwIfProviderLimit(session.messages, options.label);
 
   throw new WorkflowError(
     "Subagent did not produce valid structured_output after repair attempts",
@@ -370,6 +408,12 @@ export class WorkflowAgent {
 
       await session.prompt(this.buildPrompt(prompt, options as AgentRunOptions<any>, Boolean(options.schema)));
       if (options.signal?.aborted) throw new Error("Subagent was aborted");
+
+      // The SDK buries a provider usage/quota limit in the assistant message rather
+      // than throwing; detect it here (before the schema/empty-text branches) so it
+      // is classified as a recoverable checkpoint, not a SCHEMA_NONCOMPLIANCE failure
+      // (schema path) or a silent empty-output null (non-schema path).
+      throwIfProviderLimit(session.messages, options.label);
 
       if (options.schema) {
         return (await resolveStructuredOutput(session, capture, options.schema, options, (m) =>

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -11,6 +11,12 @@ export enum WorkflowErrorCode {
   AGENT_LIMIT_EXCEEDED = "AGENT_LIMIT_EXCEEDED",
   /** Token budget exhausted. */
   TOKEN_BUDGET_EXHAUSTED = "TOKEN_BUDGET_EXHAUSTED",
+  /**
+   * The provider's subscription/usage/quota/rate limit was hit. Distinct from the
+   * user's self-imposed TOKEN_BUDGET_EXHAUSTED: a provider limit refills on its own,
+   * so the run is checkpointed (paused) and replayed by resume() rather than failed.
+   */
+  PROVIDER_USAGE_LIMIT = "PROVIDER_USAGE_LIMIT",
   /** Script validation failed. */
   SCRIPT_VALIDATION_ERROR = "SCRIPT_VALIDATION_ERROR",
   /** A schema agent never produced valid structured_output (after repair + extraction). */
@@ -30,11 +36,13 @@ export class WorkflowError extends Error {
   readonly recoverable: boolean;
   readonly agentLabel?: string;
   readonly details?: unknown;
+  /** For PROVIDER_USAGE_LIMIT: the provider's human reset hint, e.g. "Resets in ~3h" (verbatim). */
+  readonly resetHint?: string;
 
   constructor(
     message: string,
     code: WorkflowErrorCode,
-    options: { recoverable?: boolean; agentLabel?: string; details?: unknown } = {},
+    options: { recoverable?: boolean; agentLabel?: string; details?: unknown; resetHint?: string } = {},
   ) {
     super(message);
     this.name = "WorkflowError";
@@ -42,11 +50,39 @@ export class WorkflowError extends Error {
     this.recoverable = options.recoverable ?? false;
     this.agentLabel = options.agentLabel;
     this.details = options.details;
+    this.resetHint = options.resetHint;
   }
 }
 
 export function isWorkflowError(error: unknown): error is WorkflowError {
   return error instanceof WorkflowError;
+}
+
+export function isProviderUsageLimit(error: unknown): error is WorkflowError {
+  return isWorkflowError(error) && error.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT;
+}
+
+/**
+ * Detect a provider subscription/usage/quota/rate-limit exhaustion from free-form
+ * error text, and extract the provider's human reset hint when present.
+ *
+ * The pi SDK does NOT throw these — it records them as an assistant message with
+ * stopReason "error" and an errorMessage like "Codex usage limit reached (plus
+ * plan). Resets in ~3h.". Callers reading message metadata MUST gate on
+ * stopReason === "error" before trusting this, so a task whose own output merely
+ * mentions "rate limit" is never misclassified. Patterns mirror the SDK's own
+ * non-retryable-limit table. Deliberately excludes transient overloaded/5xx
+ * errors, which stay recoverable and keep retrying.
+ */
+export function classifyProviderLimit(text: string | undefined): { matched: boolean; resetHint?: string } {
+  if (!text) return { matched: false };
+  const matched =
+    /usage limit|limit reached|insufficient[_\s]?quota|quota exceeded|exceeded your current quota|out of budget|available balance|\bquota\b|rate.?limit|too many requests|\b429\b|GoUsageLimitError|FreeUsageLimitError|\bbilling\b/i.test(
+      text,
+    );
+  if (!matched) return { matched: false };
+  const reset = text.match(/resets?\s+(?:in|at)\s+[^.\n]+/i);
+  return { matched: true, resetHint: reset?.[0]?.trim() };
 }
 
 export function isAbortError(error: unknown): boolean {
@@ -79,6 +115,21 @@ export function wrapError(error: unknown, context?: { agentLabel?: string }): Wo
       WorkflowErrorCode.AGENT_TIMEOUT,
       { recoverable: true, agentLabel: context?.agentLabel },
     );
+  }
+
+  // Defense-in-depth: today the SDK buries provider usage/quota limits in an
+  // assistant message (detected in agent.ts), but a future SDK might throw them.
+  // Classify a thrown limit here too — recoverable:false so the run checkpoints
+  // (paused) instead of being retried into the same wall or silently nulled.
+  if (error instanceof Error) {
+    const limit = classifyProviderLimit(error.message);
+    if (limit.matched) {
+      return new WorkflowError(error.message, WorkflowErrorCode.PROVIDER_USAGE_LIMIT, {
+        recoverable: false,
+        agentLabel: context?.agentLabel,
+        resetHint: limit.resetHint,
+      });
+    }
   }
 
   return new WorkflowError(

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -36,6 +36,10 @@ export interface PersistedRunState {
    * the navigator shows only the current session's runs (undefined = legacy/global). */
   sessionId?: string;
   status: RunStatus;
+  /** Why a paused run is paused (e.g. "usage_limit" when a provider quota was hit). */
+  pauseReason?: string;
+  /** Provider reset hint for a usage-limit pause, e.g. "Resets in ~3h" (verbatim). */
+  resetHint?: string;
   phases: string[];
   currentPhase?: string;
   agents: PersistedAgentState[];

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -129,6 +129,33 @@ export function installResultDelivery(pi: ExtensionAPI, manager: WorkflowManager
     if (!manager.getRun(runId)?.background) return;
     deliver(`✗ Background workflow ${runId} failed: ${error?.message ?? "unknown error"}`);
   });
+  // A provider usage/quota limit checkpoints the run as paused (not failed): tell the
+  // user it is resumable once their budget refills, rather than letting it look dead.
+  // Manual pause() also emits "paused" but with no reason — guard so only the
+  // usage-limit case delivers a message.
+  manager.on(
+    "paused",
+    ({
+      runId,
+      reason,
+      error,
+      resetHint,
+    }: {
+      runId: string;
+      reason?: string;
+      error?: { message?: string };
+      resetHint?: string;
+    }) => {
+      if (reason !== "usage_limit") return;
+      if (!manager.getRun(runId)?.background) return;
+      const when = resetHint ? ` (${resetHint})` : "";
+      const cause = error?.message ?? "provider usage limit reached";
+      deliver(
+        `⏸ Background workflow ${runId} paused: ${cause}${when}. ` +
+          `Completed steps are saved — run /workflows resume ${runId} once your usage limit resets.`,
+      );
+    },
+  );
 }
 
 export function renderPanel(manager: WorkflowManager, theme: Theme, width?: number): string[] {

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -383,16 +383,32 @@ export class WorkflowManager extends EventEmitter {
               { recoverable: true },
             );
 
+      const usageLimitPaused =
+        !managed.controller.signal.aborted && workflowError.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT;
       if (managed.controller.signal.aborted) {
         // Intentional abort (pause/stop/Esc) — preserve status set by pause()/stop()
         if (managed.status === "running") {
           managed.status = "aborted";
         }
+      } else if (usageLimitPaused) {
+        // Provider quota/usage limit: NOT a failure. Checkpoint the run as paused so
+        // the persisted journal (completed agent results) is replayed by resume()
+        // once the budget refills — instead of the user starting from scratch.
+        managed.status = "paused";
       } else {
         managed.status = "failed";
       }
       managed.error = workflowError;
-      this.emit("error", { runId: managed.runId, error: workflowError });
+      if (usageLimitPaused) {
+        this.emit("paused", {
+          runId: managed.runId,
+          reason: "usage_limit",
+          error: workflowError,
+          resetHint: workflowError.resetHint,
+        });
+      } else {
+        this.emit("error", { runId: managed.runId, error: workflowError });
+      }
 
       // Persist final state
       this.persistRun(managed);
@@ -420,6 +436,16 @@ export class WorkflowManager extends EventEmitter {
         sessionId: this.sessionId,
         journal: managed.journal,
         status: managed.status,
+        // Why a usage-limit pause happened, so the navigator / a future cold start
+        // can show it and (eventually) re-arm resume after the budget refills.
+        pauseReason:
+          managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
+            ? "usage_limit"
+            : undefined,
+        resetHint:
+          managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
+            ? managed.error.resetHint
+            : undefined,
         phases: managed.snapshot.phases,
         currentPhase: managed.snapshot.currentPhase,
         agents: managed.snapshot.agents.map((a) => ({

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  classifyProviderLimit,
+  isProviderUsageLimit,
+  WorkflowError,
+  WorkflowErrorCode,
+  wrapError,
+} from "../src/errors.js";
+
+describe("classifyProviderLimit", () => {
+  it("matches the documented provider usage/quota/rate-limit wordings", () => {
+    const cases = [
+      "You have hit your ChatGPT usage limit (plus plan).",
+      "Codex usage limit reached (plus plan). Resets in ~3h. Current premium: 5h 100%, weekly 42%.",
+      "insufficient_quota",
+      "You exceeded your current quota, please check your plan and billing details.",
+      "Error 429: too many requests",
+      "rate limit exceeded",
+      "GoUsageLimitError",
+    ];
+    for (const text of cases) {
+      assert.equal(classifyProviderLimit(text).matched, true, `should match: ${text}`);
+    }
+  });
+
+  it("does NOT match benign text or unrelated errors", () => {
+    for (const text of [
+      "file not found",
+      "TypeError: x is not a function",
+      "agent exploded",
+      "overloaded_error",
+      undefined,
+    ]) {
+      assert.equal(classifyProviderLimit(text).matched, false, `should not match: ${text}`);
+    }
+  });
+
+  it("extracts the verbatim reset hint when present, undefined otherwise", () => {
+    assert.equal(classifyProviderLimit("Codex usage limit reached. Resets in ~3h.").resetHint, "Resets in ~3h");
+    assert.equal(
+      classifyProviderLimit("usage limit reached, resets at 2026-06-20T06:00:00Z.").resetHint,
+      "resets at 2026-06-20T06:00:00Z",
+    );
+    assert.equal(classifyProviderLimit("insufficient_quota").resetHint, undefined);
+  });
+});
+
+describe("wrapError provider-limit classification", () => {
+  it("classifies a thrown usage-limit Error as non-recoverable PROVIDER_USAGE_LIMIT (defense for a throwing SDK)", () => {
+    const e = wrapError(new Error("Codex usage limit reached (plus plan). Resets in ~3h."), { agentLabel: "a" });
+    assert.equal(e.code, WorkflowErrorCode.PROVIDER_USAGE_LIMIT);
+    assert.equal(e.recoverable, false);
+    assert.equal(e.resetHint, "Resets in ~3h");
+    assert.equal(e.agentLabel, "a");
+  });
+
+  it("keeps transient overloaded/5xx errors as recoverable AGENT_EXECUTION_ERROR (not a quota pause)", () => {
+    const e = wrapError(new Error("overloaded_error: server is busy"));
+    assert.equal(e.code, WorkflowErrorCode.AGENT_EXECUTION_ERROR);
+    assert.equal(e.recoverable, true);
+  });
+
+  it("passes an existing WorkflowError through unchanged", () => {
+    const orig = new WorkflowError("nope", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, { recoverable: false });
+    assert.equal(wrapError(orig), orig);
+  });
+});
+
+describe("isProviderUsageLimit", () => {
+  it("is true only for a PROVIDER_USAGE_LIMIT WorkflowError", () => {
+    assert.equal(
+      isProviderUsageLimit(new WorkflowError("x", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, { recoverable: false })),
+      true,
+    );
+    assert.equal(isProviderUsageLimit(new WorkflowError("x", WorkflowErrorCode.SCHEMA_NONCOMPLIANCE)), false);
+    assert.equal(isProviderUsageLimit(new Error("usage limit")), false);
+  });
+});

--- a/tests/schema-resolution.test.ts
+++ b/tests/schema-resolution.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { Type } from "typebox";
-import { extractValidated, resolveStructuredOutput, type StructuredSession } from "../src/agent.js";
+import {
+  extractValidated,
+  lastAssistantError,
+  resolveStructuredOutput,
+  type StructuredSession,
+  throwIfProviderLimit,
+} from "../src/agent.js";
+import { WorkflowErrorCode } from "../src/errors.js";
 import type { StructuredOutputCapture } from "../src/structured-output.js";
 
 const Schema = Type.Object({ word: Type.String() });
@@ -93,6 +100,78 @@ describe("resolveStructuredOutput", () => {
     await assert.rejects(
       () => resolveStructuredOutput(session, capture, Schema, { ...opts, signal: ctrl.signal }, noText),
       /aborted/i,
+    );
+  });
+
+  it("surfaces a provider usage limit hit during repair as PROVIDER_USAGE_LIMIT (not SCHEMA_NONCOMPLIANCE)", async () => {
+    const { session, capture } = makeSession();
+    // The repair re-prompts ran but the turn ended in a buried provider limit.
+    session.messages = [
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        errorMessage: "Codex usage limit reached. Resets in ~3h.",
+      },
+    ];
+    await assert.rejects(
+      () => resolveStructuredOutput(session, capture, Schema, opts, () => "no json at all"),
+      (err: unknown) => {
+        assert.equal((err as { code?: string }).code, WorkflowErrorCode.PROVIDER_USAGE_LIMIT);
+        assert.equal((err as { recoverable?: boolean }).recoverable, false);
+        return true;
+      },
+    );
+  });
+});
+
+describe("lastAssistantError / throwIfProviderLimit", () => {
+  it("reads stopReason/errorMessage off the most recent assistant message", () => {
+    const messages = [
+      { role: "user", content: [] },
+      { role: "assistant", content: [], stopReason: "error", errorMessage: "boom" },
+    ];
+    assert.deepEqual(lastAssistantError(messages), { stopReason: "error", errorMessage: "boom" });
+  });
+
+  it("throws PROVIDER_USAGE_LIMIT only when stopReason is error AND the message matches a limit", () => {
+    assert.throws(
+      () =>
+        throwIfProviderLimit(
+          [
+            {
+              role: "assistant",
+              content: [],
+              stopReason: "error",
+              errorMessage: "usage limit reached. Resets in ~3h.",
+            },
+          ],
+          "lbl",
+        ),
+      (err: unknown) => {
+        assert.equal((err as { code?: string }).code, WorkflowErrorCode.PROVIDER_USAGE_LIMIT);
+        assert.equal((err as { resetHint?: string }).resetHint, "Resets in ~3h");
+        assert.equal((err as { agentLabel?: string }).agentLabel, "lbl");
+        return true;
+      },
+    );
+  });
+
+  it("does not throw for a successful turn whose text merely mentions 'rate limit'", () => {
+    assert.doesNotThrow(() =>
+      throwIfProviderLimit([
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "I handled the rate limit gracefully" }],
+          stopReason: "stop",
+        },
+      ]),
+    );
+  });
+
+  it("does not throw for a non-limit error turn", () => {
+    assert.doesNotThrow(() =>
+      throwIfProviderLimit([{ role: "assistant", content: [], stopReason: "error", errorMessage: "network blip" }]),
     );
   });
 });

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -235,6 +235,50 @@ describe("installResultDelivery", () => {
     assert.equal(calls.length, 0);
   });
 
+  // ── Paused (usage-limit checkpoint) event ──
+
+  it("delivers a resumable checkpoint message on a usage-limit paused event", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun());
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.emit("paused", {
+      runId: "test-run-1",
+      reason: "usage_limit",
+      error: { message: "Codex usage limit reached (plus plan)." },
+      resetHint: "Resets in ~3h",
+    });
+
+    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].content.includes("paused"), "should say paused");
+    assert.ok(calls[0].content.includes("/workflows resume test-run-1"), "should name the resume command");
+    assert.ok(calls[0].content.includes("Resets in ~3h"), "should include the reset hint");
+    assert.ok(!calls[0].content.includes("failed"), "should not say failed");
+  });
+
+  it("ignores a manual pause (no reason) — no delivery", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun());
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.emit("paused", { runId: "test-run-1" });
+
+    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    assert.equal(calls.length, 0);
+  });
+
+  it("skips usage-limit pause delivery for foreground runs", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun({ background: false }));
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.emit("paused", { runId: "test-run-1", reason: "usage_limit", error: { message: "usage limit" } });
+
+    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    assert.equal(calls.length, 0);
+  });
+
   // ── Holder refresh on re-call ──
 
   it("refreshes holder.pi on second call for stale ctx recovery", () => {

--- a/tests/usage-limit-integration.test.ts
+++ b/tests/usage-limit-integration.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Real-session integration test for issue #26 — provider usage-limit handling.
+ *
+ * Every other test injects a fake agent runner; this one drives the REAL
+ * `WorkflowAgent.run` → `createAgentSession` path and uses the pi SDK's built-in
+ * FAUX provider to end a turn in a "usage limit reached" error (stopReason
+ * "error" + errorMessage), exactly as a real provider buries a quota exhaustion.
+ * It is the contract guard for the load-bearing SDK assumption behind the fix:
+ * a usage limit surfaces as an error-status assistant message, not a thrown error.
+ * No network call is made and NO provider quota is consumed.
+ */
+
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { WorkflowAgent } from "../src/agent.js";
+import { WorkflowErrorCode } from "../src/errors.js";
+import { WorkflowManager } from "../src/workflow-manager.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+const USAGE_LIMIT_MSG = "Codex usage limit reached (plus plan). Resets in ~3h.";
+
+/**
+ * Load the faux provider from the SAME pi-ai instance that pi-coding-agent's
+ * createAgentSession dispatches through. pi-coding-agent ships its own nested
+ * pi-ai copy; registering on a different instance would be invisible to the
+ * session ("No API provider registered"). Prefer the nested copy when present,
+ * else fall back to the bare specifier — which, when npm has deduped to a single
+ * copy, resolves to that same shared instance. Robust to both layouts.
+ */
+async function loadFaux(): Promise<typeof import("@earendil-works/pi-ai")> {
+  const nested = fileURLToPath(
+    new URL(
+      "../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/index.js",
+      import.meta.url,
+    ),
+  );
+  const entry = existsSync(nested) ? nested : "@earendil-works/pi-ai";
+  return import(entry) as Promise<typeof import("@earendil-works/pi-ai")>;
+}
+
+/**
+ * Run `fn` with an isolated HOME and a dummy provider key so hasConfiguredAuth()
+ * passes via env — no real credentials are touched, and the faux api means the
+ * key is never actually used. A faux "deepseek" provider is registered/torn down
+ * around `fn`; `setResponses` queues the scripted turns.
+ */
+async function withFauxSession(
+  fn: (ctx: {
+    cwd: string;
+    model: unknown;
+    setResponses: (msgs: unknown[]) => void;
+    fauxAssistantMessage: typeof import("@earendil-works/pi-ai").fauxAssistantMessage;
+  }) => Promise<void>,
+): Promise<void> {
+  const { registerFauxProvider, fauxAssistantMessage } = await loadFaux();
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-i26-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-i26-cwd-"));
+  const prevKey = process.env.DEEPSEEK_API_KEY;
+  process.env.DEEPSEEK_API_KEY = "faux-dummy-key-not-used";
+  const faux = registerFauxProvider({
+    provider: "deepseek",
+    models: [{ id: "faux-deepseek", name: "Faux DeepSeek", contextWindow: 128000, maxTokens: 4096 }],
+  });
+  try {
+    await withFakeHomeAsync(home, () =>
+      fn({
+        cwd,
+        model: faux.getModel(),
+        setResponses: (msgs) => faux.setResponses(msgs as never),
+        fauxAssistantMessage,
+      }),
+    );
+  } finally {
+    faux.unregister();
+    if (prevKey === undefined) delete process.env.DEEPSEEK_API_KEY;
+    else process.env.DEEPSEEK_API_KEY = prevKey;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+test("a real subagent session that hits a usage limit surfaces PROVIDER_USAGE_LIMIT (not SCHEMA_NONCOMPLIANCE/EMPTY)", () =>
+  withFauxSession(async ({ cwd, model, setResponses, fauxAssistantMessage }) => {
+    setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: USAGE_LIMIT_MSG })]);
+    const agent = new WorkflowAgent({ cwd, session: { model: model as never } });
+    await assert.rejects(
+      () => agent.run("do the task", { label: "probe" }),
+      (err: unknown) => {
+        const e = err as { code?: string; recoverable?: boolean; message?: string; resetHint?: string };
+        assert.equal(e.code, WorkflowErrorCode.PROVIDER_USAGE_LIMIT, `got ${e.code}`);
+        assert.equal(e.recoverable, false, "must halt so the run can checkpoint, not retry-into-the-wall");
+        assert.ok(e.message?.includes("usage limit reached"), "carries the real provider message");
+        assert.equal(e.resetHint, "Resets in ~3h", "extracts the provider reset hint");
+        return true;
+      },
+    );
+  }));
+
+test("a successful real turn whose text merely mentions 'rate limit' is NOT misclassified", () =>
+  withFauxSession(async ({ cwd, model, setResponses, fauxAssistantMessage }) => {
+    setResponses([fauxAssistantMessage("Done. I handled the rate limit gracefully.", { stopReason: "stop" })]);
+    const agent = new WorkflowAgent({ cwd, session: { model: model as never } });
+    const text = await agent.run("do the task", { label: "ok" });
+    assert.ok(typeof text === "string" && text.includes("Done."), `expected normal text, got ${String(text)}`);
+  }));
+
+test("through the manager: a usage limit pauses the run (not fails) and resume replays the journal", () =>
+  withFauxSession(async ({ cwd, model, setResponses, fauxAssistantMessage }) => {
+    const managerAgent = new WorkflowAgent({ cwd, session: { model: model as never } });
+    const manager = new WorkflowManager({ cwd, agent: managerAgent });
+    const pausedReasons: Array<string | undefined> = [];
+    manager.on("paused", (e: { reason?: string }) => pausedReasons.push(e.reason));
+    manager.on("error", () => {});
+
+    const twoAgentScript = `export const meta = { name: 'i26_integration', description: 'two agents' }
+const a = await agent('first step', { label: 'first' })
+const b = await agent('second step', { label: 'second' })
+return { a, b }`;
+
+    // Agent 1 succeeds (journaled); agent 2 hits the usage limit.
+    setResponses([
+      fauxAssistantMessage("first-result-text", { stopReason: "stop" }),
+      fauxAssistantMessage("", { stopReason: "error", errorMessage: USAGE_LIMIT_MSG }),
+    ]);
+    const { runId, promise } = manager.startInBackground(twoAgentScript);
+    await promise.catch(() => {});
+
+    assert.equal(manager.getRun(runId)?.status, "paused", "run is checkpointed as paused, not failed");
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.equal(persisted?.pauseReason, "usage_limit");
+    assert.equal(persisted?.resetHint, "Resets in ~3h");
+    assert.ok((persisted?.journal?.length ?? 0) >= 1, "agent 1's result is journaled");
+    assert.ok(pausedReasons.includes("usage_limit"), "a usage_limit 'paused' event fired");
+
+    // Budget refills: agent 2 now succeeds. Resume replays agent 1 from the journal.
+    setResponses([fauxAssistantMessage("second-result-text", { stopReason: "stop" })]);
+    assert.equal(await manager.resume(runId), true, "the paused run is resumable");
+    await new Promise((r) => setTimeout(r, 100));
+
+    const done = manager.getRun(runId);
+    assert.equal(done?.status, "completed", "resumed run completes once the limit clears");
+    assert.equal((done?.result?.result as { a?: string })?.a, "first-result-text", "agent 1 replayed from journal");
+    assert.equal((done?.result?.result as { b?: string })?.b, "second-result-text", "agent 2 ran live after refill");
+  }));

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -842,6 +842,81 @@ return { a, b }`;
 );
 
 test(
+  "a provider usage limit pauses the run (not failed) and is resumable, replaying the journal",
+  withTempCwd(async (cwd) => {
+    let limitActive = true;
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string) {
+          if (prompt.includes("second") && limitActive) {
+            throw new WorkflowError(
+              "Codex usage limit reached (plus plan). Resets in ~3h.",
+              WorkflowErrorCode.PROVIDER_USAGE_LIMIT,
+              { recoverable: false, resetHint: "Resets in ~3h" },
+            );
+          }
+          return prompt.includes("first") ? "first-result" : "second-result";
+        },
+      },
+    });
+    const pausedEvents: Array<{ runId: string; reason?: string; resetHint?: string }> = [];
+    manager.on("paused", (e: { runId: string; reason?: string; resetHint?: string }) => pausedEvents.push(e));
+
+    const twoAgentScript = `export const meta = { name: 'quota_demo', description: 'two agents' }
+const a = await agent('first', { label: 'first' })
+const b = await agent('second', { label: 'second' })
+return { a, b }`;
+
+    const { runId, promise } = manager.startInBackground(twoAgentScript);
+    await promise.catch(() => {}); // settles: rejects with PROVIDER_USAGE_LIMIT
+
+    // The run is checkpointed as paused, not failed.
+    assert.equal(manager.getRun(runId)?.status, "paused");
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.equal(persisted?.status, "paused");
+    assert.equal(persisted?.pauseReason, "usage_limit");
+    assert.equal(persisted?.resetHint, "Resets in ~3h");
+    assert.ok((persisted?.journal?.length ?? 0) >= 1, "agent 1's result should be journaled");
+
+    // A 'paused' event with reason usage_limit fired (not 'error').
+    assert.equal(pausedEvents.length, 1);
+    assert.equal(pausedEvents[0].reason, "usage_limit");
+    assert.equal(pausedEvents[0].resetHint, "Resets in ~3h");
+
+    // After the budget refills, resume replays agent 1 and runs agent 2 live to completion.
+    limitActive = false;
+    const resumed = await manager.resume(runId);
+    assert.equal(resumed, true);
+    await new Promise((r) => setTimeout(r, 50));
+    const finalRun = manager.getRun(runId);
+    assert.equal(finalRun?.status, "completed", "resumed run completes once the limit clears");
+    assert.equal(finalRun?.result?.result?.a, "first-result");
+    assert.equal(finalRun?.result?.result?.b, "second-result");
+  }),
+);
+
+test(
+  "a non-quota non-recoverable agent error still fails the run (control)",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          throw new WorkflowError("schema bad", WorkflowErrorCode.SCHEMA_NONCOMPLIANCE, { recoverable: false });
+        },
+      },
+    });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await promise.catch(() => {});
+    assert.equal(manager.getRun(runId)?.status, "failed");
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.equal(persisted?.pauseReason, undefined, "a real failure carries no usage-limit pause reason");
+  }),
+);
+
+test(
   "resume returns false for completed run",
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({ cwd, agent: fakeAgent() });


### PR DESCRIPTION
Closes #26.

## Problem
When a provider usage/quota/rate limit is hit mid-run, the provider doesn't *throw* — it ends the turn as an assistant message with `stopReason: "error"` + an `errorMessage`, and the SDK treats it as non-retryable. The workflow layer never inspected that metadata, so:

- a **schema** agent resurfaced it as a non-recoverable `SCHEMA_NONCOMPLIANCE` (`did not produce valid structured_output`), and
- a **non-schema** agent collapsed it to a silent empty-output `null`.

Either way the whole run was marked **`failed`** — even though the journal of completed agents was already persisted and `resume()` could replay it. Nothing surfaced that, so it looked like the work was lost (#26).

## Fix
- **`errors.ts`** — new recoverable `PROVIDER_USAGE_LIMIT` code; `classifyProviderLimit()` (centralized detector + reset-hint extraction) and `isProviderUsageLimit()`; a defensive branch in `wrapError()` in case a future SDK *throws* the limit instead of burying it.
- **`agent.ts`** — `throwIfProviderLimit()` reads the turn's `stopReason`/`errorMessage` right after `prompt()` (before the schema/empty-output branches) and again in the structured-output repair loop. Gated on `stopReason === "error"` so a successful turn that merely mentions "rate limit" is never misclassified.
- **`workflow-manager.ts`** — convert **only this code** `failed` → `paused`; emit a `paused` event (`reason: "usage_limit"`, superset of `{ runId }`).
- **`run-persistence.ts`** — persist `pauseReason` / `resetHint`.
- **`task-panel.ts`** — deliver a resumable checkpoint message instead of `✗ … failed`:
  > ⏸ Background workflow `<id>` paused: usage limit reached (resets in ~3h). Completed steps are saved — run `/workflows resume <id>` once your usage limit resets.

`resume()` already replays the completed prefix and runs only the remainder, so no `workflow.ts` change was needed (the new code is non-recoverable and reuses the existing throw path).

## Design notes
- The provider's **self-imposed soft `TOKEN_BUDGET_EXHAUSTED`** is intentionally **not** rerouted — only `PROVIDER_USAGE_LIMIT` flips to `paused`.
- Automatic resume once the quota refills is deferred to #27; the reset time is persisted as the hook for it.

## Tests
`npm test` green (725 pass / 0 fail): unit coverage for detection / classification / pause-vs-fail / delivery, **plus a real-session integration test** that drives an actual `createAgentSession` subagent into a usage-limit turn via the SDK's `faux` provider — exercising the real path with **no network call and no quota consumed**. This also acts as a contract guard for the load-bearing SDK assumption (a usage limit surfaces as an error-status assistant message, not a thrown error).