### PR TITLE
Make workflow triggering configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Ask in plain language:
 Run a workflow to audit every route under src/routes/ for missing auth checks.
 ```
 
-Pi writes the script and runs it in the background — your turn ends immediately and a live panel tracks progress while you keep working. Or just type the word **workflows** in any message to force one. If you only want to discuss workflows without triggering one, run `/workflows-trigger off`; the preference is saved for new sessions in `~/.pi/workflows/settings.json`. Check the current state with `/workflows-trigger status`, and turn it back on with `/workflows-trigger on`.
+Pi writes the script and runs it in the background — your turn ends immediately and a live panel tracks progress while you keep working. Or just type **workflow** or **workflows** in any message to force one. To force one explicitly — even with the keyword trigger off — run `/workflows run <prompt>`. If that causes false triggers, set a custom trigger such as `pi-workflow` with `/workflows-trigger set pi-workflow` or by adding `{ "keywordTriggerWord": "pi-workflow" }` to `~/.pi/workflows/settings.json`. With that setting, only `pi-workflow` auto-arms workflows mode. If you only want to discuss workflows without triggering one, run `/workflows-trigger off`; preferences are saved for new sessions. Check the current state with `/workflows-trigger status`, and turn it back on with `/workflows-trigger on`.
 
 ![Workflows mode in the input box](https://raw.githubusercontent.com/QuintinShaw/pi-dynamic-workflows/main/docs/media/workflows-mode.jpg)
 
-If another Pi extension has already installed a custom editor component, pi-dynamic-workflows leaves it in place and keeps the submit-time workflow trigger active. In that compatibility mode, the animated keyword highlight and Backspace one-shot disarm affordance are skipped because the existing editor remains responsible for rendering and input handling; use `/workflows-trigger off` when you need to discuss workflow/workflows without auto-triggering, including in future sessions. Editor composition is load-order dependent: whichever extension installs a visual editor last owns the editor surface, while pi-dynamic-workflows still keeps its submit-time hook registered.
+If another Pi extension has already installed a custom editor component, pi-dynamic-workflows leaves it in place and keeps the submit-time workflow trigger active. In that compatibility mode, the animated keyword highlight and Backspace one-shot disarm affordance are skipped because the existing editor remains responsible for rendering and input handling; use `/workflows-trigger off` or `/workflows-trigger set <word>` when you need to discuss workflow/workflows without auto-triggering, including in future sessions. Editor composition is load-order dependent: whichever extension installs a visual editor last owns the editor surface, while pi-dynamic-workflows still keeps its submit-time hook registered.
 
 ## What a workflow looks like
 
@@ -102,7 +102,13 @@ The same model — on Pi, plus the production pieces a real run needs:
 /workflows save <name>      save the latest run's script as a reusable /<name> command
 /workflows pause|resume|stop|rm <id>
 /workflows-trigger off|on|status
-                            persistently disable, restore, or inspect keyword-triggered workflows mode
+                            persistently disable, restore, or inspect keyword triggering
+/workflows-trigger set <word>|reset
+                            customize or reset the keyword trigger word (default "workflow",
+                            also matches "workflows"; custom words match exactly, case-insensitive)
+/workflows run <prompt>     force a dynamic workflow from <prompt> on demand — the explicit
+                            twin of the keyword trigger. Works even when the keyword trigger
+                            is off (/workflows-trigger off); the run shows in the panel + /workflows.
 /workflows-progress compact|detailed|status
                             switch the live panel between the compact one-liner and the detailed
                             per-phase/per-agent view (with tokens, cost, and a live tok/s rate)
@@ -120,6 +126,16 @@ In the navigator: `↑/↓` select · `enter`/`→` open · `esc`/`←` back · 
 ## Storage
 
 Workflow state is stored under `~/.pi/workflows` so projects do not accumulate extension-owned `.pi/workflows` directories. Global settings and model tiers live at `~/.pi/workflows/settings.json` and `~/.pi/workflows/model-tiers.json`; project-scoped run history, resume journals, locks, and saved workflow overrides live under `~/.pi/workflows/projects/<project>/`. Older project-local `.pi/workflows/runs` and `.pi/workflows/saved` data is still read as a fallback, but new writes go to the user-level workflow store.
+
+To avoid accidental keyword triggers, configure a custom trigger word in `~/.pi/workflows/settings.json`:
+
+```json
+{
+  "keywordTriggerWord": "pi-workflow"
+}
+```
+
+The default `"workflow"` preserves the legacy behavior and also matches `"workflows"`. Custom trigger words are literal, case-insensitive terms with no spaces and no leading slash; for example, `"pi-workflow"` does not match `"workflow"`, `"workflows"`, or `"pi-workflows"`.
 
 ## Reference
 

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -32,13 +32,14 @@ export default function extension(pi: ExtensionAPI) {
 
   const workflowTool = createWorkflowTool({ cwd, manager, storage });
   pi.registerTool(workflowTool);
-  registerWorkflowCommands(pi, manager, { storage, cwd });
+  // Standing /effort opt-in (off|high|ultra): auto-arms a workflow for substantive
+  // messages, like CC's ultracode. Shared with the editor's input hook below and
+  // with the explicit /workflows run <prompt> manual trigger.
+  const effort = createEffortState();
+  registerWorkflowCommands(pi, manager, { storage, cwd, effort });
   registerWorkflowModelsCommand(pi);
   registerBuiltinWorkflows(pi, { cwd });
   registerAllSavedWorkflows(pi, cwd, storage, manager);
-  // Standing /effort opt-in (off|high|ultra): auto-arms a workflow for substantive
-  // messages, like CC's ultracode. Shared with the editor's input hook below.
-  const effort = createEffortState();
   registerEffortCommand(pi, effort);
   // "Workflows mode": type `workflow(s)` to arm a forced workflow (animated),
   // Backspace right after the word disarms it. Registers the `input` hook now;

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,17 @@ export const MODEL_TIERS_FILE = ".pi/workflows/model-tiers.json";
 /** User-level workflow extension settings file, relative to the home directory. */
 export const WORKFLOW_SETTINGS_FILE = ".pi/workflows/settings.json";
 
+/** Default keyword that arms workflows mode from interactive input. */
+export const DEFAULT_KEYWORD_TRIGGER_WORD = "workflow";
+
+/** Normalize a user-configured keyword trigger word. */
+export function normalizeKeywordTriggerWord(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const word = value.trim();
+  if (!word || word.startsWith("/") || /\s/.test(word)) return undefined;
+  return word;
+}
+
 /**
  * Named workflow subagent definitions directory. Resolved both project-relative
  * (cwd/.pi/agents) and home-relative (~/.pi/agents); project entries win on name

--- a/src/workflow-commands.ts
+++ b/src/workflow-commands.ts
@@ -5,8 +5,10 @@
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { recomputeWorkflowSnapshot, renderWorkflowText, type WorkflowSnapshot } from "./display.js";
+import { type EffortState, effortDirective } from "./effort-command.js";
 import type { PersistedRunState } from "./run-persistence.js";
 import { registerSavedWorkflow } from "./saved-commands.js";
+import { buildForcedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "./workflow-editor.js";
 import type { WorkflowManager } from "./workflow-manager.js";
 import type { WorkflowStorage } from "./workflow-saved.js";
 import { openWorkflowNavigator } from "./workflow-ui.js";
@@ -21,7 +23,9 @@ const STATUS_ICON: Record<string, string> = {
 };
 
 const USAGE =
-  "Usage: /workflows [list] | status <id> | watch <id> | stop <id> | pause <id> | resume <id> | rm <id> | save <name> [runId]";
+  "Usage: /workflows [list] | run <prompt> | status <id> | watch <id> | stop <id> | pause <id> | resume <id> | rm <id> | save <name> [runId]";
+
+const RUN_USAGE = "Usage: /workflows run <prompt> — force a dynamic workflow from the prompt";
 
 function summarizeRun(run: PersistedRunState): string {
   const icon = STATUS_ICON[run.status] ?? "?";
@@ -103,6 +107,8 @@ export interface WorkflowCommandOptions {
   storage?: WorkflowStorage;
   /** Working directory for saved workflows registered via `save`. */
   cwd?: string;
+  /** Standing effort mode; when high/ultra, `/workflows run` carries its directive too. */
+  effort?: EffortState;
 }
 
 /** Register the `/workflows` command against the shared manager. Idempotent. */
@@ -120,7 +126,7 @@ export function registerWorkflowCommands(
 
   pi.registerCommand("workflows", {
     description:
-      "Manage workflow runs — no args (opens navigator) | status/stop/pause/resume <id> | rm <id> | save <name> [runId]",
+      "Manage workflow runs — no args (opens navigator) | run <prompt> | status/stop/pause/resume <id> | rm <id> | save <name> [runId]",
     async handler(args: string, ctx: ExtensionCommandContext) {
       const parts = args.trim().split(/\s+/).filter(Boolean);
       const sub = (parts[0] ?? "list").toLowerCase();
@@ -128,6 +134,39 @@ export function registerWorkflowCommands(
       const print = (text: string) => pi.sendMessage({ customType: "workflows", content: text, display: true });
 
       switch (sub) {
+        case "run": {
+          const prompt = args
+            .trim()
+            .slice(parts[0]?.length ?? 0)
+            .trim();
+          if (!prompt) {
+            ctx.ui.notify(RUN_USAGE, "warning");
+            return;
+          }
+
+          // Best-effort: ensure the workflow tool is active (session_start usually has).
+          // Add-only so this does not interfere with the keyword hook's save/restore state.
+          try {
+            const active = pi.getActiveTools?.() ?? [];
+            if (!active.includes(WORKFLOW_TOOL_NAME)) pi.setActiveTools?.([...active, WORKFLOW_TOOL_NAME]);
+          } catch {
+            // ignore — the forced directive is the real forcing primitive
+          }
+
+          const effort = opts.effort;
+          const extra = effort && effort.level !== "off" ? effortDirective(effort.level) : undefined;
+          const forced = buildForcedWorkflowPrompt(prompt, extra);
+          ctx.ui.notify(`Forcing workflow: ${prompt.slice(0, 60)}${prompt.length > 60 ? "…" : ""}`, "info");
+          try {
+            await pi.sendMessage(
+              { customType: "workflow-run", content: forced, display: true },
+              { triggerTurn: true, deliverAs: "followUp" },
+            );
+          } catch {
+            ctx.ui.notify("Could not start the workflow turn.", "error");
+          }
+          return;
+        }
         case "ui":
         case "list": {
           // Interactive navigator when a UI is available; plain text otherwise

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -23,6 +23,7 @@ import {
   type ExtensionUIContext,
 } from "@earendil-works/pi-coding-agent";
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
+import { DEFAULT_KEYWORD_TRIGGER_WORD, normalizeKeywordTriggerWord } from "./config.js";
 import { type EffortState, effortDirective, isSubstantive } from "./effort-command.js";
 import {
   loadWorkflowSettings,
@@ -31,15 +32,24 @@ import {
   type WorkflowSettingsStore,
 } from "./workflow-settings.js";
 
-// A trigger is `workflow`/`workflows` (substring, case-insensitive) that is NOT
-// immediately preceded by `/` — so a slash command like `/workflows` or `/workflow`
-// is left alone (not colored, not armed).
-/** Matches a trigger anywhere in the text. */
-const TRIGGER = /(?<!\/)workflows?/i;
-/** Global variant for finding every occurrence to colorize. */
-const TRIGGER_G = /(?<!\/)workflows?/gi;
-/** True when the text immediately before the cursor ends with a trigger word. */
-const TRIGGER_AT_END = /(?<!\/)workflows?$/i;
+// A keyword trigger is a configured literal term. The default `workflow`
+// trigger keeps legacy substring behavior and plural support (`workflows`) while
+// custom trigger words match only that exact term. Slash commands like
+// `/workflows` or `/pi-workflow` are left alone (not colored, not armed).
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function triggerSource(triggerWord: string): string {
+  const escaped = escapeRegExp(triggerWord);
+  if (triggerWord.toLowerCase() === DEFAULT_KEYWORD_TRIGGER_WORD) return `(?<!\\/)${escaped}s?`;
+  return `(?<![/A-Za-z0-9_-])${escaped}(?![A-Za-z0-9_-])`;
+}
+
+function triggerRegex(triggerWord = DEFAULT_KEYWORD_TRIGGER_WORD, flags = "i", atEnd = false): RegExp {
+  const word = normalizeKeywordTriggerWord(triggerWord) ?? DEFAULT_KEYWORD_TRIGGER_WORD;
+  return new RegExp(`${triggerSource(word)}${atEnd ? "$" : ""}`, flags);
+}
 
 /** 256-color ring cycling through the spectrum — shifted by a tick to "flow". */
 export const RAINBOW = [
@@ -47,18 +57,19 @@ export const RAINBOW = [
   93, 129, 165, 201, 198, 197,
 ];
 
-export function hasTrigger(text: string): boolean {
-  return TRIGGER.test(text);
+export function hasTrigger(text: string, triggerWord = DEFAULT_KEYWORD_TRIGGER_WORD): boolean {
+  return triggerRegex(triggerWord).test(text);
 }
 
-export function endsWithTrigger(textBeforeCursor: string): boolean {
-  return TRIGGER_AT_END.test(textBeforeCursor);
+export function endsWithTrigger(textBeforeCursor: string, triggerWord = DEFAULT_KEYWORD_TRIGGER_WORD): boolean {
+  return triggerRegex(triggerWord, "i", true).test(textBeforeCursor);
 }
 
 /** Shared, mutable view of whether "workflows mode" is currently armed. */
 export interface WorkflowModeState {
   active: boolean;
   keywordTriggerEnabled: boolean;
+  keywordTriggerWord?: string;
   suppressedKeywordText?: string;
 }
 
@@ -113,17 +124,22 @@ export function tokenizeAnsi(line: string): AnsiToken[] {
  * flowing rainbow, leaving all ANSI escapes (cursor, markers) intact. Returns the
  * line unchanged when it contains no trigger.
  */
-export function colorizeWorkflow(line: string, tick: number, palette: number[] = RAINBOW): string {
+export function colorizeWorkflow(
+  line: string,
+  tick: number,
+  palette: number[] = RAINBOW,
+  triggerWord = DEFAULT_KEYWORD_TRIGGER_WORD,
+): string {
   const tokens = tokenizeAnsi(line);
   const visible = tokens
     .filter((t) => t.ch !== undefined)
     .map((t) => t.ch)
     .join("");
-  if (!TRIGGER.test(visible)) return line;
+  if (!hasTrigger(visible, triggerWord)) return line;
 
   const ranges: Array<[number, number]> = [];
-  TRIGGER_G.lastIndex = 0;
-  for (let m = TRIGGER_G.exec(visible); m; m = TRIGGER_G.exec(visible)) {
+  const globalTrigger = triggerRegex(triggerWord, "gi");
+  for (let m = globalTrigger.exec(visible); m; m = globalTrigger.exec(visible)) {
     ranges.push([m.index, m.index + m[0].length]);
   }
   const inRange = (idx: number) => ranges.some(([s, e]) => idx >= s && idx < e);
@@ -176,7 +192,11 @@ export class WorkflowEditor extends CustomEditor {
 
   /** Highlighted/armed: a trigger is present and the user hasn't toggled it off. */
   isActive(): boolean {
-    return this.modeState.keywordTriggerEnabled && !this.disabled && hasTrigger(this.getText());
+    return (
+      this.modeState.keywordTriggerEnabled &&
+      !this.disabled &&
+      hasTrigger(this.getText(), this.modeState.keywordTriggerWord)
+    );
   }
 
   override handleInput(data: string): void {
@@ -192,7 +212,7 @@ export class WorkflowEditor extends CustomEditor {
     super.handleInput(data);
     const after = this.getText();
     if (after !== before) {
-      const now = hasTrigger(after);
+      const now = hasTrigger(after, this.modeState.keywordTriggerWord);
       const normalizedAfter = after.trim();
       const suppressionCleared =
         this.modeState.suppressedKeywordText !== undefined &&
@@ -217,7 +237,11 @@ export class WorkflowEditor extends CustomEditor {
     if (!this.isActive() || lines.length === 0) return lines;
     // First and last lines are the editor's horizontal borders; only the text
     // lines in between are colorized.
-    return lines.map((ln, i) => (i === 0 || i === lines.length - 1 ? ln : colorizeWorkflow(ln, this.tick)));
+    return lines.map((ln, i) =>
+      i === 0 || i === lines.length - 1
+        ? ln
+        : colorizeWorkflow(ln, this.tick, RAINBOW, this.modeState.keywordTriggerWord),
+    );
   }
 
   /** Absolute text before the cursor, used to detect "right after the word". */
@@ -225,7 +249,7 @@ export class WorkflowEditor extends CustomEditor {
     const lines = this.getLines();
     const { line, col } = this.getCursor();
     const before = lines.slice(0, line).join("\n") + (line > 0 ? "\n" : "") + (lines[line] ?? "").slice(0, col);
-    return endsWithTrigger(before);
+    return endsWithTrigger(before, this.modeState.keywordTriggerWord);
   }
 
   private syncState(): void {
@@ -287,17 +311,19 @@ export function registerWorkflowTriggerCommand(
   settingsStore: WorkflowSettingsStore = DEFAULT_SETTINGS_STORE,
 ): void {
   pi.registerCommand?.("workflows-trigger", {
-    description: "Keyword workflow trigger: on | off | status",
+    description: "Keyword workflow trigger: on | off | set <word> | reset | status",
     async handler(args: string, _ctx: ExtensionCommandContext) {
-      const arg = args.trim().toLowerCase();
+      const raw = args.trim();
+      const [command = "status", ...rest] = raw.split(/\s+/);
+      const arg = command.toLowerCase();
       const say = (content: string) => pi.sendMessage({ customType: "workflows-trigger", content, display: true });
       if (arg === "on") {
         state.keywordTriggerEnabled = true;
         state.suppressedKeywordText = undefined;
-        const saved = persistKeywordTrigger(settingsStore, true);
+        const saved = persistWorkflowTriggerSettings(settingsStore, { keywordTriggerEnabled: true });
         await say(
           saved
-            ? "Workflows keyword trigger on — mentioning workflow/workflows in an interactive message will auto-arm workflows mode. Saved for new sessions."
+            ? `Workflows keyword trigger on — mentioning ${triggerDisplayName(state.keywordTriggerWord)} in an interactive message will auto-arm workflows mode. Saved for new sessions.`
             : "Workflows keyword trigger on for this session, but the preference could not be saved.",
         );
         return;
@@ -306,16 +332,49 @@ export function registerWorkflowTriggerCommand(
         state.keywordTriggerEnabled = false;
         state.active = false;
         state.suppressedKeywordText = undefined;
-        const saved = persistKeywordTrigger(settingsStore, false);
+        const saved = persistWorkflowTriggerSettings(settingsStore, { keywordTriggerEnabled: false });
         await say(
           saved
-            ? "Workflows keyword trigger off — messages can mention workflow/workflows without forcing the workflow tool. Saved for new sessions. Use /workflows-trigger on to restore."
+            ? `Workflows keyword trigger off — messages can mention ${triggerDisplayName(state.keywordTriggerWord)} without forcing the workflow tool. Saved for new sessions. Use /workflows-trigger on to restore.`
             : "Workflows keyword trigger off for this session, but the preference could not be saved. Use /workflows-trigger on to restore.",
         );
         return;
       }
+      if (arg === "set") {
+        const requested = rest.join(" ");
+        const keywordTriggerWord = normalizeKeywordTriggerWord(requested);
+        if (!keywordTriggerWord) {
+          await say(
+            'Invalid trigger word. Use a non-empty term with no spaces and no leading "/", e.g. /workflows-trigger set pi-workflow',
+          );
+          return;
+        }
+        state.keywordTriggerWord = keywordTriggerWord;
+        state.suppressedKeywordText = undefined;
+        const saved = persistWorkflowTriggerSettings(settingsStore, { keywordTriggerWord });
+        await say(
+          saved
+            ? `Workflows keyword trigger word set to "${keywordTriggerWord}". Saved for new sessions.`
+            : `Workflows keyword trigger word set to "${keywordTriggerWord}" for this session, but the preference could not be saved.`,
+        );
+        return;
+      }
+      if (arg === "reset") {
+        state.keywordTriggerWord = DEFAULT_KEYWORD_TRIGGER_WORD;
+        state.suppressedKeywordText = undefined;
+        const saved = persistWorkflowTriggerSettings(settingsStore, {
+          keywordTriggerWord: DEFAULT_KEYWORD_TRIGGER_WORD,
+        });
+        await say(
+          saved
+            ? 'Workflows keyword trigger word reset to "workflow" (also matches "workflows"). Saved for new sessions.'
+            : 'Workflows keyword trigger word reset to "workflow" for this session, but the preference could not be saved.',
+        );
+        return;
+      }
+      const keywordTriggerWord = resolvedTriggerWord(state.keywordTriggerWord);
       await say(
-        `Workflows keyword trigger is ${state.keywordTriggerEnabled ? "on" : "off"}. Changes are saved for new sessions. Usage: /workflows-trigger on | off | status`,
+        `Workflows keyword trigger is ${state.keywordTriggerEnabled ? "on" : "off"}; trigger word is "${keywordTriggerWord}". Changes are saved for new sessions. Usage: /workflows-trigger on | off | set <word> | reset | status`,
       );
     },
   });
@@ -386,9 +445,11 @@ export function installWorkflowEditor(
   options: InstallWorkflowEditorOptions = {},
 ): WorkflowModeState {
   const settingsStore = options.settingsStore ?? DEFAULT_SETTINGS_STORE;
+  const initialSettings = loadInitialWorkflowSettings(settingsStore);
   const state: WorkflowModeState = {
     active: false,
-    keywordTriggerEnabled: loadInitialKeywordTrigger(settingsStore),
+    keywordTriggerEnabled: initialSettings.keywordTriggerEnabled ?? true,
+    keywordTriggerWord: initialSettings.keywordTriggerWord ?? DEFAULT_KEYWORD_TRIGGER_WORD,
   };
 
   if (!ui.getEditorComponent?.()) {
@@ -418,7 +479,7 @@ export function installWorkflowEditor(
     const normalizedText = event.text.trim();
     const suppressed = state.suppressedKeywordText === normalizedText;
     if (suppressed) state.suppressedKeywordText = undefined;
-    const triggered = state.keywordTriggerEnabled && !suppressed && hasTrigger(event.text);
+    const triggered = state.keywordTriggerEnabled && !suppressed && hasTrigger(event.text, state.keywordTriggerWord);
     const byEffort = !triggered && !!effort && effort.level !== "off" && isSubstantive(event.text);
     if (!triggered && !byEffort) return { action: "continue" } as const;
     try {
@@ -457,21 +518,34 @@ const DEFAULT_SETTINGS_STORE: WorkflowSettingsStore = {
   save: saveWorkflowSettings,
 };
 
-function loadInitialKeywordTrigger(settingsStore: WorkflowSettingsStore): boolean {
+function loadInitialWorkflowSettings(settingsStore: WorkflowSettingsStore): WorkflowSettings {
   try {
-    return settingsStore.load().keywordTriggerEnabled ?? true;
+    const settings = settingsStore.load();
+    return {
+      keywordTriggerEnabled: settings.keywordTriggerEnabled,
+      keywordTriggerWord: normalizeKeywordTriggerWord(settings.keywordTriggerWord) ?? DEFAULT_KEYWORD_TRIGGER_WORD,
+    };
   } catch {
-    return true;
+    return { keywordTriggerEnabled: true, keywordTriggerWord: DEFAULT_KEYWORD_TRIGGER_WORD };
   }
 }
 
-function persistKeywordTrigger(settingsStore: WorkflowSettingsStore, enabled: boolean): boolean {
+function persistWorkflowTriggerSettings(settingsStore: WorkflowSettingsStore, settings: WorkflowSettings): boolean {
   try {
-    settingsStore.save({ keywordTriggerEnabled: enabled });
+    settingsStore.save(settings);
     return true;
   } catch {
     return false;
   }
+}
+
+function resolvedTriggerWord(keywordTriggerWord: string | undefined): string {
+  return normalizeKeywordTriggerWord(keywordTriggerWord) ?? DEFAULT_KEYWORD_TRIGGER_WORD;
+}
+
+function triggerDisplayName(keywordTriggerWord: string | undefined): string {
+  const word = resolvedTriggerWord(keywordTriggerWord);
+  return word.toLowerCase() === DEFAULT_KEYWORD_TRIGGER_WORD ? "workflow/workflows" : `"${word}"`;
 }
 
 function persistProgressSettings(settingsStore: WorkflowSettingsStore, settings: WorkflowSettings): boolean {

--- a/src/workflow-settings.ts
+++ b/src/workflow-settings.ts
@@ -7,11 +7,13 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { MAX_AGENT_RETRIES, MAX_CONCURRENCY } from "./config.js";
+import { MAX_AGENT_RETRIES, MAX_CONCURRENCY, normalizeKeywordTriggerWord } from "./config.js";
 import { workflowHomeDir, workflowProjectPaths } from "./workflow-paths.js";
 
 export interface WorkflowSettings {
   keywordTriggerEnabled?: boolean;
+  /** Literal keyword that arms workflows mode from interactive input. */
+  keywordTriggerWord?: string;
   defaultAgentTimeoutMs?: number | null;
   /** Default max concurrent agents per run. Clamped to the runtime maximum. */
   defaultConcurrency?: number;
@@ -107,6 +109,8 @@ function normalizeSettings(value: unknown): WorkflowSettings {
   if (typeof raw.keywordTriggerEnabled === "boolean") {
     settings.keywordTriggerEnabled = raw.keywordTriggerEnabled;
   }
+  const keywordTriggerWord = normalizeKeywordTriggerWord(raw.keywordTriggerWord);
+  if (keywordTriggerWord !== undefined) settings.keywordTriggerWord = keywordTriggerWord;
   if (raw.defaultAgentTimeoutMs === null) {
     settings.defaultAgentTimeoutMs = null;
   } else if (

--- a/tests/workflow-commands.test.ts
+++ b/tests/workflow-commands.test.ts
@@ -2,16 +2,32 @@ import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import test from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createEffortState, effortDirective } from "../src/effort-command.js";
 import { registerWorkflowCommands } from "../src/workflow-commands.js";
+import { buildForcedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "../src/workflow-editor.js";
 import type { WorkflowManager } from "../src/workflow-manager.js";
 
 type Handler = (args: string, ctx: any) => Promise<void>;
 
 /** Capture the registered command + outputs for assertions. */
-function harness(managerOverrides: Record<string, any> = {}) {
+function harness(
+  managerOverrides: Record<string, any> = {},
+  commandOptions: Record<string, any> = {},
+  initialTools: string[] = [WORKFLOW_TOOL_NAME],
+  sendMessageImpl?: (
+    m: { customType?: string; content?: string },
+    options?: { triggerTurn?: boolean; deliverAs?: string },
+  ) => Promise<void>,
+) {
   const printed: string[] = [];
+  const sent: Array<{
+    customType?: string;
+    content?: string;
+    options?: { triggerTurn?: boolean; deliverAs?: string };
+  }> = [];
   const notified: Array<{ message: string; type?: string }> = [];
   const calls: string[] = [];
+  const activeTools = [...initialTools];
   let handler: Handler | undefined;
 
   const pi: Partial<ExtensionAPI> = {
@@ -19,8 +35,15 @@ function harness(managerOverrides: Record<string, any> = {}) {
     registerCommand: (_name: string, opts: { handler: Handler }) => {
       handler = opts.handler;
     },
-    sendMessage: async (m: { content: string }) => {
-      printed.push(m.content);
+    sendMessage:
+      sendMessageImpl ??
+      (async (m, options) => {
+        sent.push({ ...m, options });
+        if (!options && typeof m.content === "string") printed.push(m.content);
+      }),
+    getActiveTools: () => [...activeTools],
+    setActiveTools: (toolNames: string[]) => {
+      activeTools.splice(0, activeTools.length, ...toolNames);
     },
   };
 
@@ -47,13 +70,13 @@ function harness(managerOverrides: Record<string, any> = {}) {
     ...managerOverrides,
   };
 
-  registerWorkflowCommands(pi as unknown as ExtensionAPI, manager as unknown as WorkflowManager);
+  registerWorkflowCommands(pi as unknown as ExtensionAPI, manager as unknown as WorkflowManager, commandOptions);
   const ctx = { ui: { notify: (message: string, type?: string) => notified.push({ message, type }) } };
   const run = (args: string) => {
     if (!handler) throw new Error("command not registered");
     return handler(args, ctx);
   };
-  return { run, printed, notified, calls };
+  return { run, printed, sent, notified, calls, activeTools };
 }
 
 test("/workflows list shows empty hint when no runs", async () => {
@@ -69,6 +92,53 @@ test("/workflows (no args) defaults to list", async () => {
   await h.run("");
   assert.match(h.printed[0], /Workflow runs:/);
   assert.match(h.printed[0], /run-1/);
+});
+
+test("/workflows run without prompt warns usage", async () => {
+  const h = harness();
+  await h.run("run");
+  assert.equal(h.sent.length, 0);
+  assert.equal(h.notified.length, 1);
+  assert.equal(h.notified[0].type, "warning");
+  assert.match(h.notified[0].message, /Usage: \/workflows run <prompt>/);
+});
+
+test("/workflows run <prompt> sends a forced workflow follow-up turn", async () => {
+  const h = harness();
+  await h.run("run audit auth boundaries");
+  assert.equal(h.sent.length, 1);
+  assert.equal(h.sent[0].customType, "workflow-run");
+  assert.equal(h.sent[0].content, buildForcedWorkflowPrompt("audit auth boundaries"));
+  assert.equal(h.sent[0].options?.triggerTurn, true);
+  assert.equal(h.sent[0].options?.deliverAs, "followUp");
+  assert.deepEqual(h.activeTools, [WORKFLOW_TOOL_NAME], "does not duplicate an already-active workflow tool");
+});
+
+test("/workflows run <prompt> notifies error when sendMessage rejects and does not bubble", async () => {
+  const failingSend = async () => {
+    throw new Error("send failed");
+  };
+  const h = harness({}, {}, [WORKFLOW_TOOL_NAME], failingSend);
+  await h.run("run audit auth");
+  assert.ok(
+    h.notified.some((n) => n.message === "Could not start the workflow turn."),
+    "should notify the error message",
+  );
+});
+
+test("/workflows run adds the workflow tool when absent and does not depend on the keyword trigger", async () => {
+  const h = harness({}, {}, ["bash", "read"]);
+  await h.run("run summarize the auth module");
+  assert.deepEqual(h.activeTools, ["bash", "read", WORKFLOW_TOOL_NAME]);
+  assert.equal(h.sent[0].content, buildForcedWorkflowPrompt("summarize the auth module"));
+});
+
+test("/workflows run carries standing effort directives", async () => {
+  const effort = createEffortState();
+  effort.level = "ultra";
+  const h = harness({}, { effort });
+  await h.run("run do X");
+  assert.equal(h.sent[0].content, buildForcedWorkflowPrompt("do X", effortDirective("ultra")));
 });
 
 test("/workflows stop <id> calls manager.stop", async () => {

--- a/tests/workflow-editor.test.ts
+++ b/tests/workflow-editor.test.ts
@@ -60,23 +60,26 @@ async function load() {
   return import("../src/workflow-editor.js");
 }
 
-function testSettingsOptions(keywordTriggerEnabled = true) {
+function testSettingsOptions(keywordTriggerEnabled = true, keywordTriggerWord?: string) {
   return {
     settingsStore: {
-      load: () => ({ keywordTriggerEnabled }),
+      load: () => ({ keywordTriggerEnabled, ...(keywordTriggerWord ? { keywordTriggerWord } : {}) }),
       save: () => {},
     },
   };
 }
 
-function memorySettingsOptions(keywordTriggerEnabled = true) {
-  let settings = { keywordTriggerEnabled };
-  const saved: Array<{ keywordTriggerEnabled?: boolean }> = [];
+function memorySettingsOptions(keywordTriggerEnabled = true, keywordTriggerWord?: string) {
+  let settings: { keywordTriggerEnabled?: boolean; keywordTriggerWord?: string } = {
+    keywordTriggerEnabled,
+    ...(keywordTriggerWord ? { keywordTriggerWord } : {}),
+  };
+  const saved: Array<{ keywordTriggerEnabled?: boolean; keywordTriggerWord?: string }> = [];
   return {
     options: {
       settingsStore: {
         load: () => ({ ...settings }),
-        save: (next: { keywordTriggerEnabled?: boolean }) => {
+        save: (next: { keywordTriggerEnabled?: boolean; keywordTriggerWord?: string }) => {
           settings = { ...settings, ...next };
           saved.push(next);
         },
@@ -146,6 +149,20 @@ describe("hasTrigger", () => {
     assert.equal(hasTrigger("zrób workflow test"), true);
     assert.equal(hasTrigger("uruchom workflows"), true);
   });
+
+  it("uses a configured trigger word exactly", async () => {
+    const { hasTrigger } = await load();
+    assert.equal(hasTrigger("run pi-workflow now", "pi-workflow"), true);
+    assert.equal(hasTrigger("run workflow now", "pi-workflow"), false);
+    assert.equal(hasTrigger("run pi-workflows now", "pi-workflow"), false);
+    assert.equal(hasTrigger("/pi-workflow status", "pi-workflow"), false);
+  });
+
+  it("escapes regex characters in configured trigger words", async () => {
+    const { hasTrigger } = await load();
+    assert.equal(hasTrigger("run pi.workflow", "pi.workflow"), true);
+    assert.equal(hasTrigger("run pixworkflow", "pi.workflow"), false);
+  });
 });
 
 describe("endsWithTrigger", () => {
@@ -177,6 +194,14 @@ describe("endsWithTrigger", () => {
   it("returns true with trailing non-ASCII prefix", async () => {
     const { endsWithTrigger } = await load();
     assert.equal(endsWithTrigger("zrób workflow"), true);
+  });
+
+  it("uses a configured trigger word exactly", async () => {
+    const { endsWithTrigger } = await load();
+    assert.equal(endsWithTrigger("run pi-workflow", "pi-workflow"), true);
+    assert.equal(endsWithTrigger("run workflow", "pi-workflow"), false);
+    assert.equal(endsWithTrigger("run pi-workflows", "pi-workflow"), false);
+    assert.equal(endsWithTrigger("/pi-workflow", "pi-workflow"), false);
   });
 });
 
@@ -273,6 +298,13 @@ describe("colorizeWorkflow", () => {
     // Different tick → different color codes (may differ per char)
     assert.notEqual(t0, t1, "different tick should produce different output");
   });
+
+  it("colorizes a configured trigger word without colorizing the default word", async () => {
+    const { colorizeWorkflow } = await load();
+    assert.equal(colorizeWorkflow("run workflow", 0, [196], "pi-workflow"), "run workflow");
+    const result = colorizeWorkflow("run pi-workflow", 0, [196], "pi-workflow");
+    assert.ok(result.includes("\x1b[38;5;196m"), "custom trigger should be colorized");
+  });
 });
 
 describe("buildForcedWorkflowPrompt", () => {
@@ -341,17 +373,33 @@ describe("WorkflowEditor", () => {
   });
 
   function createEditor(
-    stateOverrides?: Partial<{ active: boolean; keywordTriggerEnabled: boolean; suppressedKeywordText?: string }>,
+    stateOverrides?: Partial<{
+      active: boolean;
+      keywordTriggerEnabled: boolean;
+      keywordTriggerWord: string;
+      suppressedKeywordText?: string;
+    }>,
   ): {
     editor: InstanceType<Awaited<ReturnType<typeof load>>["WorkflowEditor"]>;
-    state: { active: boolean; keywordTriggerEnabled: boolean; suppressedKeywordText?: string };
+    state: {
+      active: boolean;
+      keywordTriggerEnabled: boolean;
+      keywordTriggerWord: string;
+      suppressedKeywordText?: string;
+    };
   } {
     const tui = createMockTui();
     const theme = makeTheme();
     const kb = new KB();
-    const state: { active: boolean; keywordTriggerEnabled: boolean; suppressedKeywordText?: string } = {
+    const state: {
+      active: boolean;
+      keywordTriggerEnabled: boolean;
+      keywordTriggerWord: string;
+      suppressedKeywordText?: string;
+    } = {
       active: false,
       keywordTriggerEnabled: true,
+      keywordTriggerWord: "workflow",
       ...stateOverrides,
     };
     const editor = new mod.WorkflowEditor(tui, theme, kb, state);
@@ -388,6 +436,15 @@ describe("WorkflowEditor", () => {
 
     state.keywordTriggerEnabled = true;
     assert.equal(editor.isActive(), true, "re-enabling the keyword trigger should re-arm matching text");
+  });
+
+  it("isActive() follows the configured trigger word", () => {
+    const { editor } = createEditor({ keywordTriggerWord: "pi-workflow" });
+    editor.setText("run a workflow test");
+    assert.equal(editor.isActive(), false, "default word should not arm when a custom trigger is configured");
+
+    editor.setText("run a pi-workflow test");
+    assert.equal(editor.isActive(), true, "custom trigger word should arm workflows mode");
   });
 
   it("isActive() returns false after backspace disarms trigger", () => {
@@ -577,6 +634,7 @@ describe("installWorkflowEditor", () => {
 
     const state = mod.installWorkflowEditor(pi, ui, undefined, store.options);
     assert.equal(state.keywordTriggerEnabled, true, "keyword trigger should default on");
+    assert.equal(state.keywordTriggerWord, "workflow", "keyword trigger word should default to workflow");
 
     const command = commands.get("workflows-trigger");
     assert.ok(command, "should register /workflows-trigger");
@@ -593,6 +651,73 @@ describe("installWorkflowEditor", () => {
     assert.deepEqual(store.settings, { keywordTriggerEnabled: true });
     assert.match(sent.at(-1)?.content ?? "", /keyword trigger on/i);
     assert.match(sent.at(-1)?.content ?? "", /saved for new sessions/i);
+  });
+
+  it("/workflows-trigger sets and reports the keyword trigger word", async () => {
+    const mod = await load();
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+    const sent: Array<{ content?: string }> = [];
+    const store = memorySettingsOptions();
+    const pi = {
+      on: () => {},
+      registerCommand: (name: string, command: { handler: (args: string, ctx: unknown) => Promise<void> }) => {
+        commands.set(name, command);
+      },
+      sendMessage: (message: { content?: string }) => {
+        sent.push(message);
+      },
+      getActiveTools: () => [],
+      setActiveTools: () => {},
+    } as unknown as ExtensionAPI;
+
+    const ui = {
+      setEditorComponent: () => {},
+    } as unknown as ExtensionUIContext;
+
+    const state = mod.installWorkflowEditor(pi, ui, undefined, store.options);
+    const command = commands.get("workflows-trigger");
+    assert.ok(command, "should register /workflows-trigger");
+
+    await command.handler("set pi-workflow", {});
+    assert.equal(state.keywordTriggerWord, "pi-workflow");
+    assert.deepEqual(store.settings, { keywordTriggerEnabled: true, keywordTriggerWord: "pi-workflow" });
+    assert.match(sent.at(-1)?.content ?? "", /pi-workflow/);
+
+    await command.handler("status", {});
+    assert.match(sent.at(-1)?.content ?? "", /pi-workflow/);
+
+    await command.handler("reset", {});
+    assert.equal(state.keywordTriggerWord, "workflow");
+    assert.deepEqual(store.settings, { keywordTriggerEnabled: true, keywordTriggerWord: "workflow" });
+  });
+
+  it("supports legacy WorkflowModeState objects without keywordTriggerWord", async () => {
+    const mod = await load();
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+    const sent: Array<{ content?: string }> = [];
+    const state = { active: false, keywordTriggerEnabled: true };
+    const pi = {
+      registerCommand: (name: string, command: { handler: (args: string, ctx: unknown) => Promise<void> }) => {
+        commands.set(name, command);
+      },
+      sendMessage: (message: { content?: string }) => {
+        sent.push(message);
+      },
+    } as unknown as ExtensionAPI;
+
+    mod.registerWorkflowTriggerCommand(pi, state, {
+      load: () => ({}),
+      save: () => {},
+    });
+
+    const command = commands.get("workflows-trigger");
+    assert.ok(command, "should register /workflows-trigger");
+
+    await command.handler("status", {});
+    assert.match(sent.at(-1)?.content ?? "", /trigger word is "workflow"/);
+
+    await command.handler("on", {});
+    assert.match(sent.at(-1)?.content ?? "", /workflow\/workflows/);
   });
 
   it("loads the persisted keyword trigger preference on install", async () => {
@@ -627,6 +752,41 @@ describe("installWorkflowEditor", () => {
 
     assert.deepEqual(result, { action: "continue" });
     assert.equal(setActiveToolsCalls, 0);
+  });
+
+  it("loads the persisted keyword trigger word on install", async () => {
+    const mod = await load();
+    const captured: Array<{ event: string; handler: (...args: unknown[]) => unknown }> = [];
+    let setActiveToolsCalls = 0;
+    const pi = {
+      on: (event: string, handler: (...args: unknown[]) => unknown) => {
+        captured.push({ event, handler });
+      },
+      registerCommand: () => {},
+      sendMessage: () => {},
+      getActiveTools: () => ["bash", "read"],
+      setActiveTools: () => {
+        setActiveToolsCalls++;
+      },
+    } as unknown as ExtensionAPI;
+
+    const ui = {
+      setEditorComponent: () => {},
+    } as unknown as ExtensionUIContext;
+
+    const state = mod.installWorkflowEditor(pi, ui, undefined, testSettingsOptions(true, "pi-workflow"));
+    assert.equal(state.keywordTriggerWord, "pi-workflow");
+
+    const inputHandler = captured.find((h) => h.event === "input")?.handler;
+    assert.ok(inputHandler, "input handler should be registered");
+    assert.deepEqual(inputHandler({ source: "interactive", text: "Please discuss workflows normally." }), {
+      action: "continue",
+    });
+    assert.equal(setActiveToolsCalls, 0);
+
+    const result = inputHandler({ source: "interactive", text: "Please run pi-workflow now." });
+    assert.equal((result as { action?: string }).action, "transform");
+    assert.equal(setActiveToolsCalls, 1);
   });
 
   it("keeps session trigger state when saving the preference fails", async () => {

--- a/tests/workflow-settings.test.ts
+++ b/tests/workflow-settings.test.ts
@@ -33,12 +33,29 @@ describe("workflow settings", () => {
     });
   });
 
-  it("saves and loads keyword trigger preference", () => {
+  it("saves and loads keyword trigger preferences", () => {
     withSettingsPath((settingsPath) => {
-      saveWorkflowSettings({ keywordTriggerEnabled: false }, settingsPath);
+      saveWorkflowSettings({ keywordTriggerEnabled: false, keywordTriggerWord: "pi-workflow" }, settingsPath);
 
       assert.ok(existsSync(settingsPath), "settings file should be created");
-      assert.deepEqual(loadWorkflowSettings(settingsPath), { keywordTriggerEnabled: false });
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {
+        keywordTriggerEnabled: false,
+        keywordTriggerWord: "pi-workflow",
+      });
+    });
+  });
+
+  it("normalizes keyword trigger word settings", () => {
+    withSettingsPath((settingsPath) => {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+
+      writeFileSync(settingsPath, JSON.stringify({ keywordTriggerWord: "  pi-workflow  " }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { keywordTriggerWord: "pi-workflow" });
+
+      for (const keywordTriggerWord of ["", "   ", "/workflow", "pi workflow", 42, false]) {
+        writeFileSync(settingsPath, JSON.stringify({ keywordTriggerWord }), "utf-8");
+        assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+      }
     });
   });
 

--- a/tests/workflow-tools-available.test.ts
+++ b/tests/workflow-tools-available.test.ts
@@ -64,10 +64,10 @@ function createMockPi(initialTools: string[] = [...DEFAULT_PI_TOOLS]): MockPi {
   };
 }
 
-function testSettingsOptions(keywordTriggerEnabled = true) {
+function testSettingsOptions(keywordTriggerEnabled = true, keywordTriggerWord?: string) {
   return {
     settingsStore: {
-      load: () => ({ keywordTriggerEnabled }),
+      load: () => ({ keywordTriggerEnabled, ...(keywordTriggerWord ? { keywordTriggerWord } : {}) }),
       save: () => {},
     },
   };
@@ -178,6 +178,30 @@ describe("installWorkflowEditor - tool availability", () => {
     // Verify original tools were restored exactly
     const restoredTools = mockPi.setActiveTools.mock.calls[1].arguments[0];
     assert.deepEqual(restoredTools, originalTools, "original tools should be restored exactly");
+  });
+
+  it("should fire for a configured trigger word but not the default word", async () => {
+    const { installWorkflowEditor } = await import("../src/workflow-editor.js");
+
+    const mockPi = createMockPi();
+    const ui = {
+      setEditorComponent: mock.fn(),
+    };
+
+    installWorkflowEditor(
+      mockPi as unknown as ExtensionAPI,
+      ui as unknown as ExtensionUIContext,
+      undefined,
+      testSettingsOptions(true, "pi-workflow"),
+    );
+
+    const inputHandlers = mockPi.handlers.input;
+    assert.deepEqual(inputHandlers[0]({ source: "interactive", text: "run workflow" }), { action: "continue" });
+    assert.equal(mockPi.setActiveTools.mock.callCount(), 0);
+
+    const result = inputHandlers[0]({ source: "interactive", text: "run pi-workflow" });
+    assert.equal(result.action, "transform");
+    assert.equal(mockPi.setActiveTools.mock.callCount(), 1);
   });
 
   it('should not fire for "/workflows" (slash command, not trigger)', async () => {


### PR DESCRIPTION
I kept accidentally triggering workflows for trivial things because I use that word a lot in my normal conversations with an agent. I didn't see an existing way to turn off the `workflow` keyword trigger and still manually trigger a workflow. So this PR ships two changes to improve this behavior. Feel free to take or leave any of it, no hard feelings.

Change 1 lets the trigger word be user configurable. For me, I have changed it to `pi-workflow` in my branch and that works infinitely better to avoid accidents.

Change 2, which is almost unnecessary now that the user trigger word is user-configurable, is the creation of a manual trigger for a workflow in case people want the automatic phrase-based trigger disabled but still want to use a workflow:

```text
/workflows run <prompt-describing-workflow-to-run>
```

## Summary

- Adds `keywordTriggerWord` setting with `/workflows-trigger set <word>` and `/workflows-trigger reset`.
- Preserves default `workflow` / `workflows` behavior for existing users.
- Makes custom trigger words literal, case-insensitive terms and excludes slash-command forms.
- Adds `/workflows run <prompt>` as an explicit manual trigger that works even when keyword triggering is off.
- Updates README documentation and regression tests.

## Validation

- `npm test` — 740 tests passing.
