### PR TITLE
feat: wire agent frontmatter isolation to worktree execution

### DIFF
--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -12,8 +12,8 @@
  * tools+model+system-prompt, not a prose hint.
  *
  * Bound today: `tools` (allowlist), `disallowedTools` (denylist), `model`,
- * and the markdown body (`prompt`). Parsed-but-ignored for now (documented):
- * `mcp`, `skills`, `background`, `isolation` — each is wired independently later.
+ * and the markdown body (`prompt`). Parsed-but-ignored for now (documented): `mcp`, `skills`, `background`.
+ * Wired: `isolation` ("worktree") → createWorktree() in workflow.ts.
  */
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
@@ -33,6 +33,8 @@ export interface AgentDefinition {
   disallowedTools?: string[];
   /** Model spec (`provider/modelId` or bare id) for this subagent. */
   model?: string;
+  /** Isolation mode. When "worktree", agents using this type run in a git worktree. */
+  isolation?: "worktree";
   /** Markdown body, prepended to the subagent's task as role guidance. */
   prompt: string;
   /** Where the definition was loaded from (project wins over user). */
@@ -75,6 +77,7 @@ export function parseAgentDefinition(
     tools: toStringArray(fm.tools),
     disallowedTools: toStringArray(fm.disallowedTools),
     model: typeof fm.model === "string" ? fm.model.trim() || undefined : undefined,
+    isolation: fm.isolation === "worktree" ? "worktree" : undefined,
     prompt,
     source,
   };
@@ -156,6 +159,7 @@ export function agentDefinitionKey(def: AgentDefinition | undefined): string | n
     tools: def.tools ?? null,
     disallowedTools: def.disallowedTools ?? null,
     model: def.model ?? null,
+    isolation: def.isolation ?? null,
     prompt: def.prompt,
   });
 }

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -77,7 +77,8 @@ export function parseAgentDefinition(
     tools: toStringArray(fm.tools),
     disallowedTools: toStringArray(fm.disallowedTools),
     model: typeof fm.model === "string" ? fm.model.trim() || undefined : undefined,
-    isolation: typeof fm.isolation === "string" && fm.isolation.toLowerCase().trim() === "worktree" ? "worktree" : undefined,
+    isolation:
+      typeof fm.isolation === "string" && fm.isolation.toLowerCase().trim() === "worktree" ? "worktree" : undefined,
     prompt,
     source,
   };

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -77,7 +77,7 @@ export function parseAgentDefinition(
     tools: toStringArray(fm.tools),
     disallowedTools: toStringArray(fm.disallowedTools),
     model: typeof fm.model === "string" ? fm.model.trim() || undefined : undefined,
-    isolation: fm.isolation === "worktree" ? "worktree" : undefined,
+    isolation: typeof fm.isolation === "string" && fm.isolation.toLowerCase().trim() === "worktree" ? "worktree" : undefined,
     prompt,
     source,
   };

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -425,7 +425,8 @@ export async function runWorkflow<T = unknown>(
 
       // Optional per-agent worktree isolation (deterministic name -> stable resume keys).
       let worktree: Worktree | undefined;
-      if (agentOptions.isolation === "worktree") {
+      const resolvedIsolation = agentOptions.isolation ?? agentDef?.isolation;
+      if (resolvedIsolation === "worktree") {
         worktree = await createWorktree(baseCwd, `${runId}-${callIndex}-${label}`);
         if (!worktree.isolated) log(`isolation ignored for "${label}" (${worktree.reason})`);
       }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -424,6 +424,10 @@ export async function runWorkflow<T = unknown>(
       options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
 
       // Optional per-agent worktree isolation (deterministic name -> stable resume keys).
+      // Precedence: explicit call-site isolation > agentDef isolation.
+      // Note: passing { isolation: undefined } falls through ?? to the def's value — there
+      // is no sentinel to suppress a def's isolation at the call site. Remove the agentType
+      // or override with a def that has no isolation field if opt-out is needed.
       let worktree: Worktree | undefined;
       const resolvedIsolation = agentOptions.isolation ?? agentDef?.isolation;
       if (resolvedIsolation === "worktree") {
@@ -462,7 +466,7 @@ export async function runWorkflow<T = unknown>(
                 label,
                 schema: agentOptions.schema,
                 signal: options.signal,
-                instructions: buildAgentInstructions(assignedPhase, agentOptions, agentDef),
+                instructions: buildAgentInstructions(assignedPhase, agentOptions, agentDef, resolvedIsolation),
                 model: modelSpec,
                 tier: agentOptions.tier,
                 toolNames: agentDef?.tools,
@@ -1063,6 +1067,7 @@ function buildAgentInstructions(
   phase: string | undefined,
   options: AgentOptions,
   def: AgentDefinition | undefined,
+  resolvedIsolation?: "worktree",
 ): string | undefined {
   const lines: string[] = [];
   // A resolved agentType binds a real role prompt (the definition body). Only
@@ -1070,7 +1075,9 @@ function buildAgentInstructions(
   if (def?.prompt) lines.push(def.prompt);
   else if (options.agentType) lines.push(`Act as workflow subagent type: ${options.agentType}`);
   if (phase) lines.push(`Workflow phase: ${phase}`);
-  if (options.isolation) lines.push(`Requested isolation: ${options.isolation}`);
+  // Use resolvedIsolation so the annotation fires whether isolation came from
+  // the call site or from the agentDef's isolation field.
+  if (resolvedIsolation) lines.push(`Requested isolation: ${resolvedIsolation}`);
   // Note: options.model is applied for real via the session, not injected as prose.
   return lines.length ? lines.join("\n\n") : undefined;
 }

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -59,6 +59,20 @@ describe("parseAgentDefinition", () => {
     const def = parseAgentDefinition(md, "project", "x.md");
     assert.deepEqual(def?.tools, ["read", "write"]);
   });
+
+  it("parses isolation: worktree from frontmatter", () => {
+    const content = "---\nname: isolated-agent\nisolation: worktree\n---\nBody.";
+    const def = parseAgentDefinition(content, "project", "isolated-agent.md");
+    assert.ok(def);
+    assert.equal(def.isolation, "worktree");
+  });
+
+  it("ignores unknown isolation values", () => {
+    const content = "---\nname: agent\nisolation: unknown-value\n---\nBody.";
+    const def = parseAgentDefinition(content, "project", "agent.md");
+    assert.ok(def);
+    assert.equal(def.isolation, undefined);
+  });
 });
 
 // ── loadAgentRegistry (dir injection) ──────────────────────────────────────
@@ -163,6 +177,11 @@ describe("agentDefinitionKey", () => {
     assert.notEqual(agentDefinitionKey(base), agentDefinitionKey({ ...base, prompt: "p2" }));
     assert.notEqual(agentDefinitionKey(base), agentDefinitionKey({ ...base, model: "m2" }));
     assert.notEqual(agentDefinitionKey(base), agentDefinitionKey({ ...base, tools: ["read", "write"] }));
+  });
+
+  it("changes when isolation changes", () => {
+    const base: AgentDefinition = { name: "x", prompt: "p", source: "project" };
+    assert.notEqual(agentDefinitionKey(base), agentDefinitionKey({ ...base, isolation: "worktree" }));
   });
 });
 

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -194,6 +195,8 @@ function capturingAgent() {
     toolNames?: string[];
     disallowedToolNames?: string[];
     instructions?: string;
+    cwd?: string;
+    cwdExists?: boolean;
   }> = [];
   const runner = {
     async run(_prompt: string, options: Record<string, unknown>) {
@@ -203,6 +206,8 @@ function capturingAgent() {
         toolNames: options.toolNames as string[] | undefined,
         disallowedToolNames: options.disallowedToolNames as string[] | undefined,
         instructions: options.instructions as string | undefined,
+        cwd: options.cwd as string | undefined,
+        cwdExists: typeof options.cwd === "string" ? existsSync(options.cwd) : undefined,
       });
       return "ok";
     },
@@ -256,6 +261,51 @@ await agent('audit', { label: 'a', agentType: 'security-auditor', tier: 'small' 
 return {}`;
     await runWorkflow(script, { agent: runner, persistLogs: false, agentRegistry: registry });
     assert.equal(seen[0].model, "vendor/auditor-model", "definition model wins over tier");
+  });
+
+  it("agentType isolation: worktree runs the agent in an isolated cwd", async () => {
+    const repo = mkdtempSync(join(tmpdir(), "pi-agent-isolation-"));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.t");
+      git("config", "user.name", "t");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+
+      const isolatedRegistry: AgentRegistry = new Map([
+        [
+          "isolated-auditor",
+          {
+            name: "isolated-auditor",
+            prompt: "Run isolated.",
+            isolation: "worktree",
+            source: "project",
+          } as AgentDefinition,
+        ],
+      ]);
+      const { seen, runner } = capturingAgent();
+      const script = `export const meta = { name: 'isolated', description: 'agentType isolation' }
+await agent('audit', { label: 'a', agentType: 'isolated-auditor' })
+return {}`;
+
+      await runWorkflow(script, {
+        cwd: repo,
+        runId: "iso-test",
+        agent: runner,
+        persistLogs: false,
+        agentRegistry: isolatedRegistry,
+      });
+
+      assert.equal(seen.length, 1);
+      assert.ok(seen[0].cwd, "isolated agent should receive a cwd");
+      assert.notEqual(seen[0].cwd, repo, "agent cwd should not be the base repo");
+      assert.equal(seen[0].cwdExists, true, "worktree cwd should exist while the agent runs");
+      assert.ok(seen[0].instructions?.includes("Requested isolation: worktree"));
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 
   it("unknown agentType logs a fallback and binds no tools/model", async () => {


### PR DESCRIPTION
## Summary

Implements upstream #37 by wiring `isolation: worktree` from agent frontmatter into workflow agent execution.

- parses `isolation: worktree` in agent definitions
- includes isolation in `agentDefinitionKey` so resume cache invalidates when isolation changes
- resolves isolation from explicit agent options first, then agent definition frontmatter
- annotates runner instructions with the resolved isolation source
- adds runtime coverage proving agent-type isolation uses an isolated worktree cwd

Closes #37.

## Review notes

Full scoped review completed before publishing. No additional findings remained after adding runtime coverage for frontmatter-driven isolation.

## Verification

- `npx biome check src/agent-registry.ts src/workflow.ts tests/agent-registry.test.ts`
- `npm run build`
- `npm run test:unit -- tests/agent-registry.test.ts tests/worktree.test.ts` (rebased branch full project script: 746 passing, 0 failing)
