### PR TITLE
feat: add workflow navigator filter, rename, and confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,25 @@ The same model — on Pi, plus the production pieces a real run needs:
 
 In the navigator: `↑/↓` select · `enter`/`→` open · `esc`/`←` back · `p` pause · `x` stop · `r` restart · `s` save · `q` quit. Each agent shows the model it ran on; the detail view shows its prompt, result, error diagnostics, and compact message/tool history.
 
+### Navigator keyboard shortcuts
+
+| Key | Where | Action |
+| --- | --- | --- |
+| `↑` / `↓` or `j` / `k` | all list views | move selection |
+| `enter` / `→` | runs, phases, agents | drill in |
+| `esc` / `←` | any view | go back (esc at top closes) |
+| `q` | any view | close navigator |
+| `p` | runs view — run selected | pause the run |
+| `x` | runs view — run selected | stop the run (press `x` again to confirm) |
+| `r` | runs view — run selected | restart the run |
+| `s` | runs view — run selected | save run script as a `/<name>` command |
+| `/` | runs view | open the filter bar; type to filter runs and saved workflows by name |
+| `esc` (in filter) | runs view, filter active | clear filter and exit filter mode |
+| `enter` (in filter) | runs view, filter active | lock in the filter and return to normal navigation |
+| `x` | runs view — saved selected, or saved detail | delete the saved workflow (press `x` again to confirm) |
+| `n` | runs view — saved selected, or saved detail | rename the saved workflow; type new name, `enter` to confirm, `esc` to cancel |
+| `j` / `k` | detail / saved detail | scroll the detail body |
+
 ## Storage
 
 Workflow state is stored under `~/.pi/workflows` so projects do not accumulate extension-owned `.pi/workflows` directories. Global settings and model tiers live at `~/.pi/workflows/settings.json` and `~/.pi/workflows/model-tiers.json`; project-scoped run history, resume journals, locks, and saved workflow overrides live under `~/.pi/workflows/projects/<project>/`. Older project-local `.pi/workflows/runs` and `.pi/workflows/saved` data is still read as a fallback, but new writes go to the user-level workflow store.

--- a/src/workflow-saved.ts
+++ b/src/workflow-saved.ts
@@ -193,6 +193,23 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
         unlinkSync(path);
         return true;
       }
+      // Legacy project directory: workflows saved before the new project-scoped
+      // path was introduced live in legacyProjectDir. The delete method already
+      // handles this dir; rename must do the same so that a legacy-dir workflow
+      // can be renamed without requiring a manual storage migration.
+      if (!location || location === "project") {
+        const legacyPath = legacyProjectWorkflowPath(oldName);
+        const wf = loadFromFile(legacyPath, "project");
+        if (wf) {
+          if (workflowExists(newName)) return false;
+          const newPath = workflowPath(newName, "project");
+          ensureDir(projectDir);
+          const renamed: SavedWorkflow = { ...wf, name: newName, path: newPath };
+          writeFileSync(newPath, JSON.stringify(renamed, null, 2));
+          unlinkSync(legacyPath);
+          return true;
+        }
+      }
       return false;
     },
   };

--- a/src/workflow-saved.ts
+++ b/src/workflow-saved.ts
@@ -32,6 +32,8 @@ export interface WorkflowStorage {
   list(): SavedWorkflow[];
   /** Delete a saved workflow. */
   delete(name: string, location?: "project" | "user"): boolean;
+  /** Rename a saved workflow. Returns true if renamed, false if not found or name conflicts. */
+  rename(oldName: string, newName: string, location?: "project" | "user"): boolean;
 }
 
 export function isSafeSavedWorkflowName(name: string): boolean {
@@ -166,6 +168,27 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
       }
 
       return deleted;
+    },
+
+    rename(oldName: string, newName: string, location?: "project" | "user"): boolean {
+      if (!isSafeSavedWorkflowName(oldName) || !isSafeSavedWorkflowName(newName)) return false;
+      if (oldName === newName) return false;
+      const locs = location ? [location] : (["project", "user"] as const);
+      for (const loc of locs) {
+        const path = workflowPath(oldName, loc);
+        const wf = loadFromFile(path, loc);
+        if (!wf) continue;
+        // Check new name not already taken in either location
+        const newPath = workflowPath(newName, loc);
+        if (existsSync(newPath)) return false;
+        const dir = loc === "project" ? projectDir : userDir;
+        ensureDir(dir);
+        const renamed: SavedWorkflow = { ...wf, name: newName, path: newPath };
+        writeFileSync(newPath, JSON.stringify(renamed, null, 2));
+        unlinkSync(path);
+        return true;
+      }
+      return false;
     },
   };
 }

--- a/src/workflow-saved.ts
+++ b/src/workflow-saved.ts
@@ -74,6 +74,10 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
     assertSafeSavedWorkflowName(name);
     return join(legacyProjectDir, `${name}.json`);
   };
