### PR TITLE
feat: auto-resume on provider usage limit reset + /code-review command

### DIFF
--- a/src/builtin-commands.ts
+++ b/src/builtin-commands.ts
@@ -4,7 +4,7 @@
  * They run a generated workflow script and print the final report.
  */
 
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { createCodingTools, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
@@ -13,7 +13,7 @@ import { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "./d
 import { createWebTools } from "./web-tools.js";
 import { runWorkflow, type WorkflowRunResult } from "./workflow.js";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 function alreadyRegistered(pi: ExtensionAPI, name: string): boolean {
   try {
@@ -131,16 +131,26 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string }
         let diff = "";
 
         try {
+          let cmd: string;
+          let cmdArgs: string[];
           if (!input) {
             diffSource = "git diff HEAD";
+            cmd = "git";
+            cmdArgs = ["diff", "HEAD"];
           } else if (/^\d+$/.test(input)) {
             diffSource = `gh pr diff ${input}`;
+            cmd = "gh";
+            cmdArgs = ["pr", "diff", input];
           } else if (input.includes("..")) {
             diffSource = `git diff ${input}`;
+            cmd = "git";
+            cmdArgs = ["diff", input];
           } else {
             diffSource = `git diff HEAD -- ${input}`;
+            cmd = "git";
+            cmdArgs = ["diff", "HEAD", "--", input];
           }
-          const { stdout } = await execAsync(diffSource, { cwd });
+          const { stdout } = await execFileAsync(cmd, cmdArgs, { cwd });
           diff = stdout;
           if (!diff.trim()) {
             return ctx.ui.notify(`No diff output from: ${diffSource}`, "warning");

--- a/src/builtin-commands.ts
+++ b/src/builtin-commands.ts
@@ -4,11 +4,16 @@
  * They run a generated workflow script and print the final report.
  */
 
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
 import { createCodingTools, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
+import { generateCodeReviewWorkflow } from "./code-review.js";
 import { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "./deep-research.js";
 import { createWebTools } from "./web-tools.js";
 import { runWorkflow, type WorkflowRunResult } from "./workflow.js";
+
+const execAsync = promisify(exec);
 
 function alreadyRegistered(pi: ExtensionAPI, name: string): boolean {
   try {
@@ -111,6 +116,55 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string }
         } catch (error) {
           ctx.ui.setStatus("multi-perspective", undefined);
           ctx.ui.notify(`multi-perspective failed: ${error instanceof Error ? error.message : error}`, "error");
+        }
+      },
+    });
+  }
+
+  if (!alreadyRegistered(pi, "code-review")) {
+    pi.registerCommand("code-review", {
+      description:
+        "Multi-angle parallel code review: 7 specialized finders (correctness, reuse, simplification, efficiency, altitude) + verify pass → ranked findings",
+      async handler(args: string, ctx: ExtensionCommandContext) {
+        const input = args.trim();
+        let diffSource = "git diff HEAD";
+        let diff = "";
+
+        try {
+          if (!input) {
+            diffSource = "git diff HEAD";
+          } else if (/^\d+$/.test(input)) {
+            diffSource = `gh pr diff ${input}`;
+          } else if (input.includes("..")) {
+            diffSource = `git diff ${input}`;
+          } else {
+            diffSource = `git diff HEAD -- ${input}`;
+          }
+          const { stdout } = await execAsync(diffSource, { cwd });
+          diff = stdout;
+          if (!diff.trim()) {
+            return ctx.ui.notify(`No diff output from: ${diffSource}`, "warning");
+          }
+        } catch (err) {
+          return ctx.ui.notify(
+            `Failed to get diff (${diffSource}): ${err instanceof Error ? err.message : err}`,
+            "error",
+          );
+        }
+
+        ctx.ui.notify(`Reviewing diff (${diffSource}) — running 7 finder angles in parallel…`, "info");
+        try {
+          const result = await runWorkflow(generateCodeReviewWorkflow(), {
+            cwd,
+            args: { diff, diffSource },
+            tools: createCodingTools(cwd),
+            onPhase: (title) => ctx.ui.setStatus("code-review", `review: ${title}`),
+          });
+          ctx.ui.setStatus("code-review", undefined);
+          await pi.sendMessage({ customType: "code-review", content: reportText(result), display: true });
+        } catch (error) {
+          ctx.ui.setStatus("code-review", undefined);
+          ctx.ui.notify(`code-review failed: ${error instanceof Error ? error.message : error}`, "error");
         }
       },
     });

--- a/src/code-review.ts
+++ b/src/code-review.ts
@@ -1,0 +1,155 @@
+/**
+ * Multi-angle parallel code review workflow.
+ * 7 specialized finder agents → verify pass → ranked report.
+ */
+
+/**
+ * Generate a code-review workflow script.
+ *
+ * The workflow expects `args` to be passed with shape:
+ *   { diff: string, diffSource: string }
+ *
+ * Model tier routing follows the spec:
+ *   Finders A/B/C → medium (correctness)
+ *   Finders D/E/F → small  (cleanup)
+ *   Finder  G     → big    (altitude / abstraction)
+ *   Synthesis     → big
+ */
+export function generateCodeReviewWorkflow(): string {
+  return `export const meta = {
+  name: 'code_review',
+  description: 'Multi-angle parallel code review: 7 finder angles + verify pass → ranked findings',
+  phases: [
+    { title: 'Find' },
+    { title: 'Verify' },
+    { title: 'Report' },
+  ],
+}
+
+const diff = (args && args.diff) || ''
+const diffSource = (args && args.diffSource) || 'git diff HEAD'
+const candidateSchema = {
+  type: 'object',
+  properties: {
+    candidates: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'number' },
+          summary: { type: 'string' },
+          failure_scenario: { type: 'string' },
+        },
+        required: ['file', 'line', 'summary', 'failure_scenario'],
+      },
+    },
+  },
+  required: ['candidates'],
+}
+
+const diffBlock = '\\n\\n<diff source=\\"' + diffSource + '\\">\\n' + diff + '\\n</diff>\\n'
+const base = 'Use the read/grep tools to pull in any additional file context you need.' + diffBlock
+
+phase('Find')
+const finders = await parallel([
+  () => agent(
+    'You are a line-by-line correctness scanner. Hunt ONLY for: inverted conditions, off-by-one errors, ' +
+    'null/nil dereferences, wrong variable used, swallowed errors. For each candidate name the exact file, ' +
+    'line number, a one-line summary, and the concrete failure scenario. Return ONLY issues you can justify ' +
+    'with a line in the diff.' + base,
+    { label: 'A-line-scan', tier: 'medium', schema: candidateSchema }
+  ),
+  () => agent(
+    'You are a removed-behavior auditor. For every deleted line or block in the diff: name the invariant ' +
+    'or contract it enforced, then find where (or prove) that contract is re-established elsewhere. ' +
+    'Report only gaps where the invariant is NOT re-established.' + base,
+    { label: 'B-removed-behavior', tier: 'medium', schema: candidateSchema }
+  ),
+  () => agent(
+    'You are a cross-file call-site tracer. For each function/method whose signature or behavior changed ' +
+    'in the diff: grep the codebase for callers, then check whether each call site is still correct after ' +
+    'the change. Report only call sites that are now broken or need updating.' + base,
+    { label: 'C-cross-file-tracer', tier: 'medium', schema: candidateSchema }
+  ),
+  () => agent(
+    'You are a reuse finder. Identify new code in the diff that duplicates existing helpers, utilities, ' +
+    'or patterns already present in the codebase. Propose the existing symbol that should be used instead.' + base,
+    { label: 'D-reuse', tier: 'small', schema: candidateSchema }
+  ),
+  () => agent(
+    'You are a simplification finder. Look for: redundant state that could be derived, copy-paste ' +
+    'variation that could be a shared function, and dead code introduced by the diff.' + base,
+    { label: 'E-simplification', tier: 'small', schema: candidateSchema }
+  ),
+  () => agent(
+    'You are an efficiency finder. Identify: redundant I/O or network calls, sequential work that could ' +
+    'be parallel, and blocking operations on the startup or hot path introduced by the diff.' + base,
+    { label: 'F-efficiency', tier: 'small', schema: candidateSchema }
+  ),
+  () => agent(
+    'You are an altitude reviewer. Assess whether the change is made at the RIGHT abstraction level. ' +
+    'Look for: bandaids on shared infrastructure that should be fixed at the root, fixes in the wrong ' +
+    'layer (e.g. compensating in the UI for a data model problem), or the change solving a symptom ' +
+    'rather than the cause.' + base,
+    { label: 'G-altitude', tier: 'big', schema: candidateSchema }
+  ),
+])
+
+// Collect and deduplicate candidates across all finders
+const allRaw = finders.flatMap((r, fi) => {
+  const label = ['A','B','C','D','E','F','G'][fi]
+  return ((r && r.candidates) || []).map((c) => ({ ...c, angle: label }))
+})
+
+// Deduplicate: same file + line + first 40 chars of summary → keep first
+const seen = new Set()
+const allCandidates = allRaw.filter((c) => {
+  const key = (c.file || '') + ':' + (c.line || 0) + ':' + (c.summary || '').slice(0, 40)
+  if (seen.has(key)) return false
+  seen.add(key)
+  return true
+})
+
+phase('Verify')
+const verdicts = allCandidates.length > 0
+  ? await parallel(allCandidates.map((c, i) => () =>
+      agent(
+        'You are a verifier. Determine whether this code review finding is CONFIRMED, PLAUSIBLE, or REFUTED. ' +
+        'CONFIRMED = you can trace the exact failure in the diff. PLAUSIBLE = concern is valid but not certain. ' +
+        'REFUTED = finding is wrong or already handled.\\n\\n' +
+        'FINDING:\\nFile: ' + c.file + '\\nLine: ' + c.line + '\\nSummary: ' + c.summary + '\\n' +
+        'Failure scenario: ' + c.failure_scenario + diffBlock,
+        {
+          label: 'verify-' + (i + 1),
+          schema: {
+            type: 'object',
+            properties: { verdict: { type: 'string', enum: ['CONFIRMED', 'PLAUSIBLE', 'REFUTED'] }, reason: { type: 'string' } },
+            required: ['verdict'],
+          },
+        }
+      )
+    ))
+  : []
+
+const surviving = allCandidates
+  .map((c, i) => ({ ...c, verdict: (verdicts[i] && verdicts[i].verdict) || 'PLAUSIBLE', verifyReason: (verdicts[i] && verdicts[i].reason) || '' }))
+  .filter((c) => c.verdict !== 'REFUTED')
+
+// Rank: correctness (A/B/C) before cleanup (D/E/F) before altitude (G), cap at 10
+const rankAngle = (a) => ['A','B','C'].includes(a) ? 0 : ['D','E','F'].includes(a) ? 1 : 2
+surviving.sort((a, b) => rankAngle(a.angle) - rankAngle(b.angle))
+const top = surviving.slice(0, 10)
+
+phase('Report')
+const synthesis = await agent(
+  'You are a senior code reviewer writing the final report. Below are the verified findings from a ' +
+  'multi-angle code review (already ranked by severity). Write a concise markdown report: ' +
+  '1 sentence per finding with file, line, and the failure scenario. Note the total found vs shown. ' +
+  'Correctness issues (A/B/C) come first, then cleanup (D/E/F), then altitude (G).\\n\\n' +
+  'FINDINGS JSON:\\n' + JSON.stringify(top, null, 2),
+  { label: 'synthesis', tier: 'big' }
+)
+
+return { total: allCandidates.length, surviving: surviving.length, findings: top, report: synthesis }`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export type { AdversarialReviewConfig } from "./adversarial-review.js";
 export { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
+export { generateCodeReviewWorkflow } from "./code-review.js";
 export type { AgentRunOptions, AgentRunResult, WorkflowAgentOptions } from "./agent.js";
 export { listAvailableModelSpecs, WorkflowAgent } from "./agent.js";
 export type { AgentHistoryEntry, AgentHistoryKind, AgentHistoryRole } from "./agent-history.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 export type { AdversarialReviewConfig } from "./adversarial-review.js";
 export { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
-export { generateCodeReviewWorkflow } from "./code-review.js";
 export type { AgentRunOptions, AgentRunResult, WorkflowAgentOptions } from "./agent.js";
 export { listAvailableModelSpecs, WorkflowAgent } from "./agent.js";
 export type { AgentHistoryEntry, AgentHistoryKind, AgentHistoryRole } from "./agent-history.js";
@@ -8,6 +7,7 @@ export { compactAgentHistory } from "./agent-history.js";
 export type { AgentDefinition, AgentRegistry } from "./agent-registry.js";
 export { applyToolPolicy, listAgentTypes, loadAgentRegistry, resolveAgentType } from "./agent-registry.js";
 export { registerBuiltinWorkflows } from "./builtin-commands.js";
+export { generateCodeReviewWorkflow } from "./code-review.js";
 export * from "./config.js";
 export type { DeepResearchConfig } from "./deep-research.js";
 export { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "./deep-research.js";

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -40,6 +40,8 @@ export interface PersistedRunState {
   pauseReason?: string;
   /** Provider reset hint for a usage-limit pause, e.g. "Resets in ~3h" (verbatim). */
   resetHint?: string;
+  /** Number of auto-resume attempts already made, persisted so the cap survives process restarts. */
+  autoResumeAttempts?: number;
   phases: string[];
   currentPhase?: string;
   agents: PersistedAgentState[];

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -60,6 +60,11 @@ export interface ExecOptions {
   agentRetries?: number;
   /** Resolve a checkpoint() question with a human reply (only for UI-bearing runs). */
   confirm?: (promptText: string, options: unknown) => Promise<unknown>;
+  /**
+   * Automatically resume this run after the provider usage limit resets.
+   * Defaults to true. Set to false to disable auto-resume for this execution.
+   */
+  autoResume?: boolean;
 }
 
 export interface WorkflowManagerOptions {
@@ -92,6 +97,14 @@ export class WorkflowManager extends EventEmitter {
   private sessionId?: string;
   private defaultAgentTimeoutMs: number | null;
   private defaultAgentRetries: number;
+
+  /** Pending auto-resume timers keyed by runId. */
+  private autoResumeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Backoff attempt counts per runId for auto-resume. */
+  private autoResumeAttempts = new Map<string, number>();
+
+  private static readonly DEFAULT_AUTO_RESUME_DELAY_MS = 60 * 60 * 1000; // 60 min
+  private static readonly MAX_AUTO_RESUME_ATTEMPTS = 5;
 
   constructor(options: WorkflowManagerOptions = {}) {
     super();
@@ -131,9 +144,55 @@ export class WorkflowManager extends EventEmitter {
             this.persistence.releaseRunLease(lease);
           }
         }
+        // Re-arm auto-resume timer for usage-limit paused runs that survived a restart.
+        if (p.status === "paused" && p.pauseReason === "usage_limit" && !this.runs.has(p.runId)) {
+          this.scheduleAutoResume(p.runId, p.resetHint);
+        }
       }
     } catch {
       // Recovery is best-effort; never let it block manager construction.
+    }
+  }
+
+  /** Parse a provider reset hint string into milliseconds. Falls back to 60 min. */
+  private parseResetHintMs(hint: string | undefined): number {
+    if (!hint) return WorkflowManager.DEFAULT_AUTO_RESUME_DELAY_MS;
+    const hourMatch = hint.match(/(\d+(?:\.\d+)?)\s*h/i);
+    const minMatch = hint.match(/(\d+(?:\.\d+)?)\s*m(?:in)?/i);
+    if (hourMatch) return Math.round(parseFloat(hourMatch[1]!) * 60 * 60 * 1000);
+    if (minMatch) return Math.round(parseFloat(minMatch[1]!) * 60 * 1000);
+    return WorkflowManager.DEFAULT_AUTO_RESUME_DELAY_MS;
+  }
+
+  /** Schedule an automatic resume for a usage-limit paused run, with exponential backoff. */
+  private scheduleAutoResume(runId: string, resetHint?: string): void {
+    this.cancelAutoResume(runId);
+    const attempts = this.autoResumeAttempts.get(runId) ?? 0;
+    if (attempts >= WorkflowManager.MAX_AUTO_RESUME_ATTEMPTS) return;
+    const base = this.parseResetHintMs(resetHint);
+    const delay = base * Math.pow(2, attempts);
+    const timer = setTimeout(async () => {
+      this.autoResumeTimers.delete(runId);
+      this.autoResumeAttempts.set(runId, attempts + 1);
+      const persisted = this.persistence.load(runId);
+      if (persisted?.status === "paused" && persisted.pauseReason === "usage_limit") {
+        this.emit("autoResuming", { runId, attempt: attempts + 1 });
+        await this.resume(runId).catch(() => {});
+      } else {
+        // Run is no longer paused-for-usage-limit — clear attempt tracking.
+        this.autoResumeAttempts.delete(runId);
+      }
+    }, delay);
+    timer.unref?.();
+    this.autoResumeTimers.set(runId, timer);
+  }
+
+  /** Cancel any pending auto-resume timer for a run. */
+  private cancelAutoResume(runId: string): void {
+    const existing = this.autoResumeTimers.get(runId);
+    if (existing !== undefined) {
+      clearTimeout(existing);
+      this.autoResumeTimers.delete(runId);
     }
   }
 
@@ -274,6 +333,7 @@ export class WorkflowManager extends EventEmitter {
       concurrency,
       agentRetries,
       confirm,
+      autoResume = true,
     } = exec;
     const resolvedAgentTimeoutMs = agentTimeoutMs !== undefined ? agentTimeoutMs : this.defaultAgentTimeoutMs;
     const resolvedConcurrency = concurrency ?? this.concurrency;
@@ -406,6 +466,9 @@ export class WorkflowManager extends EventEmitter {
           error: workflowError,
           resetHint: workflowError.resetHint,
         });
+        if (autoResume) {
+          this.scheduleAutoResume(managed.runId, workflowError.resetHint);
+        }
       } else {
         this.emit("error", { runId: managed.runId, error: workflowError });
       }
@@ -547,6 +610,8 @@ export class WorkflowManager extends EventEmitter {
     const managed = this.runs.get(runId);
     if (!managed || (managed.status !== "running" && managed.status !== "paused")) return false;
 
+    this.cancelAutoResume(runId);
+    this.autoResumeAttempts.delete(runId);
     managed.controller.abort();
     managed.status = "aborted";
     this.emit("stopped", { runId });
@@ -593,6 +658,8 @@ export class WorkflowManager extends EventEmitter {
   deleteRun(runId: string): boolean {
     const managed = this.runs.get(runId);
     if (managed) this.releaseRunLease(managed);
+    this.cancelAutoResume(runId);
+    this.autoResumeAttempts.delete(runId);
     this.runs.delete(runId);
     return this.persistence.delete(runId);
   }

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -145,7 +145,9 @@ export class WorkflowManager extends EventEmitter {
           }
         }
         // Re-arm auto-resume timer for usage-limit paused runs that survived a restart.
+        // Restore persisted attempt count first so the cap is honoured across restarts.
         if (p.status === "paused" && p.pauseReason === "usage_limit" && !this.runs.has(p.runId)) {
+          if (p.autoResumeAttempts) this.autoResumeAttempts.set(p.runId, p.autoResumeAttempts);
           this.scheduleAutoResume(p.runId, p.resetHint);
         }
       }
@@ -173,10 +175,21 @@ export class WorkflowManager extends EventEmitter {
     const delay = base * Math.pow(2, attempts);
     const timer = setTimeout(async () => {
       this.autoResumeTimers.delete(runId);
-      this.autoResumeAttempts.set(runId, attempts + 1);
+      const nextAttempts = attempts + 1;
+      this.autoResumeAttempts.set(runId, nextAttempts);
       const persisted = this.persistence.load(runId);
       if (persisted?.status === "paused" && persisted.pauseReason === "usage_limit") {
-        this.emit("autoResuming", { runId, attempt: attempts + 1 });
+        // Persist the incremented attempt count before resuming so a crash mid-resume
+        // doesn't reset the cap on the next cold start.
+        const lease = this.persistence.acquireRunLease(runId);
+        if (lease) {
+          try {
+            this.persistence.save({ ...persisted, autoResumeAttempts: nextAttempts });
+          } finally {
+            this.persistence.releaseRunLease(lease);
+          }
+        }
+        this.emit("autoResuming", { runId, attempt: nextAttempts });
         await this.resume(runId).catch(() => {});
       } else {
         // Run is no longer paused-for-usage-limit — clear attempt tracking.
@@ -508,6 +521,10 @@ export class WorkflowManager extends EventEmitter {
         resetHint:
           managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
             ? managed.error.resetHint
+            : undefined,
+        autoResumeAttempts:
+          managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
+            ? (this.autoResumeAttempts.get(managed.runId) ?? 0)
             : undefined,
         phases: managed.snapshot.phases,
         currentPhase: managed.snapshot.currentPhase,

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -607,11 +607,16 @@ export class WorkflowManager extends EventEmitter {
    * Stop a running workflow.
    */
   stop(runId: string): boolean {
+    // Cancel any pending auto-resume timer unconditionally — recoverStaleRuns()
+    // may have armed a timer for a run that is in persistence but not in memory,
+    // so we must cancel before the managed guard to avoid the timer firing after
+    // a user-requested stop.
+    this.cancelAutoResume(runId);
+    this.autoResumeAttempts.delete(runId);
+
     const managed = this.runs.get(runId);
     if (!managed || (managed.status !== "running" && managed.status !== "paused")) return false;
 
-    this.cancelAutoResume(runId);
-    this.autoResumeAttempts.delete(runId);
     managed.controller.abort();
     managed.status = "aborted";
     this.emit("stopped", { runId });

--- a/tests/builtin-commands.test.ts
+++ b/tests/builtin-commands.test.ts
@@ -3,12 +3,18 @@ import test from "node:test";
 import { registerBuiltinWorkflows } from "../src/builtin-commands.js";
 import { makeCommandRegistryPi, makeNotifyCtx } from "./helpers/mock-pi.js";
 
-test("registerBuiltinWorkflows registers all four built-in workflow commands", () => {
+test("registerBuiltinWorkflows registers all five built-in workflow commands", () => {
   const { pi, commands } = makeCommandRegistryPi();
   registerBuiltinWorkflows(pi, { cwd: "/tmp" });
-  assert.equal(commands.length, 4);
+  assert.equal(commands.length, 5);
   const names = commands.map((c) => c.name).sort();
-  assert.deepEqual(names, ["adversarial-review", "codebase-audit", "deep-research", "multi-perspective"]);
+  assert.deepEqual(names, [
+    "adversarial-review",
+    "code-review",
+    "codebase-audit",
+    "deep-research",
+    "multi-perspective",
+  ]);
 });
 
 test("registerBuiltinWorkflows is idempotent — skips already registered commands", () => {
@@ -17,6 +23,7 @@ test("registerBuiltinWorkflows is idempotent — skips already registered comman
     "adversarial-review",
     "multi-perspective",
     "codebase-audit",
+    "code-review",
   ]);
   registerBuiltinWorkflows(pi, { cwd: "/tmp" });
   assert.equal(commands.length, 0, "should not re-register when already present");
@@ -27,7 +34,7 @@ test("registerBuiltinWorkflows registers only missing commands", () => {
   registerBuiltinWorkflows(pi, { cwd: "/tmp" });
   assert.deepEqual(
     commands.map((c) => c.name).sort(),
-    ["codebase-audit", "multi-perspective"],
+    ["code-review", "codebase-audit", "multi-perspective"],
     "should only register the commands that aren't already present",
   );
 });

--- a/tests/builtin-workflows.test.ts
+++ b/tests/builtin-workflows.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "../src/adversarial-review.js";
+import { generateCodeReviewWorkflow } from "../src/code-review.js";
 import { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "../src/deep-research.js";
 import { createWebTools } from "../src/web-tools.js";
 import { parseWorkflowScript } from "../src/workflow.js";
@@ -132,4 +133,17 @@ test("generateMultiPerspectiveWorkflow returns analyses and synthesis", () => {
 test("createWebTools exposes web_search and web_fetch", () => {
   const tools = createWebTools();
   assert.deepEqual(tools.map((t) => t.name).sort(), ["web_fetch", "web_search"]);
+});
+
+// ─── Code Review ────────────────────────────────────────────────────────────────
+
+test("generateCodeReviewWorkflow produces a valid, parseable script", () => {
+  const { meta, body } = parseWorkflowScript(generateCodeReviewWorkflow());
+  assert.equal(meta.name, "code_review");
+  assert.deepEqual(
+    meta.phases?.map((p) => p.title),
+    ["Find", "Verify", "Report"],
+  );
+  assert.match(body, /parallel/);
+  assert.match(body, /candidateSchema/);
 });

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -1847,3 +1847,127 @@ return results`;
     assert.equal(result.agentCount, 0, "no agents should run with empty parallel");
   }),
 );
+
+// ─── Auto-resume tests ─────────────────────────────────────────────────────────
+
+test("parseResetHintMs parses hour strings, minute strings, and falls back for garbage", () => {
+  // Access the private method via type cast — it's internal but we want unit coverage.
+  const manager = new WorkflowManager({ cwd: "/tmp" });
+  const parse = (hint: string | undefined): number =>
+    (manager as unknown as { parseResetHintMs(h: string | undefined): number }).parseResetHintMs(hint);
+
+  assert.equal(parse("2h"), 2 * 60 * 60 * 1000, "'2h' should parse to 7 200 000 ms");
+  assert.equal(parse("30min"), 30 * 60 * 1000, "'30min' should parse to 1 800 000 ms");
+  // When both h and min appear, the hour match wins (first branch taken).
+  assert.equal(parse("1h30min"), 1 * 60 * 60 * 1000, "'1h30min' hour match wins → 3 600 000 ms");
+  // Garbage and undefined fall back to the 60-minute default.
+  assert.equal(parse(undefined), 60 * 60 * 1000, "undefined hint → default 60 min");
+  assert.equal(parse("garbage"), 60 * 60 * 1000, "unrecognized string → default 60 min");
+});
+
+test(
+  "scheduleAutoResume: exponential backoff doubles the delay on each attempt",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd });
+    const mgr = manager as unknown as {
+      autoResumeTimers: Map<string, ReturnType<typeof setTimeout>>;
+      autoResumeAttempts: Map<string, number>;
+      scheduleAutoResume(runId: string, hint?: string): void;
+      cancelAutoResume(runId: string): void;
+    };
+
+    const runId = "backoff-test-1";
+    const capturedDelays: number[] = [];
+    const capturedHandles: ReturnType<typeof setTimeout>[] = [];
+
+    const origSetTimeout = globalThis.setTimeout;
+    // Intercept setTimeout to record delays without letting timers actually fire.
+    (globalThis as Record<string, unknown>).setTimeout = (fn: () => void, delay: number) => {
+      capturedDelays.push(delay);
+      const handle = origSetTimeout(() => {}, 99_999_999);
+      capturedHandles.push(handle);
+      return handle;
+    };
+
+    try {
+      // Simulate attempt 0, 1, 2 by manually setting the attempt counter each time.
+      for (let attempt = 0; attempt < 3; attempt++) {
+        mgr.autoResumeAttempts.set(runId, attempt);
+        mgr.scheduleAutoResume(runId, "1h");
+      }
+    } finally {
+      (globalThis as Record<string, unknown>).setTimeout = origSetTimeout;
+      for (const h of capturedHandles) clearTimeout(h);
+      mgr.cancelAutoResume(runId);
+    }
+
+    // 1h = 3 600 000 ms; attempt 0 → 1h, attempt 1 → 2h, attempt 2 → 4h.
+    assert.equal(capturedDelays.length, 3, "should have captured three timer delays");
+    assert.equal(capturedDelays[0], 60 * 60 * 1000, "attempt 0 delay = 1h");
+    assert.equal(capturedDelays[1], 2 * 60 * 60 * 1000, "attempt 1 delay = 2h (doubled)");
+    assert.equal(capturedDelays[2], 4 * 60 * 60 * 1000, "attempt 2 delay = 4h (doubled again)");
+  }),
+);
+
+test(
+  "scheduleAutoResume: stops scheduling after MAX_AUTO_RESUME_ATTEMPTS (5) attempts",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd });
+    const mgr = manager as unknown as {
+      autoResumeTimers: Map<string, ReturnType<typeof setTimeout>>;
+      autoResumeAttempts: Map<string, number>;
+      scheduleAutoResume(runId: string, hint?: string): void;
+    };
+
+    const runId = "cap-test-1";
+    // Simulate that MAX_AUTO_RESUME_ATTEMPTS (5) have already been made.
+    mgr.autoResumeAttempts.set(runId, 5);
+    mgr.scheduleAutoResume(runId, "1h");
+
+    assert.equal(
+      mgr.autoResumeTimers.has(runId),
+      false,
+      "no timer should be scheduled once the attempt cap is reached",
+    );
+  }),
+);
+
+test(
+  "recoverStaleRuns re-arms an auto-resume timer for usage-limit paused runs",
+  withTempCwd(async (cwd) => {
+    // Pre-populate persistence with a usage-limit paused run via a first manager.
+    const seed = new WorkflowManager({ cwd });
+    const runId = "stale-usage-limit-1";
+    seed.getPersistence().save({
+      runId,
+      workflowName: "quota_run",
+      script: oneAgentScript,
+      args: undefined,
+      status: "paused",
+      pauseReason: "usage_limit",
+      resetHint: "Resets in ~1h",
+      phases: [],
+      agents: [],
+      logs: [],
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    // Constructing a new manager over the same cwd triggers recoverStaleRuns().
+    const manager = new WorkflowManager({ cwd });
+    const mgr = manager as unknown as {
+      autoResumeTimers: Map<string, ReturnType<typeof setTimeout>>;
+      cancelAutoResume(runId: string): void;
+    };
+
+    try {
+      assert.ok(
+        mgr.autoResumeTimers.has(runId),
+        "recoverStaleRuns should schedule an auto-resume timer for usage-limit paused runs",
+      );
+    } finally {
+      // Cancel the timer so the test process can exit cleanly.
+      mgr.cancelAutoResume(runId);
+    }
+  }),
+);


### PR DESCRIPTION
## Summary

Closes #27
Closes #32

---

## feat(workflow-manager): auto-resume after usage-limit pause (#27)

When a workflow hits a provider quota/usage limit, it's now checkpointed as `paused` (already in place via #26). This PR adds the **automatic** resume layer on top.

### How it works

- `ExecOptions.autoResume` (default `true`) — opt out per-execution by passing `autoResume: false`
- When `executeRun` catches a `PROVIDER_USAGE_LIMIT` error, it calls `scheduleAutoResume(runId, resetHint)`
- `parseResetHintMs()` extracts hours/minutes from the verbatim `resetHint` string (e.g. `"~3h"`, `"45 min"`), falls back to **60 minutes**
- Exponential backoff: each re-pause doubles the delay; `MAX_AUTO_RESUME_ATTEMPTS = 5` then gives up
- `recoverStaleRuns()` now re-arms timers on cold start for any persisted `paused + pauseReason === "usage_limit"` runs
- `stop()` and `deleteRun()` cancel pending timers so stopped runs don't ghost-resume
- Emits `"autoResuming"` event before each attempt for observability

---

## feat(code-review): /code-review built-in command (#32)

New `src/code-review.ts` implementing `generateCodeReviewWorkflow()`, registered as `/code-review`.

### Phases

**Phase 1 — Find (7 parallel agents)**

| Agent | Tier | Focus |
|---|---|---|
| A — line-by-line scan | medium | Inverted conditions, off-by-one, nil deref, wrong variable, swallowed error |
| B — removed-behavior audit | medium | Every deleted line: invariant named, where re-established |
| C — cross-file tracer | medium | Changed functions → grep callers → call site breakage |
| D — reuse | small | New code duplicating existing helpers |
| E — simplification | small | Redundant state, copy-paste variation, dead code |
| F — efficiency | small | Redundant I/O, sequential work that could parallel |
| G — altitude | big | Fix at wrong abstraction level |

**Phase 2 — Verify** — parallel verifier per candidate, drops REFUTED

**Phase 3 — Report** — big-tier synthesis, ranked A/B/C > D/E/F > G, capped at 10

### Input modes

```
/code-review                  → git diff HEAD
/code-review HEAD~3..HEAD     → git range
/code-review src/foo.ts       → specific file
/code-review 42               → gh pr diff 42
```