### PR TITLE
fix(agent-registry): align user-level agent dir and tools parsing with pi-coding-agent conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The full guide — every global, agent option, `agentType` definitions, structur
 | --- | --- |
 | `tier` | `"small"` \| `"medium"` \| `"big"` — coarse model routing (configure via `/workflows-models`; tiers may store `provider/modelId:thinking`). |
 | `model` | Exact `provider/modelId` or `provider/modelId:thinking` (always wins over `tier`). |
-| `agentType` | A named definition (`.pi/agents/<name>.md`) binding tools + model + role prompt. |
+| `agentType` | A named definition (`.pi/agents/<name>.md` project-level, or `~/.pi/agent/agents/<name>.md` user-level — `~/.pi/agents/<name>.md` still works as a deprecated fallback) binding tools + model + role prompt. |
 | `isolation: "worktree"` | Run in a throwaway git worktree for conflict-free parallel edits. |
 | `schema` | JSON Schema → the subagent returns a validated object. |
 | `label` / `phase` / `timeoutMs` | Display label / phase override / optional per-agent hard timeout. Omit `timeoutMs` for no hard timeout. |

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -6,8 +6,13 @@
  *   agent("audit this dir", { agentType: "security-auditor" })
  *
  * Definitions live as Markdown files under `.pi/agents/*.md` (project, cwd-relative)
- * and `~/.pi/agents/*.md` (user). Frontmatter binds the subagent's tools, model,
- * and a body prompt; project definitions win on a name collision. This mirrors
+ * and `~/.pi/agent/agents/*.md` (user — `getAgentDir() + "agents"`, honoring the
+ * `PI_CODING_AGENT_DIR` override), matching pi-coding-agent's own built-in agent
+ * discovery convention. The legacy `~/.pi/agents/*.md` location is still scanned as
+ * a deprecated fallback (with a one-time warning) so users who followed this repo's
+ * earlier docs are not silently broken; the new location wins on a name collision.
+ * Frontmatter binds the subagent's tools, model, and a body prompt; project
+ * definitions win over both user-level locations on a name collision. This mirrors
  * Claude Code's `.claude/agents` registry: agentType is a real binding of
  * tools+model+system-prompt, not a prose hint.
  *
@@ -17,6 +22,7 @@
  */
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
 import { AGENTS_DIR } from "./config.js";
@@ -52,7 +58,10 @@ function toStringArray(value: unknown): string[] | undefined {
   // Comma-separated string form: "read, grep, find" — the form pi-coding-agent's
   // parseFrontmatter returns and the form the official subagent example uses.
   if (typeof value === "string" && value.trim().length > 0) {
-    const arr = value.split(",").map((s) => s.trim()).filter(Boolean);
+    const arr = value
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
     return arr.length ? arr : undefined;
   }
   return undefined;
@@ -114,19 +123,32 @@ function readDefsFromDir(dir: string, source: "project" | "user"): AgentDefiniti
 }
 
 /**
- * Load the agent registry once for a run. Scans the project dir then the user
- * dir; the FIRST definition for a name wins (project > user, then filename
+ * Load the agent registry once for a run. Scans the project dir, then the
+ * user dir, then — as a deprecated fallback — the legacy user dir; the FIRST
+ * definition for a name wins (project > user > legacy user, then filename
  * order), so a name collision is resolved deterministically and silently.
+ *
+ * When a definition is only found at the legacy location (not shadowed by
+ * the new user dir), a single deprecation warning is logged for this call
+ * telling the user to move their files — not one warning per legacy file.
  *
  * `opts` overrides the scanned directories (used by tests).
  */