+  const workflowExists = (name: string): boolean =>
+    existsSync(workflowPath(name, "project")) ||
+    existsSync(legacyProjectWorkflowPath(name)) ||
+    existsSync(workflowPath(name, "user"));
 
   const loadFromFile = (path: string, location: "project" | "user"): SavedWorkflow | null => {
     try {
@@ -178,9 +182,10 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
         const path = workflowPath(oldName, loc);
         const wf = loadFromFile(path, loc);
         if (!wf) continue;
-        // Check new name not already taken in either location
+        // Check the target name against all load/list locations so renaming
+        // cannot hide or shadow an existing saved workflow.
         const newPath = workflowPath(newName, loc);
-        if (existsSync(newPath)) return false;
+        if (workflowExists(newName)) return false;
         const dir = loc === "project" ? projectDir : userDir;
         ensureDir(dir);
         const renamed: SavedWorkflow = { ...wf, name: newName, path: newPath };

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -686,6 +686,19 @@ export function openWorkflowNavigator(
             state.inputMode = undefined;
             if (newName && newName !== oldName) {
               if (model.renameSaved(oldName, newName)) {
+                // Re-register the slash command under the new name so /<newName>
+                // works immediately without requiring a session reload. Pi has no
+                // unregisterCommand, so the old /<oldName> slot becomes a no-op
+                // (the exists predicate returns false and the handler tells the
+                // user to reload), consistent with how delete is handled.
+                if (opts.storage) {
+                  const renamed = opts.storage.load(newName);
+                  if (renamed) {
+                    registerSavedWorkflow(pi, opts.cwd ?? process.cwd(), renamed, undefined, () =>
+                      opts.storage!.list().some((w) => w.name === renamed.name),
+                    );
+                  }
+                }
                 ui.notify(`Renamed /${oldName} → /${newName}`, "info");
                 state.back();
               } else {

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -376,15 +376,8 @@ export function renderNavigator(
     const runs = model.runs();
     const saved = model.saved();
     const filterLower = state.filterText.toLowerCase();
-    const filteredRuns = filterLower
-      ? runs.filter((r) => r.name.toLowerCase().includes(filterLower) || r.runId.toLowerCase().includes(filterLower))
-      : runs;
-    const filteredSaved = filterLower
-      ? saved.filter(
-          (w) =>
-            w.name.toLowerCase().includes(filterLower) || (w.description ?? "").toLowerCase().includes(filterLower),
-        )
-      : saved;
+    const filteredRuns = filterRuns(runs, filterLower);
+    const filteredSaved = filterSaved(saved, filterLower);
     const total = runs.length + saved.length;
     state.clamp(total);
     lines.push(theme.bold("Workflows"));
@@ -581,8 +574,21 @@ export function keyToAction(keyId: string | undefined, kind: ViewKind, itemKind?
   }
 }
 
+function filterRuns(runs: RunRow[], lower: string): RunRow[] {
+  return lower ? runs.filter((r) => r.name.toLowerCase().includes(lower) || r.runId.toLowerCase().includes(lower)) : runs;
+}
+
+function filterSaved(saved: SavedWorkflow[], lower: string): SavedWorkflow[] {
+  return lower
+    ? saved.filter((w) => w.name.toLowerCase().includes(lower) || (w.description ?? "").toLowerCase().includes(lower))
+    : saved;
+}
+
 function currentCount(state: NavigatorState, model: NavigatorModel): number {
-  if (state.kind === "runs") return model.runs().length + model.saved().length;
+  if (state.kind === "runs") {
+    const lower = state.filterText.toLowerCase();
+    return filterRuns(model.runs(), lower).length + filterSaved(model.saved(), lower).length;
+  }
   if (state.kind === "phases" && state.runId) return model.phases(state.runId).length;
   if (state.kind === "agents" && state.runId && state.phase) return model.agents(state.runId, state.phase).length;
   return 0;

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -76,6 +76,8 @@ interface AgentRow {
   model?: string;
 }
 
+type VisibleItem = { kind: "run"; run: RunRow } | { kind: "saved"; saved: SavedWorkflow };
+
 /** Short, human-friendly model label: drop the provider prefix for display. */
 export function shortModel(model: string | undefined): string | undefined {
   if (!model) return undefined;
@@ -260,8 +262,7 @@ export class NavigatorState {
    * runs view. Positions before runs.length are "run"; after are "saved".
    */
   itemKindAt(model: NavigatorModel, cursor: number): ItemKind {
-    const runCount = model.runs().length;
-    return cursor < runCount ? "run" : "saved";
+    return visibleItems(model, this.filterText)[cursor]?.kind ?? "run";
   }
 
   /** Clamp the cursor to [0, count). */
@@ -284,20 +285,14 @@ export class NavigatorState {
   drill(model: NavigatorModel): boolean {
     const t = this.top();
     if (t.kind === "runs") {
-      const runs = model.runs();
-      const saved = model.saved();
-      if (t.cursor < runs.length) {
-        // Drilling into a run
-        const run = runs[t.cursor];
-        if (!run) return false;
-        this.stack.push({ kind: "phases", cursor: 0, runId: run.runId });
+      const item = visibleItems(model, this.filterText)[t.cursor];
+      if (!item) return false;
+      if (item.kind === "run") {
+        this.stack.push({ kind: "phases", cursor: 0, runId: item.run.runId });
         return true;
       }
-      // Drilling into a saved workflow
-      const item = saved[t.cursor - runs.length];
-      if (!item) return false;
       this.scroll = 0;
-      this.stack.push({ kind: "savedDetail", cursor: 0, savedName: item.name });
+      this.stack.push({ kind: "savedDetail", cursor: 0, savedName: item.saved.name });
       return true;
     }
     if (t.kind === "phases" && t.runId) {
@@ -330,8 +325,18 @@ export class NavigatorState {
   activeRunId(model: NavigatorModel): string | undefined {
     if (this.runId) return this.runId;
     if (this.kind === "runs") {
-      const runs = model.runs();
-      if (this.cursor < runs.length) return runs[this.cursor]?.runId;
+      const item = visibleItems(model, this.filterText)[this.cursor];
+      if (item?.kind === "run") return item.run.runId;
+    }
+    return undefined;
+  }
+
+  /** The saved workflow name at cursor in runs/savedDetail views, or undefined. */
+  activeSavedName(model: NavigatorModel): string | undefined {
+    if (this.kind === "savedDetail") return this.savedName;
+    if (this.kind === "runs") {
+      const item = visibleItems(model, this.filterText)[this.cursor];
+      if (item?.kind === "saved") return item.saved.name;
     }
     return undefined;
   }
@@ -375,39 +380,38 @@ export function renderNavigator(
   if (state.kind === "runs") {
     const runs = model.runs();
     const saved = model.saved();
-    const filterLower = state.filterText.toLowerCase();
-    const filteredRuns = filterRuns(runs, filterLower);
-    const filteredSaved = filterSaved(saved, filterLower);
+    const items = visibleItems(model, state.filterText);
     const total = runs.length + saved.length;
-    state.clamp(total);
+    state.clamp(items.length);
     lines.push(theme.bold("Workflows"));
     if (state.filterActive || state.filterText) {
       lines.push(dim(`  Filter: ${state.filterText}█`));
     }
     if (total === 0) {
       lines.push(dim("  No runs yet. Start one with a background workflow."));
+    } else if (items.length === 0) {
+      lines.push(dim("  No workflows match the current filter."));
     }
-    // Render runs
-    filteredRuns.forEach((r, _i) => {
-      const origIdx = runs.indexOf(r);
-      const icon = STATUS_ICON[r.status] ?? "?";
-      const meta = [`${r.done}/${r.total}`, fmtTokens(r.tokens), r.cost > 0 ? `$${r.cost.toFixed(4)}` : ""]
-        .filter(Boolean)
-        .join(" · ");
-      lines.push(sel(origIdx, `${icon} ${r.name}  ${dim(`${r.runId} · ${r.status} · ${meta}`)}`));
-    });
-    // Render saved workflows after a separator
-    if (filteredSaved.length > 0) {
-      if (filteredRuns.length > 0) lines.push(dim("  ── saved ──"));
-      filteredSaved.forEach((w) => {
-        const origIdx = runs.length + saved.indexOf(w);
+    let renderedSavedSeparator = false;
+    items.forEach((item, i) => {
+      if (item.kind === "run") {
+        const r = item.run;
+        const icon = STATUS_ICON[r.status] ?? "?";
+        const meta = [`${r.done}/${r.total}`, fmtTokens(r.tokens), r.cost > 0 ? `$${r.cost.toFixed(4)}` : ""]
+          .filter(Boolean)
+          .join(" · ");
+        lines.push(sel(i, `${icon} ${r.name}  ${dim(`${r.runId} · ${r.status} · ${meta}`)}`));
+      } else {
+        if (!renderedSavedSeparator && i > 0) {
+          lines.push(dim("  ── saved ──"));
+          renderedSavedSeparator = true;
+        }
+        const w = item.saved;
         const loc = w.location === "user" ? "~" : ".";
         const desc = w.description ? dim(`  ${w.description}`) : "";
-        lines.push(sel(origIdx, `${w.name}${desc}  ${dim(loc)}`));
-      });
-    } else if (saved.length > 0 && filterLower) {
-      // Have saved items but all filtered out — still show separator if runs are shown
-    }
+        lines.push(sel(i, `${w.name}${desc}  ${dim(loc)}`));
+      }
+    });
   } else if (state.kind === "phases" && state.runId) {
     const phases = model.phases(state.runId);
     state.clamp(phases.length);
@@ -575,7 +579,9 @@ export function keyToAction(keyId: string | undefined, kind: ViewKind, itemKind?
 }
 
 function filterRuns(runs: RunRow[], lower: string): RunRow[] {
-  return lower ? runs.filter((r) => r.name.toLowerCase().includes(lower) || r.runId.toLowerCase().includes(lower)) : runs;
+  return lower
+    ? runs.filter((r) => r.name.toLowerCase().includes(lower) || r.runId.toLowerCase().includes(lower))
+    : runs;
 }
 
 function filterSaved(saved: SavedWorkflow[], lower: string): SavedWorkflow[] {
@@ -584,10 +590,17 @@ function filterSaved(saved: SavedWorkflow[], lower: string): SavedWorkflow[] {
     : saved;
 }
 
+function visibleItems(model: NavigatorModel, filterText: string): VisibleItem[] {
+  const lower = filterText.toLowerCase();
+  return [
+    ...filterRuns(model.runs(), lower).map((run): VisibleItem => ({ kind: "run", run })),
+    ...filterSaved(model.saved(), lower).map((saved): VisibleItem => ({ kind: "saved", saved })),
+  ];
+}
+
 function currentCount(state: NavigatorState, model: NavigatorModel): number {
   if (state.kind === "runs") {
-    const lower = state.filterText.toLowerCase();
-    return filterRuns(model.runs(), lower).length + filterSaved(model.saved(), lower).length;
+    return visibleItems(model, state.filterText).length;
   }
   if (state.kind === "phases" && state.runId) return model.phases(state.runId).length;
   if (state.kind === "agents" && state.runId && state.phase) return model.agents(state.runId, state.phase).length;
@@ -724,15 +737,7 @@ export function openWorkflowNavigator(
             done(undefined);
             return;
           case "deleteSaved": {
-            let targetName: string | undefined;
-            if (state.kind === "runs") {
-              const saved = model.saved();
-              const runCount = model.runs().length;
-              const item = saved[state.cursor - runCount];
-              targetName = item?.name;
-            } else if (state.kind === "savedDetail" && state.savedName) {
-              targetName = state.savedName;
-            }
+            const targetName = state.activeSavedName(model);
             if (!targetName) break;
             if (!state.pendingConfirm) {
               state.pendingConfirm = { action: "deleteSaved", label: targetName };
@@ -772,15 +777,7 @@ export function openWorkflowNavigator(
             }
             return;
           case "rename": {
-            let targetName: string | undefined;
-            if (state.kind === "savedDetail" && state.savedName) {
-              targetName = state.savedName;
-            } else if (state.kind === "runs") {
-              const saved = model.saved();
-              const runCount = model.runs().length;
-              const item = saved[state.cursor - runCount];
-              targetName = item?.name;
-            }
+            const targetName = state.activeSavedName(model);
             if (targetName) {
               state.inputMode = { type: "rename", buffer: targetName, target: targetName };
             }

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -87,7 +87,11 @@ export function shortModel(model: string | undefined): string | undefined {
 export class NavigatorModel {
   constructor(
     private readonly manager: Pick<WorkflowManager, "listRuns" | "getRun">,
-    private readonly storage?: { list(): SavedWorkflow[]; delete(name: string, location?: string): boolean },
+    private readonly storage?: {
+      list(): SavedWorkflow[];
+      delete(name: string, location?: string): boolean;
+      rename(oldName: string, newName: string): boolean;
+    },
   ) {}
 
   private snapshot(runId: string): { snapshot: WorkflowSnapshot; status: string } | undefined {
@@ -124,6 +128,12 @@ export class NavigatorModel {
   deleteSaved(name: string): boolean {
     if (!this.storage) return false;
     return this.storage.delete(name);
+  }
+
+  /** Rename a saved workflow. Returns true if successful. */
+  renameSaved(oldName: string, newName: string): boolean {
+    if (!this.storage) return false;
+    return this.storage.rename(oldName, newName);
   }
 
   runName(runId: string): string {
@@ -211,6 +221,10 @@ function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
 export class NavigatorState {
   private stack: StackFrame[] = [{ kind: "runs", cursor: 0 }];
   scroll = 0;
+  filterText = "";
+  filterActive = false;
+  inputMode?: { type: "rename"; buffer: string; target: string };
+  pendingConfirm?: { action: "deleteSaved" | "stop"; label: string };
 
   private top(): StackFrame {
     return this.stack[this.stack.length - 1];
@@ -361,29 +375,45 @@ export function renderNavigator(
   if (state.kind === "runs") {
     const runs = model.runs();
     const saved = model.saved();
+    const filterLower = state.filterText.toLowerCase();
+    const filteredRuns = filterLower
+      ? runs.filter((r) => r.name.toLowerCase().includes(filterLower) || r.runId.toLowerCase().includes(filterLower))
+      : runs;
+    const filteredSaved = filterLower
+      ? saved.filter(
+          (w) =>
+            w.name.toLowerCase().includes(filterLower) || (w.description ?? "").toLowerCase().includes(filterLower),
+        )
+      : saved;
     const total = runs.length + saved.length;
     state.clamp(total);
     lines.push(theme.bold("Workflows"));
+    if (state.filterActive || state.filterText) {
+      lines.push(dim(`  Filter: ${state.filterText}█`));
+    }
     if (total === 0) {
       lines.push(dim("  No runs yet. Start one with a background workflow."));
     }
     // Render runs
-    runs.forEach((r, i) => {
+    filteredRuns.forEach((r, _i) => {
+      const origIdx = runs.indexOf(r);
       const icon = STATUS_ICON[r.status] ?? "?";
       const meta = [`${r.done}/${r.total}`, fmtTokens(r.tokens), r.cost > 0 ? `$${r.cost.toFixed(4)}` : ""]
         .filter(Boolean)
         .join(" · ");
-      lines.push(sel(i, `${icon} ${r.name}  ${dim(`${r.runId} · ${r.status} · ${meta}`)}`));
+      lines.push(sel(origIdx, `${icon} ${r.name}  ${dim(`${r.runId} · ${r.status} · ${meta}`)}`));
     });
     // Render saved workflows after a separator
-    if (saved.length > 0) {
-      const sepOffset = runs.length;
-      if (runs.length > 0) lines.push(dim("  ── saved ──"));
-      saved.forEach((w, i) => {
+    if (filteredSaved.length > 0) {
+      if (filteredRuns.length > 0) lines.push(dim("  ── saved ──"));
+      filteredSaved.forEach((w) => {
+        const origIdx = runs.length + saved.indexOf(w);
         const loc = w.location === "user" ? "~" : ".";
         const desc = w.description ? dim(`  ${w.description}`) : "";
-        lines.push(sel(sepOffset + i, `${w.name}${desc}  ${dim(loc)}`));
+        lines.push(sel(origIdx, `${w.name}${desc}  ${dim(loc)}`));
       });
+    } else if (saved.length > 0 && filterLower) {
+      // Have saved items but all filtered out — still show separator if runs are shown
     }
   } else if (state.kind === "phases" && state.runId) {
     const phases = model.phases(state.runId);
@@ -440,6 +470,11 @@ export function renderNavigator(
     }
   }
 
+  if (state.inputMode?.type === "rename") {
+    lines.push("");
+    lines.push(dim(`  Rename to: ${state.inputMode.buffer}█  (enter confirm · esc cancel)`));
+  }
+
   lines.push("");
   lines.push(footerHint(state, model, theme));
   return lines;
@@ -453,21 +488,28 @@ function historyLabel(entry: NonNullable<WorkflowAgentSnapshot["history"]>[numbe
 }
 
 function footerHint(state: NavigatorState, model: NavigatorModel, theme: ThemeLike): string {
+  if (state.pendingConfirm) {
+    const msg =
+      state.pendingConfirm.action === "deleteSaved"
+        ? `delete /${state.pendingConfirm.label}`
+        : `stop ${state.pendingConfirm.label}`;
+    return theme.fg("dim", `x confirm ${msg} · any other key cancel`);
+  }
   const parts: string[] = [];
   switch (state.kind) {
     case "detail":
       parts.push("j/k scroll", "esc back");
       break;
     case "savedDetail":
-      parts.push("j/k scroll", "esc back", "x delete");
+      parts.push("j/k scroll", "esc back", "n rename", "x delete");
       break;
     case "runs": {
       const itemKind = model.saved().length > 0 ? state.itemKindAt(model, state.cursor) : "run";
-      parts.push("↑/↓ select", "enter open", "esc back");
+      parts.push("↑/↓ select", "enter open", "/ filter", "esc back");
       if (itemKind === "run") {
         parts.push("p pause", "x stop", "r restart", "s save");
       } else {
-        parts.push("x delete");
+        parts.push("n rename", "x delete");
       }
       parts.push("q quit");
       break;
@@ -493,6 +535,8 @@ export type NavAction =
   | { type: "restart" }
   | { type: "save" }
   | { type: "deleteSaved" }
+  | { type: "filter" }
+  | { type: "rename" }
   | { type: "none" };
 
 export function keyToAction(keyId: string | undefined, kind: ViewKind, itemKind?: "run" | "saved"): NavAction {
@@ -526,6 +570,12 @@ export function keyToAction(keyId: string | undefined, kind: ViewKind, itemKind?
     case "s":
       if (itemKind === "saved") return { type: "none" };
       return { type: "save" };
+    case "/":
+      if (kind === "runs") return { type: "filter" };
+      return { type: "none" };
+    case "n":
+      if (kind === "savedDetail" || itemKind === "saved") return { type: "rename" };
+      return { type: "none" };
     default:
       return { type: "none" };
   }
@@ -571,6 +621,83 @@ export function openWorkflowNavigator(
       };
 
       const act = (data: string) => {
+        // Filter input mode
+        if (state.filterActive) {
+          const key = parseKey(data);
+          if (key === "escape" || key === "esc") {
+            state.filterText = "";
+            state.filterActive = false;
+            state.clamp(currentCount(state, model));
+            rerender();
+            return;
+          }
+          if (key === "backspace" || key === "delete") {
+            state.filterText = state.filterText.slice(0, -1);
+            if (!state.filterText) state.filterActive = false;
+            state.clamp(currentCount(state, model));
+            rerender();
+            return;
+          }
+          if (key === "enter" || key === "return") {
+            state.filterActive = false;
+            rerender();
+            return;
+          }
+          if (data.length === 1 && data >= " ") {
+            state.filterText += data;
+            state.cursor = 0;
+            rerender();
+            return;
+          }
+          rerender();
+          return;
+        }
+
+        // Rename input mode
+        if (state.inputMode?.type === "rename") {
+          const key = parseKey(data);
+          if (key === "escape" || key === "esc") {
+            state.inputMode = undefined;
+            rerender();
+            return;
+          }
+          if (key === "enter" || key === "return") {
+            const newName = state.inputMode.buffer.trim();
+            const oldName = state.inputMode.target;
+            state.inputMode = undefined;
+            if (newName && newName !== oldName) {
+              if (model.renameSaved(oldName, newName)) {
+                ui.notify(`Renamed /${oldName} → /${newName}`, "info");
+                state.back();
+              } else {
+                ui.notify(`Could not rename — name may already be taken`, "warning");
+              }
+            }
+            rerender();
+            return;
+          }
+          if (key === "backspace" || key === "delete") {
+            state.inputMode.buffer = state.inputMode.buffer.slice(0, -1);
+            rerender();
+            return;
+          }
+          if (data.length === 1 && data >= " ") {
+            state.inputMode.buffer += data;
+            rerender();
+            return;
+          }
+          rerender();
+          return;
+        }
+
+        // Clear any pending confirmation if the user presses a non-confirming key
+        const parsedKey = parseKey(data);
+        if (state.pendingConfirm && parsedKey !== "x") {
+          state.pendingConfirm = undefined;
+          rerender();
+          return;
+        }
+
         const itemKind = state.kind === "runs" ? state.itemKindAt(model, state.cursor) : undefined;
         const action = keyToAction(parseKey(data), state.kind, itemKind);
         switch (action.type) {
@@ -591,19 +718,27 @@ export function openWorkflowNavigator(
             done(undefined);
             return;
           case "deleteSaved": {
+            let targetName: string | undefined;
             if (state.kind === "runs") {
               const saved = model.saved();
               const runCount = model.runs().length;
               const item = saved[state.cursor - runCount];
-              if (item) {
-                model.deleteSaved(item.name);
-                ui.notify(`Deleted /${item.name}`, "info");
-              }
+              targetName = item?.name;
             } else if (state.kind === "savedDetail" && state.savedName) {
-              model.deleteSaved(state.savedName);
-              ui.notify(`Deleted /${state.savedName}`, "info");
-              state.back();
+              targetName = state.savedName;
             }
+            if (!targetName) break;
+            if (!state.pendingConfirm) {
+              state.pendingConfirm = { action: "deleteSaved", label: targetName };
+              ui.notify(`Press x again to delete /${targetName}`, "warning");
+              rerender();
+              return;
+            }
+            // Confirmed — execute
+            state.pendingConfirm = undefined;
+            model.deleteSaved(targetName);
+            ui.notify(`Deleted /${targetName}`, "info");
+            if (state.kind === "savedDetail") state.back();
             break;
           }
           case "pause": {
@@ -613,8 +748,38 @@ export function openWorkflowNavigator(
           }
           case "stop": {
             const id = state.activeRunId(model);
-            if (id) ui.notify(manager.stop(id) ? `Stopped ${id}` : `Cannot stop ${id}`, "info");
+            if (!id) break;
+            if (!state.pendingConfirm) {
+              state.pendingConfirm = { action: "stop", label: id };
+              ui.notify(`Press x again to stop ${id}`, "warning");
+              rerender();
+              return;
+            }
+            state.pendingConfirm = undefined;
+            ui.notify(manager.stop(id) ? `Stopped ${id}` : `Cannot stop ${id}`, "info");
             break;
+          }
+          case "filter":
+            if (state.kind === "runs") {
+              state.filterActive = true;
+              rerender();
+            }
+            return;
+          case "rename": {
+            let targetName: string | undefined;
+            if (state.kind === "savedDetail" && state.savedName) {
+              targetName = state.savedName;
+            } else if (state.kind === "runs") {
+              const saved = model.saved();
+              const runCount = model.runs().length;
+              const item = saved[state.cursor - runCount];
+              targetName = item?.name;
+            }
+            if (targetName) {
+              state.inputMode = { type: "rename", buffer: targetName, target: targetName };
+            }
+            rerender();
+            return;
           }
           case "restart": {
             const id = state.activeRunId(model);

--- a/tests/workflow-saved.test.ts
+++ b/tests/workflow-saved.test.ts
@@ -278,6 +278,81 @@ test(
 );
 
 test(
+  "createWorkflowStorage rename moves a project workflow to a new name",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    storage.save({ name: "original", description: "orig", script: "orig script" });
+
+    const result = storage.rename("original", "renamed");
+    assert.equal(result, true, "rename should return true");
+
+    assert.equal(storage.load("original"), null, "old name should not exist");
+    const loaded = storage.load("renamed");
+    assert.ok(loaded, "new name should be loadable");
+    assert.equal(loaded?.name, "renamed");
+    assert.equal(loaded?.script, "orig script");
+  }),
+);
+
+test(
+  "createWorkflowStorage rename returns false for nonexistent workflow",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    assert.equal(storage.rename("no-such", "new-name"), false);
+  }),
+);
+
+test(
+  "createWorkflowStorage rename returns false when new name already exists",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    storage.save({ name: "wf-a", description: "a", script: "a" });
+    storage.save({ name: "wf-b", description: "b", script: "b" });
+
+    const result = storage.rename("wf-a", "wf-b");
+    assert.equal(result, false, "should not overwrite existing workflow");
+    // Both should still exist
+    assert.ok(storage.load("wf-a"), "original should still exist");
+    assert.ok(storage.load("wf-b"), "target should still exist unchanged");
+  }),
+);
+
+test(
+  "createWorkflowStorage rename returns false when old and new names are the same",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    storage.save({ name: "same", description: "s", script: "s" });
+    assert.equal(storage.rename("same", "same"), false);
+  }),
+);
+
+test(
+  "createWorkflowStorage rename rejects unsafe names",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    storage.save({ name: "valid", description: "v", script: "v" });
+    assert.equal(storage.rename("valid", "../escape"), false, "should reject unsafe new name");
+    assert.equal(storage.rename("../escape", "valid"), false, "should reject unsafe old name");
+  }),
+);
+
+test(
+  "createWorkflowStorage rename works for user-location workflows",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    storage.save({ name: "user-wf", description: "u", script: "u script" }, "user");
+
+    const result = storage.rename("user-wf", "user-wf-renamed");
+    assert.equal(result, true);
+    assert.equal(storage.load("user-wf"), null);
+    const loaded = storage.load("user-wf-renamed");
+    assert.ok(loaded);
+    assert.equal(loaded?.location, "user");
+    assert.equal(loaded?.script, "u script");
+  }),
+);
+
+test(
   "createWorkflowStorage skips legacy files with unsafe workflow names",
   withIsolatedHome(async (cwd) => {
     const storage = createWorkflowStorage(cwd);

--- a/tests/workflow-saved.test.ts
+++ b/tests/workflow-saved.test.ts
@@ -318,6 +318,20 @@ test(
 );
 
 test(
+  "createWorkflowStorage rename returns false when new name exists in another location",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    storage.save({ name: "project-wf", description: "p", script: "project" }, "project");
+    storage.save({ name: "user-wf", description: "u", script: "user" }, "user");
+
+    const result = storage.rename("project-wf", "user-wf");
+    assert.equal(result, false, "should not shadow an existing user workflow");
+    assert.equal(storage.load("project-wf")?.script, "project");
+    assert.equal(storage.load("user-wf")?.script, "user");
+  }),
+);
+
+test(
   "createWorkflowStorage rename returns false when old and new names are the same",
   withIsolatedHome(async (cwd) => {
     const storage = createWorkflowStorage(cwd);

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -660,3 +660,153 @@ test("renderNavigator footer hint changes based on item under cursor", () => {
   assert.notEqual(savedText.indexOf("x delete"), -1, "saved item should show x delete");
   assert.equal(savedText.indexOf("x stop"), -1, "saved item should NOT show x stop");
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Issue #6: Search/filter
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("keyToAction '/' in runs view returns filter action", () => {
+  assert.deepEqual(keyToAction("/", "runs"), { type: "filter" });
+});
+
+test("keyToAction '/' outside runs view returns none", () => {
+  assert.deepEqual(keyToAction("/", "phases"), { type: "none" });
+  assert.deepEqual(keyToAction("/", "savedDetail"), { type: "none" });
+});
+
+test("renderNavigator shows filter indicator when filterText is set", () => {
+  const model = new NavigatorModel(fakeManager(), savedStorage());
+  const state = new NavigatorState();
+  state.filterText = "audi";
+  state.filterActive = false;
+
+  const text = renderNavigator(state, model, 80).join("\n");
+  assert.match(text, /Filter: audi/);
+});
+
+test("renderNavigator shows filter indicator when filterActive is true", () => {
+  const model = new NavigatorModel(fakeManager(), savedStorage());
+  const state = new NavigatorState();
+  state.filterActive = true;
+
+  const text = renderNavigator(state, model, 80).join("\n");
+  assert.match(text, /Filter:/);
+});
+
+test("renderNavigator filters runs by name when filterText is set", () => {
+  const model = new NavigatorModel(fakeManager(), savedStorage());
+  const state = new NavigatorState();
+  state.filterText = "audit";
+
+  const lines = renderNavigator(state, model, 80);
+  const text = lines.join("\n");
+  assert.match(text, /audit/); // the matching run
+  // saved items should be filtered out since they don't match "audit"
+  assert.ok(!text.includes("❯ deploy"), "deploy saved should not appear");
+  assert.ok(!text.includes("❯ analyze"), "analyze saved should not appear");
+});
+
+test("renderNavigator filters saved workflows by name when filterText is set", () => {
+  const model = new NavigatorModel(fakeManager(), savedStorage());
+  const state = new NavigatorState();
+  state.filterText = "deploy";
+
+  const text = renderNavigator(state, model, 80).join("\n");
+  assert.match(text, /deploy/);
+  // "audit" run should still show because we search runs separately
+  assert.ok(!text.includes("analyze"), "analyze should not appear when filtering for deploy");
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Issue #7: Rename
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("keyToAction 'n' on savedDetail returns rename action", () => {
+  assert.deepEqual(keyToAction("n", "savedDetail"), { type: "rename" });
+});
+
+test("keyToAction 'n' on saved item in runs view returns rename action", () => {
+  assert.deepEqual(keyToAction("n", "runs", "saved"), { type: "rename" });
+});
+
+test("keyToAction 'n' on run item returns none", () => {
+  assert.deepEqual(keyToAction("n", "runs", "run"), { type: "none" });
+  assert.deepEqual(keyToAction("n", "phases"), { type: "none" });
+});
+
+test("renderNavigator shows rename prompt when inputMode is set", () => {
+  const model = new NavigatorModel(fakeManager(), savedStorage());
+  const state = new NavigatorState();
+  state.inputMode = { type: "rename", buffer: "newname", target: "deploy" };
+
+  const text = renderNavigator(state, model, 80).join("\n");
+  assert.match(text, /Rename to: newname/);
+  assert.match(text, /enter confirm/);
+  assert.match(text, /esc cancel/);
+});
+
+test("renderNavigator savedDetail footer shows 'n rename'", () => {
+  const model = new NavigatorModel(fakeManager(), savedStorage());
+  const state = new NavigatorState();
+  state.cursor = 1;
+  state.drill(model);
+  assert.equal(state.kind, "savedDetail");
+
+  const text = renderNavigator(state, model, 80).join("\n");
+  assert.match(text, /n rename/);
+});
+
+test("NavigatorModel renameSaved delegates to storage", () => {
+  let renamedOld: string | undefined;
+  let renamedNew: string | undefined;
+  const storage = {
+    list: () => [] as SavedWorkflow[],
+    delete: () => true,
+    rename: (oldName: string, newName: string) => {
+      renamedOld = oldName;
+      renamedNew = newName;
+      return true;
+    },
+  };
+  const model = new NavigatorModel(fakeManager(), storage);
+  const result = model.renameSaved("foo", "bar");
+  assert.equal(result, true);
+  assert.equal(renamedOld, "foo");
+  assert.equal(renamedNew, "bar");
+});
+
+test("NavigatorModel renameSaved returns false when no storage", () => {
+  const model = new NavigatorModel(fakeManager());
+  assert.equal(model.renameSaved("foo", "bar"), false);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Issue #8: Confirmation dialogs
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("renderNavigator footer shows pending confirm message for deleteSaved", () => {
+  const model = new NavigatorModel(fakeManager(), savedStorage());
+  const state = new NavigatorState();
+  state.pendingConfirm = { action: "deleteSaved", label: "deploy" };
+
+  const text = renderNavigator(state, model, 80).join("\n");
+  assert.match(text, /x confirm delete \/deploy/);
+  assert.match(text, /any other key cancel/);
+});
+
+test("renderNavigator footer shows pending confirm message for stop", () => {
+  const model = new NavigatorModel(fakeManager());
+  const state = new NavigatorState();
+  state.pendingConfirm = { action: "stop", label: "run-1" };
+
+  const text = renderNavigator(state, model, 80).join("\n");
+  assert.match(text, /x confirm stop run-1/);
+  assert.match(text, /any other key cancel/);
+});
+
+test("renderNavigator runs footer shows '/ filter' hint", () => {
+  const model = new NavigatorModel(fakeManager());
+  const state = new NavigatorState();
+  const text = renderNavigator(state, model, 80).join("\n");
+  assert.match(text, /\/ filter/);
+});

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -138,7 +138,11 @@ function persistedRunManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
   };
 }
 
-function savedStorage(): { list(): SavedWorkflow[]; delete(name: string, location?: string): boolean } {
+function savedStorage(): {
+  list(): SavedWorkflow[];
+  delete(name: string, location?: string): boolean;
+  rename(oldName: string, newName: string): boolean;
+} {
   return {
     list: () => [
       {
@@ -167,11 +171,16 @@ function savedStorage(): { list(): SavedWorkflow[]; delete(name: string, locatio
       },
     ],
     delete: () => true,
+    rename: () => true,
   };
 }
 
-function emptySavedStorage(): { list(): SavedWorkflow[]; delete(name: string, location?: string): boolean } {
-  return { list: () => [], delete: () => true };
+function emptySavedStorage(): {
+  list(): SavedWorkflow[];
+  delete(name: string, location?: string): boolean;
+  rename(oldName: string, newName: string): boolean;
+} {
+  return { list: () => [], delete: () => true, rename: () => true };
 }
 
 test("NavigatorModel reads runs, phases, agents, and detail", () => {
@@ -715,6 +724,33 @@ test("renderNavigator filters saved workflows by name when filterText is set", (
   assert.match(text, /deploy/);
   // "audit" run should still show because we search runs separately
   assert.ok(!text.includes("analyze"), "analyze should not appear when filtering for deploy");
+});
+
+test("NavigatorState uses filtered visible index when selecting a run", () => {
+  const model = new NavigatorModel(multiRunManager(), savedStorage());
+  const state = new NavigatorState();
+  state.filterText = "b-workflow";
+
+  renderNavigator(state, model, 80);
+
+  assert.equal(state.itemKindAt(model, state.cursor), "run");
+  assert.equal(state.activeRunId(model), "r2");
+  assert.equal(state.drill(model), true);
+  assert.equal(state.runId, "r2");
+});
+
+test("NavigatorState uses filtered visible index when selecting a saved workflow", () => {
+  const model = new NavigatorModel(fakeManager(), savedStorage());
+  const state = new NavigatorState();
+  state.filterText = "backup";
+
+  renderNavigator(state, model, 80);
+
+  assert.equal(state.itemKindAt(model, state.cursor), "saved");
+  assert.equal(state.activeSavedName(model), "backup");
+  assert.equal(state.drill(model), true);
+  assert.equal(state.kind, "savedDetail");
+  assert.equal(state.savedName, "backup");
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Implements upstream #39, #40, and #41 for the `/workflows` navigator.

- adds search/filter support for runs and saved workflows
- keeps filtered cursor selection aligned with visible rows
- adds saved workflow rename support in storage and navigator UI
- adds confirmation flow before saved workflow delete and run stop actions
- adds tests for filtering, rename, destructive confirmations, and storage rename behavior

Closes #39.
Closes #40.
Closes #41.

## Review notes

Full scoped review completed before publishing. One issue was found and fixed before PR creation: saved workflow rename now rejects target names that already exist in project, legacy project, or user locations so a rename cannot shadow another workflow.

## Verification

- `npx biome check src/workflow-saved.ts tests/workflow-saved.test.ts src/workflow-ui.ts tests/workflow-ui.test.ts`
- `npm run build`
- `npm run test:unit -- tests/workflow-saved.test.ts tests/workflow-ui.test.ts` (project script ran full unit suite: 767 passing, 0 failing)
