### PR TITLE
feat: support Pi CLI-style thinking suffixes in workflow model specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The same model — on Pi, plus the production pieces a real run needs:
                             switch the live panel between the compact one-liner and the detailed
                             per-phase/per-agent view (with tokens, cost, and a live tok/s rate)
 /workflows-progress-max <N> cap agents shown per phase in detailed mode (1-1000, default 8)
-/workflows-models           map the small / medium / big tiers to real models
+/workflows-models           map the small / medium / big tiers to real models, optionally with thinking levels
 /ultracode [off]            ultracode: auto-arm an exhaustive workflow for every substantive message
 /effort off|high|ultra      finer control over the standing opt-in (high = thorough, ultra = ultracode)
 
@@ -140,6 +140,20 @@ In the navigator: `↑/↓` select · `enter`/`→` open · `esc`/`←` back · 
 ## Storage
 
 Workflow state is stored under `~/.pi/workflows` so projects do not accumulate extension-owned `.pi/workflows` directories. Global settings and model tiers live at `~/.pi/workflows/settings.json` and `~/.pi/workflows/model-tiers.json`; project-scoped run history, resume journals, locks, and saved workflow overrides live under `~/.pi/workflows/projects/<project>/`. Older project-local `.pi/workflows/runs` and `.pi/workflows/saved` data is still read as a fallback, but new writes go to the user-level workflow store.
