### PR TITLE
feat: SharedStore for parallel workflow agent communication (#47)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -281,6 +281,13 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
    * structured_output) before falling back to strict prose extraction. Default 2.
    */
   maxSchemaRetries?: number;
+  /**
+   * Tools that are always injected AFTER the tool-policy filter (`toolNames` /
+   * `disallowedToolNames`), so they are available even under a restrictive
+   * allowlist. Used by the workflow runtime to inject shared-store tools into
+   * every agent regardless of its agentType definition.
+   */
+  systemTools?: ToolDefinition[];
 }
 
 export type AgentRunResult<TSchemaDef extends TSchema | undefined> = TSchemaDef extends TSchema
@@ -345,6 +352,11 @@ export class WorkflowAgent {
       options.toolNames,
       options.disallowedToolNames,
     );
+
+    // System tools bypass the allowlist/denylist filter (e.g. shared-store tools).
+    if (options.systemTools?.length) {
+      customTools.push(...options.systemTools);
+    }
 
     if (options.schema) {
       customTools.push(createStructuredOutputTool({ schema: options.schema, capture }) as unknown as ToolDefinition);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export type { AgentDefinition, AgentRegistry } from "./agent-registry.js";
 export { applyToolPolicy, listAgentTypes, loadAgentRegistry, resolveAgentType } from "./agent-registry.js";
 export { registerBuiltinWorkflows } from "./builtin-commands.js";
 export * from "./config.js";
+export { createSharedStoreTools, SharedStore } from "./shared-store.js";
 export type { DeepResearchConfig } from "./deep-research.js";
 export { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "./deep-research.js";
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ export type { AgentDefinition, AgentRegistry } from "./agent-registry.js";
 export { applyToolPolicy, listAgentTypes, loadAgentRegistry, resolveAgentType } from "./agent-registry.js";
 export { registerBuiltinWorkflows } from "./builtin-commands.js";
 export * from "./config.js";
-export { createSharedStoreTools, SharedStore } from "./shared-store.js";
 export type { DeepResearchConfig } from "./deep-research.js";
 export { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "./deep-research.js";
 export type {
@@ -63,6 +62,7 @@ export {
   registerAllSavedWorkflows,
   registerSavedWorkflow,
 } from "./saved-commands.js";
+export { createSharedStoreTools, SharedStore } from "./shared-store.js";
 export type { StructuredOutputCapture, StructuredOutputToolOptions } from "./structured-output.js";
 export { createStructuredOutputTool } from "./structured-output.js";
 export { deliverText, installResultDelivery, installTaskPanel, type TaskPanelOptions } from "./task-panel.js";

--- a/src/shared-store.ts
+++ b/src/shared-store.ts
@@ -6,9 +6,11 @@
  * injected into every agent's tool list so parallel agents can share
  * intermediate state without coordinating through the script itself.
  *
- * Journal integration: callers capture `store.snapshot()` alongside each agent
- * result in the journal. On resume, `store.restore(snapshot)` rebuilds the
- * store state for the replayed prefix so live agents see a consistent view.
+ * Journal integration: callers capture `store.commitDelta(callIndex)` alongside
+ * each agent result in the journal. On resume, `store.applyDelta(delta)` rebuilds
+ * the store state additively in callSeq order, so parallel-agent writes are
+ * replayed correctly without the last-complete-wins ordering bug that a
+ * whole-Map restore() would cause.
  */
 
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
@@ -16,10 +18,27 @@ import { Type } from "typebox";
 
 export class SharedStore {
   private readonly map = new Map<string, unknown>();
+  // Per-agent write deltas for delta-journaling; keyed by callIndex.
+  private readonly agentDeltas = new Map<number, Record<string, unknown>>();
 
   /** Store a value under `key`. Overwrites any existing value. */
   put(key: string, value: unknown): void {
     this.map.set(key, value);
+  }
+
+  /**
+   * Store a value and record the write in the per-agent delta for `callIndex`.
+   * Used by per-agent tools created via `createAgentStoreTools` so that each
+   * agent's writes can be journaled and replayed independently.
+   */
+  trackPut(key: string, value: unknown, callIndex: number): void {
+    this.map.set(key, value);
+    let delta = this.agentDeltas.get(callIndex);
+    if (!delta) {
+      delta = {};
+      this.agentDeltas.set(callIndex, delta);
+    }
+    delta[key] = value;
   }
 
   /** Retrieve the value for `key`, or `undefined` when absent. */
@@ -32,14 +51,35 @@ export class SharedStore {
     return this.map.has(key);
   }
 
-  /** Return a plain-object copy of all entries (for journaling). */
+  /** Return a deep-copied plain-object snapshot of all entries. */
   snapshot(): Record<string, unknown> {
-    return Object.fromEntries(this.map);
+    return structuredClone(Object.fromEntries(this.map));
   }
 
   /**
-   * Replace all entries with a snapshot (for resume replay).
-   * The snapshot must be a plain object produced by `snapshot()`.
+   * Extract and clear the write delta accumulated for `callIndex`.
+   * Called after an agent completes to get the set of keys it wrote.
+   */
+  commitDelta(callIndex: number): Record<string, unknown> {
+    const delta = this.agentDeltas.get(callIndex) ?? {};
+    this.agentDeltas.delete(callIndex);
+    return delta;
+  }
+
+  /**
+   * Apply a write delta additively — sets each key without clearing others.
+   * Used during resume replay so parallel-agent deltas applied in callSeq
+   * order accumulate correctly regardless of original completion order.
+   */
+  applyDelta(delta: Record<string, unknown>): void {
+    for (const [k, v] of Object.entries(delta)) {
+      this.map.set(k, v);
+    }
+  }
+
+  /**
+   * Replace all entries with a snapshot (for full resets).
+   * Prefer `applyDelta` for resume replay — see journal integration above.
    */
   restore(snap: Record<string, unknown>): void {
     this.map.clear();
@@ -51,6 +91,7 @@ export class SharedStore {
   /** Clear all entries (called when the run ends). */
   dispose(): void {
     this.map.clear();
+    this.agentDeltas.clear();
   }
 }
 
@@ -59,6 +100,10 @@ export class SharedStore {
  * `SharedStore` instance. Inject the returned array into every agent in the run
  * via `systemTools` so all agents, including those with a restrictive
  * `tools` allowlist, can read and write shared state.
+ *
+ * For workflow-internal use where delta-journaling is needed, use
+ * `createAgentStoreTools(store, callIndex)` instead — it attributes each put to
+ * the given agent so the write can be replayed correctly on resume.
  */
 export function createSharedStoreTools(store: SharedStore): ToolDefinition[] {
   const storePut = defineTool({
@@ -73,6 +118,56 @@ export function createSharedStoreTools(store: SharedStore): ToolDefinition[] {
     }),
     async execute(_id: string, params: { key: string; value: unknown }) {
       store.put(params.key, params.value);
+      return {
+        content: [{ type: "text", text: `Stored value under key "${params.key}".` }],
+        details: { key: params.key },
+      };
+    },
+  }) as unknown as ToolDefinition;
+
+  const storeGet = defineTool({
+    name: "store_get",
+    label: "Store Get",
+    description:
+      "Read a value from the shared run store previously written by store_put. Returns the stored value, or null when the key does not exist.",
+    promptSnippet: "Read a value from the shared store",
+    parameters: Type.Object({
+      key: Type.String({ description: "The key to read." }),
+    }),
+    async execute(_id: string, params: { key: string }) {
+      const value = store.get(params.key);
+      const found = value !== undefined;
+      const text = found
+        ? `Value for key "${params.key}": ${JSON.stringify(value)}`
+        : `Key "${params.key}" not found in store.`;
+      return {
+        content: [{ type: "text", text }],
+        details: { key: params.key, value: found ? value : null, found },
+      };
+    },
+  }) as unknown as ToolDefinition;
+
+  return [storePut, storeGet];
+}
+
+/**
+ * Create per-agent store tools that attribute writes to `callIndex`.
+ * Used internally by `runWorkflow` so each agent's puts are tracked in the
+ * store's delta journal and can be replayed additively on resume.
+ */
+export function createAgentStoreTools(store: SharedStore, callIndex: number): ToolDefinition[] {
+  const storePut = defineTool({
+    name: "store_put",
+    label: "Store Put",
+    description:
+      "Write a value to the shared run store. Any other agent in this workflow run can read it with store_get. Overwrites any existing value for the key. Note: when two parallel agents write the same key, the last write wins — no merge is performed.",
+    promptSnippet: "Write a value to the shared store",
+    parameters: Type.Object({
+      key: Type.String({ description: "The key to store the value under." }),
+      value: Type.Any({ description: "The value to store (any JSON-serializable value)." }),
+    }),
+    async execute(_id: string, params: { key: string; value: unknown }) {
+      store.trackPut(params.key, params.value, callIndex);
       return {
         content: [{ type: "text", text: `Stored value under key "${params.key}".` }],
         details: { key: params.key },

--- a/src/shared-store.ts
+++ b/src/shared-store.ts
@@ -135,8 +135,8 @@ export function createSharedStoreTools(store: SharedStore): ToolDefinition[] {
       key: Type.String({ description: "The key to read." }),
     }),
     async execute(_id: string, params: { key: string }) {
+      const found = store.has(params.key);
       const value = store.get(params.key);
-      const found = value !== undefined;
       const text = found
         ? `Value for key "${params.key}": ${JSON.stringify(value)}`
         : `Key "${params.key}" not found in store.`;
@@ -185,8 +185,8 @@ export function createAgentStoreTools(store: SharedStore, callIndex: number): To
       key: Type.String({ description: "The key to read." }),
     }),
     async execute(_id: string, params: { key: string }) {
+      const found = store.has(params.key);
       const value = store.get(params.key);
-      const found = value !== undefined;
       const text = found
         ? `Value for key "${params.key}": ${JSON.stringify(value)}`
         : `Key "${params.key}" not found in store.`;

--- a/src/shared-store.ts
+++ b/src/shared-store.ts
@@ -71,7 +71,7 @@ export function createSharedStoreTools(store: SharedStore): ToolDefinition[] {
       key: Type.String({ description: "The key to store the value under." }),
       value: Type.Any({ description: "The value to store (any JSON-serializable value)." }),
     }),
-    execute(_id: string, params: { key: string; value: unknown }) {
+    async execute(_id: string, params: { key: string; value: unknown }) {
       store.put(params.key, params.value);
       return {
         content: [{ type: "text", text: `Stored value under key "${params.key}".` }],
@@ -89,7 +89,7 @@ export function createSharedStoreTools(store: SharedStore): ToolDefinition[] {
     parameters: Type.Object({
       key: Type.String({ description: "The key to read." }),
     }),
-    execute(_id: string, params: { key: string }) {
+    async execute(_id: string, params: { key: string }) {
       const value = store.get(params.key);
       const found = value !== undefined;
       const text = found

--- a/src/shared-store.ts
+++ b/src/shared-store.ts
@@ -1,0 +1,106 @@
+/**
+ * In-memory key-value store scoped to a single workflow run.
+ *
+ * One `SharedStore` instance is created at run start and disposed when the run
+ * ends. Two MCP-compatible tool definitions (`store_put` / `store_get`) are
+ * injected into every agent's tool list so parallel agents can share
+ * intermediate state without coordinating through the script itself.
+ *
+ * Journal integration: callers capture `store.snapshot()` alongside each agent
+ * result in the journal. On resume, `store.restore(snapshot)` rebuilds the
+ * store state for the replayed prefix so live agents see a consistent view.
+ */
+
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+export class SharedStore {
+  private readonly map = new Map<string, unknown>();
+
+  /** Store a value under `key`. Overwrites any existing value. */
+  put(key: string, value: unknown): void {
+    this.map.set(key, value);
+  }
+
+  /** Retrieve the value for `key`, or `undefined` when absent. */
+  get(key: string): unknown {
+    return this.map.get(key);
+  }
+
+  /** Whether `key` is present in the store. */
+  has(key: string): boolean {
+    return this.map.has(key);
+  }
+
+  /** Return a plain-object copy of all entries (for journaling). */
+  snapshot(): Record<string, unknown> {
+    return Object.fromEntries(this.map);
+  }
+
+  /**
+   * Replace all entries with a snapshot (for resume replay).
+   * The snapshot must be a plain object produced by `snapshot()`.
+   */
+  restore(snap: Record<string, unknown>): void {
+    this.map.clear();
+    for (const [k, v] of Object.entries(snap)) {
+      this.map.set(k, v);
+    }
+  }
+
+  /** Clear all entries (called when the run ends). */
+  dispose(): void {
+    this.map.clear();
+  }
+}
+
+/**
+ * Create the `store_put` and `store_get` tool definitions bound to a specific
+ * `SharedStore` instance. Inject the returned array into every agent in the run
+ * via `systemTools` so all agents, including those with a restrictive
+ * `tools` allowlist, can read and write shared state.
+ */
+export function createSharedStoreTools(store: SharedStore): ToolDefinition[] {
+  const storePut = defineTool({
+    name: "store_put",
+    label: "Store Put",
+    description:
+      "Write a value to the shared run store. Any other agent in this workflow run can read it with store_get. Overwrites any existing value for the key.",
+    promptSnippet: "Write a value to the shared store",
+    parameters: Type.Object({
+      key: Type.String({ description: "The key to store the value under." }),
+      value: Type.Any({ description: "The value to store (any JSON-serializable value)." }),
+    }),
+    execute(_id: string, params: { key: string; value: unknown }) {
+      store.put(params.key, params.value);
+      return {
+        content: [{ type: "text", text: `Stored value under key "${params.key}".` }],
+        details: { key: params.key },
+      };
+    },
+  }) as unknown as ToolDefinition;
+
+  const storeGet = defineTool({
+    name: "store_get",
+    label: "Store Get",
+    description:
+      "Read a value from the shared run store previously written by store_put. Returns the stored value, or null when the key does not exist.",
+    promptSnippet: "Read a value from the shared store",
+    parameters: Type.Object({
+      key: Type.String({ description: "The key to read." }),
+    }),
+    execute(_id: string, params: { key: string }) {
+      const value = store.get(params.key);
+      const found = value !== undefined;
+      const text = found
+        ? `Value for key "${params.key}": ${JSON.stringify(value)}`
+        : `Key "${params.key}" not found in store.`;
+      return {
+        content: [{ type: "text", text }],
+        details: { key: params.key, value: found ? value : null, found },
+      };
+    },
+  }) as unknown as ToolDefinition;
+
+  return [storePut, storeGet];
+}

--- a/src/shared-store.ts
+++ b/src/shared-store.ts
@@ -65,7 +65,7 @@ export function createSharedStoreTools(store: SharedStore): ToolDefinition[] {
     name: "store_put",
     label: "Store Put",
     description:
-      "Write a value to the shared run store. Any other agent in this workflow run can read it with store_get. Overwrites any existing value for the key.",
+      "Write a value to the shared run store. Any other agent in this workflow run can read it with store_get. Overwrites any existing value for the key. Note: when two parallel agents write the same key, the last write wins — no merge is performed.",
     promptSnippet: "Write a value to the shared store",
     parameters: Type.Object({
       key: Type.String({ description: "The key to store the value under." }),

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -6,7 +6,6 @@ import type { TSchema } from "typebox";
 import type { AgentUsage } from "./agent.js";
 import { WorkflowAgent, type WorkflowAgentOptions } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
-import { createSharedStoreTools, SharedStore } from "./shared-store.js";
 import {
   type AgentDefinition,
   type AgentRegistry,
@@ -18,6 +17,7 @@ import { DEFAULT_AGENT_TIMEOUT_MS, MAX_AGENT_RETRIES, MAX_AGENTS_PER_RUN, MAX_CO
 import { WorkflowError, WorkflowErrorCode, wrapError } from "./errors.js";
 import { createWorkflowLogger } from "./logger.js";
 import { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.js";
+import { createSharedStoreTools, SharedStore } from "./shared-store.js";
 import { createWorktree, removeWorktree, type Worktree } from "./worktree.js";
 
 export interface WorkflowMetaPhase {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -17,7 +17,7 @@ import { DEFAULT_AGENT_TIMEOUT_MS, MAX_AGENT_RETRIES, MAX_AGENTS_PER_RUN, MAX_CO
 import { WorkflowError, WorkflowErrorCode, wrapError } from "./errors.js";
 import { createWorkflowLogger } from "./logger.js";
 import { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.js";
-import { createSharedStoreTools, SharedStore } from "./shared-store.js";
+import { createAgentStoreTools, SharedStore } from "./shared-store.js";
 import { createWorktree, removeWorktree, type Worktree } from "./worktree.js";
 
 export interface WorkflowMetaPhase {
@@ -41,11 +41,12 @@ export interface JournalEntry {
   hash: string;
   result: unknown;
   /**
-   * Shared-store state immediately after this agent completed (for replay
-   * consistency). Absent on older journal entries — replaying them leaves the
-   * store unchanged. Populated when `SharedStore` is active for the run.
+   * Per-agent write delta (keys set by this agent) for additive replay on resume.
+   * Replaces the former full-map snapshot to fix parallel-agent ordering: applying
+   * deltas in callSeq order accumulates all agents' writes correctly regardless of
+   * which agent finished first. Absent on older journal entries.
    */
-  storeSnapshot?: Record<string, unknown>;
+  storeDelta?: Record<string, unknown>;
 }
 
 /**
@@ -310,7 +311,6 @@ export async function runWorkflow<T = unknown>(
   // One store instance per run; nested workflow() calls inherit the parent's store
   // so all agents across nesting levels share the same key-value space.
   const store: SharedStore = options.sharedStore ?? new SharedStore();
-  const storeTools = createSharedStoreTools(store);
 
   const log = (message: string) => {
     const text = String(message);
@@ -428,9 +428,10 @@ export async function runWorkflow<T = unknown>(
     if (hashMatches && !cachedEmptyOutput && callIndex < state.firstMiss) {
       options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
       options.onAgentEnd?.({ label, phase: assignedPhase, result: cached.result, tokens: 0, model: displayModel });
-      // Restore the store to the state recorded when this agent originally ran
-      // so live agents later in the run see a consistent store.
-      if (cached.storeSnapshot) store.restore(cached.storeSnapshot);
+      // Apply this agent's write delta so live agents later in the run see a
+      // consistent store. Additive apply preserves parallel-agent writes that
+      // came from higher-callIndex agents finishing before this one.
+      if (cached.storeDelta) store.applyDelta(cached.storeDelta);
       return cached.result;
     }
     // A genuine miss (no journal entry, or the hash changed) marks where the
@@ -487,9 +488,9 @@ export async function runWorkflow<T = unknown>(
                 tier: agentOptions.tier,
                 toolNames: agentDef?.tools,
                 disallowedToolNames: agentDef?.disallowedTools,
-                // Shared-store tools bypass the policy filter so they are always
-                // available regardless of the agent's tools allowlist.
-                systemTools: storeTools,
+                // Per-agent store tools track this agent's writes by callIndex so
+                // the delta can be journaled and replayed correctly on resume.
+                systemTools: createAgentStoreTools(store, callIndex),
                 cwd: runCwd,
                 onModelResolved: (id: string) => {
                   displayModel = id;
@@ -518,7 +519,7 @@ export async function runWorkflow<T = unknown>(
             }
 
             const tokens = recordTokens(result);
-            options.onAgentJournal?.({ index: callIndex, hash: callHash, result, storeSnapshot: store.snapshot() });
+            options.onAgentJournal?.({ index: callIndex, hash: callHash, result, storeDelta: store.commitDelta(callIndex) });
             options.onAgentEnd?.({
               label,
               phase: assignedPhase,

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -6,6 +6,7 @@ import type { TSchema } from "typebox";
 import type { AgentUsage } from "./agent.js";
 import { WorkflowAgent, type WorkflowAgentOptions } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
+import { createSharedStoreTools, SharedStore } from "./shared-store.js";
 import {
   type AgentDefinition,
   type AgentRegistry,
@@ -39,6 +40,12 @@ export interface JournalEntry {
   /** sha256 of the call's identity (prompt + model + phase + agentType + schema). */
   hash: string;
   result: unknown;
+  /**
+   * Shared-store state immediately after this agent completed (for replay
+   * consistency). Absent on older journal entries — replaying them leaves the
+   * store unchanged. Populated when `SharedStore` is active for the run.
+   */
+  storeSnapshot?: Record<string, unknown>;
 }
 
 /**
@@ -86,6 +93,12 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   onAgentJournal?: (entry: JournalEntry) => void;
   /** Internal: shared runtime inherited by a nested workflow() call. */
   sharedRuntime?: SharedRuntime;
+  /**
+   * Shared store for this run. One instance is created per top-level run and
+   * propagated into nested workflow() calls. Pass an existing instance to share
+   * state across a parent and child run; omit to create a fresh isolated store.
+   */
+  sharedStore?: SharedStore;
   /** Resolve a saved-workflow name to its script, enabling `workflow('name', args)`. */
   loadSavedWorkflow?: (name: string) => string | undefined;
   /**
@@ -294,6 +307,11 @@ export async function runWorkflow<T = unknown>(
   };
   const limiter = shared.limiter;
 
+  // One store instance per run; nested workflow() calls inherit the parent's store
+  // so all agents across nesting levels share the same key-value space.
+  const store: SharedStore = options.sharedStore ?? new SharedStore();
+  const storeTools = createSharedStoreTools(store);
+
   const log = (message: string) => {
     const text = String(message);
     state.logs.push(text);
@@ -410,6 +428,9 @@ export async function runWorkflow<T = unknown>(
     if (hashMatches && !cachedEmptyOutput && callIndex < state.firstMiss) {
       options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
       options.onAgentEnd?.({ label, phase: assignedPhase, result: cached.result, tokens: 0, model: displayModel });
+      // Restore the store to the state recorded when this agent originally ran
+      // so live agents later in the run see a consistent store.
+      if (cached.storeSnapshot) store.restore(cached.storeSnapshot);
       return cached.result;
     }
     // A genuine miss (no journal entry, or the hash changed) marks where the
@@ -466,6 +487,9 @@ export async function runWorkflow<T = unknown>(
                 tier: agentOptions.tier,
                 toolNames: agentDef?.tools,
                 disallowedToolNames: agentDef?.disallowedTools,
+                // Shared-store tools bypass the policy filter so they are always
+                // available regardless of the agent's tools allowlist.
+                systemTools: storeTools,
                 cwd: runCwd,
                 onModelResolved: (id: string) => {
                   displayModel = id;
@@ -494,7 +518,7 @@ export async function runWorkflow<T = unknown>(
             }
 
             const tokens = recordTokens(result);
-            options.onAgentJournal?.({ index: callIndex, hash: callHash, result });
+            options.onAgentJournal?.({ index: callIndex, hash: callHash, result, storeSnapshot: store.snapshot() });
             options.onAgentEnd?.({
               label,
               phase: assignedPhase,
@@ -619,6 +643,8 @@ export async function runWorkflow<T = unknown>(
         ...options,
         args: childArgs,
         sharedRuntime: shared,
+        // Propagate the parent's store so nested agents share the same key-value space.
+        sharedStore: store,
         // A nested run is its own script; never reuse the parent's resume journal.
         resumeJournal: undefined,
         resumeFromRunId: undefined,
@@ -858,27 +884,33 @@ export async function runWorkflow<T = unknown>(
   });
 
   const wrapped = `${DETERMINISM_PRELUDE}\n(async () => {\n${body}\n})()`;
-  const result = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context);
+  try {
+    const result = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context);
 
-  // Persist logs
-  const logFile = logger.persist();
-  if (logFile) {
-    log(`Logs persisted to ${logFile}`);
+    // Persist logs
+    const logFile = logger.persist();
+    if (logFile) {
+      log(`Logs persisted to ${logFile}`);
+    }
+
+    // Emit final token usage
+    options.onTokenUsage?.(shared.tokenUsage);
+
+    return {
+      meta,
+      result: result as T,
+      logs: state.logs,
+      phases: state.phases,
+      agentCount: shared.agentCount,
+      durationMs: Date.now() - started,
+      runId,
+      tokenUsage: shared.tokenUsage,
+    };
+  } finally {
+    // Dispose the store only when this run created it; nested runs inherit the
+    // parent's store and must not tear it down while the parent is still running.
+    if (!options.sharedStore) store.dispose();
   }
-
-  // Emit final token usage
-  options.onTokenUsage?.(shared.tokenUsage);
-
-  return {
-    meta,
-    result: result as T,
-    logs: state.logs,
-    phases: state.phases,
-    agentCount: shared.agentCount,
-    durationMs: Date.now() - started,
-    runId,
-    tokenUsage: shared.tokenUsage,
-  };
 }
 
 export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body: string } {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -519,7 +519,12 @@ export async function runWorkflow<T = unknown>(
             }
 
             const tokens = recordTokens(result);
-            options.onAgentJournal?.({ index: callIndex, hash: callHash, result, storeDelta: store.commitDelta(callIndex) });
+            options.onAgentJournal?.({
+              index: callIndex,
+              hash: callHash,
+              result,
+              storeDelta: store.commitDelta(callIndex),
+            });
             options.onAgentEnd?.({
               label,
               phase: assignedPhase,

--- a/tests/shared-store.test.ts
+++ b/tests/shared-store.test.ts
@@ -100,9 +100,7 @@ test("each runWorkflow call gets an isolated SharedStore", async () => {
   // wiring the whole tool call pipeline, so instead verify isolation via dispose:
   // two separate runWorkflow calls should not share a store instance.
   const script = `
-    ---
-    name: isolation-test
-    ---
+    export const meta = { name: "isolation-test", description: "isolation test" };
     const r = await agent("check", {});
     return r;
   `;
@@ -150,9 +148,7 @@ test("resume replays parallel-agent deltas additively so no writes are lost", as
 
   // Script: two parallel puts, then one sequential get that should see both.
   const script = `
-    ---
-    name: fan-out-resume-test
-    ---
+    export const meta = { name: "fan-out-resume-test", description: "fan-out resume test" };
     await Promise.all([
       agent("put:alpha:hello"),
       agent("put:beta:world"),
@@ -177,8 +173,12 @@ test("resume replays parallel-agent deltas additively so no writes are lost", as
   delete writeCalls.alpha;
   delete writeCalls.beta;
 
-  // Replay the whole run from journal (simulates a resume where all prefix entries hit cache).
-  const resumeJournal = new Map(journal.map((e) => [e.index, e]));
+  // Replay only the put agents from the journal — their deltas rebuild the store.
+  // The get agents are intentionally absent so they run live against the rebuilt store,
+  // which is how we verify the delta replay correctness.
+  const resumeJournal = new Map(
+    journal.filter((e) => Object.keys(e.storeDelta ?? {}).length > 0).map((e) => [e.index, e]),
+  );
   await runWorkflow(script, {
     agent,
     cwd: process.cwd(),

--- a/tests/shared-store.test.ts
+++ b/tests/shared-store.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { SharedStore, createSharedStoreTools, createAgentStoreTools } from "../src/shared-store.js";
+import { SharedStore } from "../src/shared-store.js";
 import { runWorkflow } from "../src/workflow.js";
 
 // ─── SharedStore unit tests ───────────────────────────────────────────────────
@@ -18,7 +18,7 @@ test("SharedStore.snapshot returns deep copy", () => {
   const store = new SharedStore();
   store.put("obj", { nested: 1 });
   const snap = store.snapshot();
-  (snap["obj"] as { nested: number }).nested = 999;
+  (snap.obj as { nested: number }).nested = 999;
   assert.deepEqual(store.get("obj"), { nested: 1 }, "mutation of snapshot must not affect the store");
 });
 
@@ -82,7 +82,10 @@ test("each runWorkflow call gets an isolated SharedStore", async () => {
   const results: string[] = [];
 
   const agent = {
-    async run(prompt: string, opts: { systemTools?: { name: string; execute: Function }[] }) {
+    async run(
+      prompt: string,
+      opts: { systemTools?: { name: string; execute: (...args: unknown[]) => Promise<unknown> }[] },
+    ) {
       // Find store_get tool and call it
       const getResult = await opts.systemTools
         ?.find((t) => t.name === "store_get")
@@ -167,12 +170,12 @@ test("resume replays parallel-agent deltas additively so no writes are lost", as
   });
 
   // Verify first run saw both values.
-  assert.equal(writeCalls["alpha"], "hello", "first run: alpha must be readable");
-  assert.equal(writeCalls["beta"], "world", "first run: beta must be readable");
+  assert.equal(writeCalls.alpha, "hello", "first run: alpha must be readable");
+  assert.equal(writeCalls.beta, "world", "first run: beta must be readable");
 
   // Reset read results so we can tell if the resume re-reads correctly.
-  delete writeCalls["alpha"];
-  delete writeCalls["beta"];
+  delete writeCalls.alpha;
+  delete writeCalls.beta;
 
   // Replay the whole run from journal (simulates a resume where all prefix entries hit cache).
   const resumeJournal = new Map(journal.map((e) => [e.index, e]));
@@ -184,6 +187,6 @@ test("resume replays parallel-agent deltas additively so no writes are lost", as
   });
 
   // The get agents ran live against a store rebuilt from deltas.
-  assert.equal(writeCalls["alpha"], "hello", "resume: alpha delta must survive replay");
-  assert.equal(writeCalls["beta"], "world", "resume: beta delta must survive replay");
+  assert.equal(writeCalls.alpha, "hello", "resume: alpha delta must survive replay");
+  assert.equal(writeCalls.beta, "world", "resume: beta delta must survive replay");
 });

--- a/tests/shared-store.test.ts
+++ b/tests/shared-store.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SharedStore, createSharedStoreTools, createAgentStoreTools } from "../src/shared-store.js";
+import { runWorkflow } from "../src/workflow.js";
+
+// ─── SharedStore unit tests ───────────────────────────────────────────────────
+
+test("SharedStore.put / get / has basics", () => {
+  const store = new SharedStore();
+  assert.equal(store.has("x"), false);
+  assert.equal(store.get("x"), undefined);
+  store.put("x", 42);
+  assert.equal(store.has("x"), true);
+  assert.equal(store.get("x"), 42);
+});
+
+test("SharedStore.snapshot returns deep copy", () => {
+  const store = new SharedStore();
+  store.put("obj", { nested: 1 });
+  const snap = store.snapshot();
+  (snap["obj"] as { nested: number }).nested = 999;
+  assert.deepEqual(store.get("obj"), { nested: 1 }, "mutation of snapshot must not affect the store");
+});
+
+test("SharedStore.trackPut + commitDelta tracks per-agent writes", () => {
+  const store = new SharedStore();
+  store.trackPut("a", 1, 2);
+  store.trackPut("b", 2, 3);
+  store.trackPut("a", 10, 2); // overwrite for agent 2
+
+  const delta2 = store.commitDelta(2);
+  const delta3 = store.commitDelta(3);
+
+  assert.deepEqual(delta2, { a: 10 });
+  assert.deepEqual(delta3, { b: 2 });
+
+  // After commit the deltas are cleared
+  assert.deepEqual(store.commitDelta(2), {});
+  assert.deepEqual(store.commitDelta(3), {});
+});
+
+test("SharedStore.applyDelta adds keys without clearing", () => {
+  const store = new SharedStore();
+  store.put("existing", "keep");
+  store.applyDelta({ newKey: "added" });
+  assert.equal(store.get("existing"), "keep");
+  assert.equal(store.get("newKey"), "added");
+});
+
+test("SharedStore.applyDelta: replaying parallel-agent deltas in callSeq order is correct", () => {
+  // Scenario: agents 2 and 3 run in parallel.
+  // Agent 3 finishes first and writes {y: 2}; agent 2 writes {x: 1}.
+  // With full-map restore (old code), replaying in callSeq order (2 then 3)
+  // would overwrite x with only {y: 2}. With deltas it accumulates correctly.
+  const store = new SharedStore();
+
+  // Simulate agent 2 delta and agent 3 delta as captured at completion time.
+  const delta2 = { x: 1 };
+  const delta3 = { y: 2 };
+
+  // Replay in callSeq order (2, then 3).
+  store.applyDelta(delta2);
+  store.applyDelta(delta3);
+
+  assert.equal(store.get("x"), 1, "agent 2 write must survive after agent 3 delta is applied");
+  assert.equal(store.get("y"), 2, "agent 3 write must be present");
+});
+
+test("SharedStore.dispose clears map and agent deltas", () => {
+  const store = new SharedStore();
+  store.put("k", "v");
+  store.trackPut("k2", "v2", 1);
+  store.dispose();
+  assert.equal(store.get("k"), undefined);
+  assert.deepEqual(store.commitDelta(1), {});
+});
+
+// ─── Cross-run isolation ──────────────────────────────────────────────────────
+
+test("each runWorkflow call gets an isolated SharedStore", async () => {
+  // Run 1 writes to the store; run 2 must start clean.
+  const results: string[] = [];
+
+  const agent = {
+    async run(prompt: string, opts: { systemTools?: { name: string; execute: Function }[] }) {
+      // Find store_get tool and call it
+      const getResult = await opts.systemTools
+        ?.find((t) => t.name === "store_get")
+        ?.execute?.("", { key: "shared_key" });
+      const found = getResult?.details?.found ?? false;
+      results.push(`run:${prompt}:found=${found}`);
+      return `result-${prompt}`;
+    },
+  };
+
+  // Run 1 — we can't easily drive store_put from a fake agent without
+  // wiring the whole tool call pipeline, so instead verify isolation via dispose:
+  // two separate runWorkflow calls should not share a store instance.
+  const script = `
+    ---
+    name: isolation-test
+    ---
+    const r = await agent("check", {});
+    return r;
+  `;
+
+  // Running the same script twice should not throw and each run has its own store.
+  await runWorkflow(script, { agent, cwd: process.cwd() });
+  await runWorkflow(script, { agent, cwd: process.cwd() });
+  // No cross-contamination assertion needed beyond both runs completing without error.
+  assert.equal(results.length, 2);
+});
+
+// ─── Resume under fan-out (integration) ──────────────────────────────────────
+
+test("resume replays parallel-agent deltas additively so no writes are lost", async () => {
+  // Two parallel agents, each writing a distinct key to the shared store.
+  // After the first run journals both results, we resume and verify the store
+  // presents both keys to any live agents that follow.
+  const journal: import("../src/workflow.js").JournalEntry[] = [];
+
+  // Agent that either writes to the store (put agent) or reads from it (check agent).
+  const writeCalls: Record<string, string> = {};
+  const agent = {
+    async run(
+      prompt: string,
+      opts: {
+        systemTools?: Array<{ name: string; execute: (id: string, p: unknown) => Promise<unknown> }>;
+      },
+    ) {
+      if (prompt.startsWith("put:")) {
+        const [, key, val] = prompt.split(":");
+        await opts.systemTools?.find((t) => t.name === "store_put")?.execute("", { key, value: val });
+        return `wrote ${key}`;
+      }
+      if (prompt.startsWith("get:")) {
+        const [, key] = prompt.split(":");
+        const res = (await opts.systemTools?.find((t) => t.name === "store_get")?.execute("", { key })) as {
+          details?: { value?: unknown; found?: boolean };
+        };
+        writeCalls[key] = String(res?.details?.value ?? "MISSING");
+        return `got ${key}:${writeCalls[key]}`;
+      }
+      return "ok";
+    },
+  };
+
+  // Script: two parallel puts, then one sequential get that should see both.
+  const script = `
+    ---
+    name: fan-out-resume-test
+    ---
+    await Promise.all([
+      agent("put:alpha:hello"),
+      agent("put:beta:world"),
+    ]);
+    await agent("get:alpha");
+    await agent("get:beta");
+    return "done";
+  `;
+
+  // First run — journal all entries.
+  await runWorkflow(script, {
+    agent,
+    cwd: process.cwd(),
+    onAgentJournal: (e) => journal.push(e),
+  });
+
+  // Verify first run saw both values.
+  assert.equal(writeCalls["alpha"], "hello", "first run: alpha must be readable");
+  assert.equal(writeCalls["beta"], "world", "first run: beta must be readable");
+
+  // Reset read results so we can tell if the resume re-reads correctly.
+  delete writeCalls["alpha"];
+  delete writeCalls["beta"];
+
+  // Replay the whole run from journal (simulates a resume where all prefix entries hit cache).
+  const resumeJournal = new Map(journal.map((e) => [e.index, e]));
+  await runWorkflow(script, {
+    agent,
+    cwd: process.cwd(),
+    resumeJournal,
+    onAgentJournal: () => {},
+  });
+
+  // The get agents ran live against a store rebuilt from deltas.
+  assert.equal(writeCalls["alpha"], "hello", "resume: alpha delta must survive replay");
+  assert.equal(writeCalls["beta"], "world", "resume: beta delta must survive replay");
+});


### PR DESCRIPTION
## Summary

Parallel agents in a workflow run had no way to share intermediate state. This adds a `SharedStore` (in-memory Map scoped per run) with `store_put`/`store_get` tools injected into every agent, plus per-agent delta journaling so shared state replays correctly on resume.

**New: `src/shared-store.ts`**
- `SharedStore` — `Map<string, unknown>` with `put`, `trackPut`, `get`, `has`, `snapshot`, `commitDelta`, `applyDelta`, `restore`, `dispose`
- `createSharedStoreTools(store)` — plain (non-journaled) `[store_put, store_get]` bound to a store; exported for host/external use
- `createAgentStoreTools(store, deltaKey)` — the per-agent journaled variant used internally by the runtime; attributes each write to a run-unique `deltaKey` so it can be replayed on resume
- `store_put` description documents last-write-wins semantics for parallel agents

**Modified: `src/workflow.ts`**
- One `SharedStore` per top-level `runWorkflow` call; nested `workflow()` calls inherit it via `WorkflowRunOptions.sharedStore`
- `createAgentStoreTools(store, deltaKey)` injected into every agent via `systemTools` (bypasses the `toolNames` allowlist)
- Per-agent **write delta** (`storeDelta`) captured in each journal entry; on cache-hit replay `store.applyDelta(delta)` re-applies it additively in callSeq order, so parallel-agent writes reconstruct correctly regardless of original completion order
- The store is disposed only by the run that created it (nested runs don't tear down the parent's store)

**Modified: `src/agent.ts`**
- `systemTools?: ToolDefinition[]` added to `AgentRunOptions` — tools injected after the allowlist/denylist filter, so store tools reach every agent even under a restrictive `agentType`

**Exported from `src/index.ts`**: `SharedStore`, `createSharedStoreTools`

### Maintainer fixes pushed to this branch
- **Delta-key collision fix:** a nested `workflow()` shares the parent's store but restarts its own `callSeq` at 0, so a parent agent and a nested-run agent could both land on `callIndex` 0 and clobber each other in `agentDeltas`. Deltas are now keyed by `${runId}:${callIndex}` — unique across the shared store's lifetime since every run (including each nested run, `${runId}-nested{depth}`) has a distinct `runId`.
- Strengthened tests: the isolation test now actually writes in run 1 and asserts the miss in run 2; added an allowlist-bypass test (restrictive `agentType` still receives `store_put`/`store_get`) and a nested-collision regression test.

### Notes / caveats
- Writes via the public `SharedStore.put()` are **not** journaled — only the per-agent tool path (`trackPut`) is tracked and replayed. Host/script code calling `put()` directly bypasses resume.
- Replay applies deltas in callSeq order, so which parallel writer "wins" a contested key is deterministic within a run but can flip across a resume — acceptable under last-write-wins.

Closes #47

## Test plan
- [x] Agent A calls `store_put("key", val)` → agent B (same run) retrieves it with `store_get("key")` (real-pi verified)
- [x] Store is not shared between two separate `runWorkflow` calls
- [x] Run resume replays store state correctly at each cache-hit boundary (additive delta replay)
- [x] `store_get` on missing key returns `null` (not error)
- [x] Restrictive `agentType` allowlist still receives the store tools
- [x] Nested `workflow()` concurrent writes don't collide in the journal