-export function loadAgentRegistry(cwd: string, opts?: { projectDir?: string; userDir?: string }): AgentRegistry {
+export function loadAgentRegistry(
+  cwd: string,
+  opts?: { projectDir?: string; userDir?: string; legacyUserDir?: string },
+): AgentRegistry {
   const projectDir = opts?.projectDir ?? join(cwd, AGENTS_DIR);
   // User-level definitions live under the agent dir (e.g. ~/.pi/agent/agents/),
   // matching the convention used by pi-coding-agent's built-in agent discovery
   // and the official subagent extension example. Reading getAgentDir() also
   // honors the PI_CODING_AGENT_DIR env override.
   const userDir = opts?.userDir ?? join(getAgentDir(), "agents");
+  // Deprecated: this repo's docs used to point users at ~/.pi/agents/ before
+  // pi-coding-agent's convention (~/.pi/agent/agents/) was known. Keep scanning
+  // it as a fallback so those files don't silently stop resolving.
+  const legacyUserDir = opts?.legacyUserDir ?? join(homedir(), AGENTS_DIR);
+
   const registry: AgentRegistry = new Map();
   for (const def of readDefsFromDir(projectDir, "project")) {
     if (def.name && !registry.has(def.name)) registry.set(def.name, def);
@@ -134,6 +156,21 @@ export function loadAgentRegistry(cwd: string, opts?: { projectDir?: string; use
   if (userDir !== projectDir) {
     for (const def of readDefsFromDir(userDir, "user")) {
       if (def.name && !registry.has(def.name)) registry.set(def.name, def);
+    }
+  }
+  if (legacyUserDir !== projectDir && legacyUserDir !== userDir) {
+    let warnedLegacy = false;
+    for (const def of readDefsFromDir(legacyUserDir, "user")) {
+      if (def.name && !registry.has(def.name)) {
+        registry.set(def.name, def);
+        if (!warnedLegacy) {
+          console.warn(
+            `[agent-registry] Loaded agent definition(s) from the deprecated location "${legacyUserDir}". ` +
+              `Move them to "${userDir}" — the old location may stop being read in a future release.`,
+          );
+          warnedLegacy = true;
+        }
+      }
     }
   }
   return registry;

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -17,9 +17,8 @@
  */
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { basename, join } from "node:path";
-import { parseFrontmatter } from "@earendil-works/pi-coding-agent";
+import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
 import { AGENTS_DIR } from "./config.js";
 
 export interface AgentDefinition {
@@ -44,9 +43,19 @@ export interface AgentDefinition {
 export type AgentRegistry = Map<string, AgentDefinition>;
 
 function toStringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  const arr = value.filter((v): v is string => typeof v === "string" && v.trim().length > 0).map((v) => v.trim());
-  return arr.length ? arr : undefined;
+  if (value == null) return undefined;
+  // YAML list form: ["read", "grep"]
+  if (Array.isArray(value)) {
+    const arr = value.filter((v): v is string => typeof v === "string" && v.trim().length > 0).map((v) => v.trim());
+    return arr.length ? arr : undefined;
+  }
+  // Comma-separated string form: "read, grep, find" — the form pi-coding-agent's
+  // parseFrontmatter returns and the form the official subagent example uses.
+  if (typeof value === "string" && value.trim().length > 0) {
+    const arr = value.split(",").map((s) => s.trim()).filter(Boolean);
+    return arr.length ? arr : undefined;
+  }
+  return undefined;
 }
 
 /**
@@ -113,7 +122,11 @@ function readDefsFromDir(dir: string, source: "project" | "user"): AgentDefiniti
  */
 export function loadAgentRegistry(cwd: string, opts?: { projectDir?: string; userDir?: string }): AgentRegistry {
   const projectDir = opts?.projectDir ?? join(cwd, AGENTS_DIR);
-  const userDir = opts?.userDir ?? join(homedir(), AGENTS_DIR);
+  // User-level definitions live under the agent dir (e.g. ~/.pi/agent/agents/),
+  // matching the convention used by pi-coding-agent's built-in agent discovery
+  // and the official subagent extension example. Reading getAgentDir() also
+  // honors the PI_CODING_AGENT_DIR env override.
+  const userDir = opts?.userDir ?? join(getAgentDir(), "agents");
   const registry: AgentRegistry = new Map();
   for (const def of readDefsFromDir(projectDir, "project")) {
     if (def.name && !registry.has(def.name)) registry.set(def.name, def);

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,8 +44,12 @@ export function normalizeKeywordTriggerWord(value: unknown): string | undefined 
 }
 
 /**
- * Named workflow subagent definitions directory. Resolved both project-relative
- * (cwd/.pi/agents) and home-relative (~/.pi/agents); project entries win on name
- * collision. Each `*.md` file is an agent definition (frontmatter + body prompt).
+ * Named workflow subagent definitions directory. Resolved project-relative
+ * (cwd/.pi/agents), plus user-level at `~/.pi/agent/agents/` (the primary
+ * location, via `getAgentDir()` in agent-registry.ts) with the legacy
+ * `~/.pi/agents/` (this constant, home-relative) scanned as a deprecated
+ * fallback. Project entries win on name collision, then the primary user
+ * location, then the legacy one. Each `*.md` file is an agent definition
+ * (frontmatter + body prompt).
  */
 export const AGENTS_DIR = ".pi/agents";

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -69,8 +69,9 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   mainModel?: string;
   /**
    * Named subagent definitions for `agent({ agentType })`. Snapshotted once per
-   * run for determinism. Defaults to scanning `.pi/agents` (project) + `~/.pi/agents`.
-   * Injectable for tests.
+   * run for determinism. Defaults to scanning `.pi/agents` (project) +
+   * `~/.pi/agent/agents` (user, primary) + `~/.pi/agents` (user, deprecated
+   * fallback). Injectable for tests.
    */
   agentRegistry?: AgentRegistry;
   concurrency?: number;

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import {
   type AgentDefinition,
   type AgentRegistry,
@@ -92,7 +93,7 @@ describe("loadAgentRegistry", () => {
     writeDef(userDir, "reviewer.md", "---\nname: reviewer\nmodel: user/model\n---\nuser body");
     writeDef(userDir, "researcher.md", "---\nname: researcher\n---\nuser-only researcher");
 
-    const reg = loadAgentRegistry(root, { projectDir, userDir });
+    const reg = loadAgentRegistry(root, { projectDir, userDir, legacyUserDir: join(root, "legacy-none") });
     assert.equal(reg.size, 2);
     assert.equal(reg.get("reviewer")?.model, "project/model", "project def wins");
     assert.equal(reg.get("reviewer")?.source, "project");
@@ -104,6 +105,7 @@ describe("loadAgentRegistry", () => {
     const reg = loadAgentRegistry("/nonexistent", {
       projectDir: "/nonexistent/a",
       userDir: "/nonexistent/b",
+      legacyUserDir: "/nonexistent/c",
     });
     assert.equal(reg.size, 0);
   });
@@ -113,8 +115,149 @@ describe("loadAgentRegistry", () => {
     const projectDir = join(root, "p");
     writeDef(projectDir, "ok.md", "---\nname: ok\n---\nbody");
     writeDef(projectDir, "notes.txt", "ignored");
-    const reg = loadAgentRegistry(root, { projectDir, userDir: join(root, "none") });
+    const reg = loadAgentRegistry(root, {
+      projectDir,
+      userDir: join(root, "none"),
+      legacyUserDir: join(root, "legacy-none"),
+    });
     assert.deepEqual([...reg.keys()], ["ok"]);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("comma-separated tools/disallowedTools string form parses like the YAML list form", () => {
+    const root = mkdtempSync(join(tmpdir(), "agents-"));
+    const projectDir = join(root, "p");
+    writeDef(
+      projectDir,
+      "scout.md",
+      ["---", "name: scout", "tools: read, grep, find", "disallowedTools: write, bash", "---", "Scout body."].join(
+        "\n",
+      ),
+    );
+    const reg = loadAgentRegistry(root, {
+      projectDir,
+      userDir: join(root, "none"),
+      legacyUserDir: join(root, "legacy-none"),
+    });
+    assert.deepEqual(reg.get("scout")?.tools, ["read", "grep", "find"]);
+    assert.deepEqual(reg.get("scout")?.disallowedTools, ["write", "bash"]);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("default userDir resolution uses getAgentDir() (~/.pi/agent/agents) with no injected opts", () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), "pi-home-"));
+    const originalHome = process.env.HOME;
+    const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
+    delete process.env.PI_CODING_AGENT_DIR;
+    process.env.HOME = tmpHome;
+    try {
+      const expectedUserDir = join(getAgentDir(), "agents");
+      assert.equal(expectedUserDir, join(tmpHome, ".pi", "agent", "agents"), "sanity: HOME override took effect");
+      writeDef(expectedUserDir, "scout.md", "---\nname: scout\n---\nUser-level scout.");
+
+      const cwd = mkdtempSync(join(tmpdir(), "pi-cwd-"));
+      const reg = loadAgentRegistry(cwd);
+      assert.equal(reg.get("scout")?.source, "user");
+      assert.equal(reg.get("scout")?.prompt, "User-level scout.");
+      rmSync(cwd, { recursive: true, force: true });
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalAgentDirEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
+      else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── loadAgentRegistry dual-scan: new location + deprecated legacy fallback ──
+
+describe("loadAgentRegistry legacy ~/.pi/agents fallback", () => {
+  function writeDef(dir: string, file: string, content: string) {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, file), content, "utf-8");
+  }
+
+  function withCapturedWarnings<T>(fn: () => T): { result: T; warnings: string[] } {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      const result = fn();
+      return { result, warnings };
+    } finally {
+      console.warn = originalWarn;
+    }
+  }
+
+  it("resolves a definition that exists only in the legacy location and warns once", () => {
+    const root = mkdtempSync(join(tmpdir(), "agents-legacy-"));
+    const legacyUserDir = join(root, "legacy-user");
+    writeDef(legacyUserDir, "scout.md", "---\nname: scout\ntools: read, grep\n---\nLegacy scout.");
+    writeDef(legacyUserDir, "other.md", "---\nname: other\n---\nAnother legacy agent.");
+
+    const { result: reg, warnings } = withCapturedWarnings(() =>
+      loadAgentRegistry(root, {
+        projectDir: join(root, "project-none"),
+        userDir: join(root, "user-none"),
+        legacyUserDir,
+      }),
+    );
+
+    assert.equal(reg.get("scout")?.source, "user");
+    assert.equal(reg.get("scout")?.prompt, "Legacy scout.");
+    assert.deepEqual(reg.get("scout")?.tools, ["read", "grep"]);
+    assert.ok(reg.get("other"), "second legacy-only def also resolves");
+    assert.equal(warnings.length, 1, "exactly one deprecation warning, not one per legacy file");
+    assert.match(warnings[0], /deprecated/i);
+    assert.match(warnings[0], new RegExp(legacyUserDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("a new-location definition shadows a same-named legacy definition and suppresses its warning", () => {
+    const root = mkdtempSync(join(tmpdir(), "agents-legacy-"));
+    const userDir = join(root, "user");
+    const legacyUserDir = join(root, "legacy-user");
+    writeDef(userDir, "scout.md", "---\nname: scout\nmodel: new/model\n---\nNew scout.");
+    writeDef(legacyUserDir, "scout.md", "---\nname: scout\nmodel: old/model\n---\nOld scout.");
+
+    const { result: reg, warnings } = withCapturedWarnings(() =>
+      loadAgentRegistry(root, {
+        projectDir: join(root, "project-none"),
+        userDir,
+        legacyUserDir,
+      }),
+    );
+
+    assert.equal(reg.size, 1);
+    assert.equal(reg.get("scout")?.model, "new/model", "new location wins over legacy");
+    assert.equal(reg.get("scout")?.prompt, "New scout.");
+    assert.equal(warnings.length, 0, "no deprecation warning when the legacy file is fully shadowed");
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("mixes new and legacy-only names: new wins on collision, legacy fills the rest, one warning", () => {
+    const root = mkdtempSync(join(tmpdir(), "agents-legacy-"));
+    const userDir = join(root, "user");
+    const legacyUserDir = join(root, "legacy-user");
+    writeDef(userDir, "scout.md", "---\nname: scout\nmodel: new/model\n---\nNew scout.");
+    writeDef(legacyUserDir, "scout.md", "---\nname: scout\nmodel: old/model\n---\nOld scout.");
+    writeDef(legacyUserDir, "researcher.md", "---\nname: researcher\n---\nLegacy-only researcher.");
+
+    const { result: reg, warnings } = withCapturedWarnings(() =>
+      loadAgentRegistry(root, {
+        projectDir: join(root, "project-none"),
+        userDir,
+        legacyUserDir,
+      }),
+    );
+
+    assert.equal(reg.size, 2);
+    assert.equal(reg.get("scout")?.model, "new/model");
+    assert.equal(reg.get("researcher")?.source, "user");
+    assert.equal(warnings.length, 1, "warns once for the researcher-only legacy resolution");
     rmSync(root, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary

Aligns `loadAgentRegistry` and the `tools` / `disallowedTools` parser with the conventions actually used by pi-coding-agent. Today, an `agentType` reference silently falls back to "unknown agentType" for any user whose agent markdowns live at the standard pi-coding-agent location (`~/.pi/agent/agents/*.md`), because two related bugs in `agent-registry.ts` prevent the files from being bound correctly.

## Problem

**1. Wrong user-level scan path**

The user-level directory was scanned at `~/.pi/agents/`, but pi-coding-agent's built-in agent discovery and the official subagent extension example both scan `~/.pi/agent/agents/` (i.e. `getAgentDir() + "agents"`).

For users with markdowns at the standard location, the registry came back empty and every `agentType` reference logged the fallback warning.

**2. `tools` / `disallowedTools` parsing only accepts YAML list form**

```ts
function toStringArray(value: unknown): string[] | undefined {
  if (!Array.isArray(value)) return undefined;  // strings always rejected
  ...
}
```

But `parseFrontmatter` (the standard frontmatter parser from pi-coding-agent) returns `tools` as a comma-separated **string** for `tools: read, grep, find, ls`, not an array. The official subagent example just calls `.split(",")` on it. QuintinShaw's own tests cover the YAML list form (`tools: [read, grep]`) but never the string form, so the bug slipped through.

## Fix

**1. Use `getAgentDir()`** for the user-level directory:

```diff
- const userDir = opts?.userDir ?? join(homedir(), AGENTS_DIR);
+ const userDir = opts?.userDir ?? join(getAgentDir(), "agents");
```

This matches pi-coding-agent's standard path and also honors the `PI_CODING_AGENT_DIR` env override. Project-level resolution (`cwd + ".pi/agents/"`) is unchanged.

**2. Extend `toStringArray()`** to also split a comma-separated string, matching the format used by the official subagent example:

```diff
 function toStringArray(value: unknown): string[] | undefined {
+  if (value == null) return undefined;
+  if (Array.isArray(value)) {
+    const arr = value.filter(...).map(...);
+    return arr.length ? arr : undefined;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.split(",").map((s) => s.trim()).filter(Boolean);
+  }
   return undefined;
 }
```

The existing array-form path is preserved so the project's own tests (still passing) keep working.

## Verification

- `tsc --noEmit`: clean
- `npx tsx --test tests/*.test.ts`: **787 / 787 passing**
- `tests/agent-registry.test.ts`: 25 / 25 passing (including the existing array-form cases)
- End-to-end: with markdowns at the standard `~/.pi/agent/agents/*.md` location, both `model` and `tools` now resolve correctly and `source` is reported as `"user"`.

### End-to-end output

```
=== Result: found 2 agentTypes ===
  - code-reviewer
    source: user
    model:  <provider>/<model-id>     # from the markdown frontmatter
    tools:  ["read","grep","find","ls","bash","codegraph_affected"]
  - scout
    source: user
    model:  <provider>/<model-id>     # from the markdown frontmatter
    tools:  ["read","grep","find","ls"]
```