### PR TITLE
feat: register /multi-perspective and /codebase-audit commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,21 @@ The same model — on Pi, plus the production pieces a real run needs:
 
 /deep-research <question>   web-researched, source-cross-checked report
 /adversarial-review <task>  findings vetted by skeptical reviewers
+/multi-perspective "<topic>" [angle …]
+                            analyze a topic from several independent angles, then synthesize
+/codebase-audit <scope> "<check>" …
+                            run parallel checks over a scope, then cross-validate and report
 ```
+
+`/multi-perspective` and `/codebase-audit` take quoted arguments so a topic or check can be multiple words:
+
+```
+/multi-perspective "should we use Redis or Postgres for session storage"
+/multi-perspective "JWT vs session cookies" security scalability developer-experience
+/codebase-audit src/ "missing error handling" "unused exports" "inconsistent naming"
+```
+
+`/multi-perspective` needs a topic; with fewer than two angles it defaults to `technical, product, security, user experience, maintainability`. `/codebase-audit` needs a scope and at least one check.
 
 In the navigator: `↑/↓` select · `enter`/`→` open · `esc`/`←` back · `p` pause · `x` stop · `r` restart · `s` save · `q` quit. Each agent shows the model it ran on; the detail view shows its prompt, result, error diagnostics, and compact message/tool history.
 

--- a/src/builtin-commands.ts
+++ b/src/builtin-commands.ts
@@ -1,11 +1,12 @@
 /**
- * Bundled workflow commands: `/deep-research` and `/adversarial-review`.
+ * Bundled workflow commands: `/deep-research`, `/adversarial-review`,
+ * `/multi-perspective`, and `/codebase-audit`.
  * They run a generated workflow script and print the final report.
  */
 
 import { createCodingTools, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { generateAdversarialReviewWorkflow } from "./adversarial-review.js";
-import { generateDeepResearchWorkflow } from "./deep-research.js";
+import { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
+import { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "./deep-research.js";
 import { createWebTools } from "./web-tools.js";
 import { runWorkflow, type WorkflowRunResult } from "./workflow.js";
 
@@ -15,6 +16,15 @@ function alreadyRegistered(pi: ExtensionAPI, name: string): boolean {
   } catch {
     return false;
   }
+}
+
+/** Split a command argument string into tokens, respecting single/double quotes. */
+function tokenizeArgs(input: string): string[] {
+  const tokens: string[] = [];
+  for (const m of input.matchAll(/"([^"]*)"|'([^']*)'|(\S+)/g)) {
+    tokens.push(m[1] ?? m[2] ?? m[3] ?? "");
+  }
+  return tokens;
 }
 
 function reportText(result: WorkflowRunResult): string {
@@ -70,6 +80,62 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string }
         } catch (error) {
           ctx.ui.setStatus("adversarial-review", undefined);
           ctx.ui.notify(`adversarial-review failed: ${error instanceof Error ? error.message : error}`, "error");
+        }
+      },
+    });
+  }
+
+  if (!alreadyRegistered(pi, "multi-perspective")) {
+    pi.registerCommand("multi-perspective", {
+      description: "Analyze a topic from several independent perspectives in parallel, then synthesize",
+      async handler(args: string, ctx: ExtensionCommandContext) {
+        const [topic, ...rest] = tokenizeArgs(args);
+        if (!topic) {
+          return ctx.ui.notify('Usage: /multi-perspective "<topic>" [perspective1] [perspective2] …', "warning");
+        }
+        // Fall back to a broadly-useful default set when fewer than two are given.
+        const perspectives =
+          rest.length >= 2 ? rest : ["technical", "product", "security", "user experience", "maintainability"];
+        ctx.ui.notify(`Analyzing from ${perspectives.length} perspectives…`, "info");
+        try {
+          const result = await runWorkflow(generateMultiPerspectiveWorkflow(topic, perspectives), {
+            cwd,
+            tools: createCodingTools(cwd),
+            onPhase: (title) => ctx.ui.setStatus("multi-perspective", `perspectives: ${title}`),
+          });
+          ctx.ui.setStatus("multi-perspective", undefined);
+          // This workflow returns its prose under `synthesis`, not `report`.
+          const r = result.result as { synthesis?: unknown } | undefined;
+          const content = r && typeof r.synthesis === "string" && r.synthesis.trim() ? r.synthesis : reportText(result);
+          await pi.sendMessage({ customType: "multi-perspective", content, display: true });
+        } catch (error) {
+          ctx.ui.setStatus("multi-perspective", undefined);
+          ctx.ui.notify(`multi-perspective failed: ${error instanceof Error ? error.message : error}`, "error");
+        }
+      },
+    });
+  }
+
+  if (!alreadyRegistered(pi, "codebase-audit")) {
+    pi.registerCommand("codebase-audit", {
+      description: "Run parallel checks against a codebase scope, then cross-validate and report",
+      async handler(args: string, ctx: ExtensionCommandContext) {
+        const [scope, ...checks] = tokenizeArgs(args);
+        if (!scope || checks.length === 0) {
+          return ctx.ui.notify('Usage: /codebase-audit <scope> "<check1>" ["<check2>" …]', "warning");
+        }
+        ctx.ui.notify(`Auditing ${scope} across ${checks.length} checks…`, "info");
+        try {
+          const result = await runWorkflow(generateCodebaseAuditWorkflow(scope, checks), {
+            cwd,
+            tools: createCodingTools(cwd),
+            onPhase: (title) => ctx.ui.setStatus("codebase-audit", `audit: ${title}`),
+          });
+          ctx.ui.setStatus("codebase-audit", undefined);
+          await pi.sendMessage({ customType: "codebase-audit", content: reportText(result), display: true });
+        } catch (error) {
+          ctx.ui.setStatus("codebase-audit", undefined);
+          ctx.ui.notify(`codebase-audit failed: ${error instanceof Error ? error.message : error}`, "error");
         }
       },
     });

--- a/tests/builtin-commands.test.ts
+++ b/tests/builtin-commands.test.ts
@@ -3,27 +3,32 @@ import test from "node:test";
 import { registerBuiltinWorkflows } from "../src/builtin-commands.js";
 import { makeCommandRegistryPi, makeNotifyCtx } from "./helpers/mock-pi.js";
 
-test("registerBuiltinWorkflows registers deep-research and adversarial-review commands", () => {
+test("registerBuiltinWorkflows registers all four built-in workflow commands", () => {
   const { pi, commands } = makeCommandRegistryPi();
   registerBuiltinWorkflows(pi, { cwd: "/tmp" });
-  assert.equal(commands.length, 2);
+  assert.equal(commands.length, 4);
   const names = commands.map((c) => c.name).sort();
-  assert.deepEqual(names, ["adversarial-review", "deep-research"]);
+  assert.deepEqual(names, ["adversarial-review", "codebase-audit", "deep-research", "multi-perspective"]);
 });
 
 test("registerBuiltinWorkflows is idempotent — skips already registered commands", () => {
-  const { pi, commands } = makeCommandRegistryPi(["deep-research", "adversarial-review"]);
+  const { pi, commands } = makeCommandRegistryPi([
+    "deep-research",
+    "adversarial-review",
+    "multi-perspective",
+    "codebase-audit",
+  ]);
   registerBuiltinWorkflows(pi, { cwd: "/tmp" });
   assert.equal(commands.length, 0, "should not re-register when already present");
 });
 
 test("registerBuiltinWorkflows registers only missing commands", () => {
-  const { pi, commands } = makeCommandRegistryPi(["deep-research"]);
+  const { pi, commands } = makeCommandRegistryPi(["deep-research", "adversarial-review"]);
   registerBuiltinWorkflows(pi, { cwd: "/tmp" });
   assert.deepEqual(
-    commands.map((c) => c.name),
-    ["adversarial-review"],
-    "should only register the missing command",
+    commands.map((c) => c.name).sort(),
+    ["codebase-audit", "multi-perspective"],
+    "should only register the commands that aren't already present",
   );
 });
 
@@ -49,6 +54,33 @@ test("registerBuiltinWorkflows adversarial-review handler validates empty args (
 
   const { ctx, notified } = makeNotifyCtx();
   await advHandler("", ctx);
+  assert.equal(notified.length, 1, "should notify with warning");
+  assert.equal(notified[0].type, "warning", "should be a warning");
+  assert.ok(notified[0].message.includes("Usage"), "should tell the user how to use it");
+});
+
+test("registerBuiltinWorkflows multi-perspective handler validates empty args (returns early)", async () => {
+  const { pi, commands } = makeCommandRegistryPi();
+  registerBuiltinWorkflows(pi, { cwd: "/tmp" });
+  const handler = commands.find((c) => c.name === "multi-perspective")?.handler;
+  assert.ok(handler, "multi-perspective handler should exist");
+
+  const { ctx, notified } = makeNotifyCtx();
+  await handler("", ctx);
+  assert.equal(notified.length, 1, "should notify with warning");
+  assert.equal(notified[0].type, "warning", "should be a warning");
+  assert.ok(notified[0].message.includes("Usage"), "should tell the user how to use it");
+});
+
+test("registerBuiltinWorkflows codebase-audit handler validates missing checks (returns early)", async () => {
+  const { pi, commands } = makeCommandRegistryPi();
+  registerBuiltinWorkflows(pi, { cwd: "/tmp" });
+  const handler = commands.find((c) => c.name === "codebase-audit")?.handler;
+  assert.ok(handler, "codebase-audit handler should exist");
+
+  const { ctx, notified } = makeNotifyCtx();
+  // scope but no checks → should warn and return early
+  await handler("src/", ctx);
   assert.equal(notified.length, 1, "should notify with warning");
   assert.equal(notified[0].type, "warning", "should be a warning");
   assert.ok(notified[0].message.includes("Usage"), "should tell the user how to use it");


### PR DESCRIPTION
Closes #33
Closes #34

## What

Both `generateMultiPerspectiveWorkflow` (`src/adversarial-review.ts`) and `generateCodebaseAuditWorkflow` (`src/deep-research.ts`) already existed and were exported, but neither was ever registered as a slash command — so the functionality was unreachable from the CLI. This wires both up as built-in commands, following the existing `/deep-research` and `/adversarial-review` pattern in `src/builtin-commands.ts`.

## Commands

- **`/multi-perspective "<topic>" [angle …]`** — analyze a topic from several independent angles in parallel, then synthesize. Defaults to `technical, product, security, user experience, maintainability` when fewer than two angles are supplied.
- **`/codebase-audit <scope> "<check>" …`** — run parallel checks over a scope, then cross-validate and report. Requires a scope plus at least one check.

## Notes

- Added a quote-aware `tokenizeArgs()` helper so a topic or check can span multiple words (e.g. `"missing error handling"`).
- `/multi-perspective`'s generator returns its prose under `synthesis` (not `report`), so the handler presents `synthesis` and falls back to the JSON dump otherwise.
- The two generator functions themselves are unchanged — this PR is purely the registration + tests + docs.

## Verification

- `npm run build` (tsc): clean
- `npm run check` (biome): clean
- `npm run test:unit`: **742/742 pass** (updated the count/idempotency/missing-only registration tests; added empty-arg validation tests for both new commands)

✅ Also verified end-to-end through the real SDK path on `deepseek/deepseek-v4-flash` — both commands ran with 0 errored agents and returned real non-empty `synthesis`/`report` prose. See the verification comment below.