+
+`model-tiers.json` uses Pi CLI-style model parsing. A tier can be a plain model spec or include an optional thinking suffix:
+
+```json
+{
+  "tiers": {
+    "small": "openai-codex/gpt-5.4-mini:low",
+    "medium": "openai-codex/gpt-5.4:medium",
+    "big": "openai-codex/gpt-5.5:xhigh"
+  }
+}
+```
+
+Use `/workflows-models` to edit these in the TUI: choose the base model first, then choose `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, or the session default.
 
 To avoid accidental keyword triggers, configure a custom trigger word in `~/.pi/workflows/settings.json`:
 
@@ -168,8 +182,8 @@ The full guide — every global, agent option, `agentType` definitions, structur
 
 | Agent option | Description |
 | --- | --- |
-| `tier` | `"small"` \| `"medium"` \| `"big"` — coarse model routing (configure via `/workflows-models`). |
-| `model` | Exact `provider/modelId` (always wins over `tier`). |
+| `tier` | `"small"` \| `"medium"` \| `"big"` — coarse model routing (configure via `/workflows-models`; tiers may store `provider/modelId:thinking`). |
+| `model` | Exact `provider/modelId` or `provider/modelId:thinking` (always wins over `tier`). |
 | `agentType` | A named definition (`.pi/agents/<name>.md`) binding tools + model + role prompt. |
 | `isolation: "worktree"` | Run in a throwaway git worktree for conflict-free parallel edits. |
 | `schema` | JSON Schema → the subagent returns a validated object. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@earendil-works/pi-ai": "latest",
         "@earendil-works/pi-coding-agent": "latest",
         "@earendil-works/pi-tui": "latest",
+        "fast-check": "^4.8.0",
         "tsx": "latest",
         "typebox": "latest",
         "typescript": "latest"
@@ -1260,7 +1261,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3545,6 +3546,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
@@ -3932,6 +3956,23 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.1.tgz",
+      "integrity": "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/retry": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@earendil-works/pi-ai": "latest",
     "@earendil-works/pi-coding-agent": "latest",
     "@earendil-works/pi-tui": "latest",
+    "fast-check": "^4.8.0",
     "tsx": "latest",
     "typebox": "latest",
     "typescript": "latest"

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -16,6 +16,7 @@ import { Check, Convert } from "typebox/value";
 import { type AgentHistoryEntry, compactAgentHistory } from "./agent-history.js";
 import { applyToolPolicy } from "./agent-registry.js";
 import { classifyProviderLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
+import { canonicalModelSpec, resolveModelSpecWithThinking } from "./model-spec.js";
 import { loadModelTierConfig, type ModelTierConfig, resolveTierModel } from "./model-tier-config.js";
 import { createStructuredOutputTool, type StructuredOutputCapture } from "./structured-output.js";
 
@@ -220,13 +221,14 @@ export interface WorkflowAgentOptions {
  */
 export function listAvailableModelSpecs(registry?: ModelRegistry): string[] {
   try {
-    if (registry) {
-      return registry.getAvailable().map((m) => `${m.provider}/${m.id}`);
-    }
-    const dir = getAgentDir();
-    const auth = AuthStorage.create(join(dir, "auth.json"));
-    const r = ModelRegistry.create(auth, join(dir, "models.json"));
-    return r.getAvailable().map((m) => `${m.provider}/${m.id}`);
+    const modelRegistry =
+      registry ??
+      (() => {
+        const dir = getAgentDir();
+        const auth = AuthStorage.create(join(dir, "auth.json"));
+        return ModelRegistry.create(auth, join(dir, "models.json"));
+      })();
+    return modelRegistry.getAvailable().map(canonicalModelSpec);
   } catch {
     return [];
   }
@@ -355,20 +357,6 @@ export class WorkflowAgent {
     return this.registry;
   }
 
-  /**
-   * Resolve a model spec to a Model. Accepts `provider/modelId` (unambiguous)
-   * or a bare `modelId` (prefers auth-configured models, then any known model).
-   * Returns undefined when nothing matches.
-   */
-  private resolveModel(spec: string, perRunRegistry?: ModelRegistry): Model<any> | undefined {
-    const registry = this.getRegistry(perRunRegistry);
-    const slash = spec.indexOf("/");
-    if (slash > 0) {
-      return registry.find(spec.slice(0, slash), spec.slice(slash + 1));
-    }
-    return registry.getAvailable().find((m) => m.id === spec) ?? registry.getAll().find((m) => m.id === spec);
-  }
-
   async run<TSchemaDef extends TSchema | undefined = undefined>(
     prompt: string,
     options: AgentRunOptions<TSchemaDef> = {},
@@ -400,13 +388,20 @@ export class WorkflowAgent {
     // options.model when a phase pattern matches — so an explicit model wins.
     const modelSpec = resolveAgentModelSpec(options, this.mainModel);
 
-    // Resolve a requested model spec to a Model object. A given-but-unresolved
-    // spec falls back to the session default (with a warning) rather than failing.
+    // Resolve a requested model spec to a Model object. Specs use Pi CLI-style
+    // parsing, including an optional :thinking suffix such as gpt-5.5:xhigh.
+    // A given-but-unresolved spec falls back to the session default (with a
+    // warning) rather than failing.
+    const modelRegistry = this.getRegistry(options.modelRegistry);
     let resolvedModel: Model<any> | undefined;
+    let resolvedThinkingLevel: CreateAgentSessionOptions["thinkingLevel"] | undefined;
     if (modelSpec) {
-      resolvedModel = this.resolveModel(modelSpec, options.modelRegistry);
-      if (resolvedModel) {
-        options.onModelResolved?.(`${resolvedModel.provider}/${resolvedModel.id}`);
+      const resolved = resolveModelSpecWithThinking(modelSpec, modelRegistry);
+      if (resolved.warning) console.warn(`[workflow] ${resolved.warning}`);
+      if (resolved.model) {
+        resolvedModel = resolved.model;
+        resolvedThinkingLevel = resolved.thinkingLevel;
+        options.onModelResolved?.(resolved.resolvedSpec ?? canonicalModelSpec(resolved.model));
       } else {
         console.warn(`[workflow] model "${modelSpec}" not found; using session default`);
         options.onModelFallback?.(modelSpec);
@@ -424,14 +419,15 @@ export class WorkflowAgent {
       // not have valid auth, causing silent empty responses.
       settingsManager: SettingsManager.create(this.cwd, agentDir),
       customTools,
-      // Per-run modelRegistry wins over the constructor's shared registry, same
-      // precedence as resolveModel() above.
+      // Per-run modelRegistry wins over the constructor's shared registry
+      // (see getRegistry() precedence above).
       ...(options.modelRegistry || this.sharedRegistry
         ? { modelRegistry: options.modelRegistry ?? this.sharedRegistry }
         : {}),
       ...this.sessionOptions,
-      // Per-call model wins over any sessionOptions.model.
+      // Per-call model/thinking wins over any sessionOptions defaults.
       ...(resolvedModel ? { model: resolvedModel } : {}),
+      ...(resolvedThinkingLevel ? { thinkingLevel: resolvedThinkingLevel } : {}),
     });
 
     let removeAbortListener: (() => void) | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,15 @@ export type { WorkflowLogger, WorkflowLoggerOptions } from "./logger.js";
 export { createWorkflowLogger } from "./logger.js";
 export type { ModelRoute, ModelRoutingConfig } from "./model-routing.js";
 export { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.js";
+export type { ModelThinkingLevel, ResolvedModelSpec } from "./model-spec.js";
+export {
+  canonicalModelSpec,
+  formatModelSpecWithThinking,
+  isThinkingLevel,
+  resolveModelSpecWithThinking,
+  splitModelSpecThinking,
+  THINKING_LEVELS,
+} from "./model-spec.js";
 export type { ModelTierConfig } from "./model-tier-config.js";
 export {
   buildDefaultTierConfig,

--- a/src/model-spec.ts
+++ b/src/model-spec.ts
@@ -1,0 +1,309 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+
+export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+
+export type ModelThinkingLevel = (typeof THINKING_LEVELS)[number];
+
+export interface ResolvedModelSpec {
+  requestedSpec: string;
+  model?: Model<Api>;
+  thinkingLevel?: ModelThinkingLevel;
+  resolvedSpec?: string;
+  warning?: string;
+  error?: string;
+}
+
+interface ParseModelPatternOptions {
+  allowInvalidThinkingLevelFallback?: boolean;
+}
+
+interface ParsedModelPattern {
+  model?: Model<Api>;
+  thinkingLevel?: ModelThinkingLevel;
+  warning?: string;
+}
+
+const DEFAULT_MODEL_PER_PROVIDER: Record<string, string> = {
+  "amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
+  anthropic: "claude-opus-4-8",
+  openai: "gpt-5.4",
+  "azure-openai-responses": "gpt-5.4",
+  "openai-codex": "gpt-5.5",
+  deepseek: "deepseek-v4-pro",
+  google: "gemini-3.1-pro-preview",
+  "google-vertex": "gemini-3.1-pro-preview",
+  "github-copilot": "gpt-5.4",
+  openrouter: "moonshotai/kimi-k2.6",
+  "vercel-ai-gateway": "zai/glm-5.1",
+  zai: "glm-5.1",
+  mistral: "devstral-medium-latest",
+  minimax: "MiniMax-M2.7",
+  "minimax-cn": "MiniMax-M2.7",
+  moonshotai: "kimi-k2.6",
+  "moonshotai-cn": "kimi-k2.6",
+  huggingface: "moonshotai/Kimi-K2.6",
+  fireworks: "accounts/fireworks/models/kimi-k2p6",
+  together: "moonshotai/Kimi-K2.6",
+  opencode: "kimi-k2.6",
+  "opencode-go": "kimi-k2.6",
+  "kimi-coding": "kimi-for-coding",
+  "cloudflare-workers-ai": "@cf/moonshotai/kimi-k2.6",
+  "cloudflare-ai-gateway": "workers-ai/@cf/moonshotai/kimi-k2.6",
+  xiaomi: "mimo-v2.5-pro",
+  "xiaomi-token-plan-cn": "mimo-v2.5-pro",
+  "xiaomi-token-plan-ams": "mimo-v2.5-pro",
+  "xiaomi-token-plan-sgp": "mimo-v2.5-pro",
+};
+
+export function isThinkingLevel(value: string): value is ModelThinkingLevel {
+  return (THINKING_LEVELS as readonly string[]).includes(value);
+}
+
+export function formatModelSpecWithThinking(modelSpec: string, thinkingLevel: ModelThinkingLevel | undefined): string {
+  return thinkingLevel ? `${modelSpec}:${thinkingLevel}` : modelSpec;
+}
+
+export function canonicalModelSpec(model: Model<Api>): string {
+  return `${model.provider}/${model.id}`;
+}
+
+/**
+ * Split a stored tier spec for display/editing. Exact known model specs win, so
+ * model ids that legitimately contain colons are not mistaken for thinking.
+ */
+export function splitModelSpecThinking(
+  spec: string | undefined,
+  knownModelSpecs?: readonly string[],
+): { modelSpec: string; thinkingLevel?: ModelThinkingLevel } {
+  const trimmed = spec?.trim() ?? "";
+  if (!trimmed) return { modelSpec: "", thinkingLevel: undefined };
+
+  const known = knownModelSpecs ? new Set(knownModelSpecs) : undefined;
+  if (known?.has(trimmed)) return { modelSpec: trimmed, thinkingLevel: undefined };
+
+  const lastColon = trimmed.lastIndexOf(":");
+  if (lastColon === -1) return { modelSpec: trimmed, thinkingLevel: undefined };
+
+  const prefix = trimmed.slice(0, lastColon);
+  const suffix = trimmed.slice(lastColon + 1);
+  if (!prefix || !isThinkingLevel(suffix)) return { modelSpec: trimmed, thinkingLevel: undefined };
+  if (known && !known.has(prefix)) return { modelSpec: trimmed, thinkingLevel: undefined };
+  return { modelSpec: prefix, thinkingLevel: suffix };
+}
+
+function isAlias(id: string): boolean {
+  if (id.endsWith("-latest")) return true;
+  return !/-\d{8}$/.test(id);
+}
+
+function findExactModelReferenceMatch(modelReference: string, availableModels: Model<Api>[]): Model<Api> | undefined {
+  const trimmedReference = modelReference.trim();
+  if (!trimmedReference) return undefined;
+  const normalizedReference = trimmedReference.toLowerCase();
+
+  const canonicalMatches = availableModels.filter(
+    (model) => canonicalModelSpec(model).toLowerCase() === normalizedReference,
+  );
+  if (canonicalMatches.length === 1) return canonicalMatches[0];
+  if (canonicalMatches.length > 1) return undefined;
+
+  const slashIndex = trimmedReference.indexOf("/");
+  if (slashIndex !== -1) {
+    const provider = trimmedReference.slice(0, slashIndex).trim();
+    const modelId = trimmedReference.slice(slashIndex + 1).trim();
+    if (provider && modelId) {
+      const providerMatches = availableModels.filter(
+        (model) =>
+          model.provider.toLowerCase() === provider.toLowerCase() && model.id.toLowerCase() === modelId.toLowerCase(),
+      );
+      if (providerMatches.length === 1) return providerMatches[0];
+      if (providerMatches.length > 1) return undefined;
+    }
+  }
+
+  const idMatches = availableModels.filter((model) => model.id.toLowerCase() === normalizedReference);
+  return idMatches.length === 1 ? idMatches[0] : undefined;
+}
+
+function tryMatchModel(modelPattern: string, availableModels: Model<Api>[]): Model<Api> | undefined {
+  const exactMatch = findExactModelReferenceMatch(modelPattern, availableModels);
+  if (exactMatch) return exactMatch;
+
+  const normalizedPattern = modelPattern.toLowerCase();
+  const matches = availableModels.filter(
+    (model) =>
+      model.id.toLowerCase().includes(normalizedPattern) || model.name?.toLowerCase().includes(normalizedPattern),
+  );
+  if (matches.length === 0) return undefined;
+
+  const aliases = matches.filter((model) => isAlias(model.id));
+  if (aliases.length > 0) {
+    aliases.sort((a, b) => b.id.localeCompare(a.id));
+    return aliases[0];
+  }
+
+  const datedVersions = matches.filter((model) => !isAlias(model.id));
+  datedVersions.sort((a, b) => b.id.localeCompare(a.id));
+  return datedVersions[0];
+}
+
+function parseModelPattern(
+  pattern: string,
+  availableModels: Model<Api>[],
+  options?: ParseModelPatternOptions,
+): ParsedModelPattern {
+  const exactMatch = tryMatchModel(pattern, availableModels);
+  if (exactMatch) return { model: exactMatch };
+
+  const lastColonIndex = pattern.lastIndexOf(":");
+  if (lastColonIndex === -1) return {};
+
+  const prefix = pattern.slice(0, lastColonIndex);
+  const suffix = pattern.slice(lastColonIndex + 1);
+  if (isThinkingLevel(suffix)) {
+    const result = parseModelPattern(prefix, availableModels, options);
+    if (!result.model) return result;
+    return {
+      model: result.model,
+      thinkingLevel: result.warning ? undefined : suffix,
+      warning: result.warning,
+    };
+  }
+
+  if (options?.allowInvalidThinkingLevelFallback === false) return {};
+
+  const result = parseModelPattern(prefix, availableModels, options);
+  if (!result.model) return result;
+  return {
+    model: result.model,
+    warning: `Invalid thinking level "${suffix}" in pattern "${pattern}". Using default instead.`,
+  };
+}
+
+function buildFallbackModel(provider: string, modelId: string, availableModels: Model<Api>[]): Model<Api> | undefined {
+  const providerModels = availableModels.filter((model) => model.provider === provider);
+  if (providerModels.length === 0) return undefined;
+  const defaultId = DEFAULT_MODEL_PER_PROVIDER[provider];
+  const baseModel = defaultId
+    ? (providerModels.find((model) => model.id === defaultId) ?? providerModels[0])
+    : providerModels[0];
+  return { ...baseModel, id: modelId, name: modelId };
+}
+
+/**
+ * Resolve a workflow model-tier/agent model string with the same user-facing
+ * grammar as Pi CLI `--model`: `provider/modelId[:thinking]`, bare model ids,
+ * fuzzy patterns, and exact colon-containing model ids.
+ */
+export function resolveModelSpecWithThinking(
+  spec: string,
+  modelRegistry: Pick<ModelRegistry, "getAll">,
+): ResolvedModelSpec {
+  const requestedSpec = spec.trim();
+  if (!requestedSpec) return { requestedSpec, error: "No model spec provided." };
+
+  const availableModels = modelRegistry.getAll();
+  if (availableModels.length === 0) {
+    return {
+      requestedSpec,
+      error: "No models available. Check your installation or add models to models.json.",
+    };
+  }
+
+  const providerMap = new Map<string, string>();
+  for (const model of availableModels) {
+    providerMap.set(model.provider.toLowerCase(), model.provider);
+  }
+
+  let provider: string | undefined;
+  let pattern = requestedSpec;
+  let inferredProvider = false;
+  const slashIndex = requestedSpec.indexOf("/");
+  if (slashIndex !== -1) {
+    const maybeProvider = requestedSpec.slice(0, slashIndex);
+    const canonicalProvider = providerMap.get(maybeProvider.toLowerCase());
+    if (canonicalProvider) {
+      provider = canonicalProvider;
+      pattern = requestedSpec.slice(slashIndex + 1);
+      inferredProvider = true;
+    }
+  }
+
+  if (!provider) {
+    const exact = findExactModelReferenceMatch(requestedSpec, availableModels);
+    if (exact) {
+      return { requestedSpec, model: exact, resolvedSpec: canonicalModelSpec(exact) };
+    }
+  }
+
+  const candidates = provider ? availableModels.filter((model) => model.provider === provider) : availableModels;
+  const { model, thinkingLevel, warning } = parseModelPattern(pattern, candidates, {
+    allowInvalidThinkingLevelFallback: false,
+  });
+  if (model) {
+    return {
+      requestedSpec,
+      model,
+      thinkingLevel,
+      warning,
+      resolvedSpec: formatModelSpecWithThinking(canonicalModelSpec(model), thinkingLevel),
+    };
+  }
+
+  if (inferredProvider) {
+    const exact = findExactModelReferenceMatch(requestedSpec, availableModels);
+    if (exact) {
+      return { requestedSpec, model: exact, resolvedSpec: canonicalModelSpec(exact) };
+    }
+
+    const fallback = parseModelPattern(requestedSpec, availableModels, {
+      allowInvalidThinkingLevelFallback: false,
+    });
+    if (fallback.model) {
+      return {
+        requestedSpec,
+        model: fallback.model,
+        thinkingLevel: fallback.thinkingLevel,
+        warning: fallback.warning,
+        resolvedSpec: formatModelSpecWithThinking(canonicalModelSpec(fallback.model), fallback.thinkingLevel),
+      };
+    }
+  }
+
+  if (provider) {
+    let fallbackPattern = pattern;
+    let fallbackThinking: ModelThinkingLevel | undefined;
+    const lastColon = pattern.lastIndexOf(":");
+    if (lastColon !== -1) {
+      const suffix = pattern.slice(lastColon + 1);
+      if (isThinkingLevel(suffix)) {
+        fallbackPattern = pattern.slice(0, lastColon);
+        fallbackThinking = suffix;
+      }
+    }
+
+    const fallbackModel = buildFallbackModel(provider, fallbackPattern, availableModels);
+    if (fallbackModel) {
+      const modelWithReasoning =
+        fallbackThinking && fallbackThinking !== "off" ? { ...fallbackModel, reasoning: true } : fallbackModel;
+      const fallbackWarning = warning
+        ? `${warning} Model "${fallbackPattern}" not found for provider "${provider}". Using custom model id.`
+        : `Model "${fallbackPattern}" not found for provider "${provider}". Using custom model id.`;
+      return {
+        requestedSpec,
+        model: modelWithReasoning,
+        thinkingLevel: fallbackThinking,
+        warning: fallbackWarning,
+        resolvedSpec: formatModelSpecWithThinking(canonicalModelSpec(modelWithReasoning), fallbackThinking),
+      };
+    }
+  }
+
+  const display = provider ? `${provider}/${pattern}` : requestedSpec;
+  return {
+    requestedSpec,
+    warning,
+    error: `Model "${display}" not found. Use /workflows-models to choose an available model.`,
+  };
+}

--- a/src/model-tier-config.ts
+++ b/src/model-tier-config.ts
@@ -2,9 +2,10 @@
  * Model tier configuration for workflow subagent model routing.
  *
  * A tier is a named slot (small/medium/big) holding exactly ONE model spec
- * string (e.g. "openai/gpt-4.1-mini"). When an agent() call specifies
- * opts.tier, that single model is resolved and used as the subagent's model
- * (unless an explicit opts.model is given, which always wins — see agent.ts).
+ * string (e.g. "openai/gpt-4.1-mini" or "openai-codex/gpt-5.5:xhigh").
+ * When an agent() call specifies opts.tier, that single model is resolved with
+ * Pi CLI-style parsing and used as the subagent's model/thinking level (unless
+ * an explicit opts.model is given, which always wins — see agent.ts).
  *
  * This augments the phase-pattern routing in model-routing.ts: phase routing
  * maps workflow phases → models via the script's meta; tiers give scripts a
@@ -24,7 +25,8 @@ import { MODEL_TIERS_FILE } from "./config.js";
 
 /**
  * Model tier configuration. Maps tier names (e.g. "small", "medium", "big")
- * to a single model spec string (e.g. "gpt-4.1-mini" or "openai/gpt-4.1-mini").
+ * to a single model spec string (e.g. "gpt-4.1-mini", "openai/gpt-4.1-mini",
+ * or "openai-codex/gpt-5.5:xhigh").
  */
 export interface ModelTierConfig {
   tiers: Record<string, string>;

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -43,6 +43,7 @@ export function modelRoutingGuideline(registry?: ModelRegistry | (() => ModelReg
     "Big tier: synthesis/judgment/decision agents spanning the full context.",
     "An agent with no opts.tier and no opts.model falls back to the user's medium tier; do not rely on that — tag agents explicitly so small/big are used where they fit.",
     "If the user named a specific model, use opts.model with that exact provider/id; opts.model always takes precedence over opts.tier.",
+    "Exact model specs may include Pi CLI-style thinking suffixes such as openai-codex/gpt-5.5:xhigh when the user requests a specific effort level.",
     list,
   ].join(" ");
 }

--- a/src/workflows-models-command.ts
+++ b/src/workflows-models-command.ts
@@ -8,8 +8,9 @@
  * see every provider Pi can reach, including extension-registered providers such
  * as `ollama-cloud`.
  *
- * Each tier holds exactly one model spec string.
- * When editing a tier, a single-select picker is used (like Pi's `/model`).
+ * Each tier holds exactly one model spec string. The string may include Pi
+ * CLI-style thinking suffixes, e.g. `openai-codex/gpt-5.5:xhigh`.
+ * When editing a tier, users pick a model, then an optional thinking level.
  */
 
 import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent";
@@ -23,6 +24,12 @@ import {
   type TUI,
 } from "@earendil-works/pi-tui";
 import { listAvailableModelSpecs } from "./agent.js";
+import {
+  formatModelSpecWithThinking,
+  type ModelThinkingLevel,
+  splitModelSpecThinking,
+  THINKING_LEVELS,
+} from "./model-spec.js";
 import {
   buildDefaultTierConfig,
   loadModelTierConfig,
@@ -104,14 +111,21 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
   });
 }
 
+const DEFAULT_THINKING_CHOICE = "Default thinking (session setting)";
+const THINKING_CHOICES = [DEFAULT_THINKING_CHOICE, ...THINKING_LEVELS] as const;
+
+function fromThinkingChoice(choice: string | undefined): ModelThinkingLevel | undefined {
+  return THINKING_LEVELS.find((level) => level === choice);
+}
+
 /**
- * Interactive editor for a single tier — scrollable model picker.
+ * Interactive editor for a single tier — scrollable model picker plus optional
+ * thinking-level picker.
  *
- * Uses `ctx.ui.custom()` with Pi TUI's `SelectList` for proper
- * scrollable list with limited visible rows (like `/advisor`).
- *
- * The currently selected model is shown in the dialog title.
- * User scrolls with ↑↓, selects with Enter, cancels with Escape.
+ * Uses `ctx.ui.custom()` with Pi TUI's `SelectList` for proper scrollable list
+ * with limited visible rows (like `/advisor`). The currently selected base
+ * model is shown in the dialog title. After choosing the model, users can set
+ * a Pi CLI-style thinking suffix or keep the session default.
  *
  * Returns the updated tiers object, or null if nothing changed.
  */
@@ -121,12 +135,14 @@ export async function editSingleTier(
   tierName: string,
 ): Promise<Record<string, string> | null> {
   const available = listAvailableModelSpecs(ctx.modelRegistry);
+  const knownSpecs = available.length > 0 ? available : undefined;
   const current = tiers[tierName];
+  const currentParts = splitModelSpecThinking(current, knownSpecs);
 
   // Build SelectItems: all available models as scrollable list
   const items: SelectItem[] = available.map((m) => ({ value: m, label: m }));
 
-  const result = await ctx.ui.custom<string | null>((tui: TUI, theme: Theme, _keybindings, done) => {
+  const selectedModel = await ctx.ui.custom<string | null>((tui: TUI, theme: Theme, _keybindings, done) => {
     const container = new Container();
 
     // Title showing current model
@@ -147,9 +163,9 @@ export async function editSingleTier(
 
     const selectList = new SelectList(items, 12, selectTheme);
 
-    // Preselect the current model
-    if (current) {
-      const idx = items.findIndex((i) => i.value === current);
+    // Preselect the current base model even when the stored tier has :thinking.
+    if (currentParts.modelSpec) {
+      const idx = items.findIndex((i) => i.value === currentParts.modelSpec);
       if (idx >= 0) selectList.setSelectedIndex(idx);
     }
 
@@ -159,7 +175,9 @@ export async function editSingleTier(
 
     container.addChild(selectList);
     container.addChild(new Spacer(1));
-    container.addChild(new Text(theme.fg("dim", "↑↓ navigate  enter select  esc cancel"), 1, 0));
+    container.addChild(
+      new Text(theme.fg("dim", "↑↓ navigate  enter select  esc cancel  · thinking is chosen next"), 1, 0),
+    );
 
     return {
       render: (w: number) => container.render(w),
@@ -171,7 +189,18 @@ export async function editSingleTier(
     };
   });
 
-  if (!result || result === current) return null;
+  if (!selectedModel) return null;
+
+  const currentThinkingLabel = currentParts.thinkingLevel ?? DEFAULT_THINKING_CHOICE;
+  const thinkingChoice = await ctx.ui.select(
+    `Thinking for "${tierName}" tier (current: ${currentThinkingLabel})`,
+    THINKING_CHOICES.map((choice) => String(choice)),
+  );
+  if (!thinkingChoice) return null;
+
+  const thinkingLevel = fromThinkingChoice(thinkingChoice);
+  const result = formatModelSpecWithThinking(selectedModel, thinkingLevel);
+  if (result === current) return null;
 
   ctx.ui.notify(`"${tierName}" tier → ${result}`, "info");
   return { ...tiers, [tierName]: result };

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import type { AgentRunOptions, AgentUsage } from "../src/agent.js";
 import { listAvailableModelSpecs, resolveAgentModelSpec, WorkflowAgent } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
+import { resolveModelSpecWithThinking } from "../src/model-spec.js";
 import type { ModelTierConfig } from "../src/model-tier-config.js";
 import { runWorkflow } from "../src/workflow.js";
 
@@ -114,8 +115,8 @@ test("WorkflowAgent reuses an injected ModelRegistry instead of building its own
   } as any;
 
   const agent = new WorkflowAgent({ cwd: "/tmp", modelRegistry: registry });
-  const resolved = (agent as any).resolveModel("mock/shared");
-  assert.equal(resolved, mockModel, "should resolve via the injected registry");
+  const resolved = resolveModelSpecWithThinking("mock/shared", (agent as any).getRegistry());
+  assert.equal(resolved.model, mockModel, "should resolve via the injected registry");
 });
 
 test("WorkflowAgent falls back to building a disk registry when no registry is injected", () => {
@@ -136,8 +137,8 @@ test("WorkflowAgent.resolveModel resolves via a per-run registry when the constr
   } as any;
 
   const agent = new WorkflowAgent({ cwd: "/tmp" });
-  const resolved = (agent as any).resolveModel("router/per-run-only", perRunRegistry);
-  assert.equal(resolved, perRunModel, "should resolve via the per-run registry, not a disk registry");
+  const resolved = resolveModelSpecWithThinking("router/per-run-only", (agent as any).getRegistry(perRunRegistry));
+  assert.equal(resolved.model, perRunModel, "should resolve via the per-run registry, not a disk registry");
 });
 
 test("WorkflowAgent.resolveModel: per-run registry takes precedence over the constructor's shared registry", () => {
@@ -157,11 +158,11 @@ test("WorkflowAgent.resolveModel: per-run registry takes precedence over the con
 
   const agent = new WorkflowAgent({ cwd: "/tmp", modelRegistry: constructorRegistry });
   // The per-run registry, not the constructor's, is consulted when both are set.
-  const resolved = (agent as any).resolveModel("run/override", perRunRegistry);
-  assert.equal(resolved, perRunModel, "per-run registry should win over the constructor's shared registry");
+  const resolved = resolveModelSpecWithThinking("run/override", (agent as any).getRegistry(perRunRegistry));
+  assert.equal(resolved.model, perRunModel, "per-run registry should win over the constructor's shared registry");
   // And the constructor registry is still used when no per-run registry is given.
-  const fallback = (agent as any).resolveModel("ctor/shared");
-  assert.equal(fallback, constructorModel, "constructor registry should still apply without a per-run override");
+  const fallback = resolveModelSpecWithThinking("ctor/shared", (agent as any).getRegistry());
+  assert.equal(fallback.model, constructorModel, "constructor registry should still apply without a per-run override");
 });
 
 test("WorkflowAgent.getRegistry: per-run registry wins, then constructor's shared registry, then disk", () => {
@@ -378,6 +379,20 @@ test("agent() in workflow passes model spec to runner", async () => {
   );
   assert.equal(rec.calls.length, 1);
   assert.equal((rec.calls[0].options as { model?: string }).model, "fast-llm/model");
+});
+
+test("agent() in workflow forwards modelRegistry for CLI-style model parsing", async () => {
+  const rec = new CallRecordingAgent();
+  const modelRegistry = { getAll: () => [] };
+  await runWorkflow(
+    `export const meta = { name: 'test', description: 't' }
+     const r = await agent('task', { label: 't', model: 'fast-llm/model:xhigh' })
+     return r`,
+    { agent: rec, modelRegistry: modelRegistry as never, persistLogs: false },
+  );
+  assert.equal(rec.calls.length, 1);
+  assert.equal((rec.calls[0].options as { modelRegistry?: unknown }).modelRegistry, modelRegistry);
+  assert.equal((rec.calls[0].options as { model?: string }).model, "fast-llm/model:xhigh");
 });
 
 test("agent() in workflow fires onAgentStart and onAgentEnd callbacks", async () => {

--- a/tests/model-spec.test.ts
+++ b/tests/model-spec.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import fc from "fast-check";
+import {
+  formatModelSpecWithThinking,
+  resolveModelSpecWithThinking,
+  splitModelSpecThinking,
+  THINKING_LEVELS,
+} from "../src/model-spec.js";
+
+function model(provider: string, id: string, name = id): Model<Api> {
+  return { provider, id, name } as Model<Api>;
+}
+
+function registry(models: Model<Api>[]): Pick<ModelRegistry, "getAll"> {
+  return { getAll: () => models } as Pick<ModelRegistry, "getAll">;
+}
+
+const letters = "abcdefghijklmnopqrstuvwxyz".split("");
+const identifierChars = "abcdefghijklmnopqrstuvwxyz0123456789-".split("");
+const segment = fc
+  .tuple(fc.constantFrom(...letters), fc.array(fc.constantFrom(...identifierChars), { maxLength: 12 }))
+  .map(([head, tail]) => `${head}${tail.join("")}`);
+const providerSpec = segment;
+const modelIdSpec = fc.array(segment, { minLength: 1, maxLength: 3 }).map((parts) => parts.join("/"));
+const thinkingSpec = fc.constantFrom(...THINKING_LEVELS);
+
+describe("model spec thinking suffixes", () => {
+  it("resolves provider/model:thinking using Pi CLI-style parsing", () => {
+    const gpt55 = model("openai-codex", "gpt-5.5");
+    const resolved = resolveModelSpecWithThinking(
+      "openai-codex/gpt-5.5:xhigh",
+      registry([gpt55, model("openrouter", "openai/gpt-5.5-pro")]),
+    );
+
+    assert.equal(resolved.model, gpt55);
+    assert.equal(resolved.thinkingLevel, "xhigh");
+    assert.equal(resolved.resolvedSpec, "openai-codex/gpt-5.5:xhigh");
+  });
+
+  it("does not strip colon suffixes from exact model ids", () => {
+    const exactColonModel = model("openrouter", "some:model");
+    const resolved = resolveModelSpecWithThinking("openrouter/some:model", registry([exactColonModel]));
+
+    assert.equal(resolved.model, exactColonModel);
+    assert.equal(resolved.thinkingLevel, undefined);
+    assert.equal(resolved.resolvedSpec, "openrouter/some:model");
+  });
+
+  it("uses Pi CLI-style custom provider model fallback without a thinking suffix", () => {
+    const base = model("openai-codex", "gpt-5.5");
+    const resolved = resolveModelSpecWithThinking("openai-codex/custom-model", registry([base]));
+
+    assert.equal(resolved.model?.provider, "openai-codex");
+    assert.equal(resolved.model?.id, "custom-model");
+    assert.equal(resolved.thinkingLevel, undefined);
+    assert.equal(resolved.resolvedSpec, "openai-codex/custom-model");
+    assert.match(resolved.warning ?? "", /Using custom model id/);
+  });
+
+  it("preserves valid thinking suffixes for custom provider model ids", () => {
+    const base = model("openai-codex", "gpt-5.5");
+    const resolved = resolveModelSpecWithThinking("openai-codex/custom-model:xhigh", registry([base]));
+
+    assert.equal(resolved.model?.provider, "openai-codex");
+    assert.equal(resolved.model?.id, "custom-model");
+    assert.equal(resolved.thinkingLevel, "xhigh");
+    assert.equal(resolved.resolvedSpec, "openai-codex/custom-model:xhigh");
+  });
+
+  it("property: invalid thinking-like suffixes stay part of unregistered provider model ids", () => {
+    fc.assert(
+      fc.property(
+        modelIdSpec,
+        fc.constantFrom("notalevel", "x-high", "HIGH", "reasoning", "ultra"),
+        (modelId, suffix) => {
+          const base = model("openai-codex", "gpt-5.5");
+          const customId = `${modelId}:${suffix}`;
+          const resolved = resolveModelSpecWithThinking(`openai-codex/${customId}`, registry([base]));
+
+          assert.equal(resolved.model?.provider, "openai-codex");
+          assert.equal(resolved.model?.id, customId);
+          assert.equal(resolved.thinkingLevel, undefined);
+          assert.equal(resolved.resolvedSpec, `openai-codex/${customId}`);
+        },
+      ),
+      { numRuns: 150 },
+    );
+  });
+
+  it("formats and splits model specs with optional thinking", () => {
+    assert.equal(formatModelSpecWithThinking("openai-codex/gpt-5.5", "xhigh"), "openai-codex/gpt-5.5:xhigh");
+    assert.equal(formatModelSpecWithThinking("openai-codex/gpt-5.5", undefined), "openai-codex/gpt-5.5");
+
+    assert.deepEqual(splitModelSpecThinking("openai-codex/gpt-5.5:xhigh", ["openai-codex/gpt-5.5"]), {
+      modelSpec: "openai-codex/gpt-5.5",
+      thinkingLevel: "xhigh",
+    });
+    assert.deepEqual(splitModelSpecThinking("openrouter/some:model", ["openrouter/some:model"]), {
+      modelSpec: "openrouter/some:model",
+      thinkingLevel: undefined,
+    });
+  });
+
+  it("property: formatting then splitting a known model spec preserves model and thinking", () => {
+    fc.assert(
+      fc.property(
+        providerSpec,
+        modelIdSpec,
+        fc.option(thinkingSpec, { nil: undefined }),
+        (provider, modelId, thinking) => {
+          const canonical = `${provider}/${modelId}`;
+          const stored = formatModelSpecWithThinking(canonical, thinking);
+          assert.deepEqual(splitModelSpecThinking(stored, [canonical]), {
+            modelSpec: canonical,
+            thinkingLevel: thinking,
+          });
+        },
+      ),
+      { numRuns: 150 },
+    );
+  });
+
+  it("property: resolver agrees with formatter for arbitrary known provider/model specs", () => {
+    fc.assert(
+      fc.property(
+        providerSpec,
+        modelIdSpec,
+        fc.option(thinkingSpec, { nil: undefined }),
+        (provider, modelId, thinking) => {
+          const knownModel = model(provider, modelId);
+          const spec = formatModelSpecWithThinking(`${provider}/${modelId}`, thinking);
+          const resolved = resolveModelSpecWithThinking(spec, registry([knownModel]));
+          assert.equal(resolved.model, knownModel);
+          assert.equal(resolved.thinkingLevel, thinking);
+          assert.equal(resolved.resolvedSpec, spec);
+        },
+      ),
+      { numRuns: 150 },
+    );
+  });
+
+  it("property: exact model ids containing colons are not treated as thinking suffixes", () => {
+    fc.assert(
+      fc.property(providerSpec, segment, segment, (provider, left, right) => {
+        const colonModelId = `${left}:${right}`;
+        const knownModel = model(provider, colonModelId);
+        const spec = `${provider}/${colonModelId}`;
+        const resolved = resolveModelSpecWithThinking(spec, registry([knownModel]));
+
+        assert.equal(resolved.model, knownModel);
+        assert.equal(resolved.thinkingLevel, undefined);
+        assert.equal(resolved.resolvedSpec, spec);
+        assert.deepEqual(splitModelSpecThinking(spec, [spec]), { modelSpec: spec, thinkingLevel: undefined });
+      }),
+      { numRuns: 150 },
+    );
+  });
+});

--- a/tests/workflows-models-command.test.ts
+++ b/tests/workflows-models-command.test.ts
@@ -71,12 +71,13 @@ describe("workflows-models-command", () => {
       assert.equal(result, null);
     });
 
-    it("returns null when user selects the same model (no change)", async () => {
+    it("returns null when user selects the same model and default thinking (no change)", async () => {
       const { editSingleTier } = await import("../src/workflows-models-command.js");
       // Mock ctx.ui.custom to return the same model that's already selected
       const ctx = {
         ui: {
           custom: mock.fn(async () => "gpt-4.1-mini"),
+          select: mock.fn(async () => "Default thinking (session setting)"),
           notify: mock.fn(),
         },
       };
@@ -86,12 +87,13 @@ describe("workflows-models-command", () => {
       assert.equal(result, null); // no change
     });
 
-    it("selects a different model and returns updated tiers", async () => {
+    it("selects a different model and returns updated tiers with default thinking", async () => {
       const { editSingleTier } = await import("../src/workflows-models-command.js");
       // Mock ctx.ui.custom to return a different model
       const ctx = {
         ui: {
           custom: mock.fn(async () => "gpt-5"),
+          select: mock.fn(async () => "Default thinking (session setting)"),
           notify: mock.fn(),
         },
       };
@@ -103,11 +105,48 @@ describe("workflows-models-command", () => {
       assert.equal(typeof result.small, "string", "should still be a string");
     });
 
+    it("lets users choose a thinking level for the selected model", async () => {
+      const { editSingleTier } = await import("../src/workflows-models-command.js");
+      let thinkingOptions: string[] = [];
+      const ctx = {
+        ui: {
+          custom: mock.fn(async () => "openai-codex/gpt-5.5"),
+          select: mock.fn(async (_title: string, options: string[]) => {
+            thinkingOptions = options;
+            return "xhigh";
+          }),
+          notify: mock.fn(),
+        },
+      };
+      const tiers: Record<string, string> = { big: "openai-codex/gpt-5.5" };
+
+      const result = await editSingleTier(ctx as never, tiers, "big");
+      assert.ok(result, "should return updated tiers");
+      assert.equal(result.big, "openai-codex/gpt-5.5:xhigh");
+      assert.ok(thinkingOptions.includes("xhigh"), "TUI should offer xhigh thinking");
+    });
+
+    it("preselects the base model when the current tier has a thinking suffix", async () => {
+      const { editSingleTier } = await import("../src/workflows-models-command.js");
+      const ctx = {
+        ui: {
+          custom: mock.fn(async () => "openai-codex/gpt-5.5"),
+          select: mock.fn(async () => "xhigh"),
+          notify: mock.fn(),
+        },
+      };
+      const tiers: Record<string, string> = { big: "openai-codex/gpt-5.5:xhigh" };
+
+      const result = await editSingleTier(ctx as never, tiers, "big");
+      assert.equal(result, null, "same model plus same thinking suffix should be unchanged");
+    });
+
     it("selects a model when no current model exists", async () => {
       const { editSingleTier } = await import("../src/workflows-models-command.js");
       const ctx = {
         ui: {
           custom: mock.fn(async () => "openai/gpt-4.1-mini"),
+          select: mock.fn(async () => "Default thinking (session setting)"),
           notify: mock.fn(),
         },
       };


### PR DESCRIPTION
## What

Workflow model specs and tiers now accept an optional Pi CLI-style thinking suffix, e.g. `openai-codex/gpt-5.5:xhigh`, parsed with the same grammar as `pi --model`. When an agent resolves such a spec, the matched model is used and the thinking level is forwarded to the created subagent session.

```json
{
  "tiers": {
    "small": "openai-codex/gpt-5.4-mini:low",
    "medium": "openai-codex/gpt-5.4:medium",
    "big": "openai-codex/gpt-5.5:xhigh"
  }
}
```

`/workflows-models` now offers a thinking-level picker (`off`/`minimal`/`low`/`medium`/`high`/`xhigh`, or session default) after the model is chosen, and preselects the base model when the stored tier already carries a suffix.

## Why

The CLI already lets users dial thinking per model. Workflows routed by `opts.tier` / `opts.model` could not, so tier-bound subagents ran at the session default thinking level regardless of intent. This makes the workflow grammar match the rest of Pi.

## Changes

- **`src/model-spec.ts`** (new): `canonicalModelSpec`, `splitModelSpecThinking`, `formatModelSpecWithThinking`, `isThinkingLevel`, `THINKING_LEVELS`, and registry-aware `resolveModelSpecWithThinking`. Includes `fast-check` property tests for the round-trip.
- **`src/agent.ts`**: `run()` resolves the spec via `resolveModelSpecWithThinking` and forwards the parsed `thinkingLevel` to `createAgentSession`. `listAvailableModelSpecs` canonicalizes its output so a tier with a suffix round-trips through the picker.
- **`src/workflow-manager.ts` / `extensions/workflow.ts` / `src/workflow.ts`**: thread the host session's `ModelRegistry` into each `agent()` run so dynamic/authed providers resolve like the parent session (composes with #49).
- **`src/workflows-models-command.ts`**: second-stage thinking picker in the tier editor.
- **`src/index.ts`**: export the new model-spec API.
- **`README.md`**: document the `provider/modelId:thinking` format in the agent-options table and the `model-tiers.json` paragraph.

## Backward compatibility

All new options are additive. A spec without a suffix resolves identically to before. No settings migration is required; existing `model-tiers.json` values keep working.

## Verification

- `npm test` green: Biome check + `tsc` build + **767** unit tests.
- Per CONTRIBUTING ("When you change runtime behavior"), verified end-to-end against a real Pi subagent session: a workflow agent run with `model: "openai-codex/gpt-5.4-mini:low"` resolved the spec with the suffix intact (`onModelResolved` = `openai-codex/gpt-5.4-mini:low`, no fallback) and the real model responded. Throwaway harness run in the repo root and deleted.