### PR TITLE
feat: use workflow meta.name as semantic prefix in run IDs

### DIFF
--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -176,9 +176,16 @@ export class WorkflowManager extends EventEmitter {
     args?: unknown,
     exec: ExecOptions = {},
   ): { runId: string; promise: Promise<WorkflowRunResult> } {
-    const runId = generateRunId();
-    const controller = new AbortController();
     const parsed = parseWorkflowScript(script);
+    const slug = parsed.meta.name
+      ? parsed.meta.name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "")
+          .slice(0, 40) || "workflow"
+      : "";
+    const runId = slug ? `${slug}-${generateRunId()}` : generateRunId();
+    const controller = new AbortController();
     const lease = this.persistence.acquireRunLease(runId);
     if (!lease) throw new Error(`Could not acquire workflow run lease for ${runId}`);
 
@@ -260,8 +267,16 @@ export class WorkflowManager extends EventEmitter {
   /** Build a fresh managed run with an empty snapshot. */
   private createManaged(script: string, args?: unknown): ManagedRun {
     const parsed = parseWorkflowScript(script);
+    const slug = parsed.meta.name
+      ? parsed.meta.name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "")
+          .slice(0, 40) || "workflow"
+      : "";
+    const runId = slug ? `${slug}-${generateRunId()}` : generateRunId();
     return {
-      runId: generateRunId(),
+      runId,
       status: "running",
       snapshot: {
         name: parsed.meta.name,


### PR DESCRIPTION
## What

Workflow run IDs (e.g. `mr90ravb-lnxzrd`) are currently opaque random strings. This PR uses the workflow's `meta.name` (e.g. `profile_sync_upgrade`) as a human-readable prefix, so run IDs become `profile-sync-upgrade-mr90ravb-lnxzrd`.

## How

- Slugify `meta.name` in `startInBackground()` and `createManaged()`
- Prepend slug to the auto-generated `generateRunId()` output
- Fallback to original format when `meta.name` is empty or missing

## What's unchanged

- No API or schema changes — fully backward compatible
- `generateRunId()` signature untouched
- `/workflows status` already shows `workflowName`; this just makes IDs readable too
- Single file: `src/workflow-manager.ts` (+18/-3)