### PR TITLE
feat: add built-in /code-review workflow command

### DIFF
--- a/src/builtin-commands.ts
+++ b/src/builtin-commands.ts
@@ -1,11 +1,12 @@
 /**
  * Bundled workflow commands: `/deep-research`, `/adversarial-review`,
- * `/multi-perspective`, and `/codebase-audit`.
+ * `/code-review`, `/multi-perspective`, and `/codebase-audit`.
  * They run a generated workflow script and print the final report.
  */
 
 import { createCodingTools, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
+import { generateCodeReviewWorkflow } from "./code-review.js";
 import { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "./deep-research.js";
 import { createWebTools } from "./web-tools.js";
 import { runWorkflow, type WorkflowRunResult } from "./workflow.js";
@@ -80,6 +81,29 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string }
         } catch (error) {
           ctx.ui.setStatus("adversarial-review", undefined);
           ctx.ui.notify(`adversarial-review failed: ${error instanceof Error ? error.message : error}`, "error");
+        }
+      },
+    });
+  }
+
+  if (!alreadyRegistered(pi, "code-review")) {
+    pi.registerCommand("code-review", {
+      description: "Run a 7-angle parallel code review with adversarial verification against a diff or path",
+      async handler(args: string, ctx: ExtensionCommandContext) {
+        const target = args.trim() || ".";
+        ctx.ui.notify("Reviewing code across 7 parallel angles…", "info");
+        try {
+          const result = await runWorkflow(generateCodeReviewWorkflow(), {
+            cwd,
+            args: { target },
+            tools: createCodingTools(cwd),
+            onPhase: (title) => ctx.ui.setStatus("code-review", `review: ${title}`),
+          });
+          ctx.ui.setStatus("code-review", undefined);
+          await pi.sendMessage({ customType: "code-review", content: reportText(result), display: true });
+        } catch (error) {
+          ctx.ui.setStatus("code-review", undefined);
+          ctx.ui.notify(`code-review failed: ${error instanceof Error ? error.message : error}`, "error");
         }
       },
     });

--- a/src/code-review.ts
+++ b/src/code-review.ts
@@ -1,0 +1,125 @@
+/**
+ * 7-angle parallel code review workflow.
+ */
+export function generateCodeReviewWorkflow(): string {
+  return `export const meta = {
+  name: 'code_review',
+  description: '7-angle parallel code review with adversarial verification',
+  phases: [
+    { title: 'Gather' },
+    { title: 'Angles' },
+    { title: 'Verify' },
+    { title: 'Report' },
+  ],
+}
+
+const target = (args && args.target) || '.'
+
+phase('Gather')
+const gathered = await agent(
+  'Gather the code diff to review. Target: ' + target + '\\n\\n' +
+  'Run: git diff @{upstream}...HEAD (or git diff HEAD~1 if no upstream). ' +
+  'If the diff is empty, also try git diff HEAD for uncommitted changes. ' +
+  'Read the enclosing functions for each changed hunk. ' +
+  'Return the diff text and the list of changed file paths.',
+  { label: 'gather', schema: { type: 'object', properties: { diff: { type: 'string' }, files: { type: 'array', items: { type: 'string' } } }, required: ['diff', 'files'] } }
+)
+
+if (!gathered || !gathered.diff || !gathered.diff.trim()) {
+  return { findings: [], report: 'No diff found — nothing to review.' }
+}
+
+phase('Angles')
+const candidates = await parallel([
+  () => agent(
+    'CODE REVIEW ANGLE A — Line-by-line scan.\\n\\nDiff:\\n' + gathered.diff +
+    '\\n\\nRead every hunk line by line. Also read the enclosing function for each hunk — bugs in unchanged lines of a touched function are in scope. ' +
+    'For every line ask: what input, state, timing, or platform makes this line wrong? ' +
+    'Find: inverted/wrong conditions, off-by-one, null/undefined deref, missing await, falsy-zero checks, wrong-variable copy-paste, swallowed error. ' +
+    'Return up to 6 findings.',
+    { label: 'angle-A', schema: { type: 'object', properties: { findings: { type: 'array', items: { type: 'object', properties: { file: { type: 'string' }, line: { type: 'number' }, summary: { type: 'string' }, failure_scenario: { type: 'string' } }, required: ['file', 'line', 'summary', 'failure_scenario'] } } }, required: ['findings'] } }
+  ),
+  () => agent(
+    'CODE REVIEW ANGLE B — Removed-behavior audit.\\n\\nDiff:\\n' + gathered.diff +
+    '\\n\\nFor every line the diff DELETES or replaces, name the invariant or behavior it enforced, ' +
+    'then search the new code for where that invariant is re-established. ' +
+    'If you cannot find it, that is a finding: a removed guard, dropped error path, narrowed validation, deleted test. ' +
+    'Return up to 6 findings.',
+    { label: 'angle-B', schema: { type: 'object', properties: { findings: { type: 'array', items: { type: 'object', properties: { file: { type: 'string' }, line: { type: 'number' }, summary: { type: 'string' }, failure_scenario: { type: 'string' } }, required: ['file', 'line', 'summary', 'failure_scenario'] } } }, required: ['findings'] } }
+  ),
+  () => agent(
+    'CODE REVIEW ANGLE C — Cross-file tracer.\\n\\nDiff:\\n' + gathered.diff + '\\nChanged files: ' + JSON.stringify(gathered.files) +
+    '\\n\\nFor each function the diff changes, use grep to find its callers. ' +
+    'Check whether the change breaks any call site: new precondition, changed return shape, new exception, timing dependency. ' +
+    'Also check callees: does a parallel change make a call unsafe? Return up to 6 findings.',
+    { label: 'angle-C', schema: { type: 'object', properties: { findings: { type: 'array', items: { type: 'object', properties: { file: { type: 'string' }, line: { type: 'number' }, summary: { type: 'string' }, failure_scenario: { type: 'string' } }, required: ['file', 'line', 'summary', 'failure_scenario'] } } }, required: ['findings'] } }
+  ),
+  () => agent(
+    'CODE REVIEW ANGLE D — Language pitfalls.\\n\\nDiff:\\n' + gathered.diff +
+    '\\n\\nCheck for language-specific pitfalls: nil-map write, range-variable capture, defer-in-loop, ' +
+    'goroutine leak, context misuse, sync primitive copy (Go); missing await, undefined access, ' +
+    'prototype pollution, event listener leak (JS/TS); mutable default arguments, reference aliasing (Python). ' +
+    'Return up to 6 findings.',
+    { label: 'angle-D', schema: { type: 'object', properties: { findings: { type: 'array', items: { type: 'object', properties: { file: { type: 'string' }, line: { type: 'number' }, summary: { type: 'string' }, failure_scenario: { type: 'string' } }, required: ['file', 'line', 'summary', 'failure_scenario'] } } }, required: ['findings'] } }
+  ),
+  () => agent(
+    'CODE REVIEW ANGLE E — Reuse check.\\n\\nDiff:\\n' + gathered.diff + '\\nChanged files: ' + JSON.stringify(gathered.files) +
+    '\\n\\nGrep shared/utility modules and files adjacent to the changes for existing helpers this new code duplicates. ' +
+    'Name the existing helper that should be called instead. Return up to 6 findings.',
+    { label: 'angle-E', schema: { type: 'object', properties: { findings: { type: 'array', items: { type: 'object', properties: { file: { type: 'string' }, line: { type: 'number' }, summary: { type: 'string' }, failure_scenario: { type: 'string' } }, required: ['file', 'line', 'summary', 'failure_scenario'] } } }, required: ['findings'] } }
+  ),
+  () => agent(
+    'CODE REVIEW ANGLE F — Simplification.\\n\\nDiff:\\n' + gathered.diff +
+    '\\n\\nFlag unnecessary complexity the diff adds: redundant or derivable state, copy-paste with slight variation, ' +
+    'deep nesting, dead code left behind. Name the simpler form that does the same job. Return up to 6 findings.',
+    { label: 'angle-F', schema: { type: 'object', properties: { findings: { type: 'array', items: { type: 'object', properties: { file: { type: 'string' }, line: { type: 'number' }, summary: { type: 'string' }, failure_scenario: { type: 'string' } }, required: ['file', 'line', 'summary', 'failure_scenario'] } } }, required: ['findings'] } }
+  ),
+  () => agent(
+    'CODE REVIEW ANGLE G — Altitude.\\n\\nDiff:\\n' + gathered.diff +
+    '\\n\\nCheck that each change is implemented at the right depth. Special cases layered on shared infrastructure ' +
+    'are a sign the fix is not deep enough. Prefer generalizing the underlying mechanism over adding special cases. ' +
+    'Return up to 6 findings.',
+    { label: 'angle-G', tier: 'big', schema: { type: 'object', properties: { findings: { type: 'array', items: { type: 'object', properties: { file: { type: 'string' }, line: { type: 'number' }, summary: { type: 'string' }, failure_scenario: { type: 'string' } }, required: ['file', 'line', 'summary', 'failure_scenario'] } } }, required: ['findings'] } }
+  ),
+])
+
+const allFindings = candidates
+  .filter(Boolean)
+  .flatMap((c) => (c && c.findings) || [])
+  .slice(0, 42)
+
+if (allFindings.length === 0) {
+  return { findings: [], report: 'No issues found across all review angles.' }
+}
+
+phase('Verify')
+const verdicts = await parallel(allFindings.map((f, i) => () =>
+  agent(
+    'Verify this code review finding. ' +
+    'Return CONFIRMED (can name inputs → wrong output), PLAUSIBLE (mechanism real, trigger uncertain), or REFUTED (factually wrong or already guarded). ' +
+    'PLAUSIBLE by default for races, nil on rare paths, off-by-one on non-excluded boundaries. ' +
+    'REFUTED only when constructible from code: factually wrong, provably impossible, or already handled.\\n\\n' +
+    'FINDING: ' + JSON.stringify(f),
+    { label: 'verify-' + (i + 1), schema: { type: 'object', properties: { verdict: { type: 'string', enum: ['CONFIRMED', 'PLAUSIBLE', 'REFUTED'] }, reason: { type: 'string' } }, required: ['verdict', 'reason'] } }
+  )
+))
+
+const survivors = allFindings
+  .filter((_, i) => {
+    const v = verdicts[i]
+    return v && v.verdict !== 'REFUTED'
+  })
+  .slice(0, 10)
+
+phase('Report')
+const report = await agent(
+  'Write a code review report. Include ONLY the findings that survived verification (below), ranked most-severe first. ' +
+  'Cap at 10 findings. For each finding: **[SEVERITY]** \x60file:line\x60 — summary\\n> Failure scenario: concrete inputs → wrong output or crash\\n\\n' +
+  'Severity levels: CRITICAL / HIGH / MEDIUM / LOW / CLEANUP. ' +
+  'Correctness bugs outrank cleanup. Note how many candidates were generated vs. survived.\\n\\n' +
+  'SURVIVORS:\\n' + JSON.stringify(survivors),
+  { label: 'report', tier: 'big' }
+)
+
+return { findings: survivors, report }`;
+}

--- a/tests/builtin-commands.test.ts
+++ b/tests/builtin-commands.test.ts
@@ -3,21 +3,18 @@ import test from "node:test";
 import { registerBuiltinWorkflows } from "../src/builtin-commands.js";
 import { makeCommandRegistryPi, makeNotifyCtx } from "./helpers/mock-pi.js";
 
-test("registerBuiltinWorkflows registers all four built-in workflow commands", () => {
+const BUILTIN_COMMANDS = ["adversarial-review", "code-review", "codebase-audit", "deep-research", "multi-perspective"];
+
+test("registerBuiltinWorkflows registers all five built-in workflow commands", () => {
   const { pi, commands } = makeCommandRegistryPi();
   registerBuiltinWorkflows(pi, { cwd: "/tmp" });
-  assert.equal(commands.length, 4);
+  assert.equal(commands.length, 5);
   const names = commands.map((c) => c.name).sort();
-  assert.deepEqual(names, ["adversarial-review", "codebase-audit", "deep-research", "multi-perspective"]);
+  assert.deepEqual(names, BUILTIN_COMMANDS);
 });
 
 test("registerBuiltinWorkflows is idempotent — skips already registered commands", () => {
-  const { pi, commands } = makeCommandRegistryPi([
-    "deep-research",
-    "adversarial-review",
-    "multi-perspective",
-    "codebase-audit",
-  ]);
+  const { pi, commands } = makeCommandRegistryPi(BUILTIN_COMMANDS);
   registerBuiltinWorkflows(pi, { cwd: "/tmp" });
   assert.equal(commands.length, 0, "should not re-register when already present");
 });
@@ -27,7 +24,7 @@ test("registerBuiltinWorkflows registers only missing commands", () => {
   registerBuiltinWorkflows(pi, { cwd: "/tmp" });
   assert.deepEqual(
     commands.map((c) => c.name).sort(),
-    ["codebase-audit", "multi-perspective"],
+    ["code-review", "codebase-audit", "multi-perspective"],
     "should only register the commands that aren't already present",
   );
 });
@@ -57,6 +54,14 @@ test("registerBuiltinWorkflows adversarial-review handler validates empty args (
   assert.equal(notified.length, 1, "should notify with warning");
   assert.equal(notified[0].type, "warning", "should be a warning");
   assert.ok(notified[0].message.includes("Usage"), "should tell the user how to use it");
+});
+
+test("registerBuiltinWorkflows code-review handler accepts empty args as current directory", () => {
+  const { pi, commands } = makeCommandRegistryPi();
+  registerBuiltinWorkflows(pi, { cwd: "/tmp" });
+  const handler = commands.find((c) => c.name === "code-review")?.handler;
+  assert.ok(handler, "code-review handler should exist");
+  assert.equal(typeof handler, "function");
 });
 
 test("registerBuiltinWorkflows multi-perspective handler validates empty args (returns early)", async () => {
@@ -102,4 +107,9 @@ test("registerBuiltinWorkflows creates handlers with expected structure", () => 
     "should contain Investigate",
   );
   assert.equal(typeof advReviewCmd.handler, "function");
+
+  const codeReviewCmd = commands.find((c) => c.name === "code-review");
+  assert.ok(codeReviewCmd, "code-review should be registered");
+  assert.ok(codeReviewCmd.description?.includes("code review"), "should have code review description");
+  assert.equal(typeof codeReviewCmd.handler, "function");
 });

--- a/tests/builtin-workflows.test.ts
+++ b/tests/builtin-workflows.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "../src/adversarial-review.js";
+import { generateCodeReviewWorkflow } from "../src/code-review.js";
 import { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "../src/deep-research.js";
 import { createWebTools } from "../src/web-tools.js";
 import { parseWorkflowScript } from "../src/workflow.js";
@@ -41,6 +42,34 @@ test("generateAdversarialReviewWorkflow phases are Investigate, Refute, Consensu
     meta.phases?.map((p) => p.title),
     ["Investigate", "Refute", "Consensus"],
   );
+});
+
+// ─── Code Review ────────────────────────────────────────────────────────────────
+
+test("generateCodeReviewWorkflow produces a valid, parseable script", () => {
+  const { meta, body } = parseWorkflowScript(generateCodeReviewWorkflow());
+  assert.equal(meta.name, "code_review");
+  assert.deepEqual(
+    meta.phases?.map((p) => p.title),
+    ["Gather", "Angles", "Verify", "Report"],
+  );
+  assert.match(body, /args && args\.target/);
+  assert.match(body, /parallel\(/);
+  assert.match(body, /!gathered \|\| !gathered\.diff/);
+});
+
+test("generateCodeReviewWorkflow contains the 7 review angles and verifier verdicts", () => {
+  const body = generateCodeReviewWorkflow();
+  assert.match(body, /angle-A/);
+  assert.match(body, /angle-B/);
+  assert.match(body, /angle-C/);
+  assert.match(body, /angle-D/);
+  assert.match(body, /angle-E/);
+  assert.match(body, /angle-F/);
+  assert.match(body, /angle-G/);
+  assert.match(body, /CONFIRMED/);
+  assert.match(body, /PLAUSIBLE/);
+  assert.match(body, /REFUTED/);
 });
 
 // ─── Codebase Audit ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements upstream #32 by adding a built-in `/code-review` workflow command.

- adds `generateCodeReviewWorkflow()` with 7 parallel review angles, verification, and final report phases
- registers `/code-review` alongside the existing built-in workflow commands
- defaults an empty command argument to the current directory
- handles missing/empty gather output without throwing
- adds parser and command registration coverage

Closes #32.

## Review notes

Full scoped review completed before publishing. One issue was found and fixed before PR creation: the gather phase now handles `null`/missing output instead of dereferencing `gathered.diff`.

## Verification

- `npx biome check src/code-review.ts src/builtin-commands.ts tests/builtin-commands.test.ts tests/builtin-workflows.test.ts`
- `npm run build`
- `npm run test:unit -- tests/builtin-workflows.test.ts` (project script ran full unit suite: 745 passing, 0 failing)
