### PR TITLE
fix: share host ModelRegistry with workflow subagents

### DIFF
--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -54,6 +54,9 @@ export default function extension(pi: ExtensionAPI) {
     // Tell the manager the session's main model so "explore" agents auto-tier
     // down to a lighter same-family sibling (e.g. Claude → Haiku).
     manager.setMainModel(ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined);
+    // Share the host session's model registry so tier/phase routing resolves
+    // extension-registered providers (e.g. ollama-cloud) consistently.
+    manager.setModelRegistry(ctx.modelRegistry);
     // Scope the /workflows history to this session: runs persist on disk across
     // sessions, but the navigator/task panel show only the current session's runs.
     // Switching back to a previous session re-shows that session's runs.

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -47,16 +47,19 @@ export default function extension(pi: ExtensionAPI) {
   let editorInstalled = false;
 
   pi.on("session_start", (_event: unknown, ctx: ExtensionContext) => {
-    const active = pi.getActiveTools();
-    if (!active.includes(workflowTool.name)) {
-      pi.setActiveTools([...active, workflowTool.name]);
-    }
     // Tell the manager the session's main model so "explore" agents auto-tier
     // down to a lighter same-family sibling (e.g. Claude → Haiku).
     manager.setMainModel(ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined);
     // Share the host session's model registry so tier/phase routing resolves
-    // extension-registered providers (e.g. ollama-cloud) consistently.
+    // extension-registered providers (e.g. ollama-cloud) consistently. Set it
+    // before activating the tool: the tool's promptGuidelines read the
+    // manager's registry lazily, so tool-registry refreshes from here on
+    // advertise the shared registry's models.
     manager.setModelRegistry(ctx.modelRegistry);
+    const active = pi.getActiveTools();
+    if (!active.includes(workflowTool.name)) {
+      pi.setActiveTools([...active, workflowTool.name]);
+    }
     // Scope the /workflows history to this session: runs persist on disk across
     // sessions, but the navigator/task panel show only the current session's runs.
     // Switching back to a previous session re-shows that session's runs.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -292,6 +292,14 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
    * structured_output) before falling back to strict prose extraction. Default 2.
    */
   maxSchemaRetries?: number;
+  /**
+   * Per-run model registry override. Takes precedence over the constructor's
+   * `modelRegistry` (WorkflowAgentOptions.modelRegistry) for both model
+   * resolution and the `createAgentSession` call this run makes. Falls back to
+   * the constructor's shared registry, then a lazily-built disk registry, when
+   * omitted.
+   */
+  modelRegistry?: ModelRegistry;
 }
 
 export type AgentRunResult<TSchemaDef extends TSchema | undefined> = TSchemaDef extends TSchema
@@ -318,7 +326,15 @@ export class WorkflowAgent {
     this.sharedRegistry = options.modelRegistry;
   }
 
-  private getRegistry(): ModelRegistry {
+  /**
+   * Resolve the registry for a run: an explicit per-run registry wins, then the
+   * constructor's shared registry, then a lazily-built disk registry (shared
+   * across calls once built).
+   */
+  private getRegistry(perRunRegistry?: ModelRegistry): ModelRegistry {
+    if (perRunRegistry) {
+      return perRunRegistry;
+    }
     if (this.sharedRegistry) {
       return this.sharedRegistry;
     }
@@ -337,8 +353,8 @@ export class WorkflowAgent {
    * or a bare `modelId` (prefers auth-configured models, then any known model).
    * Returns undefined when nothing matches.
    */
-  private resolveModel(spec: string): Model<any> | undefined {
-    const registry = this.getRegistry();
+  private resolveModel(spec: string, perRunRegistry?: ModelRegistry): Model<any> | undefined {
+    const registry = this.getRegistry(perRunRegistry);
     const slash = spec.indexOf("/");
     if (slash > 0) {
       return registry.find(spec.slice(0, slash), spec.slice(slash + 1));
@@ -376,7 +392,7 @@ export class WorkflowAgent {
     // spec falls back to the session default (with a warning) rather than failing.
     let resolvedModel: Model<any> | undefined;
     if (modelSpec) {
-      resolvedModel = this.resolveModel(modelSpec);
+      resolvedModel = this.resolveModel(modelSpec, options.modelRegistry);
       if (resolvedModel) {
         options.onModelResolved?.(`${resolvedModel.provider}/${resolvedModel.id}`);
       } else {
@@ -396,7 +412,11 @@ export class WorkflowAgent {
       // not have valid auth, causing silent empty responses.
       settingsManager: SettingsManager.create(this.cwd, agentDir),
       customTools,
-      ...(this.sharedRegistry ? { modelRegistry: this.sharedRegistry } : {}),
+      // Per-run modelRegistry wins over the constructor's shared registry, same
+      // precedence as resolveModel() above.
+      ...(options.modelRegistry || this.sharedRegistry
+        ? { modelRegistry: options.modelRegistry ?? this.sharedRegistry }
+        : {}),
       ...this.sessionOptions,
       // Per-call model wins over any sessionOptions.model.
       ...(resolvedModel ? { model: resolvedModel } : {}),

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -203,6 +203,14 @@ export interface WorkflowAgentOptions {
    * to the session default when no config is saved yet.
    */
   mainModel?: string;
+  /**
+   * Shared model registry from the host Pi session. When provided, subagents
+   * resolve tier/model specs against the same registry the main session uses,
+   * including dynamically-registered providers such as ollama-cloud. Without
+   * this, the agent builds an isolated registry from disk and may miss models
+   * that are only available via extension registration.
+   */
+  modelRegistry?: ModelRegistry;
 }
 
 /**
@@ -210,12 +218,15 @@ export interface WorkflowAgentOptions {
  * `provider/modelId` specs. Used to tell the workflow author which models it may
  * route agents to. Best-effort: returns [] if the registry can't be built.
  */
-export function listAvailableModelSpecs(): string[] {
+export function listAvailableModelSpecs(registry?: ModelRegistry): string[] {
   try {
+    if (registry) {
+      return registry.getAvailable().map((m) => `${m.provider}/${m.id}`);
+    }
     const dir = getAgentDir();
     const auth = AuthStorage.create(join(dir, "auth.json"));
-    const registry = ModelRegistry.create(auth, join(dir, "models.json"));
-    return registry.getAvailable().map((m) => `${m.provider}/${m.id}`);
+    const r = ModelRegistry.create(auth, join(dir, "models.json"));
+    return r.getAvailable().map((m) => `${m.provider}/${m.id}`);
   } catch {
     return [];
   }
@@ -293,6 +304,8 @@ export class WorkflowAgent {
   private readonly sessionOptions: Partial<CreateAgentSessionOptions>;
   private readonly instructions?: string;
   private readonly mainModel?: string;
+  /** Shared registry from the host session, when provided. */
+  private readonly sharedRegistry?: ModelRegistry;
   /** Lazily built once; shares the SDK's agentDir/auth so resolved models are authed. */
   private registry?: ModelRegistry;
 
@@ -302,9 +315,13 @@ export class WorkflowAgent {
     this.sessionOptions = options.session ?? {};
     this.instructions = options.instructions;
     this.mainModel = options.mainModel;
+    this.sharedRegistry = options.modelRegistry;
   }
 
   private getRegistry(): ModelRegistry {
+    if (this.sharedRegistry) {
+      return this.sharedRegistry;
+    }
     if (!this.registry) {
       const dir = getAgentDir();
       // Same agentDir/auth files createAgentSession uses by default, so a model
@@ -379,6 +396,7 @@ export class WorkflowAgent {
       // not have valid auth, causing silent empty responses.
       settingsManager: SettingsManager.create(this.cwd, agentDir),
       customTools,
+      ...(this.sharedRegistry ? { modelRegistry: this.sharedRegistry } : {}),
       ...this.sessionOptions,
       // Per-call model wins over any sessionOptions.model.
       ...(resolvedModel ? { model: resolvedModel } : {}),

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -425,6 +425,7 @@ export class WorkflowAgent {
       }
 
       await session.prompt(this.buildPrompt(prompt, options as AgentRunOptions<any>, Boolean(options.schema)));
+
       if (options.signal?.aborted) throw new Error("Subagent was aborted");
 
       // The SDK buries a provider usage/quota limit in the assistant message rather

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -158,6 +158,16 @@ export class WorkflowManager extends EventEmitter {
   }
 
   /**
+   * The host session's model registry, when set. Read lazily (e.g. by the
+   * workflow tool's model routing guideline) since `setModelRegistry` is called
+   * from `session_start`, which runs after the tool is created — a snapshot
+   * taken at tool-creation time would miss it.
+   */
+  getModelRegistry(): ModelRegistry | undefined {
+    return this.modelRegistry;
+  }
+
+  /**
    * Start a workflow in the background.
    * Returns immediately with a run ID; the workflow executes asynchronously.
    */

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -3,6 +3,7 @@
  */
 
 import { EventEmitter } from "node:events";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { WorkflowAgent } from "./agent.js";
 import { preview, type WorkflowSnapshot } from "./display.js";
 import { WorkflowError, WorkflowErrorCode } from "./errors.js";
@@ -71,6 +72,12 @@ export interface WorkflowManagerOptions {
   agent?: Pick<WorkflowAgent, "run">;
   /** The session's main model (provider/id), for auto-tiering explore agents. */
   mainModel?: string;
+  /**
+   * The host Pi session's model registry. When provided, workflow subagents
+   * resolve models against the same registry as the main session, including
+   * extension-registered providers such as ollama-cloud.
+   */
+  modelRegistry?: ModelRegistry;
   /** The pi session id to tag runs with (see setSessionId). */
   sessionId?: string;
   /** Default per-agent timeout when a run does not pass agentTimeoutMs. null means no hard timeout. */
@@ -88,6 +95,8 @@ export class WorkflowManager extends EventEmitter {
   private agent?: Pick<WorkflowAgent, "run">;
   /** The session's main model (provider/id), for auto-tiering explore agents. */
   private mainModel?: string;
+  /** The host Pi session's model registry, shared with subagents. */
+  private modelRegistry?: ModelRegistry;
   /** The current pi session id; runs are stamped with it and listRuns() filters by it. */
   private sessionId?: string;
   private defaultAgentTimeoutMs: number | null;
@@ -100,6 +109,7 @@ export class WorkflowManager extends EventEmitter {
     this.loadSavedWorkflow = options.loadSavedWorkflow;
     this.agent = options.agent;
     this.mainModel = options.mainModel;
+    this.modelRegistry = options.modelRegistry;
     this.sessionId = options.sessionId;
     this.defaultAgentTimeoutMs = options.defaultAgentTimeoutMs ?? null;
     this.defaultAgentRetries = options.defaultAgentRetries ?? 0;
@@ -140,6 +150,11 @@ export class WorkflowManager extends EventEmitter {
   /** Set the session's main model (provider/id). Used to auto-tier explore agents. */
   setMainModel(spec: string | undefined): void {
     this.mainModel = spec;
+  }
+
+  /** Set the host session's model registry so subagents resolve models consistently. */
+  setModelRegistry(registry: ModelRegistry): void {
+    this.modelRegistry = registry;
   }
 
   /**
@@ -290,6 +305,7 @@ export class WorkflowManager extends EventEmitter {
         args,
         agent: this.agent,
         mainModel: this.mainModel,
+        modelRegistry: this.modelRegistry,
         signal: managed.controller.signal,
         concurrency: resolvedConcurrency,
         agentRetries: resolvedAgentRetries,

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -25,10 +25,9 @@ import { loadWorkflowSettings } from "./workflow-settings.js";
  * therefore appears in the LLM's system prompt for every workflow execution.
  *
  * `registry` is a live host-session ModelRegistry (or a getter reaching one),
- * e.g. from WorkflowManager.getModelRegistry(). The manager's registry is set
- * on session_start — after the tool (and this string) is built — so a getter
- * lets each call see the registry as it stands then, rather than a snapshot
- * taken before it was populated.
+ * e.g. from WorkflowManager.getModelRegistry(). A getter lets each call see
+ * the registry as it stands at that moment — the manager's registry is set on
+ * session_start, after the tool is created, so an early snapshot would miss it.
  */
 export function modelRoutingGuideline(registry?: ModelRegistry | (() => ModelRegistry | undefined)): string {
   const resolvedRegistry = typeof registry === "function" ? registry() : registry;
@@ -163,36 +162,37 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
     ].join(" "),
     promptSnippet:
       "Run a deterministic JavaScript workflow. Required script header: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }.",
-    promptGuidelines: [
-      "Use workflow only when the user explicitly asks for a workflow, workflows, fan-out, or multi-agent orchestration.",
-      "For workflow, always pass one raw JavaScript string in the required script parameter; do not include Markdown fences or prose around the script.",
-      "For workflow, the script's first statement must be `export const meta = { name: 'short_snake_case', description: 'non-empty human description', phases: [{ title: 'Phase name' }] }`; meta.name and meta.description are required non-empty strings.",
-      "For workflow, write plain JavaScript after the meta export. Do not use TypeScript syntax, imports, require(), fs, Date.now(), Math.random(), or new Date().",
-      "For workflow, available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), args, cwd, process.cwd(), and budget. Every workflow must call agent() at least once; do not use workflow only to declare phases or return a static object.",
-      "For workflow, prefer the built-in quality helpers when they fit (each is built on agent()/parallel() and returns plain data): verify(item, {reviewers, threshold, lens}) for adversarial fact-checking; judgePanel(attempts, {judges, rubric}) to score N candidates and return the best; loopUntilDry({round, key, consecutiveEmpty}) to keep finding until rounds stop yielding new items; completenessCheck(args, results) as a final 'what's missing' critic.",
-      "For workflow, when meta.phases declares more than one phase, call phase('Exact Title') at the start of each phase's work (or set opts.phase on each agent) so every agent groups under the correct phase; never declare a phase you don't switch into — a declared phase with no agents shows as 0/0 and any agent you forgot to move stays in the previous phase.",
-      "For workflow, do not set tokenBudget or agentTimeoutMs unless the user explicitly asks to cap spend or time; the defaults are unbounded.",
-      "For workflow, to bound spend: pass tokenBudget for a hard run-wide cap; carve a per-phase ceiling with phase('Name', {budget: N}) (that phase throws at its sub-budget without touching the run total — wrap its work in try/catch so later phases proceed); use retry(thunk, {attempts, until}) for bounded retry, and gate(thunk, validator, {attempts}) when a validator's feedback should steer the next attempt. To degrade gracefully, branch on budget.remaining() to skip optional rounds or choose a lighter tier.",
-      "For workflow, prefer it for decomposable work: repository inspection, independent research/checks, multi-perspective review, or fan-out/fan-in synthesis. Do not use it for a single quick file read/edit or when ordinary tools are enough.",
-      "For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.",
-      "For workflow, pipeline(items, ...stages) runs each item through stages sequentially, while different items may run concurrently. Each stage receives (previousValue, originalItem, index).",
-      "For workflow, every agent() call should include a unique short label option, 2-5 words, such as { label: 'repo inventory' } or { label: 'source modules' }; unique labels make live status and error reporting readable.",
-      "For workflow, use low concurrency and agentRetries for unstable provider/transport fan-out runs; retries apply only to recoverable agent failures and still require explicit null handling after exhaustion.",
-      "For workflow, failed agent(), parallel(), or pipeline() branches return null and log the failure unless the workflow is aborted. Check for nulls before synthesizing conclusions.",
-      "For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.",
-      "For workflow, if agent() needs machine-readable output, pass a plain JSON Schema via opts.schema; agent() will return the validated object. Use JSON Schema syntax, not TypeScript or TypeBox constructors.",
-      // The guideline string is built once here, at tool creation — pi has no
-      // re-render hook for promptGuidelines. Passing manager.getModelRegistry
-      // (rather than the registry itself) means this still picks up whatever
-      // registry the manager holds at THIS moment; a registry set later via
-      // setModelRegistry (session_start runs after tool creation) is not
-      // reflected unless the tool is recreated. See modelRoutingGuideline's doc.
-      modelRoutingGuideline(() => manager.getModelRegistry()),
-      agentTypeGuideline(),
-      "For workflow, do not assume the parent assistant has repository code context inside subagents; include enough task context and relevant paths in each agent prompt.",
-      "For workflow, runs are background by default: the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when the run finishes. Pass background: false only when you must use the result inline in this same turn (it will block).",
-      "For workflow, you may call `await workflow('saved-name', argsObject)` to run a saved workflow inline and use its result; nesting is one level deep only, and the global 16-concurrent / 1000-total caps hold across the nesting.",
-    ].filter((g): g is string => typeof g === "string" && g.length > 0),
+    // Lazy accessor: the SDK re-reads definition.promptGuidelines on every
+    // tool-registry refresh, so each read sees the manager's registry as it
+    // stands then (setModelRegistry runs on session_start, after tool creation).
+    // Residual caveat: providers registered after the last refresh won't appear
+    // until the next one.
+    get promptGuidelines() {
+      return [
+        "Use workflow only when the user explicitly asks for a workflow, workflows, fan-out, or multi-agent orchestration.",
+        "For workflow, always pass one raw JavaScript string in the required script parameter; do not include Markdown fences or prose around the script.",
+        "For workflow, the script's first statement must be `export const meta = { name: 'short_snake_case', description: 'non-empty human description', phases: [{ title: 'Phase name' }] }`; meta.name and meta.description are required non-empty strings.",
+        "For workflow, write plain JavaScript after the meta export. Do not use TypeScript syntax, imports, require(), fs, Date.now(), Math.random(), or new Date().",
+        "For workflow, available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), args, cwd, process.cwd(), and budget. Every workflow must call agent() at least once; do not use workflow only to declare phases or return a static object.",
+        "For workflow, prefer the built-in quality helpers when they fit (each is built on agent()/parallel() and returns plain data): verify(item, {reviewers, threshold, lens}) for adversarial fact-checking; judgePanel(attempts, {judges, rubric}) to score N candidates and return the best; loopUntilDry({round, key, consecutiveEmpty}) to keep finding until rounds stop yielding new items; completenessCheck(args, results) as a final 'what's missing' critic.",
+        "For workflow, when meta.phases declares more than one phase, call phase('Exact Title') at the start of each phase's work (or set opts.phase on each agent) so every agent groups under the correct phase; never declare a phase you don't switch into — a declared phase with no agents shows as 0/0 and any agent you forgot to move stays in the previous phase.",
+        "For workflow, do not set tokenBudget or agentTimeoutMs unless the user explicitly asks to cap spend or time; the defaults are unbounded.",
+        "For workflow, to bound spend: pass tokenBudget for a hard run-wide cap; carve a per-phase ceiling with phase('Name', {budget: N}) (that phase throws at its sub-budget without touching the run total — wrap its work in try/catch so later phases proceed); use retry(thunk, {attempts, until}) for bounded retry, and gate(thunk, validator, {attempts}) when a validator's feedback should steer the next attempt. To degrade gracefully, branch on budget.remaining() to skip optional rounds or choose a lighter tier.",
+        "For workflow, prefer it for decomposable work: repository inspection, independent research/checks, multi-perspective review, or fan-out/fan-in synthesis. Do not use it for a single quick file read/edit or when ordinary tools are enough.",
+        "For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.",
+        "For workflow, pipeline(items, ...stages) runs each item through stages sequentially, while different items may run concurrently. Each stage receives (previousValue, originalItem, index).",
+        "For workflow, every agent() call should include a unique short label option, 2-5 words, such as { label: 'repo inventory' } or { label: 'source modules' }; unique labels make live status and error reporting readable.",
+        "For workflow, use low concurrency and agentRetries for unstable provider/transport fan-out runs; retries apply only to recoverable agent failures and still require explicit null handling after exhaustion.",
+        "For workflow, failed agent(), parallel(), or pipeline() branches return null and log the failure unless the workflow is aborted. Check for nulls before synthesizing conclusions.",
+        "For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.",
+        "For workflow, if agent() needs machine-readable output, pass a plain JSON Schema via opts.schema; agent() will return the validated object. Use JSON Schema syntax, not TypeScript or TypeBox constructors.",
+        modelRoutingGuideline(() => manager.getModelRegistry()),
+        agentTypeGuideline(),
+        "For workflow, do not assume the parent assistant has repository code context inside subagents; include enough task context and relevant paths in each agent prompt.",
+        "For workflow, runs are background by default: the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when the run finishes. Pass background: false only when you must use the result inline in this same turn (it will block).",
+        "For workflow, you may call `await workflow('saved-name', argsObject)` to run a saved workflow inline and use its result; nesting is one level deep only, and the global 16-concurrent / 1000-total caps hold across the nesting.",
+      ].filter((g): g is string => typeof g === "string" && g.length > 0);
+    },
     parameters: workflowToolSchema,
     prepareArguments(args) {
       return normalizeWorkflowToolArgs(args);

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -1,4 +1,4 @@
-import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { defineTool, type ModelRegistry, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { listAvailableModelSpecs } from "./agent.js";
@@ -23,9 +23,16 @@ import { loadWorkflowSettings } from "./workflow-settings.js";
  *
  * This string is injected into the workflow tool's promptGuidelines and
  * therefore appears in the LLM's system prompt for every workflow execution.
+ *
+ * `registry` is a live host-session ModelRegistry (or a getter reaching one),
+ * e.g. from WorkflowManager.getModelRegistry(). The manager's registry is set
+ * on session_start — after the tool (and this string) is built — so a getter
+ * lets each call see the registry as it stands then, rather than a snapshot
+ * taken before it was populated.
  */
-export function modelRoutingGuideline(): string {
-  const available = listAvailableModelSpecs();
+export function modelRoutingGuideline(registry?: ModelRegistry | (() => ModelRegistry | undefined)): string {
+  const resolvedRegistry = typeof registry === "function" ? registry() : registry;
+  const available = listAvailableModelSpecs(resolvedRegistry);
   const list = available.length
     ? `The user's currently available models (route only to these) are: ${available.join(", ")}.`
     : "Use models the user has configured.";
@@ -174,7 +181,13 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       "For workflow, failed agent(), parallel(), or pipeline() branches return null and log the failure unless the workflow is aborted. Check for nulls before synthesizing conclusions.",
       "For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.",
       "For workflow, if agent() needs machine-readable output, pass a plain JSON Schema via opts.schema; agent() will return the validated object. Use JSON Schema syntax, not TypeScript or TypeBox constructors.",
-      modelRoutingGuideline(),
+      // The guideline string is built once here, at tool creation — pi has no
+      // re-render hook for promptGuidelines. Passing manager.getModelRegistry
+      // (rather than the registry itself) means this still picks up whatever
+      // registry the manager holds at THIS moment; a registry set later via
+      // setModelRegistry (session_start runs after tool creation) is not
+      // reflected unless the tool is recreated. See modelRoutingGuideline's doc.
+      modelRoutingGuideline(() => manager.getModelRegistry()),
       agentTypeGuideline(),
       "For workflow, do not assume the parent assistant has repository code context inside subagents; include enough task context and relevant paths in each agent prompt.",
       "For workflow, runs are background by default: the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when the run finishes. Pass background: false only when you must use the result inline in this same turn (it will block).",

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -486,7 +486,7 @@ export async function runWorkflow<T = unknown>(
                 onHistory: (history: AgentHistoryEntry[]) => {
                   options.onAgentHistory?.({ label, phase: assignedPhase, history });
                 },
-              } as any),
+              }),
               timeout,
               label,
             );

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -469,6 +469,7 @@ export async function runWorkflow<T = unknown>(
                 instructions: buildAgentInstructions(assignedPhase, agentOptions, agentDef, resolvedIsolation),
                 model: modelSpec,
                 tier: agentOptions.tier,
+                modelRegistry: options.modelRegistry,
                 toolNames: agentDef?.tools,
                 disallowedToolNames: agentDef?.disallowedTools,
                 cwd: runCwd,

--- a/src/workflows-models-command.ts
+++ b/src/workflows-models-command.ts
@@ -4,8 +4,9 @@
  * Uses Pi's built-in `ctx.ui.select()`, `ctx.ui.confirm()`, and `ctx.ui.notify()`
  * to let users view and manage model tier configuration for workflows.
  *
- * Model selection draws from the same `listAvailableModelSpecs()` that powers
- * Pi's `/model` command, so users see exactly the same models.
+ * Model selection draws from the host session's shared model registry so users
+ * see every provider Pi can reach, including extension-registered providers such
+ * as `ollama-cloud`.
  *
  * Each tier holds exactly one model spec string.
  * When editing a tier, a single-select picker is used (like Pi's `/model`).
@@ -119,7 +120,7 @@ export async function editSingleTier(
   tiers: Record<string, string>,
   tierName: string,
 ): Promise<Record<string, string> | null> {
-  const available = listAvailableModelSpecs();
+  const available = listAvailableModelSpecs(ctx.modelRegistry);
   const current = tiers[tierName];
 
   // Build SelectItems: all available models as scrollable list

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -90,11 +90,38 @@ test("WorkflowAgent constructor accepts all option shapes without throwing", () 
     { cwd: "/tmp", tools: [], session: {}, instructions: "test" },
     { cwd: "/tmp", mainModel: "openai/gpt-4.1" },
     { cwd: "/tmp", tools: [], session: {}, instructions: "test", mainModel: "openai/gpt-4.1" },
+    {
+      cwd: "/tmp",
+      modelRegistry: {
+        getAvailable: () => [{ provider: "mock", id: "model" }],
+        find: () => undefined,
+        getAll: () => [],
+      } as any,
+    },
   ];
   for (const opts of optionSets) {
     const agent = opts ? new WorkflowAgent(opts) : new WorkflowAgent();
     assert.ok(agent instanceof WorkflowAgent, `agent should be constructed for options: ${JSON.stringify(opts)}`);
   }
+});
+
+test("WorkflowAgent reuses an injected ModelRegistry instead of building its own", () => {
+  const mockModel = { provider: "mock", id: "shared" } as any;
+  const registry = {
+    find: (provider: string, id: string) => (provider === "mock" && id === "shared" ? mockModel : undefined),
+    getAvailable: () => [mockModel],
+    getAll: () => [mockModel],
+  } as any;
+
+  const agent = new WorkflowAgent({ cwd: "/tmp", modelRegistry: registry });
+  const resolved = (agent as any).resolveModel("mock/shared");
+  assert.equal(resolved, mockModel, "should resolve via the injected registry");
+});
+
+test("WorkflowAgent falls back to building a disk registry when no registry is injected", () => {
+  const agent = new WorkflowAgent({ cwd: "/tmp" });
+  // Should not throw; getRegistry() lazily builds a ModelRegistry.
+  assert.doesNotThrow(() => (agent as any).getRegistry());
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -274,6 +301,19 @@ test("agent() in workflow passes prompt and label to runner", async () => {
   );
   assert.equal(rec.calls.length, 1);
   assert.equal(rec.calls[0].prompt, "analyze this");
+});
+
+test("agent() in workflow forwards modelRegistry to the runner", async () => {
+  const rec = new CallRecordingAgent();
+  const fakeRegistry = { getAvailable: () => [], find: () => undefined, getAll: () => [] } as any;
+  await runWorkflow(
+    `export const meta = { name: 'test', description: 't' }
+     const r = await agent('task', { label: 't' })
+     return r`,
+    { agent: rec, persistLogs: false, modelRegistry: fakeRegistry },
+  );
+  assert.equal(rec.calls.length, 1);
+  assert.equal((rec.calls[0].options as { modelRegistry?: any }).modelRegistry, fakeRegistry);
 });
 
 test("agent() in workflow passes model spec to runner", async () => {

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -124,6 +124,58 @@ test("WorkflowAgent falls back to building a disk registry when no registry is i
   assert.doesNotThrow(() => (agent as any).getRegistry());
 });
 
+test("WorkflowAgent.resolveModel resolves via a per-run registry when the constructor got none", () => {
+  // Regression test for the per-run `modelRegistry` AgentRunOptions field: a
+  // model present only in a registry passed to run() (not the constructor)
+  // must still resolve.
+  const perRunModel = { provider: "router", id: "per-run-only" } as any;
+  const perRunRegistry = {
+    find: (provider: string, id: string) => (provider === "router" && id === "per-run-only" ? perRunModel : undefined),
+    getAvailable: () => [perRunModel],
+    getAll: () => [perRunModel],
+  } as any;
+
+  const agent = new WorkflowAgent({ cwd: "/tmp" });
+  const resolved = (agent as any).resolveModel("router/per-run-only", perRunRegistry);
+  assert.equal(resolved, perRunModel, "should resolve via the per-run registry, not a disk registry");
+});
+
+test("WorkflowAgent.resolveModel: per-run registry takes precedence over the constructor's shared registry", () => {
+  const constructorModel = { provider: "ctor", id: "shared" } as any;
+  const constructorRegistry = {
+    find: (provider: string, id: string) => (provider === "ctor" && id === "shared" ? constructorModel : undefined),
+    getAvailable: () => [constructorModel],
+    getAll: () => [constructorModel],
+  } as any;
+
+  const perRunModel = { provider: "run", id: "override" } as any;
+  const perRunRegistry = {
+    find: (provider: string, id: string) => (provider === "run" && id === "override" ? perRunModel : undefined),
+    getAvailable: () => [perRunModel],
+    getAll: () => [perRunModel],
+  } as any;
+
+  const agent = new WorkflowAgent({ cwd: "/tmp", modelRegistry: constructorRegistry });
+  // The per-run registry, not the constructor's, is consulted when both are set.
+  const resolved = (agent as any).resolveModel("run/override", perRunRegistry);
+  assert.equal(resolved, perRunModel, "per-run registry should win over the constructor's shared registry");
+  // And the constructor registry is still used when no per-run registry is given.
+  const fallback = (agent as any).resolveModel("ctor/shared");
+  assert.equal(fallback, constructorModel, "constructor registry should still apply without a per-run override");
+});
+
+test("WorkflowAgent.getRegistry: per-run registry wins, then constructor's shared registry, then disk", () => {
+  const constructorRegistry = { getAvailable: () => [], find: () => undefined, getAll: () => [] } as any;
+  const perRunRegistry = { getAvailable: () => [], find: () => undefined, getAll: () => [] } as any;
+
+  const agent = new WorkflowAgent({ cwd: "/tmp", modelRegistry: constructorRegistry });
+  assert.equal((agent as any).getRegistry(perRunRegistry), perRunRegistry);
+  assert.equal((agent as any).getRegistry(), constructorRegistry);
+
+  const bareAgent = new WorkflowAgent({ cwd: "/tmp" });
+  assert.doesNotThrow(() => (bareAgent as any).getRegistry());
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // buildPrompt — verifies that the agent's internal prompt assembly is correct
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -386,6 +386,30 @@ test(
 );
 
 test(
+  "setModelRegistry stores the registry and forwards it to subagent runs",
+  withTempCwd(async (cwd) => {
+    const fakeRegistry = {
+      getAvailable: () => [{ provider: "mock", id: "m" }],
+      find: () => undefined,
+      getAll: () => [],
+    } as any;
+    const rec = new (class {
+      calls: Array<{ options: any }> = [];
+      async run(_prompt: string, options: any) {
+        this.calls.push({ options });
+        options.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
+        return "ok";
+      }
+    })();
+    const manager = new WorkflowManager({ cwd, agent: rec });
+    manager.setModelRegistry(fakeRegistry);
+    await manager.runSync(oneAgentScript);
+    assert.equal(rec.calls.length, 1);
+    assert.equal(rec.calls[0].options.modelRegistry, fakeRegistry);
+  }),
+);
+
+test(
   "setMainModel sets the main model used for default agents",
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({ cwd, agent: fakeAgent() });

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -193,6 +193,26 @@ test("createWorkflowTool advertises models from the manager's shared registry wh
   assert.match(all, /router\/wired-model/);
 });
 
+test("createWorkflowTool promptGuidelines reflect a registry set AFTER tool creation (lazy accessor)", () => {
+  // Mirrors the real ordering: createWorkflowTool() runs at extension load,
+  // setModelRegistry() runs later in session_start. The SDK re-reads
+  // definition.promptGuidelines on every tool-registry refresh, so a fresh
+  // property read must see the late-set registry.
+  const manager = new WorkflowManager({ cwd: "/tmp" });
+  manager.setModelRegistry(fakeRegistry([]));
+  const tool = createWorkflowTool({ cwd: "/tmp", manager });
+  assert.doesNotMatch(tool.promptGuidelines.join(" "), /router\/late-model/);
+
+  manager.setModelRegistry(fakeRegistry([{ provider: "router", id: "late-model" }]));
+  assert.match(tool.promptGuidelines.join(" "), /router\/late-model/);
+
+  // Replacing the registry again is also reflected.
+  manager.setModelRegistry(fakeRegistry([{ provider: "router", id: "replacement-model" }]));
+  const latest = tool.promptGuidelines.join(" ");
+  assert.match(latest, /router\/replacement-model/);
+  assert.doesNotMatch(latest, /router\/late-model/);
+});
+
 test("modelRoutingGuideline output is non-empty and well-formed", () => {
   const text = modelRoutingGuideline();
   assert.ok(text.length > 50, "should be a substantial instruction");

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { WorkflowManager } from "../src/workflow-manager.js";
 import { backgroundStartedText, createWorkflowTool, modelRoutingGuideline } from "../src/workflow-tool.js";
+
+/** Minimal fake ModelRegistry, matching the shape the PR's existing tests use. */
+function fakeRegistry(models: Array<{ provider: string; id: string }>) {
+  return {
+    getAvailable: () => models,
+    find: () => undefined,
+    getAll: () => models,
+  } as any;
+}
 
 // ─── backgroundStartedText ─────────────────────────────────────────────────────
 
@@ -152,6 +162,35 @@ test("createWorkflowTool invalid args throws descriptive error", () => {
 test("createWorkflowTool with custom cwd creates tool", () => {
   const tool = createWorkflowTool({ cwd: "/tmp" });
   assert.equal(tool.name, "workflow");
+});
+
+test("modelRoutingGuideline advertises models from an injected registry", () => {
+  const registry = fakeRegistry([{ provider: "router", id: "shared-model" }]);
+  const text = modelRoutingGuideline(registry);
+  assert.match(text, /route only to these/i);
+  assert.match(text, /router\/shared-model/);
+});
+
+test("modelRoutingGuideline accepts a getter and resolves it lazily at call time", () => {
+  // Empty registry (not undefined) so the getter path is exercised end-to-end
+  // rather than falling through to the disk-registry default.
+  let registry: any = fakeRegistry([]);
+  const text = modelRoutingGuideline(() => registry);
+  assert.doesNotMatch(text, /router\/late-model/);
+
+  // Registering after construction (simulating session_start running after the
+  // guideline string was first read) is reflected on the next call.
+  registry = fakeRegistry([{ provider: "router", id: "late-model" }]);
+  const later = modelRoutingGuideline(() => registry);
+  assert.match(later, /router\/late-model/);
+});
+
+test("createWorkflowTool advertises models from the manager's shared registry when set before creation", () => {
+  const manager = new WorkflowManager({ cwd: "/tmp" });
+  manager.setModelRegistry(fakeRegistry([{ provider: "router", id: "wired-model" }]));
+  const tool = createWorkflowTool({ cwd: "/tmp", manager });
+  const all = tool.promptGuidelines.join(" ");
+  assert.match(all, /router\/wired-model/);
 });
 
 test("modelRoutingGuideline output is non-empty and well-formed", () => {


### PR DESCRIPTION
**Problem**
Workflow subagents build an isolated `ModelRegistry` from `auth.json` + `models.json`. Providers registered dynamically by extensions (e.g. `pi-ollama-cloud`) are not visible to this isolated registry. As a result, tier/phase routing to `ollama-cloud/*` models silently falls back to the session default (often Anthropic), producing unexpected credit-balance errors and costs.

**Fix**
Thread the host Pi session's `ctx.modelRegistry` through the extension so subagents resolve models against the same registry as the main Pi session:
- `extensions/workflow.ts` passes `ctx.modelRegistry` to `WorkflowManager` via `setModelRegistry()`
- `WorkflowManager` stores it and forwards it into `runWorkflow`
- `runWorkflow` passes it to `WorkflowAgent` via constructor options and per-run `agent()` options
- `WorkflowAgent` reuses the shared registry for both model resolution and the `createAgentSession` call
- Nested `workflow()` calls inherit `modelRegistry` via `...options`
- `listAvailableModelSpecs()` optionally accepts the shared registry so the workflow tool advertises the same models as the host session

The per-run `modelRegistry` option is forwarded explicitly to injected runners primarily for test observability and to keep the option surface consistent with the constructor.

**Verification**
```js
export const meta = { name: 'routing_check', description: 'verify tier routing', phases: [{ title: 'Routing' }] };
const result = await agent('Return JSON {provider, modelId}.', {
  label: 'medium probe',
  tier: 'medium',
  schema: { type: 'object', properties: { provider: { type: 'string' }, modelId: { type: 'string' } }, required: ['provider', 'modelId'] }
});
// result.provider === 'ollama-cloud'
```

**Tests added**
- `WorkflowAgent` reuses an injected `ModelRegistry`
- `runWorkflow` forwards `modelRegistry` to the runner
- `WorkflowManager.setModelRegistry` stores and forwards the registry

**Files changed**
- `src/agent.ts`
- `src/workflow.ts`
- `src/workflow-manager.ts`
- `extensions/workflow.ts`
- `tests/agent.test.ts`
- `tests/workflow-manager.test.ts`
