### PR TITLE
feat(workflows): add thinking levels and live token progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The same model — on Pi, plus the production pieces a real run needs:
                             switch the live panel between the compact one-liner and the detailed
                             per-phase/per-agent view (with tokens, cost, and a live tok/s rate)
 /workflows-progress-max <N> cap agents shown per phase in detailed mode (1-1000, default 8)
-/workflows-models           map the small / medium / big tiers to real models
+/workflows-models           map the small / medium / big tiers to models + thinking levels
 /ultracode [off]            ultracode: auto-arm an exhaustive workflow for every substantive message
 /effort off|high|ultra      finer control over the standing opt-in (high = thorough, ultra = ultracode)
 
@@ -135,7 +135,7 @@ The same model — on Pi, plus the production pieces a real run needs:
 
 `/multi-perspective` needs a topic; with fewer than two angles it defaults to `technical, product, security, user experience, maintainability`. `/codebase-audit` needs a scope and at least one check.
 
-In the navigator: `↑/↓` select · `enter`/`→` open · `esc`/`←` back · `p` pause · `x` stop · `r` restart · `s` save · `q` quit. Each agent shows the model it ran on; the detail view shows its prompt, result, error diagnostics, and compact message/tool history.
+In the navigator: `↑/↓` select · `enter`/`→` open · `esc`/`←` back · `p` pause · `x` stop · `r` restart · `s` save · `q` quit. Each agent shows the model it ran on plus its thinking level when one was requested; the detail view shows its prompt, result, error diagnostics, and compact message/tool history.
 
 ## Storage
 
@@ -168,8 +168,9 @@ The full guide — every global, agent option, `agentType` definitions, structur
 
 | Agent option | Description |
 | --- | --- |
-| `tier` | `"small"` \| `"medium"` \| `"big"` — coarse model routing (configure via `/workflows-models`). |
-| `model` | Exact `provider/modelId` (always wins over `tier`). |
+| `tier` | `"small"` \| `"medium"` \| `"big"` — coarse model + thinking routing (configure via `/workflows-models`). |
+| `model` | Exact `provider/modelId` (wins over `tier` for the model). |
+| `thinkingLevel` | Optional Pi reasoning effort: `"off"` \| `"minimal"` \| `"low"` \| `"medium"` \| `"high"` \| `"xhigh"`. Overrides the tier's thinking level. |
 | `agentType` | A named definition (`.pi/agents/<name>.md`) binding tools + model + role prompt. |
 | `isolation: "worktree"` | Run in a throwaway git worktree for conflict-free parallel edits. |
 | `schema` | JSON Schema → the subagent returns a validated object. |
@@ -186,7 +187,7 @@ Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()
 
 ## Default tier assignment
 
-When no `~/.pi/workflows/model-tiers.json` exists, pi-dynamic-workflows builds a default config from the models you have authenticated. The registry returns models grouped by provider, not ranked by capability, so a naive positional spread (`first → small`, `last → big`) can put a mini or flash model in the big slot — or even collapse two tiers onto the same model. To avoid this, `buildDefaultTierConfig` first ranks every available model with a capability score based on well-known substrings: names containing `mini`, `flash`, `haiku`, `nano`, or `small` rank lowest, names containing `opus`, `pro`, `ultra`, `large`, or `plus` rank highest, and everything else ranks neutral (checks are case-insensitive; a name matching both hint sets ranks as small, so it can never outrank a bigger model). Models keep their registry order within the same rank. Tiers are then assigned from this single ranked pool — the least-capable model becomes `small`, the most-capable becomes `big`, and the middle-ranked one becomes `medium` — so distinct tiers never collapse onto the same model and a smaller model can never land in a higher tier than a bigger one. With fewer than 3 distinct models the assignment degrades gracefully: with 2 models the weaker one becomes `small` and the stronger one covers both `medium` and `big`; with 1 (or 0) models every tier resolves to that model (or the current Pi model / empty string as a last resort). You can review or override the assignment at any time with `/workflows-models`.
+When no `~/.pi/workflows/model-tiers.json` exists, pi-dynamic-workflows builds a default config from the models you have authenticated. The registry returns models grouped by provider, not ranked by capability, so a naive positional spread (`first → small`, `last → big`) can put a mini or flash model in the big slot — or even collapse two tiers onto the same model. To avoid this, `buildDefaultTierConfig` first ranks every available model with a capability score based on well-known substrings: names containing `mini`, `flash`, `haiku`, `nano`, or `small` rank lowest, names containing `opus`, `pro`, `ultra`, `large`, or `plus` rank highest, and everything else ranks neutral (checks are case-insensitive; a name matching both hint sets ranks as small, so it can never outrank a bigger model). Models keep their registry order within the same rank. Tiers are then assigned from this single ranked pool — the least-capable model becomes `small`, the most-capable becomes `big`, and the middle-ranked one becomes `medium` — so distinct tiers never collapse onto the same model and a smaller model can never land in a higher tier than a bigger one. With fewer than 3 distinct models the assignment degrades gracefully: with 2 models the weaker one becomes `small` and the stronger one covers both `medium` and `big`; with 1 (or 0) models every tier resolves to that model (or the current Pi model / empty string as a last resort). Default entries do not set a thinking level, so subagents inherit Pi's session/default thinking until you choose a per-tier value such as `high` or `xhigh` in `/workflows-models`. Existing string-only `model-tiers.json` files are still read and normalized to `{ "model": "..." }` entries. You can review or override the assignment at any time with `/workflows-models`.
 
 ## Development
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -16,8 +16,15 @@ import { Check, Convert } from "typebox/value";
 import { type AgentHistoryEntry, compactAgentHistory } from "./agent-history.js";
 import { applyToolPolicy } from "./agent-registry.js";
 import { classifyProviderLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
-import { loadModelTierConfig, type ModelTierConfig, resolveTierModel } from "./model-tier-config.js";
+import {
+  loadModelTierConfig,
+  type ModelTierConfig,
+  resolveTierModel,
+  resolveTierThinkingLevel,
+  type ThinkingLevel,
+} from "./model-tier-config.js";
 import { createStructuredOutputTool, type StructuredOutputCapture } from "./structured-output.js";
+import { estimateCharCountTokens, estimateTextTokens } from "./token-estimate.js";
 
 /**
  * Find a JSON object/array in free-form text: a fenced ```json block if present,
@@ -155,8 +162,8 @@ export async function resolveStructuredOutput<T>(
 }
 
 /**
- * Resolve which concrete model spec a subagent should use. Precedence, most
- * specific first:
+ * Resolve which concrete model spec and thinking level a subagent should use.
+ * Model precedence, most specific first:
  *   1. options.model — an explicit per-agent model (also carries agentType /
  *      phase model, which the workflow layer folds into options.model).
  *   2. options.tier  — resolved via the model-tiers config, falling back to the
@@ -166,26 +173,53 @@ export async function resolveStructuredOutput<T>(
  *      actually affects the whole workflow (not just agents the script tagged).
  *      Fresh-install medium == the session model, so this is a no-op until the
  *      user customizes tiers via /workflows-models.
- * Returns undefined when nothing applies, so the session default is used.
+ * Thinking precedence is options.thinkingLevel, then the selected tier's
+ * thinkingLevel, then the session default (undefined here).
  *
  * `loadConfig` is injectable for testing; it defaults to reading from disk.
  */
-export function resolveAgentModelSpec(
-  options: { model?: string; tier?: string },
+export interface AgentModelSelection {
+  model?: string;
+  thinkingLevel?: ThinkingLevel;
+}
+
+/** Resolve the model plus optional thinking level for an agent run. */
+export function resolveAgentModelSelection(
+  options: { model?: string; tier?: string; thinkingLevel?: ThinkingLevel },
   mainModel: string | undefined,
   loadConfig: () => ModelTierConfig | null = loadModelTierConfig,
-): string | undefined {
-  if (options.model) return options.model;
-  const config = loadConfig();
-  if (options.tier) {
-    return (config ? resolveTierModel(options.tier, config) : undefined) ?? mainModel;
+): AgentModelSelection {
+  const needsTierConfig = Boolean(options.tier) || !options.model;
+  const config = needsTierConfig ? loadConfig() : null;
+
+  if (options.model) {
+    const tierThinking = options.tier && config ? resolveTierThinkingLevel(options.tier, config) : undefined;
+    return { model: options.model, thinkingLevel: options.thinkingLevel ?? tierThinking };
   }
+
+  if (options.tier) {
+    return {
+      model: (config ? resolveTierModel(options.tier, config) : undefined) ?? mainModel,
+      thinkingLevel: options.thinkingLevel ?? (config ? resolveTierThinkingLevel(options.tier, config) : undefined),
+    };
+  }
+
   // Untagged agent: default to the configured medium tier when one exists.
   if (config) {
     const medium = resolveTierModel("medium", config);
-    if (medium) return medium;
+    if (medium) {
+      return { model: medium, thinkingLevel: options.thinkingLevel ?? resolveTierThinkingLevel("medium", config) };
+    }
   }
-  return undefined;
+  return { thinkingLevel: options.thinkingLevel };
+}
+
+export function resolveAgentModelSpec(
+  options: { model?: string; tier?: string; thinkingLevel?: ThinkingLevel },
+  mainModel: string | undefined,
+  loadConfig: () => ModelTierConfig | null = loadModelTierConfig,
+): string | undefined {
+  return resolveAgentModelSelection(options, mainModel, loadConfig).model;
 }
 
 export interface WorkflowAgentOptions {
@@ -242,6 +276,56 @@ export interface AgentUsage {
   cost: number;
 }
 
+export interface AgentUsageUpdate extends AgentUsage {
+  /** True when this is a live estimate; omitted/false means provider-reported usage. */
+  estimated?: boolean;
+}
+
+const ZERO_USAGE: AgentUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 };
+const LIVE_USAGE_THROTTLE_MS = 250;
+const LIVE_REASONING_TOKENS_PER_SECOND = 3;
+
+function usageFromStats(stats: unknown): AgentUsage | undefined {
+  const s = stats as
+    | {
+        tokens?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; total?: number };
+        cost?: number;
+      }
+    | undefined;
+  const t = s?.tokens;
+  if (!t) return undefined;
+  const input = finiteNumber(t.input);
+  const output = finiteNumber(t.output);
+  const cacheRead = finiteNumber(t.cacheRead);
+  const cacheWrite = finiteNumber(t.cacheWrite);
+  const total = finiteNumber(t.total) || input + output + cacheRead + cacheWrite;
+  return { input, output, cacheRead, cacheWrite, total, cost: finiteNumber(s?.cost) };
+}
+
+function usageFromAssistantUsage(usage: unknown): AgentUsage | undefined {
+  const u = usage as
+    | {
+        input?: number;
+        output?: number;
+        cacheRead?: number;
+        cacheWrite?: number;
+        totalTokens?: number;
+        cost?: { total?: number };
+      }
+    | undefined;
+  if (!u) return undefined;
+  const input = finiteNumber(u.input);
+  const output = finiteNumber(u.output);
+  const cacheRead = finiteNumber(u.cacheRead);
+  const cacheWrite = finiteNumber(u.cacheWrite);
+  const total = finiteNumber(u.totalTokens) || input + output + cacheRead + cacheWrite;
+  return { input, output, cacheRead, cacheWrite, total, cost: finiteNumber(u.cost?.total) };
+}
+
+function finiteNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
 export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefined> {
   label?: string;
   schema?: TSchemaDef;
@@ -255,6 +339,12 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
    */
   onUsage?: (usage: AgentUsage) => void;
   /**
+   * Live usage progress for display while the subagent is still running. Exact
+   * provider usage is generally unavailable until the turn ends, so updates may
+   * be estimated and should not be used for billing/budget accounting.
+   */
+  onUsageUpdate?: (usage: AgentUsageUpdate) => void;
+  /**
    * Model spec for this subagent: either `provider/modelId` (unambiguous) or a
    * bare `modelId`. When it can't be resolved, the session default is used and
    * a warning is logged. When omitted, the session default applies.
@@ -264,13 +354,18 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
    * Model tier name (e.g. "small", "medium", "big"). When set (and no explicit
    * `model` is given), the model is resolved from the user's model-tiers.json
    * config before `run()` starts, falling back to the session's main model when
-   * the tier has no configured entry. An explicit `model` always takes priority,
-   * so workflow scripts can use `{ tier: "small" }` for coarse routing without
-   * caring which concrete model backs that tier.
+   * the tier has no configured entry. The tier's thinkingLevel is also applied
+   * unless `thinkingLevel` is set. An explicit `model` always takes priority for
+   * the model, so workflow scripts can use `{ tier: "small" }` for coarse routing
+   * without caring which concrete model backs that tier.
    */
   tier?: string;
+  /** Explicit Pi thinking/reasoning level for this agent. Overrides the tier's configured level. */
+  thinkingLevel?: ThinkingLevel;
   /** Called with the resolved model id once known (for display/telemetry). */
   onModelResolved?: (modelId: string) => void;
+  /** Called with the requested/effective thinking level once known (for display/telemetry). */
+  onThinkingLevelResolved?: (thinkingLevel: ThinkingLevel) => void;
   /** Called when `model`/`tier`/phase resolved to a spec that wasn't found (fell back to session default). */
   onModelFallback?: (requestedSpec: string) => void;
   /** Called with a compact snapshot of this subagent's message/tool history. */
@@ -391,14 +486,18 @@ export class WorkflowAgent {
       customTools.push(...options.systemTools);
     }
 
+    const structured = Boolean(options.schema);
     if (options.schema) {
       customTools.push(createStructuredOutputTool({ schema: options.schema, capture }) as unknown as ToolDefinition);
     }
+    const fullPrompt = this.buildPrompt(prompt, options as AgentRunOptions<any>, structured);
 
     // Resolve the model spec (explicit model > tier > session default). This
     // composes with phase-based routing in workflow.ts, which only supplies
     // options.model when a phase pattern matches — so an explicit model wins.
-    const modelSpec = resolveAgentModelSpec(options, this.mainModel);
+    const modelSelection = resolveAgentModelSelection(options, this.mainModel);
+    const modelSpec = modelSelection.model;
+    const requestedThinkingLevel = modelSelection.thinkingLevel;
 
     // Resolve a requested model spec to a Model object. A given-but-unresolved
     // spec falls back to the session default (with a warning) rather than failing.
@@ -430,13 +529,27 @@ export class WorkflowAgent {
         ? { modelRegistry: options.modelRegistry ?? this.sharedRegistry }
         : {}),
       ...this.sessionOptions,
+      // Per-call tier/agent thinking wins over any sessionOptions.thinkingLevel.
+      ...(requestedThinkingLevel ? { thinkingLevel: requestedThinkingLevel } : {}),
       // Per-call model wins over any sessionOptions.model.
       ...(resolvedModel ? { model: resolvedModel } : {}),
     });
 
+    const effectiveThinkingLevel =
+      ((session as unknown as { thinkingLevel?: ThinkingLevel }).thinkingLevel as ThinkingLevel | undefined) ??
+      requestedThinkingLevel;
+    if (effectiveThinkingLevel) options.onThinkingLevelResolved?.(effectiveThinkingLevel);
+
     let removeAbortListener: (() => void) | undefined;
     let removeHistoryListener: (() => void) | undefined;
+    let removeUsageListener: (() => void) | undefined;
+    let liveUsageTimer: ReturnType<typeof setInterval> | undefined;
     let lastHistoryEmit = 0;
+    let lastUsageEmit = 0;
+    let lastUsageTotal = 0;
+    let liveOutputChars = 0;
+    let generationStartedAt: number | undefined;
+    let lastActualUsage: AgentUsage | undefined;
     const emitHistory = () => options.onHistory?.(compactAgentHistory(session.messages));
     const maybeEmitHistory = () => {
       if (!options.onHistory) return;
@@ -444,6 +557,69 @@ export class WorkflowAgent {
       if (now - lastHistoryEmit < 250) return;
       lastHistoryEmit = now;
       emitHistory();
+    };
+    const emitUsageUpdate = (usage: AgentUsageUpdate, force = false) => {
+      if (!options.onUsageUpdate) return;
+      if (usage.total <= 0) return;
+      const now = Date.now();
+      if (!force && usage.total === lastUsageTotal && now - lastUsageEmit < LIVE_USAGE_THROTTLE_MS) return;
+      if (!force && usage.estimated && usage.total < lastUsageTotal) return;
+      lastUsageTotal = usage.total;
+      lastUsageEmit = now;
+      options.onUsageUpdate(usage);
+    };
+    const readActualUsage = (): AgentUsage | undefined => {
+      try {
+        return usageFromStats(session.getSessionStats());
+      } catch {
+        return undefined;
+      }
+    };
+    const emitActualUsage = (usage: AgentUsage | undefined, force = false) => {
+      if (!usage || usage.total <= 0) return false;
+      lastActualUsage = usage;
+      emitUsageUpdate({ ...usage, estimated: false }, force);
+      return true;
+    };
+    const inputEstimate = estimateTextTokens(fullPrompt);
+    const emitEstimatedUsage = (force = false) => {
+      const elapsedSeconds = generationStartedAt ? Math.max(0, (Date.now() - generationStartedAt) / 1000) : 0;
+      const streamedOutput = estimateCharCountTokens(liveOutputChars);
+      const heartbeatOutput = Math.ceil(elapsedSeconds * LIVE_REASONING_TOKENS_PER_SECOND);
+      const output = Math.max(streamedOutput, heartbeatOutput);
+      emitUsageUpdate(
+        { ...ZERO_USAGE, input: inputEstimate, output, total: inputEstimate + output, estimated: true },
+        force,
+      );
+    };
+    const handleUsageEvent = (event: unknown) => {
+      const e = event as {
+        type?: string;
+        assistantMessageEvent?: { type?: string; delta?: string; partial?: { usage?: unknown } };
+        message?: { usage?: unknown };
+      };
+      if (e.type === "turn_start" || e.type === "message_start") {
+        generationStartedAt = Date.now();
+        emitEstimatedUsage(true);
+        return;
+      }
+      if (e.type === "message_update") {
+        generationStartedAt ??= Date.now();
+        const actual = usageFromAssistantUsage(e.assistantMessageEvent?.partial?.usage);
+        if (actual?.total) {
+          emitActualUsage(actual);
+          return;
+        }
+        const updateType = e.assistantMessageEvent?.type;
+        if (updateType === "text_delta" || updateType === "thinking_delta" || updateType === "toolcall_delta") {
+          liveOutputChars += e.assistantMessageEvent?.delta?.length ?? 0;
+          emitEstimatedUsage();
+        }
+        return;
+      }
+      if (e.type === "turn_end") {
+        emitActualUsage(usageFromAssistantUsage(e.message?.usage) ?? readActualUsage(), true);
+      }
     };
     try {
       if (options.signal?.aborted) throw new Error("Subagent was aborted");
@@ -455,8 +631,16 @@ export class WorkflowAgent {
       if (options.onHistory) {
         removeHistoryListener = session.subscribe(() => maybeEmitHistory());
       }
+      if (options.onUsageUpdate) {
+        emitEstimatedUsage(true);
+        removeUsageListener = session.subscribe((event) => handleUsageEvent(event));
+        liveUsageTimer = setInterval(() => {
+          if (emitActualUsage(readActualUsage())) return;
+          if (session.isStreaming || generationStartedAt) emitEstimatedUsage();
+        }, 1000);
+      }
 
-      await session.prompt(this.buildPrompt(prompt, options as AgentRunOptions<any>, Boolean(options.schema)));
+      await session.prompt(fullPrompt);
 
       if (options.signal?.aborted) throw new Error("Subagent was aborted");
 
@@ -483,6 +667,8 @@ export class WorkflowAgent {
     } finally {
       removeAbortListener?.();
       removeHistoryListener?.();
+      removeUsageListener?.();
+      if (liveUsageTimer) clearInterval(liveUsageTimer);
       try {
         emitHistory();
       } catch {
@@ -491,15 +677,11 @@ export class WorkflowAgent {
       // Read real usage before disposing — dispose tears down the session state.
       if (options.onUsage) {
         try {
-          const { tokens, cost } = session.getSessionStats();
-          options.onUsage({
-            input: tokens.input,
-            output: tokens.output,
-            cacheRead: tokens.cacheRead,
-            cacheWrite: tokens.cacheWrite,
-            total: tokens.total,
-            cost,
-          });
+          const usage = readActualUsage() ?? lastActualUsage;
+          if (usage) {
+            options.onUsageUpdate?.({ ...usage, estimated: false });
+            options.onUsage(usage);
+          }
         } catch {
           // Usage is best-effort; never let stats failure mask the real result/error.
         }

--- a/src/display.ts
+++ b/src/display.ts
@@ -1,6 +1,8 @@
 import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import type { WorkflowErrorCode } from "./errors.js";
+import { formatModelWithThinking } from "./model-display.js";
+import type { ThinkingLevel } from "./model-tier-config.js";
 import type { WorkflowMeta } from "./workflow.js";
 
 export type WorkflowAgentStatus = "queued" | "running" | "done" | "error" | "skipped";
@@ -16,10 +18,14 @@ export interface WorkflowAgentSnapshot {
   errorCode?: WorkflowErrorCode;
   recoverable?: boolean;
   history?: AgentHistoryEntry[];
-  /** Tokens used by this agent. */
+  /** Tokens used by this agent. Running agents may hold a live estimate until provider usage finalizes. */
   tokens?: number;
+  /** True when `tokens` is a live estimate rather than finalized provider usage. */
+  tokensEstimated?: boolean;
   /** The model this agent ran on (provider/id), when known. */
   model?: string;
+  /** Pi thinking/reasoning level requested or used by this agent, when known. */
+  thinkingLevel?: ThinkingLevel;
 }
 
 export interface WorkflowSnapshot {
@@ -183,7 +189,8 @@ export function renderWorkflowLines(
   // Build header with token info (and cost when the provider reports it)
   const usage = snapshot.tokenUsage;
   const costInfo = usage?.cost ? ` · $${usage.cost.toFixed(4)}` : "";
-  const tokenInfo = usage ? ` · ${usage.total.toLocaleString()} tokens${costInfo}` : "";
+  const tokenEstimatePrefix = snapshot.agents.some((agent) => agent.tokensEstimated) ? "~" : "";
+  const tokenInfo = usage ? ` · ${tokenEstimatePrefix}${usage.total.toLocaleString()} tokens${costInfo}` : "";
   const lines = [
     `${theme.bold(`◆ Workflow: ${snapshot.name}`)} (${snapshot.doneCount}/${snapshot.agentCount} done${state}${tokenInfo})`,
   ];
@@ -214,8 +221,12 @@ export function renderWorkflowLines(
     for (const agent of visibleAgents) {
       const order = `[${agent.id}]`;
       const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
-      const agentTokens = agent.tokens ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`) : "";
-      lines.push(`    ${order} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
+      const agentTokens = formatAgentTokens(agent, theme);
+      const modelInfo = formatModelWithThinking(agent.model, agent.thinkingLevel);
+      const agentModel = modelInfo ? theme.fg("dim", ` [${modelInfo}]`) : "";
+      lines.push(
+        `    ${order} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${agentModel}${result}`,
+      );
     }
     if (agents.length > visibleAgents.length)
       lines.push(theme.fg("dim", `    … ${agents.length - visibleAgents.length} earlier agents`));
@@ -226,8 +237,12 @@ export function renderWorkflowLines(
     lines.push(theme.fg("accent", "  Unphased"));
     for (const agent of unphased.slice(-maxAgents)) {
       const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
-      const agentTokens = agent.tokens ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`) : "";
-      lines.push(`    [${agent.id}] ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
+      const agentTokens = formatAgentTokens(agent, theme);
+      const modelInfo = formatModelWithThinking(agent.model, agent.thinkingLevel);
+      const agentModel = modelInfo ? theme.fg("dim", ` [${modelInfo}]`) : "";
+      lines.push(
+        `    [${agent.id}] ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${agentModel}${result}`,
+      );
     }
   }
 
@@ -244,6 +259,12 @@ function statusLine(snapshot: WorkflowSnapshot, completed: boolean): string {
   if (snapshot.runningCount > 0)
     return `workflow ${snapshot.name}: ${snapshot.runningCount} running, ${snapshot.doneCount}/${snapshot.agentCount} done`;
   return `workflow ${snapshot.name}: ${snapshot.doneCount}/${snapshot.agentCount} done`;
+}
+
+function formatAgentTokens(agent: WorkflowAgentSnapshot, theme: ThemeLike): string {
+  if (agent.tokens === undefined) return "";
+  const prefix = agent.tokensEstimated ? "~" : "";
+  return theme.fg("dim", ` [${prefix}${agent.tokens.toLocaleString()} tok]`);
 }
 
 export function statusIcon(status: WorkflowAgentStatus): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export type { AdversarialReviewConfig } from "./adversarial-review.js";
 export { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
-export type { AgentRunOptions, AgentRunResult, WorkflowAgentOptions } from "./agent.js";
+export type { AgentRunOptions, AgentRunResult, AgentUsage, AgentUsageUpdate, WorkflowAgentOptions } from "./agent.js";
 export { listAvailableModelSpecs, WorkflowAgent } from "./agent.js";
 export type { AgentHistoryEntry, AgentHistoryKind, AgentHistoryRole } from "./agent-history.js";
 export { compactAgentHistory } from "./agent-history.js";
@@ -44,16 +44,23 @@ export {
 } from "./errors.js";
 export type { WorkflowLogger, WorkflowLoggerOptions } from "./logger.js";
 export { createWorkflowLogger } from "./logger.js";
+export { formatModelWithThinking, shortModel } from "./model-display.js";
 export type { ModelRoute, ModelRoutingConfig } from "./model-routing.js";
 export { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.js";
-export type { ModelTierConfig } from "./model-tier-config.js";
+export type { ModelTierConfig, ModelTierEntry, ModelTierValue, ThinkingLevel } from "./model-tier-config.js";
 export {
   buildDefaultTierConfig,
   getModelTierConfigPath,
+  isThinkingLevel,
   loadModelTierConfig,
+  normalizeModelTierConfig,
+  normalizeTierEntry,
+  resolveTierEntry,
   resolveTierModel,
+  resolveTierThinkingLevel,
   saveModelTierConfig,
   sortedTierNames,
+  THINKING_LEVELS,
 } from "./model-tier-config.js";
 export type { PersistedRunState, RunPersistence, RunStatus } from "./run-persistence.js";
 export { createRunPersistence, generateRunId } from "./run-persistence.js";

--- a/src/model-display.ts
+++ b/src/model-display.ts
@@ -1,0 +1,20 @@
+import type { ThinkingLevel } from "./model-tier-config.js";
+
+/** Short, human-friendly model label: drop the provider prefix for display. */
+export function shortModel(model: string | undefined): string | undefined {
+  if (!model) return undefined;
+  const slash = model.indexOf("/");
+  return slash > 0 ? model.slice(slash + 1) : model;
+}
+
+/** Format a model label with its optional thinking/reasoning effort beside it. */
+export function formatModelWithThinking(
+  model: string | undefined,
+  thinkingLevel: ThinkingLevel | undefined,
+): string | undefined {
+  const modelLabel = shortModel(model);
+  if (modelLabel && thinkingLevel) return `${modelLabel} · ${thinkingLevel}`;
+  if (modelLabel) return modelLabel;
+  if (thinkingLevel) return `thinking ${thinkingLevel}`;
+  return undefined;
+}

--- a/src/model-tier-config.ts
+++ b/src/model-tier-config.ts
@@ -1,10 +1,12 @@
 /**
- * Model tier configuration for workflow subagent model routing.
+ * Model tier configuration for workflow subagent routing.
  *
- * A tier is a named slot (small/medium/big) holding exactly ONE model spec
- * string (e.g. "openai/gpt-4.1-mini"). When an agent() call specifies
- * opts.tier, that single model is resolved and used as the subagent's model
- * (unless an explicit opts.model is given, which always wins — see agent.ts).
+ * A tier is a named slot (small/medium/big) holding one model spec plus an
+ * optional Pi thinking/reasoning effort level. When an agent() call specifies
+ * opts.tier, that tier's model and thinkingLevel are applied to the subagent
+ * (unless an explicit opts.model is given, which still wins for the model — see
+ * agent.ts). Legacy configs that stored a tier as a plain string are accepted
+ * and normalized to { model: string } on load/save.
  *
  * This augments the phase-pattern routing in model-routing.ts: phase routing
  * maps workflow phases → models via the script's meta; tiers give scripts a
@@ -22,12 +24,24 @@ import { MODEL_TIERS_FILE } from "./config.js";
 // Types
 // ---------------------------------------------------------------------------
 
+export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
+
+/** One tier's concrete runtime selection. */
+export interface ModelTierEntry {
+  model: string;
+  thinkingLevel?: ThinkingLevel;
+}
+
+/** Backward-compatible in-memory value: legacy callers may still pass strings. */
+export type ModelTierValue = string | ModelTierEntry;
+
 /**
  * Model tier configuration. Maps tier names (e.g. "small", "medium", "big")
- * to a single model spec string (e.g. "gpt-4.1-mini" or "openai/gpt-4.1-mini").
+ * to one model spec and, optionally, one Pi thinking/reasoning effort level.
  */
 export interface ModelTierConfig {
-  tiers: Record<string, string>;
+  tiers: Record<string, ModelTierValue>;
 }
 
 // ---------------------------------------------------------------------------
@@ -37,6 +51,45 @@ export interface ModelTierConfig {
 /** Path to the model tiers JSON config file (~/.pi/workflows/model-tiers.json). */
 export function getModelTierConfigPath(): string {
   return join(homedir(), MODEL_TIERS_FILE);
+}
+
+// ---------------------------------------------------------------------------
+// Thinking-level validation / normalization
+// ---------------------------------------------------------------------------
+
+export function isThinkingLevel(value: unknown): value is ThinkingLevel {
+  return typeof value === "string" && (THINKING_LEVELS as readonly string[]).includes(value);
+}
+
+/** Normalize a legacy string or object tier entry. Returns null for invalid shapes. */
+export function normalizeTierEntry(value: unknown): ModelTierEntry | null {
+  if (typeof value === "string") return { model: value };
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+  const entry = value as { model?: unknown; thinkingLevel?: unknown };
+  if (typeof entry.model !== "string") return null;
+
+  const normalized: ModelTierEntry = { model: entry.model };
+  if (entry.thinkingLevel != null) {
+    if (!isThinkingLevel(entry.thinkingLevel)) return null;
+    normalized.thinkingLevel = entry.thinkingLevel;
+  }
+  return normalized;
+}
+
+/** Normalize a full tier config to the object-entry shape used when saving. */
+export function normalizeModelTierConfig(config: unknown): ModelTierConfig | null {
+  if (!config || typeof config !== "object" || Array.isArray(config)) return null;
+  const tiers = (config as { tiers?: unknown }).tiers;
+  if (!tiers || typeof tiers !== "object" || Array.isArray(tiers)) return null;
+
+  const normalized: Record<string, ModelTierEntry> = {};
+  for (const [name, raw] of Object.entries(tiers)) {
+    const entry = normalizeTierEntry(raw);
+    if (!entry) return null;
+    normalized[name] = entry;
+  }
+  return { tiers: normalized };
 }
 
 // ---------------------------------------------------------------------------
@@ -87,11 +140,16 @@ function rankByCapability(available: string[]): string[] {
 // Defaults
 // ---------------------------------------------------------------------------
 
+function tier(model: string): ModelTierEntry {
+  return { model };
+}
+
 /**
  * Build a default tier config. When the available model registry is known,
  * spread it across tiers so small/medium/big routing is meaningful out of the
- * box. When the registry is empty or unavailable, fall back to the current Pi
- * model so fresh installs still get usable tier values.
+ * box. Default entries intentionally omit thinkingLevel so existing sessions
+ * keep their current/default Pi thinking behavior until the user chooses a
+ * per-tier value with `/workflows-models`.
  *
  * Models are first ranked least → most capable via `rankByCapability` (which
  * consults `SMALL_MODEL_HINTS` / `BIG_MODEL_HINTS`, falling back to registry
@@ -126,18 +184,18 @@ export function buildDefaultTierConfig(currentModelSpec?: string, _availableMode
     const small = ranked[0];
     const big = ranked[ranked.length - 1];
     const medium = ranked[Math.floor(ranked.length / 2)];
-    return { tiers: { small, medium, big } };
+    return { tiers: { small: tier(small), medium: tier(medium), big: tier(big) } };
   }
   if (ranked.length === 2) {
     const [weaker, stronger] = ranked;
-    return { tiers: { small: weaker, medium: stronger, big: stronger } };
+    return { tiers: { small: tier(weaker), medium: tier(stronger), big: tier(stronger) } };
   }
   const fallback = ranked[0] ?? currentModelSpec ?? "";
   return {
     tiers: {
-      small: fallback,
-      medium: fallback,
-      big: fallback,
+      small: tier(fallback),
+      medium: tier(fallback),
+      big: tier(fallback),
     },
   };
 }
@@ -148,7 +206,8 @@ export function buildDefaultTierConfig(currentModelSpec?: string, _availableMode
 
 /**
  * Load the model tier config from disk. Returns null if the file does not
- * exist or is unparseable (callers fall back to a default).
+ * exist or is unparseable (callers fall back to a default). Legacy string-valued
+ * tier configs are accepted and normalized to object entries.
  */
 export function loadModelTierConfig(configPath?: string): ModelTierConfig | null {
   const path = configPath ?? getModelTierConfigPath();
@@ -156,12 +215,7 @@ export function loadModelTierConfig(configPath?: string): ModelTierConfig | null
   try {
     const raw = readFileSync(path, "utf-8");
     const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") return null;
-    if (!parsed.tiers || typeof parsed.tiers !== "object") return null;
-    for (const val of Object.values(parsed.tiers)) {
-      if (typeof val !== "string") return null;
-    }
-    return parsed as ModelTierConfig;
+    return normalizeModelTierConfig(parsed);
   } catch {
     return null;
   }
@@ -171,24 +225,38 @@ export function loadModelTierConfig(configPath?: string): ModelTierConfig | null
  * Save a model tier config to disk. Creates parent directories if needed.
  */
 export function saveModelTierConfig(config: ModelTierConfig, configPath?: string): void {
+  const normalized = normalizeModelTierConfig(config);
+  if (!normalized) throw new Error("Invalid model tier config");
+
   const path = configPath ?? getModelTierConfigPath();
   const dir = dirname(path);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  writeFileSync(path, JSON.stringify(config, null, 2), "utf-8");
+  writeFileSync(path, JSON.stringify(normalized, null, 2), "utf-8");
 }
 
 // ---------------------------------------------------------------------------
 // Resolve / helpers
 // ---------------------------------------------------------------------------
 
+/** Resolve a tier name to its normalized entry, or undefined if missing/invalid. */
+export function resolveTierEntry(tierName: string, config: ModelTierConfig): ModelTierEntry | undefined {
+  const entry = normalizeTierEntry(config.tiers[tierName]);
+  return entry ?? undefined;
+}
+
 /**
  * Resolve a tier name to its configured model spec, or undefined if the tier
  * is not configured.
  */
-export function resolveTierModel(tier: string, config: ModelTierConfig): string | undefined {
-  return config.tiers[tier];
+export function resolveTierModel(tierName: string, config: ModelTierConfig): string | undefined {
+  return resolveTierEntry(tierName, config)?.model;
+}
+
+/** Resolve a tier name to its configured thinking level, if any. */
+export function resolveTierThinkingLevel(tierName: string, config: ModelTierConfig): ThinkingLevel | undefined {
+  return resolveTierEntry(tierName, config)?.thinkingLevel;
 }
 
 /** Return all tier names sorted: small < medium < big, then alphabetically. */

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -6,6 +6,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSyn
 import { join } from "node:path";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import type { WorkflowErrorCode } from "./errors.js";
+import type { ThinkingLevel } from "./model-tier-config.js";
 import { workflowProjectPaths } from "./workflow-paths.js";
 
 export type RunStatus = "pending" | "running" | "paused" | "completed" | "failed" | "aborted";
@@ -25,6 +26,12 @@ export interface PersistedAgentState {
   endedAt?: string;
   /** The model this agent ran on (provider/id), when known. */
   model?: string;
+  /** Pi thinking/reasoning level requested or used by this agent, when known. */
+  thinkingLevel?: ThinkingLevel;
+  /** Tokens used by this agent; may be estimated while a run is still active. */
+  tokens?: number;
+  /** True when `tokens` is a live estimate rather than finalized provider usage. */
+  tokensEstimated?: boolean;
 }
 
 export interface PersistedRunState {

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -9,16 +9,17 @@
 import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
 import { type Component, type TUI, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { shorten, statusIcon, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
+import { formatModelWithThinking } from "./model-display.js";
 import type { ManagedRun, WorkflowManager } from "./workflow-manager.js";
 import type { WorkflowStorage } from "./workflow-saved.js";
 import type { WorkflowSettings } from "./workflow-settings.js";
-import { shortModel } from "./workflow-ui.js";
 
 // `tokenUsage` is included so the detailed panel's live token/s counter refreshes
 // as tokens accrue (not only on agent start/end). It is harmless in compact mode —
 // it redraws identical content.
 const RUN_EVENTS = [
   "agentStart",
+  "agentProgress",
   "agentEnd",
   "phase",
   "log",
@@ -262,11 +263,12 @@ function renderRunBody(
     const complete = done + errors + skipped === phaseAgents.length;
     const marker = running > 0 || (!complete && snap.currentPhase === title) ? "▶" : complete ? "✓" : " ";
     const phaseTokens = phaseAgents.reduce((n, a) => n + (a.tokens ?? 0), 0);
+    const phaseTokensEstimated = phaseAgents.some((a) => a.tokensEstimated);
     const phaseMeta = [
       `${done}/${phaseAgents.length} agents`,
       running ? `${running} running` : "",
       errors ? `${errors} errors` : "",
-      phaseTokens > 0 ? `${fmtTokensShort(phaseTokens)} tok` : "",
+      phaseTokens > 0 ? `${phaseTokensEstimated ? "~" : ""}${fmtTokensShort(phaseTokens)} tok` : "",
     ]
       .filter(Boolean)
       .join(" · ");
@@ -274,8 +276,8 @@ function renderRunBody(
 
     const visible = phaseAgents.slice(-maxAgents);
     for (const a of visible) {
-      const tok = a.tokens ? dim(` ${fmtTokensShort(a.tokens)} tok`) : "";
-      const mdl = shortModel(a.model);
+      const tok = a.tokens !== undefined ? dim(` ${a.tokensEstimated ? "~" : ""}${fmtTokensShort(a.tokens)} tok`) : "";
+      const mdl = formatModelWithThinking(a.model, a.thinkingLevel);
       const model = mdl ? dim(` · ${mdl}`) : "";
       lines.push(`    [${a.id}] ${statusIcon(a.status)} ${shorten(a.label, 40)}${tok}${model}`);
     }
@@ -311,13 +313,11 @@ export function renderPanelDetailed(
     const done = agents.filter((a) => a.status === "done").length;
     const icon = r.status === "paused" ? "⏸" : "◆";
     const usage = snap?.tokenUsage ?? r.tokenUsage;
-    // The run-level tokenUsage aggregate is only finalized when the run ends, so
-    // it reads 0 for the whole live run. Per-agent `tokens` update on each agent
-    // completion, so sum those for a live total (and keep the header consistent
-    // with the per-phase subtotals). Note: tokens land at agent-completion
-    // granularity, so the rate reflects completion throughput — it decays to 0
-    // during a single long-running agent or a stall (which is the intended signal).
+    // Sum per-agent tokens for the live total so running agents can show
+    // streaming/heartbeat estimates before provider usage finalizes. The final
+    // exact provider usage replaces the estimate on agent completion.
     const total = agents.reduce((n, a) => n + (a.tokens ?? 0), 0);
+    const totalEstimated = agents.some((a) => a.tokensEstimated);
     // Sample the running total and derive the rolling token/s. Paused runs don't
     // accrue tokens, so their rate is suppressed (a stalled rate would mislead).
     sampleTokens(r.runId, total, now);
@@ -325,7 +325,7 @@ export function renderPanelDetailed(
     const meta = [
       `${done}/${agents.length} agents`,
       snap?.currentPhase || "",
-      total > 0 ? `${fmtTokensShort(total)} tok` : "",
+      total > 0 ? `${totalEstimated ? "~" : ""}${fmtTokensShort(total)} tok` : "",
       // 2 decimals for ≥1¢, 4 for sub-cent so a real cost never shows as "$0.00".
       // (cost is only known once the run finalizes its usage.)
       usage?.cost ? `$${usage.cost.toFixed(usage.cost >= 0.01 ? 2 : 4)}` : "",

--- a/src/token-estimate.ts
+++ b/src/token-estimate.ts
@@ -1,0 +1,19 @@
+/** Lightweight token estimates for live progress displays.
+ *
+ * Providers generally report exact usage only after a turn finishes. While a
+ * subagent is still streaming/thinking, use the common ~4 chars/token heuristic
+ * so the UI can show activity. Final accounting still uses provider usage when
+ * available.
+ */
+export function estimateTextTokens(text: string): number {
+  return estimateCharCountTokens(text.length);
+}
+
+export function estimateCharCountTokens(charCount: number): number {
+  if (!charCount || charCount <= 0) return 0;
+  return Math.max(1, Math.ceil(charCount / 4));
+}
+
+export function estimateTokens(value: unknown): number {
+  return estimateTextTokens(JSON.stringify(value ?? ""));
+}

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -304,6 +304,11 @@ export class WorkflowManager extends EventEmitter {
     const resolvedConcurrency = concurrency ?? this.concurrency;
     const resolvedAgentRetries = agentRetries ?? this.defaultAgentRetries;
     const progress = () => onProgress?.(managed.snapshot);
+    const refreshLiveTokenUsage = () => {
+      const total = managed.snapshot.agents.reduce((sum, agent) => sum + (agent.tokens ?? 0), 0);
+      if (total <= 0 && !managed.snapshot.tokenUsage) return;
+      managed.snapshot.tokenUsage = { ...(managed.snapshot.tokenUsage ?? { input: 0, output: 0 }), total };
+    };
     // Let a host abort (e.g. Esc during a blocking tool call) cancel this run.
     if (externalSignal) {
       if (externalSignal.aborted) managed.controller.abort();
@@ -353,6 +358,7 @@ export class WorkflowManager extends EventEmitter {
             prompt: event.prompt,
             status: "running",
             model: event.model,
+            thinkingLevel: event.thinkingLevel,
           });
           this.emit("agentStart", { runId: managed.runId, ...event });
           progress();
@@ -368,9 +374,26 @@ export class WorkflowManager extends EventEmitter {
             agent.errorCode = event.errorCode;
             agent.recoverable = event.recoverable;
             agent.tokens = event.tokens;
+            agent.tokensEstimated = false;
             if (event.model) agent.model = event.model;
+            if (event.thinkingLevel) agent.thinkingLevel = event.thinkingLevel;
           }
+          refreshLiveTokenUsage();
           this.emit("agentEnd", { runId: managed.runId, ...event });
+          progress();
+        },
+        onAgentProgress: (event) => {
+          const agent = [...managed.snapshot.agents]
+            .reverse()
+            .find((a) => a.label === event.label && a.status === "running");
+          if (agent) {
+            agent.tokens = event.tokens;
+            agent.tokensEstimated = event.estimated ?? true;
+            if (event.model) agent.model = event.model;
+            if (event.thinkingLevel) agent.thinkingLevel = event.thinkingLevel;
+          }
+          refreshLiveTokenUsage();
+          this.emit("agentProgress", { runId: managed.runId, ...event });
           progress();
         },
         onAgentHistory: (event) => {

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -19,7 +19,8 @@ import { loadWorkflowSettings } from "./workflow-settings.js";
 /**
  * Model routing guideline for workflow authors.
  * Tells the LLM about opts.tier (small/medium/big) for runtime-enforced
- * model selection, and opts.model for an exact provider/id override.
+ * model + thinking-level selection, opts.thinkingLevel for an exact reasoning
+ * effort override, and opts.model for an exact provider/id override.
  *
  * This string is injected into the workflow tool's promptGuidelines and
  * therefore appears in the LLM's system prompt for every workflow execution.
@@ -36,13 +37,13 @@ export function modelRoutingGuideline(registry?: ModelRegistry | (() => ModelReg
     ? `The user's currently available models (route only to these) are: ${available.join(", ")}.`
     : "Use models the user has configured.";
   return [
-    "For workflow, the user configures per-tier models (/workflows-models), so TAG EVERY agent with opts.tier by role so those models are actually used.",
-    "opts.tier accepts 'small', 'medium', or 'big' and is enforced at runtime.",
+    "For workflow, the user configures per-tier models and thinking levels (/workflows-models), so TAG EVERY agent with opts.tier by role so those settings are actually used.",
+    "opts.tier accepts 'small', 'medium', or 'big' and is enforced at runtime for both model and configured thinking level.",
     "Small tier: lightweight exploration/search/inventory agents.",
     "Medium tier: balanced analysis agents.",
     "Big tier: synthesis/judgment/decision agents spanning the full context.",
     "An agent with no opts.tier and no opts.model falls back to the user's medium tier; do not rely on that — tag agents explicitly so small/big are used where they fit.",
-    "If the user named a specific model, use opts.model with that exact provider/id; opts.model always takes precedence over opts.tier.",
+    "If the user named a specific model, use opts.model with that exact provider/id; opts.model takes precedence over opts.tier for the model. Use opts.thinkingLevel ('off'|'minimal'|'low'|'medium'|'high'|'xhigh') only when the user asks for a specific reasoning effort; otherwise let the tier setting apply.",
     list,
   ].join(" ");
 }

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -17,6 +17,8 @@ import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi
 import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
 import { parseKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { WorkflowAgentSnapshot, WorkflowSnapshot } from "./display.js";
+import { formatModelWithThinking } from "./model-display.js";
+import type { ThinkingLevel } from "./model-tier-config.js";
 import type { PersistedRunState } from "./run-persistence.js";
 import { registerSavedWorkflow } from "./saved-commands.js";
 import type { WorkflowManager } from "./workflow-manager.js";
@@ -59,6 +61,7 @@ interface RunRow {
   done: number;
   total: number;
   tokens: number;
+  tokensEstimated?: boolean;
   cost: number;
 }
 interface PhaseRow {
@@ -66,6 +69,7 @@ interface PhaseRow {
   done: number;
   total: number;
   tokens: number;
+  tokensEstimated?: boolean;
 }
 interface AgentRow {
   id: number;
@@ -73,15 +77,12 @@ interface AgentRow {
   status: string;
   phase?: string;
   tokens?: number;
+  tokensEstimated?: boolean;
   model?: string;
+  thinkingLevel?: ThinkingLevel;
 }
 
-/** Short, human-friendly model label: drop the provider prefix for display. */
-export function shortModel(model: string | undefined): string | undefined {
-  if (!model) return undefined;
-  const slash = model.indexOf("/");
-  return slash > 0 ? model.slice(slash + 1) : model;
-}
+export { formatModelWithThinking, shortModel } from "./model-display.js";
 
 /** Reads run/phase/agent data from the manager, preferring live snapshots. */
 export class NavigatorModel {
@@ -109,6 +110,7 @@ export class NavigatorModel {
         done: agents.filter((a) => a.status === "done").length,
         total: agents.length,
         tokens: (live?.snapshot.tokenUsage ?? p.tokenUsage)?.total ?? 0,
+        tokensEstimated: agents.some((a) => a.tokensEstimated),
         cost: (live?.snapshot.tokenUsage ?? p.tokenUsage)?.cost ?? 0,
       };
     });
@@ -152,6 +154,7 @@ export class NavigatorModel {
         done: agents.filter((a) => a.status === "done").length,
         total: agents.length,
         tokens: agents.reduce((n, a) => n + (a.tokens ?? 0), 0),
+        tokensEstimated: agents.some((a) => a.tokensEstimated),
       };
     });
   }
@@ -161,7 +164,16 @@ export class NavigatorModel {
     if (!snap) return [];
     return snap.agents
       .filter((a) => (a.phase ?? "(no phase)") === phase)
-      .map((a) => ({ id: a.id, label: a.label, status: a.status, phase: a.phase, tokens: a.tokens, model: a.model }));
+      .map((a) => ({
+        id: a.id,
+        label: a.label,
+        status: a.status,
+        phase: a.phase,
+        tokens: a.tokens,
+        tokensEstimated: a.tokensEstimated,
+        model: a.model,
+        thinkingLevel: a.thinkingLevel,
+      }));
   }
 
   agentDetail(runId: string, agentId: number): WorkflowAgentSnapshot | undefined {
@@ -196,7 +208,10 @@ function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
       errorCode: a.errorCode,
       recoverable: a.recoverable,
       history: a.history,
+      tokens: a.tokens,
+      tokensEstimated: a.tokensEstimated,
       model: a.model,
+      thinkingLevel: a.thinkingLevel,
     })),
     agentCount: p.agents.length,
     runningCount: p.agents.filter((a) => a.status === "running").length,
@@ -327,8 +342,12 @@ function pad(n: number): string {
   return n.toLocaleString();
 }
 
-function fmtTokens(t: number): string {
-  return t > 0 ? `${pad(t)} tok` : "";
+function fmtTokens(t: number, estimated = false): string {
+  return t > 0 ? `${estimated ? "~" : ""}${pad(t)} tok` : "";
+}
+
+function compactTokenText(t: number, estimated = false): string {
+  return `${estimated ? "~" : ""}${compactTokens(t)} tok`;
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -451,8 +470,8 @@ function rightAgentRow(
   theme: ThemeLike,
 ): string {
   const dotColor = AGENT_DOT_COLOR[a.status] ?? "dim";
-  const stats = `${compactTokens(a.tokens ?? 0)} tok`;
-  const model = shortModel(a.model) ?? "";
+  const stats = compactTokenText(a.tokens ?? 0, a.tokensEstimated);
+  const model = formatModelWithThinking(a.model, a.thinkingLevel) ?? "";
 
   // Stable 2-cell marker so columns never shift on selection: "› " | "  ".
   // Layout: <marker:2><dot><sp><name> … <model> … <stats(right-aligned)>.
@@ -486,7 +505,7 @@ function rightAgentRow(
   const statsStyled = theme.fg("dim", stats);
 
   // Assemble with explicit cell padding (visibleWidth-driven gaps).
-  let out = marker + dot + " " + nameStyled;
+  let out = `${marker}${dot} ${nameStyled}`;
   const afterName = nameStart + visibleWidth(nameOut);
   if (modelOut) {
     out += " ".repeat(Math.max(0, modelStart - afterName)) + modelStyled;
@@ -763,7 +782,11 @@ export function renderNavigator(
     // Render runs
     runs.forEach((r, i) => {
       const icon = STATUS_ICON[r.status] ?? "?";
-      const meta = [`${r.done}/${r.total}`, fmtTokens(r.tokens), r.cost > 0 ? `$${r.cost.toFixed(4)}` : ""]
+      const meta = [
+        `${r.done}/${r.total}`,
+        fmtTokens(r.tokens, r.tokensEstimated),
+        r.cost > 0 ? `$${r.cost.toFixed(4)}` : "",
+      ]
         .filter(Boolean)
         .join(" · ");
       lines.push(sel(i, `${icon} ${r.name}  ${dim(`${r.runId} · ${r.status} · ${meta}`)}`));
@@ -799,7 +822,9 @@ export function renderNavigator(
     if (a) {
       const body: string[] = [];
       body.push(dim("Status: ") + (a.status ?? ""));
-      if (a.model) body.push(dim("Model: ") + (shortModel(a.model) ?? ""));
+      if (a.tokens !== undefined) body.push(dim("Tokens: ") + compactTokenText(a.tokens, a.tokensEstimated));
+      const modelInfo = formatModelWithThinking(a.model, a.thinkingLevel);
+      if (modelInfo) body.push(dim("Model: ") + modelInfo);
       if (a.error) body.push(dim("Error: ") + a.error);
       if (a.errorCode) body.push(`${dim("Error code: ")}${a.errorCode}${a.recoverable ? " (recoverable)" : ""}`);
       body.push("", dim("Prompt:"));
@@ -854,17 +879,19 @@ function twoPaneHeader(
   let done = 0;
   let total = 0;
   let tokens = 0;
+  let tokensEstimated = false;
   for (const p of phases) {
     done += p.done;
     total += p.total;
     tokens += p.tokens;
+    tokensEstimated ||= Boolean(p.tokensEstimated);
   }
   // Line 0 — name (accent + bold), truncated to width if needed.
   const nameText = truncateToWidth(name, width, ELLIPSIS, false);
   const line0 = theme.fg("accent", theme.bold(nameText));
 
   // Line 1 — left status, right summary.
-  const rightRaw = `${done}/${total} ${pluralize("agent", total)}${tokens > 0 ? ` · ${compactTokens(tokens)} tok` : ""}`;
+  const rightRaw = `${done}/${total} ${pluralize("agent", total)}${tokens > 0 ? ` · ${compactTokenText(tokens, tokensEstimated)}` : ""}`;
   const rightW = visibleWidth(rightRaw);
   const gap = 2;
   let line1: string;
@@ -999,7 +1026,18 @@ export function openWorkflowNavigator(
   return ui.custom<void>(
     (tui: TUI, theme: Theme, _keybindings, done: (r: undefined) => void) => {
       const rerender = () => tui.requestRender();
-      const events = ["agentStart", "agentEnd", "phase", "log", "complete", "error", "stopped", "paused", "resumed"];
+      const events = [
+        "agentStart",
+        "agentProgress",
+        "agentEnd",
+        "phase",
+        "log",
+        "complete",
+        "error",
+        "stopped",
+        "paused",
+        "resumed",
+      ];
       const onEvent = () => rerender();
       for (const ev of events) manager.on(ev, onEvent);
       const cleanup = () => {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -3,7 +3,7 @@ import vm from "node:vm";
 import type { Node } from "acorn";
 import { parse } from "acorn";
 import type { TSchema } from "typebox";
-import type { AgentUsage } from "./agent.js";
+import type { AgentUsage, AgentUsageUpdate } from "./agent.js";
 import { WorkflowAgent, type WorkflowAgentOptions } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import {
@@ -17,7 +17,14 @@ import { DEFAULT_AGENT_TIMEOUT_MS, MAX_AGENT_RETRIES, MAX_AGENTS_PER_RUN, MAX_CO
 import { WorkflowError, WorkflowErrorCode, wrapError } from "./errors.js";
 import { createWorkflowLogger } from "./logger.js";
 import { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.js";
+import {
+  loadModelTierConfig,
+  resolveTierModel,
+  resolveTierThinkingLevel,
+  type ThinkingLevel,
+} from "./model-tier-config.js";
 import { createAgentStoreTools, SharedStore } from "./shared-store.js";
+import { estimateTokens } from "./token-estimate.js";
 import { createWorktree, removeWorktree, type Worktree } from "./worktree.js";
 
 export interface WorkflowMetaPhase {
@@ -110,7 +117,13 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   confirm?: (promptText: string, options: CheckpointOptions) => Promise<unknown>;
   onLog?: (message: string) => void;
   onPhase?: (title: string) => void;
-  onAgentStart?: (event: { label: string; phase?: string; prompt: string; model?: string }) => void;
+  onAgentStart?: (event: {
+    label: string;
+    phase?: string;
+    prompt: string;
+    model?: string;
+    thinkingLevel?: ThinkingLevel;
+  }) => void;
   onAgentEnd?: (event: {
     label: string;
     phase?: string;
@@ -118,9 +131,19 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
     tokens?: number;
     worktree?: string;
     model?: string;
+    thinkingLevel?: ThinkingLevel;
     error?: string;
     errorCode?: WorkflowErrorCode;
     recoverable?: boolean;
+  }) => void;
+  /** Live display-only token progress for a running agent. Final accounting still comes from onAgentEnd/onTokenUsage. */
+  onAgentProgress?: (event: {
+    label: string;
+    phase?: string;
+    tokens: number;
+    estimated?: boolean;
+    model?: string;
+    thinkingLevel?: ThinkingLevel;
   }) => void;
   onAgentHistory?: (event: { label: string; phase?: string; history: AgentHistoryEntry[] }) => void;
   onTokenUsage?: (usage: {
@@ -165,10 +188,13 @@ export interface AgentOptions<TSchemaDef extends TSchema | undefined = TSchema |
   /**
    * Coarse model tier ("small" | "medium" | "big"), resolved from the user's
    * model-tiers config (see /workflows-models). An explicit `model` takes
-   * precedence; a tier takes precedence over the phase model. When the tier has
-   * no configured entry it falls back to the session's main model.
+   * precedence for the model; a tier takes precedence over the phase model.
+   * The tier's configured thinking level is also used unless `thinkingLevel` is set.
+   * When the tier has no configured entry it falls back to the session's main model.
    */
   tier?: string;
+  /** Explicit Pi thinking/reasoning level for this agent. Overrides the tier's configured level. */
+  thinkingLevel?: ThinkingLevel;
   isolation?: "worktree";
   /**
    * Name of a registered subagent definition (`.pi/agents/<name>.md`, project >
@@ -399,15 +425,26 @@ export async function runWorkflow<T = unknown>(
     const explicitModel = agentOptions.model ?? agentDef?.model;
     const modelSpec =
       explicitModel ?? (agentOptions.tier ? undefined : resolveModelForPhase(assignedPhase, routingConfig));
-    // For display in /workflows: the model this agent runs on — its explicit/phase
-    // spec, else the session's main model. The real resolved id overrides this via
-    // onModelResolved once the subagent session is created.
-    let displayModel = modelSpec ?? options.mainModel;
+    // For display in /workflows: the model/thinking this agent runs on — its
+    // explicit/phase spec, else the selected tier model, else the session's main
+    // model. The real resolved id and effective thinking level override this via
+    // callbacks once the subagent session is created.
+    const tierHashIdentity = resolveTierHashIdentity(agentOptions, modelSpec);
+    let displayModel = modelSpec ?? tierHashIdentity?.model ?? options.mainModel;
+    let displayThinkingLevel = agentOptions.thinkingLevel;
+    if (!displayThinkingLevel) displayThinkingLevel = tierHashIdentity?.thinkingLevel ?? undefined;
 
     // Deterministic resume key: assigned at lexical call time, before the limiter,
     // so parallel()/pipeline() fan-out is reproducible for a fixed script.
     const callIndex = state.callSeq++;
-    const callHash = hashAgentCall(prompt, modelSpec, assignedPhase, agentOptions, agentDefinitionKey(agentDef));
+    const callHash = hashAgentCall(
+      prompt,
+      modelSpec,
+      assignedPhase,
+      agentOptions,
+      agentDefinitionKey(agentDef),
+      tierHashIdentity,
+    );
     // Store delta key: callIndex alone is NOT run-unique. A nested workflow()
     // call (see workflowFn below) shares this run's SharedStore instance but
     // restarts its own callSeq at 0, so a parent agent and a concurrently
@@ -435,8 +472,21 @@ export async function runWorkflow<T = unknown>(
     const hashMatches = cached != null && cached.hash === callHash;
     const cachedEmptyOutput = hashMatches && isEmptyTextAgentResult(cached.result, agentOptions.schema);
     if (hashMatches && !cachedEmptyOutput && callIndex < state.firstMiss) {
-      options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
-      options.onAgentEnd?.({ label, phase: assignedPhase, result: cached.result, tokens: 0, model: displayModel });
+      options.onAgentStart?.({
+        label,
+        phase: assignedPhase,
+        prompt,
+        model: displayModel,
+        thinkingLevel: displayThinkingLevel,
+      });
+      options.onAgentEnd?.({
+        label,
+        phase: assignedPhase,
+        result: cached.result,
+        tokens: 0,
+        model: displayModel,
+        thinkingLevel: displayThinkingLevel,
+      });
       // Apply this agent's write delta so live agents later in the run see a
       // consistent store. Additive apply preserves parallel-agent writes that
       // came from higher-callIndex agents finishing before this one.
@@ -452,7 +502,13 @@ export async function runWorkflow<T = unknown>(
       const retryAttempts = normalizeAgentRetries(agentOptions.retries ?? options.agentRetries ?? 0);
       const maxAttempts = retryAttempts + 1;
 
-      options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
+      options.onAgentStart?.({
+        label,
+        phase: assignedPhase,
+        prompt,
+        model: displayModel,
+        thinkingLevel: displayThinkingLevel,
+      });
 
       // Optional per-agent worktree isolation (deterministic name -> stable resume keys).
       // Precedence: explicit call-site isolation > agentDef isolation.
@@ -471,6 +527,18 @@ export async function runWorkflow<T = unknown>(
       // estimate when the provider reports no usage (total === 0). Usage is reset
       // per retry attempt so a failed attempt does not double-count the next one.
       let usage: AgentUsage | undefined;
+      let agentTotalTokens = 0;
+      const emitAgentProgress = (attemptUsage: AgentUsageUpdate) => {
+        const liveTokens = Math.max(0, agentTotalTokens + Math.max(0, attemptUsage.total || 0));
+        options.onAgentProgress?.({
+          label,
+          phase: assignedPhase,
+          tokens: liveTokens,
+          estimated: attemptUsage.estimated ?? true,
+          model: displayModel,
+          thinkingLevel: displayThinkingLevel,
+        });
+      };
       const recordTokens = (result: unknown): number => {
         const tokens = usage && usage.total > 0 ? usage.total : estimateTokens(result) + estimateTokens(prompt);
         if (usage) {
@@ -482,6 +550,7 @@ export async function runWorkflow<T = unknown>(
         }
         shared.tokenUsage.total += tokens;
         shared.spent += tokens;
+        agentTotalTokens += tokens;
         return tokens;
       };
 
@@ -500,6 +569,7 @@ export async function runWorkflow<T = unknown>(
                 instructions: buildAgentInstructions(assignedPhase, agentOptions, agentDef, resolvedIsolation),
                 model: modelSpec,
                 tier: agentOptions.tier,
+                thinkingLevel: agentOptions.thinkingLevel,
                 modelRegistry: options.modelRegistry,
                 toolNames: agentDef?.tools,
                 disallowedToolNames: agentDef?.disallowedTools,
@@ -512,12 +582,18 @@ export async function runWorkflow<T = unknown>(
                 onModelResolved: (id: string) => {
                   displayModel = id;
                 },
+                onThinkingLevelResolved: (thinkingLevel: ThinkingLevel) => {
+                  displayThinkingLevel = thinkingLevel;
+                },
                 onModelFallback: (spec: string) => {
                   // Make the silent degrade visible in /workflows, not just console.
                   log(`${label}: model "${spec}" unavailable — using the session default`);
                 },
                 onUsage: (u: AgentUsage) => {
                   usage = u;
+                },
+                onUsageUpdate: (u: AgentUsageUpdate) => {
+                  emitAgentProgress(u);
                 },
                 onHistory: (history: AgentHistoryEntry[]) => {
                   options.onAgentHistory?.({ label, phase: assignedPhase, history });
@@ -535,7 +611,7 @@ export async function runWorkflow<T = unknown>(
               });
             }
 
-            const tokens = recordTokens(result);
+            recordTokens(result);
             options.onAgentJournal?.({
               index: callIndex,
               hash: callHash,
@@ -546,9 +622,10 @@ export async function runWorkflow<T = unknown>(
               label,
               phase: assignedPhase,
               result,
-              tokens,
+              tokens: agentTotalTokens,
               worktree: runCwd,
               model: displayModel,
+              thinkingLevel: displayThinkingLevel,
             });
             return result;
           } catch (error) {
@@ -556,7 +633,7 @@ export async function runWorkflow<T = unknown>(
 
             const workflowError = wrapError(error, { agentLabel: label });
             logger.error(`agent ${label} attempt ${attempt}/${maxAttempts} failed: ${workflowError.message}`);
-            const tokens = recordTokens(null);
+            recordTokens(null);
 
             if (workflowError.recoverable && attempt < maxAttempts) {
               log(
@@ -569,9 +646,10 @@ export async function runWorkflow<T = unknown>(
               label,
               phase: assignedPhase,
               result: null,
-              tokens,
+              tokens: agentTotalTokens,
               worktree: runCwd,
               model: displayModel,
+              thinkingLevel: displayThinkingLevel,
               error: workflowError.message,
               errorCode: workflowError.code,
               recoverable: workflowError.recoverable,
@@ -1092,17 +1170,59 @@ function hashCheckpoint(promptText: string, options: CheckpointOptions): string 
   return createHash("sha256").update(identity).digest("hex");
 }
 
+interface TierHashIdentity {
+  tier: string;
+  model?: string | null;
+  thinkingLevel?: ThinkingLevel | null;
+}
+
+function resolveTierHashIdentity(options: AgentOptions, modelSpec: string | undefined): TierHashIdentity | null {
+  let config: ReturnType<typeof loadModelTierConfig>;
+  try {
+    config = loadModelTierConfig();
+  } catch {
+    config = null;
+  }
+  if (!config) return null;
+
+  if (options.tier) {
+    return {
+      tier: options.tier,
+      // When an explicit/agentType model is already supplied, the tier's model is
+      // not applied; still include tier thinking when it can affect the session.
+      model: modelSpec ? null : (resolveTierModel(options.tier, config) ?? null),
+      thinkingLevel: options.thinkingLevel ? null : (resolveTierThinkingLevel(options.tier, config) ?? null),
+    };
+  }
+
+  // Untagged agents only consult the medium tier when no explicit/phase model
+  // is supplied. Include it so changing the configured default tier invalidates
+  // resume cache entries that would otherwise replay with stale routing.
+  if (!modelSpec) {
+    return {
+      tier: "medium",
+      model: resolveTierModel("medium", config) ?? null,
+      thinkingLevel: options.thinkingLevel ? null : (resolveTierThinkingLevel("medium", config) ?? null),
+    };
+  }
+
+  return null;
+}
+
 function hashAgentCall(
   prompt: string,
   model: string | undefined,
   phase: string | undefined,
   options: AgentOptions,
   agentDefKey: string | null,
+  tierConfig: TierHashIdentity | null,
 ): string {
   const identity = JSON.stringify({
     prompt,
     model: model ?? null,
     tier: options.tier ?? null,
+    tierConfig,
+    thinkingLevel: options.thinkingLevel ?? null,
     phase: phase ?? null,
     agentType: options.agentType ?? null,
     // Resolved definition (tools/model/prompt) so editing an agent .md invalidates
@@ -1134,10 +1254,6 @@ function buildAgentInstructions(
 
 function isEmptyTextAgentResult(result: unknown, schema: TSchema | undefined): boolean {
   return schema === undefined && typeof result === "string" && result.trim().length === 0;
-}
-
-function estimateTokens(value: unknown): number {
-  return Math.ceil(JSON.stringify(value ?? "").length / 4);
 }
 
 function normalizeConcurrency(value: unknown): number {

--- a/src/workflows-models-command.ts
+++ b/src/workflows-models-command.ts
@@ -8,8 +8,8 @@
  * see every provider Pi can reach, including extension-registered providers such
  * as `ollama-cloud`.
  *
- * Each tier holds exactly one model spec string.
- * When editing a tier, a single-select picker is used (like Pi's `/model`).
+ * Each tier holds exactly one model spec plus an optional Pi thinking level.
+ * When editing a tier, users can change the model and/or thinking effort.
  */
 
 import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent";
@@ -26,8 +26,14 @@ import { listAvailableModelSpecs } from "./agent.js";
 import {
   buildDefaultTierConfig,
   loadModelTierConfig,
+  type ModelTierConfig,
+  type ModelTierEntry,
+  type ModelTierValue,
+  normalizeTierEntry,
   saveModelTierConfig,
   sortedTierNames,
+  THINKING_LEVELS,
+  type ThinkingLevel,
 } from "./model-tier-config.js";
 
 /**
@@ -35,15 +41,18 @@ import {
  */
 export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
   pi.registerCommand("workflows-models", {
-    description: "View and edit model tiers used by workflows (small/medium/big)",
+    description: "View and edit workflow model tiers and thinking levels (small/medium/big)",
     handler: async (_args, ctx) => {
       await ctx.waitForIdle();
 
       // Load the saved config, or build an in-memory default spread across the
       // available models. If the model registry is empty, fall back to the
-      // current Pi model so the tiers are still usable.
+      // current Pi model so the tiers are still usable. Defaults intentionally
+      // leave thinkingLevel unset (inherit session/default) until the user picks
+      // a tier-specific level.
       const currentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
-      let config = loadModelTierConfig() ?? buildDefaultTierConfig(currentModel, listAvailableModelSpecs());
+      const availableModels = () => listAvailableModelSpecs(ctx.modelRegistry);
+      let config = loadModelTierConfig() ?? buildDefaultTierConfig(currentModel, availableModels());
       let dirty = false;
 
       const ensureFresh = (cfg: typeof config) => {
@@ -58,8 +67,8 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
 
         menuOptions.push("─".repeat(30));
         for (const name of tiers) {
-          const model = config.tiers[name];
-          menuOptions.push(`${name} tier → ${model}`);
+          const entry = getTierEntry(config.tiers[name]);
+          menuOptions.push(`${name} tier → ${formatTierEntry(entry)}`);
         }
         menuOptions.push("─".repeat(30));
 
@@ -84,10 +93,10 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
         if (choice === "Reset to defaults") {
           const confirmed = await ctx.ui.confirm(
             "Reset model tiers",
-            "This will reset tiers from your available model list. Continue?",
+            "This will reset tiers from your available model list and clear tier-specific thinking levels. Continue?",
           );
           if (confirmed) {
-            ensureFresh(buildDefaultTierConfig(currentModel, listAvailableModelSpecs()));
+            ensureFresh(buildDefaultTierConfig(currentModel, availableModels()));
             ctx.ui.notify("Tiers reset to defaults. Use 'Save and exit' to persist.", "info");
           }
         }
@@ -104,27 +113,85 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
   });
 }
 
+function getTierEntry(value: ModelTierValue | undefined): ModelTierEntry {
+  return normalizeTierEntry(value) ?? { model: "" };
+}
+
+function formatThinking(thinkingLevel: ThinkingLevel | undefined): string {
+  return thinkingLevel ?? "inherit";
+}
+
+function withThinking(entry: ModelTierEntry, thinkingLevel: ThinkingLevel | undefined): ModelTierEntry {
+  return thinkingLevel ? { model: entry.model, thinkingLevel } : { model: entry.model };
+}
+
+function formatTierEntry(entry: ModelTierEntry): string {
+  const model = entry.model || "(none)";
+  return `${model} · thinking: ${formatThinking(entry.thinkingLevel)}`;
+}
+
 /**
- * Interactive editor for a single tier — scrollable model picker.
+ * Interactive editor for a single tier — model picker + thinking-level picker.
  *
- * Uses `ctx.ui.custom()` with Pi TUI's `SelectList` for proper
- * scrollable list with limited visible rows (like `/advisor`).
- *
- * The currently selected model is shown in the dialog title.
- * User scrolls with ↑↓, selects with Enter, cancels with Escape.
- *
- * Returns the updated tiers object, or null if nothing changed.
+ * Returns the updated tiers object, or null if nothing changed / user cancelled.
  */
 export async function editSingleTier(
   ctx: ExtensionCommandContext,
-  tiers: Record<string, string>,
+  tiers: ModelTierConfig["tiers"],
   tierName: string,
-): Promise<Record<string, string> | null> {
-  const available = listAvailableModelSpecs(ctx.modelRegistry);
-  const current = tiers[tierName];
+): Promise<ModelTierConfig["tiers"] | null> {
+  let entry = getTierEntry(tiers[tierName]);
+  let dirty = false;
 
-  // Build SelectItems: all available models as scrollable list
-  const items: SelectItem[] = available.map((m) => ({ value: m, label: m }));
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const choice = await ctx.ui.select(`Edit "${tierName}" tier`, [
+      `Model → ${entry.model || "(none)"}`,
+      `Thinking → ${formatThinking(entry.thinkingLevel)}`,
+      dirty ? "Save tier" : "Done",
+      "Cancel",
+    ]);
+
+    if (!choice || choice === "Cancel") return null;
+
+    if (choice.startsWith("Model →")) {
+      const nextModel = await pickModelForTier(ctx, tierName, entry.model);
+      if (nextModel != null && nextModel !== entry.model) {
+        entry = { ...entry, model: nextModel };
+        dirty = true;
+      }
+      continue;
+    }
+
+    if (choice.startsWith("Thinking →")) {
+      const nextThinking = await pickThinkingLevel(ctx, tierName, entry.thinkingLevel);
+      if (nextThinking !== null && nextThinking !== entry.thinkingLevel) {
+        entry = withThinking(entry, nextThinking);
+        dirty = true;
+      }
+      continue;
+    }
+
+    if (choice === "Save tier" || choice === "Done") {
+      if (!dirty) return null;
+      ctx.ui.notify(`"${tierName}" tier → ${formatTierEntry(entry)}`, "info");
+      return { ...tiers, [tierName]: entry };
+    }
+  }
+}
+
+/** Scrollable model picker for a tier. Returns null on cancel. */
+async function pickModelForTier(
+  ctx: ExtensionCommandContext,
+  tierName: string,
+  current: string | undefined,
+): Promise<string | null> {
+  const available = listAvailableModelSpecs(ctx.modelRegistry);
+  const choices = current && !available.includes(current) ? [current, ...available] : available;
+
+  // Build SelectItems: all available models as scrollable list.
+  const items: SelectItem[] = choices.map((m) => ({ value: m, label: m }));
+  if (items.length === 0) items.push({ value: "", label: "(no available models)" });
 
   const result = await ctx.ui.custom<string | null>((tui: TUI, theme: Theme, _keybindings, done) => {
     const container = new Container();
@@ -171,8 +238,19 @@ export async function editSingleTier(
     };
   });
 
-  if (!result || result === current) return null;
+  return result;
+}
 
-  ctx.ui.notify(`"${tierName}" tier → ${result}`, "info");
-  return { ...tiers, [tierName]: result };
+/** Thinking-level picker. Undefined means inherit the session/default level; null means cancel. */
+async function pickThinkingLevel(
+  ctx: ExtensionCommandContext,
+  tierName: string,
+  current: ThinkingLevel | undefined,
+): Promise<ThinkingLevel | undefined | null> {
+  const inherit = "Inherit session/default";
+  const options = [inherit, ...THINKING_LEVELS];
+  const choice = await ctx.ui.select(`Thinking level for "${tierName}" (current: ${formatThinking(current)})`, options);
+  if (!choice) return null;
+  if (choice === inherit) return undefined;
+  return (THINKING_LEVELS as readonly string[]).includes(choice) ? (choice as ThinkingLevel) : null;
 }

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { AgentRunOptions, AgentUsage } from "../src/agent.js";
-import { listAvailableModelSpecs, resolveAgentModelSpec, WorkflowAgent } from "../src/agent.js";
+import {
+  listAvailableModelSpecs,
+  resolveAgentModelSelection,
+  resolveAgentModelSpec,
+  WorkflowAgent,
+} from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import type { ModelTierConfig } from "../src/model-tier-config.js";
 import { runWorkflow } from "../src/workflow.js";
@@ -34,7 +39,11 @@ test("listAvailableModelSpecs entries have provider/model format when non-empty"
 // ═══════════════════════════════════════════════════════════════════════════
 
 const tierConfig: ModelTierConfig = {
-  tiers: { small: "vendor/small", medium: "vendor/medium", big: "vendor/big" },
+  tiers: {
+    small: { model: "vendor/small", thinkingLevel: "low" },
+    medium: { model: "vendor/medium", thinkingLevel: "high" },
+    big: { model: "vendor/big", thinkingLevel: "xhigh" },
+  },
 };
 const loadCfg = () => tierConfig;
 const noCfg = () => null;
@@ -80,6 +89,44 @@ test("resolveAgentModelSpec: untagged agent with a config lacking a medium tier 
 
 test("resolveAgentModelSpec: tier with no main model and no config yields undefined", () => {
   assert.equal(resolveAgentModelSpec({ tier: "small" }, undefined, noCfg), undefined);
+});
+
+test("resolveAgentModelSelection: tier resolves model plus thinking level", () => {
+  assert.deepEqual(resolveAgentModelSelection({ tier: "big" }, "main/model", loadCfg), {
+    model: "vendor/big",
+    thinkingLevel: "xhigh",
+  });
+});
+
+test("resolveAgentModelSelection: explicit model wins but tier thinking still applies", () => {
+  assert.deepEqual(resolveAgentModelSelection({ model: "explicit/model", tier: "small" }, "main/model", loadCfg), {
+    model: "explicit/model",
+    thinkingLevel: "low",
+  });
+});
+
+test("resolveAgentModelSelection: explicit thinking overrides tier thinking", () => {
+  assert.deepEqual(
+    resolveAgentModelSelection({ model: "explicit/model", tier: "small", thinkingLevel: "off" }, "main/model", loadCfg),
+    {
+      model: "explicit/model",
+      thinkingLevel: "off",
+    },
+  );
+});
+
+test("resolveAgentModelSelection: untagged agent defaults to medium model and thinking", () => {
+  assert.deepEqual(resolveAgentModelSelection({}, "main/model", loadCfg), {
+    model: "vendor/medium",
+    thinkingLevel: "high",
+  });
+});
+
+test("resolveAgentModelSelection: explicit thinking does not opt out of default medium model", () => {
+  assert.deepEqual(resolveAgentModelSelection({ thinkingLevel: "low" }, "main/model", loadCfg), {
+    model: "vendor/medium",
+    thinkingLevel: "low",
+  });
 });
 
 test("WorkflowAgent constructor accepts all option shapes without throwing", () => {
@@ -380,6 +427,18 @@ test("agent() in workflow passes model spec to runner", async () => {
   assert.equal((rec.calls[0].options as { model?: string }).model, "fast-llm/model");
 });
 
+test("agent() in workflow passes explicit thinkingLevel to runner", async () => {
+  const rec = new CallRecordingAgent();
+  await runWorkflow(
+    `export const meta = { name: 'test', description: 't' }
+     const r = await agent('task', { label: 't', thinkingLevel: 'high' })
+     return r`,
+    { agent: rec, persistLogs: false },
+  );
+  assert.equal(rec.calls.length, 1);
+  assert.equal((rec.calls[0].options as { thinkingLevel?: string }).thinkingLevel, "high");
+});
+
 test("agent() in workflow fires onAgentStart and onAgentEnd callbacks", async () => {
   const rec = new CallRecordingAgent();
   const events: string[] = [];
@@ -536,6 +595,43 @@ test("agent() in workflow reports non-recoverable errors before throwing", async
   assert.equal(end?.recoverable, false);
 });
 
+test("agent() reports live usage progress while running", async () => {
+  const runner = {
+    async run(_prompt: string, options: any) {
+      options.onUsageUpdate?.({
+        input: 8,
+        output: 4,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 12,
+        cost: 0,
+        estimated: true,
+      });
+      options.onUsage?.({ input: 20, output: 10, cacheRead: 0, cacheWrite: 0, total: 30, cost: 0.001 });
+      return "ok";
+    },
+  };
+  const progress: Array<{ label: string; tokens: number; estimated?: boolean }> = [];
+  let endedTokens = 0;
+
+  await runWorkflow(
+    `export const meta = { name: 'test', description: 't' }
+     await agent('task', { label: 't' })
+     return 1`,
+    {
+      agent: runner,
+      persistLogs: false,
+      onAgentProgress: (e) => progress.push({ label: e.label, tokens: e.tokens, estimated: e.estimated }),
+      onAgentEnd: (e) => {
+        endedTokens = e.tokens ?? 0;
+      },
+    },
+  );
+
+  assert.deepEqual(progress, [{ label: "t", tokens: 12, estimated: true }]);
+  assert.equal(endedTokens, 30, "final agent tokens use provider usage, not the live estimate");
+});
+
 test("agent() in workflow fires onTokenUsage after run", async () => {
   const rec = new CallRecordingAgent();
   const usageEvents: Array<{ input: number; output: number; total: number }> = [];
@@ -568,6 +664,27 @@ test("agent() passes onModelResolved callback for display model updates", async 
     },
   );
   assert.ok(rec.calls.length > 0, "rec.calls should not be empty");
+});
+
+test("agent() passes onThinkingLevelResolved callback for display thinking updates", async () => {
+  const rec = {
+    async run(_prompt: string, options: { onThinkingLevelResolved?: (level: "xhigh") => void }) {
+      options.onThinkingLevelResolved?.("xhigh");
+      return "ok";
+    },
+  };
+  await runWorkflow(
+    `export const meta = { name: 'test', description: 't' }
+     await agent('task', { label: 't', thinkingLevel: 'high' })
+     return 1`,
+    {
+      agent: rec,
+      persistLogs: false,
+      onAgentEnd: (e) => {
+        assert.equal(e.thinkingLevel, "xhigh");
+      },
+    },
+  );
 });
 
 test("agent() accumulates usage across multiple agents", async () => {

--- a/tests/model-tier-config.test.ts
+++ b/tests/model-tier-config.test.ts
@@ -8,7 +8,7 @@
  * 4. save/load round-trip + all validation/error paths (scoped to a temp dir)
  * 5. sortedTierNames helper
  *
- * All tier configs are single-model-per-tier (Record<string, string>).
+ * Tier configs are model-plus-thinking entries, with legacy string values normalized on load.
  */
 
 import assert from "node:assert/strict";
@@ -21,6 +21,12 @@ async function loadModule() {
   return await import("../src/model-tier-config.js");
 }
 
+function tierModels(config: { tiers: Record<string, string | { model: string }> }): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(config.tiers).map(([name, value]) => [name, typeof value === "string" ? value : value.model]),
+  );
+}
+
 describe("model-tier-config", () => {
   describe("buildDefaultTierConfig", () => {
     it("sets every tier to the provided current model when no models are available", async () => {
@@ -29,25 +35,31 @@ describe("model-tier-config", () => {
       // known" fallback rather than depending on whatever registry happens to
       // be configured in the environment running the tests.
       const cfg = buildDefaultTierConfig("openai/gpt-4.1", []);
-      assert.deepEqual(cfg.tiers, {
+      assert.deepEqual(tierModels(cfg), {
         small: "openai/gpt-4.1",
         medium: "openai/gpt-4.1",
         big: "openai/gpt-4.1",
       });
     });
 
-    it("each tier holds a single string", async () => {
+    it("each tier holds an object entry with a model and no default thinking override", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig("openai/gpt-4.1", []);
-      for (const [name, model] of Object.entries(cfg.tiers)) {
-        assert.equal(typeof model, "string", `${name} tier should hold a string`);
+      for (const [name, entry] of Object.entries(cfg.tiers)) {
+        assert.equal(typeof entry, "object", `${name} tier should hold an object entry`);
+        assert.equal(typeof (entry as { model?: unknown }).model, "string", `${name} tier should hold a model`);
+        assert.equal(
+          (entry as { thinkingLevel?: unknown }).thinkingLevel,
+          undefined,
+          `${name} tier should inherit thinking by default`,
+        );
       }
     });
 
     it("always produces the three standard tiers", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig("openai/gpt-4.1", []);
-      assert.deepEqual(Object.keys(cfg.tiers).sort(), ["big", "medium", "small"]);
+      assert.deepEqual(Object.keys(tierModels(cfg)).sort(), ["big", "medium", "small"]);
     });
 
     it("spreads three or more available models across tiers", async () => {
@@ -56,8 +68,8 @@ describe("model-tier-config", () => {
       // verify the structure is still valid.
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig();
-      assert.deepEqual(Object.keys(cfg.tiers).sort(), ["big", "medium", "small"]);
-      for (const val of Object.values(cfg.tiers)) {
+      assert.deepEqual(Object.keys(tierModels(cfg)).sort(), ["big", "medium", "small"]);
+      for (const val of Object.values(tierModels(cfg))) {
         assert.equal(typeof val, "string");
       }
     });
@@ -77,8 +89,8 @@ describe("model-tier-config", () => {
       const withCurrentModel = buildDefaultTierConfig("openai/gpt-4.1", ["a", "b", "c"]);
       const withoutCurrentModel = buildDefaultTierConfig(undefined, ["a", "b", "c"]);
       assert.deepEqual(
-        withCurrentModel.tiers,
-        withoutCurrentModel.tiers,
+        tierModels(withCurrentModel),
+        tierModels(withoutCurrentModel),
         "passing currentModelSpec must not change how availableModels are used",
       );
     });
@@ -86,15 +98,15 @@ describe("model-tier-config", () => {
     it("spreads exactly three available models across small/medium/big (no overlap)", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["model-a", "model-b", "model-c"]);
-      assert.equal(cfg.tiers.small, "model-a");
-      assert.equal(cfg.tiers.medium, "model-b");
-      assert.equal(cfg.tiers.big, "model-c");
+      assert.equal(tierModels(cfg).small, "model-a");
+      assert.equal(tierModels(cfg).medium, "model-b");
+      assert.equal(tierModels(cfg).big, "model-c");
     });
 
     it("spreads available models even when a current model fallback is provided", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig("current-model", ["model-a", "model-b", "model-c"]);
-      assert.deepEqual(cfg.tiers, {
+      assert.deepEqual(tierModels(cfg), {
         small: "model-a",
         medium: "model-b",
         big: "model-c",
@@ -104,15 +116,15 @@ describe("model-tier-config", () => {
     it("spreads two available models: small gets first, medium and big get second", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["model-a", "model-b"]);
-      assert.equal(cfg.tiers.small, "model-a");
-      assert.equal(cfg.tiers.medium, "model-b");
-      assert.equal(cfg.tiers.big, "model-b");
+      assert.equal(tierModels(cfg).small, "model-a");
+      assert.equal(tierModels(cfg).medium, "model-b");
+      assert.equal(tierModels(cfg).big, "model-b");
     });
 
     it("with exactly one available model, all three tiers resolve to it (no crash)", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["only-model"]);
-      assert.deepEqual(cfg.tiers, {
+      assert.deepEqual(tierModels(cfg), {
         small: "only-model",
         medium: "only-model",
         big: "only-model",
@@ -122,7 +134,7 @@ describe("model-tier-config", () => {
     it("with exactly one available model, the current model fallback is ignored in favor of it", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig("current-model", ["only-model"]);
-      assert.deepEqual(cfg.tiers, {
+      assert.deepEqual(tierModels(cfg), {
         small: "only-model",
         medium: "only-model",
         big: "only-model",
@@ -135,33 +147,33 @@ describe("model-tier-config", () => {
       // "medium"/"big", inverting capability. The fix must rank first.
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["claude-3-opus", "gpt-4o-mini"]);
-      assert.equal(cfg.tiers.small, "gpt-4o-mini");
-      assert.equal(cfg.tiers.medium, "claude-3-opus");
-      assert.equal(cfg.tiers.big, "claude-3-opus");
+      assert.equal(tierModels(cfg).small, "gpt-4o-mini");
+      assert.equal(tierModels(cfg).medium, "claude-3-opus");
+      assert.equal(tierModels(cfg).big, "claude-3-opus");
     });
 
     it("respects capability hints for the 2-model case regardless of registry order", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["gpt-4o-mini", "claude-3-opus"]);
-      assert.equal(cfg.tiers.small, "gpt-4o-mini");
-      assert.equal(cfg.tiers.medium, "claude-3-opus");
-      assert.equal(cfg.tiers.big, "claude-3-opus");
+      assert.equal(tierModels(cfg).small, "gpt-4o-mini");
+      assert.equal(tierModels(cfg).medium, "claude-3-opus");
+      assert.equal(tierModels(cfg).big, "claude-3-opus");
     });
 
     it("with four available models, assigns middle index to medium", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["m-a", "m-b", "m-c", "m-d"]);
       // Math.floor(4 / 2) = 2 → medium = m-c
-      assert.equal(cfg.tiers.small, "m-a");
-      assert.equal(cfg.tiers.medium, "m-c");
-      assert.equal(cfg.tiers.big, "m-d");
+      assert.equal(tierModels(cfg).small, "m-a");
+      assert.equal(tierModels(cfg).medium, "m-c");
+      assert.equal(tierModels(cfg).big, "m-d");
     });
 
     it("falls back to empty string for all tiers when no models available", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, []);
-      assert.deepEqual(Object.keys(cfg.tiers).sort(), ["big", "medium", "small"]);
-      for (const val of Object.values(cfg.tiers)) {
+      assert.deepEqual(Object.keys(tierModels(cfg)).sort(), ["big", "medium", "small"]);
+      for (const val of Object.values(tierModels(cfg))) {
         assert.equal(val, "");
       }
     });
@@ -169,7 +181,7 @@ describe("model-tier-config", () => {
     it("falls back to the current model when no available models are known", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig("current-model", []);
-      assert.deepEqual(cfg.tiers, {
+      assert.deepEqual(tierModels(cfg), {
         small: "current-model",
         medium: "current-model",
         big: "current-model",
@@ -186,27 +198,27 @@ describe("model-tier-config", () => {
       // With hint matching, "mini" wins for small regardless of position.
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["gpt-4o-mini", "claude-3-5-sonnet", "gpt-4o"]);
-      assert.equal(cfg.tiers.small, "gpt-4o-mini");
-      assert.equal(cfg.tiers.medium, "claude-3-5-sonnet");
-      assert.equal(cfg.tiers.big, "gpt-4o");
+      assert.equal(tierModels(cfg).small, "gpt-4o-mini");
+      assert.equal(tierModels(cfg).medium, "claude-3-5-sonnet");
+      assert.equal(tierModels(cfg).big, "gpt-4o");
     });
 
     it("assigns small and big via hints when both hint sets match, ignoring list position", async () => {
       // "claude-3-opus" is at index 0 but should be big; "gpt-4o-mini" is at index 2 but should be small.
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["claude-3-opus", "claude-3-5-sonnet", "gpt-4o-mini"]);
-      assert.equal(cfg.tiers.small, "gpt-4o-mini");
-      assert.equal(cfg.tiers.medium, "claude-3-5-sonnet");
-      assert.equal(cfg.tiers.big, "claude-3-opus");
+      assert.equal(tierModels(cfg).small, "gpt-4o-mini");
+      assert.equal(tierModels(cfg).medium, "claude-3-5-sonnet");
+      assert.equal(tierModels(cfg).big, "claude-3-opus");
     });
 
     it("falls back to positional for small/big when no hint matches", async () => {
       // Generic names have no hint substrings — positional behaviour must be preserved.
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["model-a", "model-b", "model-c"]);
-      assert.equal(cfg.tiers.small, "model-a");
-      assert.equal(cfg.tiers.medium, "model-b");
-      assert.equal(cfg.tiers.big, "model-c");
+      assert.equal(tierModels(cfg).small, "model-a");
+      assert.equal(tierModels(cfg).medium, "model-b");
+      assert.equal(tierModels(cfg).big, "model-c");
     });
 
     // -----------------------------------------------------------------------
@@ -221,10 +233,10 @@ describe("model-tier-config", () => {
       // assign from one pool with exclusion so no model is used twice.
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["gpt-4o-mini-pro", "gpt-4o", "claude-3-sonnet"]);
-      const values = Object.values(cfg.tiers);
+      const values = Object.values(tierModels(cfg));
       assert.equal(new Set(values).size, values.length, "all three tiers must be distinct models");
-      assert.equal(cfg.tiers.small, "gpt-4o-mini-pro");
-      assert.notEqual(cfg.tiers.big, cfg.tiers.small);
+      assert.equal(tierModels(cfg).small, "gpt-4o-mini-pro");
+      assert.notEqual(tierModels(cfg).big, tierModels(cfg).small);
     });
 
     it("never inverts capability ranking: big is always at least as capable as medium and small across many model sets", async () => {
@@ -243,15 +255,15 @@ describe("model-tier-config", () => {
       };
       for (const models of scenarios) {
         const cfg = buildDefaultTierConfig(undefined, models);
-        const values = Object.values(cfg.tiers);
+        const values = Object.values(tierModels(cfg));
         assert.equal(new Set(values).size, values.length, `tiers must be distinct for ${JSON.stringify(models)}`);
         assert.ok(
-          rank(cfg.tiers.big) >= rank(cfg.tiers.medium),
-          `big (${cfg.tiers.big}) must not be weaker than medium (${cfg.tiers.medium})`,
+          rank(tierModels(cfg).big) >= rank(tierModels(cfg).medium),
+          `big (${tierModels(cfg).big}) must not be weaker than medium (${tierModels(cfg).medium})`,
         );
         assert.ok(
-          rank(cfg.tiers.medium) >= rank(cfg.tiers.small),
-          `medium (${cfg.tiers.medium}) must not be weaker than small (${cfg.tiers.small})`,
+          rank(tierModels(cfg).medium) >= rank(tierModels(cfg).small),
+          `medium (${tierModels(cfg).medium}) must not be weaker than small (${tierModels(cfg).small})`,
         );
       }
     });
@@ -262,15 +274,15 @@ describe("model-tier-config", () => {
       // small one, and small must never end up in a higher tier.
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["vendor/neutral-model", "vendor/tiny-mini-model"]);
-      assert.equal(cfg.tiers.small, "vendor/tiny-mini-model");
-      assert.equal(cfg.tiers.medium, "vendor/neutral-model");
-      assert.equal(cfg.tiers.big, "vendor/neutral-model");
+      assert.equal(tierModels(cfg).small, "vendor/tiny-mini-model");
+      assert.equal(tierModels(cfg).medium, "vendor/neutral-model");
+      assert.equal(tierModels(cfg).big, "vendor/neutral-model");
     });
 
     it("with 3+ distinct models, small/medium/big are always pairwise distinct", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig(undefined, ["model-a", "model-b", "model-c", "model-d", "model-e"]);
-      const values = Object.values(cfg.tiers);
+      const values = Object.values(tierModels(cfg));
       assert.equal(new Set(values).size, 3, "small/medium/big must all be distinct with 5 available models");
     });
   });
@@ -303,7 +315,11 @@ describe("model-tier-config", () => {
       const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
       const cfgPath = join(tmpDir, "model-tiers.json");
       const config = {
-        tiers: { small: "gpt-4.1-mini", medium: "gpt-4.1", big: "gpt-5" },
+        tiers: {
+          small: { model: "gpt-4.1-mini", thinkingLevel: "low" as const },
+          medium: { model: "gpt-4.1", thinkingLevel: "high" as const },
+          big: { model: "gpt-5", thinkingLevel: "xhigh" as const },
+        },
       };
       saveModelTierConfig(config, cfgPath);
       const loaded = loadModelTierConfig(cfgPath);
@@ -343,7 +359,7 @@ describe("model-tier-config", () => {
       rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it("returns null when a tier value is not a string", async () => {
+    it("returns null when a tier value is neither a string nor an entry object", async () => {
       const { loadModelTierConfig } = await loadModule();
       const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
       const cfgPath = join(tmpDir, "model-tiers.json");
@@ -352,13 +368,45 @@ describe("model-tier-config", () => {
       rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it("accepts a config where a tier value is a valid string", async () => {
-      const { loadModelTierConfig } = await loadModule();
+    it("accepts and normalizes a legacy string tier value", async () => {
+      const { loadModelTierConfig, resolveTierModel } = await loadModule();
       const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
       const cfgPath = join(tmpDir, "model-tiers.json");
       writeFileSync(cfgPath, '{"tiers": {"small": "gpt-4.1-mini"}}', "utf-8");
       const result = loadModelTierConfig(cfgPath);
-      assert.equal(result?.tiers.small, "gpt-4.1-mini");
+      assert.ok(result);
+      assert.equal(resolveTierModel("small", result), "gpt-4.1-mini");
+      assert.deepEqual(result.tiers.small, { model: "gpt-4.1-mini" });
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("accepts valid thinking levels and resolves them", async () => {
+      const { loadModelTierConfig, resolveTierModel, resolveTierThinkingLevel } = await loadModule();
+      const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
+      const cfgPath = join(tmpDir, "model-tiers.json");
+      writeFileSync(cfgPath, '{"tiers": {"small": {"model": "gpt-5-mini", "thinkingLevel": "high"}}}', "utf-8");
+      const result = loadModelTierConfig(cfgPath);
+      assert.ok(result);
+      assert.equal(resolveTierModel("small", result), "gpt-5-mini");
+      assert.equal(resolveTierThinkingLevel("small", result), "high");
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns null for invalid thinking levels", async () => {
+      const { loadModelTierConfig } = await loadModule();
+      const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
+      const cfgPath = join(tmpDir, "model-tiers.json");
+      writeFileSync(cfgPath, '{"tiers": {"small": {"model": "gpt-5-mini", "thinkingLevel": "ultra"}}}', "utf-8");
+      assert.equal(loadModelTierConfig(cfgPath), null);
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns null when an entry object lacks a model string", async () => {
+      const { loadModelTierConfig } = await loadModule();
+      const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
+      const cfgPath = join(tmpDir, "model-tiers.json");
+      writeFileSync(cfgPath, '{"tiers": {"small": {"thinkingLevel": "high"}}}', "utf-8");
+      assert.equal(loadModelTierConfig(cfgPath), null);
       rmSync(tmpDir, { recursive: true, force: true });
     });
   });

--- a/tests/run-persistence.test.ts
+++ b/tests/run-persistence.test.ts
@@ -457,7 +457,7 @@ test(
       phases: ["Scan", "Analyze", "Report"],
       currentPhase: "Analyze",
       agents: [
-        { id: 1, label: "agent-a", prompt: "scan", status: "done", result: { found: true } },
+        { id: 1, label: "agent-a", prompt: "scan", status: "done", result: { found: true }, thinkingLevel: "high" },
         { id: 2, label: "agent-b", prompt: "analyze", status: "running" },
       ],
       logs: ["started", "phase: Scan", "phase: Analyze"],
@@ -480,6 +480,7 @@ test(
     assert.deepEqual(loaded.phases, ["Scan", "Analyze", "Report"]);
     assert.equal(loaded.agents.length, 2);
     assert.deepEqual(loaded.agents[0].result, { found: true });
+    assert.equal(loaded.agents[0].thinkingLevel, "high");
     assert.equal(loaded.agents[1].status, "running");
     assert.deepEqual(loaded.logs, ["started", "phase: Scan", "phase: Analyze"]);
     assert.deepEqual(loaded.tokenUsage, { input: 500, output: 200, total: 700 });

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -495,6 +495,7 @@ describe("renderPanelDetailed", () => {
           phase: "Scan",
           tokens: blueTokens,
           model: "anthropic/claude-haiku-4-5",
+          thinkingLevel: "low",
         },
         { id: 2, label: "audit_auth", status: "running", phase: "Scan", tokens: 1800 },
         { id: 3, label: "scan_middleware", status: "queued", phase: "Scan" },
@@ -533,8 +534,8 @@ describe("renderPanelDetailed", () => {
     );
     // Agent rows: status icons + label + tokens + model
     assert.ok(
-      lines.some((l) => l.includes("[1] ✓ discover_routes") && /2\.1K tok/.test(l) && /claude-haiku-4-5/.test(l)),
-      "done agent row with model",
+      lines.some((l) => l.includes("[1] ✓ discover_routes") && /2\.1K tok/.test(l) && /claude-haiku-4-5 · low/.test(l)),
+      "done agent row with model and thinking",
     );
     assert.ok(
       lines.some((l) => l.includes("[2] ● audit_auth") && /1\.8K tok/.test(l)),

--- a/tests/workflow-display.test.ts
+++ b/tests/workflow-display.test.ts
@@ -30,7 +30,7 @@ function agent(
   label: string,
   status: "queued" | "running" | "done" | "error" | "skipped",
   phase?: string,
-  opts?: { resultPreview?: string; tokens?: number; model?: string; prompt?: string },
+  opts?: { resultPreview?: string; tokens?: number; model?: string; thinkingLevel?: string; prompt?: string },
 ) {
   return {
     id,
@@ -41,6 +41,7 @@ function agent(
     ...(opts?.resultPreview ? { resultPreview: opts.resultPreview } : {}),
     ...(opts?.tokens ? { tokens: opts.tokens } : {}),
     ...(opts?.model ? { model: opts.model } : {}),
+    ...(opts?.thinkingLevel ? { thinkingLevel: opts.thinkingLevel } : {}),
   };
 }
 
@@ -170,6 +171,16 @@ describe("renderWorkflowText", () => {
     // toLocaleString() output depends on locale (UK/US uses commas, PL uses NBSP)
     // Check with a regex matching any thousands separator between 12 and 345
     assert.ok(/12[ ,.\u00a0]345/.test(text), "should show formatted token count");
+  });
+
+  it("shows agent model with thinking level when available", async () => {
+    const { createWorkflowSnapshot, renderWorkflowLines } = await loadDisplay();
+    const snap = createWorkflowSnapshot(fakeMeta());
+    snap.agents = [
+      agent(1, "reasoner", "done", "Research", { model: "openai/gpt-5.5", thinkingLevel: "xhigh" }),
+    ] as never[];
+    const text = renderWorkflowLines(snap).join("\n");
+    assert.ok(text.includes("gpt-5.5 · xhigh"), "should show model with thinking level");
   });
 
   it("truncates long agent labels", async () => {

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -223,6 +223,60 @@ return { a, b }`;
 );
 
 test(
+  "each agent's thinking level is recorded for /workflows",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: fakeAgent(), mainModel: "anthropic/claude-opus-4-8" });
+    const script = `export const meta = { name: 'thinking_demo', description: 'per-agent thinking' }
+const a = await agent('reason', { label: 'judge', thinkingLevel: 'xhigh' })
+return { a }`;
+    await manager.runSync(script);
+
+    const run = manager.listRuns().find((r) => r.workflowName === "thinking_demo");
+    assert.equal(run?.agents[0]?.thinkingLevel, "xhigh");
+  }),
+);
+
+test(
+  "live agent token progress updates the running snapshot",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(_prompt: string, options: any) {
+          options.onUsageUpdate?.({
+            input: 9,
+            output: 6,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 15,
+            cost: 0,
+            estimated: true,
+          });
+          options.onUsage?.({ input: 20, output: 10, cacheRead: 0, cacheWrite: 0, total: 30, cost: 0.001 });
+          return "ok";
+        },
+      },
+    });
+    const progressTotals: Array<{ tokens?: number; estimated?: boolean; runTotal?: number }> = [];
+    manager.on("agentProgress", ({ runId }) => {
+      const snap = manager.getRun(runId)?.snapshot;
+      progressTotals.push({
+        tokens: snap?.agents[0]?.tokens,
+        estimated: snap?.agents[0]?.tokensEstimated,
+        runTotal: snap?.tokenUsage?.total,
+      });
+    });
+
+    await manager.runSync(oneAgentScript);
+
+    assert.deepEqual(progressTotals, [{ tokens: 15, estimated: true, runTotal: 15 }]);
+    const run = manager.listRuns().find((r) => r.workflowName === "tracked_demo");
+    assert.equal(run?.agents[0]?.tokens, 30);
+    assert.equal(run?.agents[0]?.tokensEstimated, false);
+  }),
+);
+
+test(
   "runSync persists recoverable agent error details for /workflows",
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -383,6 +383,27 @@ test("resume re-runs only the changed call (hash mismatch)", async () => {
   assert.equal(second.state.calls, 1, "only the edited call re-runs");
 });
 
+test("resume re-runs when an agent thinkingLevel changes", async () => {
+  const script = (thinking: string) => `export const meta = { name: 'thinking_resume', description: 'resume' }
+const a = await agent('work', { label: 'a', thinkingLevel: '${thinking}' })
+return { a }`;
+  const first = countingAgent();
+  const journal: JournalEntry[] = [];
+  await runWorkflow(script("high"), {
+    agent: first.runner,
+    persistLogs: false,
+    onAgentJournal: (e) => journal.push(e),
+  });
+
+  const second = countingAgent();
+  await runWorkflow(script("xhigh"), {
+    agent: second.runner,
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((e) => [e.index, e])),
+  });
+  assert.equal(second.state.calls, 1, "thinking changes must invalidate the cached agent result");
+});
+
 const threeCallScript = `export const meta = { name: 'prefix', description: 'prefix resume' }
 const a = await agent('A', { label: 'a' })
 const b = await agent('B', { label: 'b' })

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -71,6 +71,7 @@ test("createWorkflowTool promptGuidelines mention model routing", () => {
   const all = tool.promptGuidelines.join(" ");
   assert.ok(all.includes("opts.tier"), "should mention opts.tier");
   assert.ok(all.includes("opts.model"), "should mention opts.model");
+  assert.ok(all.includes("opts.thinkingLevel"), "should mention opts.thinkingLevel");
   assert.ok(all.includes("small") || all.includes("medium") || all.includes("big"), "should mention tier names");
 });
 
@@ -126,6 +127,7 @@ test("modelRoutingGuideline explains tier vs model priority", () => {
   const text = modelRoutingGuideline();
   assert.ok(text.includes("opts.tier"), "should mention opts.tier");
   assert.ok(text.includes("opts.model"), "should mention opts.model");
+  assert.ok(text.includes("thinking"), "should mention thinking levels");
   assert.ok(
     /opts\.(tier|model).+opts\.(model|tier)/.test(text),
     "should explain ordering / relationship between tier and model",

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -24,6 +24,7 @@ function fakeManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
         resultPreview: "found 2",
         tokens: 100,
         model: "fast-llm/model",
+        thinkingLevel: "high",
       },
       {
         id: 2,
@@ -34,6 +35,7 @@ function fakeManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
         resultPreview: "found 1",
         tokens: 50,
         model: "fast-llm/model",
+        thinkingLevel: "low",
       },
       { id: 3, label: "write report", phase: "Report", prompt: "write it", status: "running", tokens: 0 },
     ],
@@ -452,7 +454,7 @@ test("renderNavigator shows agent detail view", () => {
   assert.match(text, /found 2/);
   assert.match(text, /Status:/);
   assert.match(text, /Model:/);
-  assert.match(text, /model/); // shortModel strips provider prefix
+  assert.match(text, /model · high/); // shortModel strips provider prefix and shows thinking
   assert.match(text, /j\/k scroll/); // detail view footer
 });
 
@@ -473,14 +475,14 @@ test("renderNavigator shows agent error diagnostics in detail view", () => {
   assert.match(text, /tool read: README content/);
 });
 
-test("renderNavigator shows model info in agent rows", () => {
+test("renderNavigator shows model and thinking info in agent rows", () => {
   const model = new NavigatorModel(fakeManager());
   const state = new NavigatorState();
   state.drill(model);
   state.drill(model);
   const lines = renderNavigator(state, model, 80);
   const text = lines.join("\n");
-  assert.match(text, /model/);
+  assert.match(text, /model · high/);
 });
 
 test("renderNavigator shows correct footer hint per view", () => {

--- a/tests/workflows-models-command.test.ts
+++ b/tests/workflows-models-command.test.ts
@@ -3,10 +3,7 @@
  *
  * Since pi.registerCommand and ctx.ui functions are only available at runtime
  * inside Pi, these tests focus on the pure logic: command creation,
- * the editSingleTier single-select helper, and integration with model-tier-config.
- *
- * editSingleTier now uses ctx.ui.custom() with SelectList.
- * In tests, we mock ctx.ui.custom to directly return the expected value.
+ * the editSingleTier helper, and integration with model-tier-config.
  */
 
 import assert from "node:assert/strict";
@@ -15,6 +12,25 @@ import { describe, it, mock } from "node:test";
 async function loadCommand() {
   const mod = await import("../src/workflows-models-command.js");
   return mod;
+}
+
+function editCtx(selectResults: Array<string | null>, customResult: string | null = null) {
+  let selectIndex = 0;
+  return {
+    ui: {
+      select: mock.fn(async () => selectResults[selectIndex++] ?? null),
+      custom: mock.fn(async () => customResult),
+      notify: mock.fn(),
+    },
+    modelRegistry: {
+      getAvailable: () => [
+        { provider: "openai", id: "gpt-4.1-mini" },
+        { provider: "openai", id: "gpt-5" },
+      ],
+      getAll: () => [],
+      find: () => undefined,
+    },
+  };
 }
 
 describe("workflows-models-command", () => {
@@ -47,6 +63,7 @@ describe("workflows-models-command", () => {
       registerWorkflowModelsCommand(mockPi as never);
       assert.ok(capturedDescription.length > 0, "description should not be empty");
       assert.ok(capturedDescription.toLowerCase().includes("tier"), "description should mention tiers");
+      assert.ok(capturedDescription.toLowerCase().includes("thinking"), "description should mention thinking");
     });
   });
 
@@ -56,66 +73,63 @@ describe("workflows-models-command", () => {
       assert.equal(typeof mod.editSingleTier, "function");
     });
 
-    it("returns null when user presses Escape (done with null)", async () => {
+    it("returns null when user cancels", async () => {
       const { editSingleTier } = await import("../src/workflows-models-command.js");
-      // Mock ctx.ui.custom to return null (simulating user cancelling)
-      const ctx = {
-        ui: {
-          custom: mock.fn(async () => null),
-          notify: mock.fn(),
-        },
-      };
-      const tiers: Record<string, string> = { small: "gpt-4.1-mini" };
+      const ctx = editCtx(["Cancel"]);
+      const tiers = { small: { model: "gpt-4.1-mini" } };
 
       const result = await editSingleTier(ctx as never, tiers, "small");
       assert.equal(result, null);
     });
 
-    it("returns null when user selects the same model (no change)", async () => {
+    it("returns null when user selects Done without changes", async () => {
       const { editSingleTier } = await import("../src/workflows-models-command.js");
-      // Mock ctx.ui.custom to return the same model that's already selected
-      const ctx = {
-        ui: {
-          custom: mock.fn(async () => "gpt-4.1-mini"),
-          notify: mock.fn(),
-        },
-      };
-      const tiers: Record<string, string> = { small: "gpt-4.1-mini" };
+      const ctx = editCtx(["Done"]);
+      const tiers = { small: { model: "gpt-4.1-mini" } };
 
       const result = await editSingleTier(ctx as never, tiers, "small");
-      assert.equal(result, null); // no change
+      assert.equal(result, null);
     });
 
     it("selects a different model and returns updated tiers", async () => {
       const { editSingleTier } = await import("../src/workflows-models-command.js");
-      // Mock ctx.ui.custom to return a different model
-      const ctx = {
-        ui: {
-          custom: mock.fn(async () => "gpt-5"),
-          notify: mock.fn(),
-        },
-      };
-      const tiers: Record<string, string> = { small: "gpt-4.1-mini" };
+      const ctx = editCtx(["Model → gpt-4.1-mini", "Save tier"], "openai/gpt-5");
+      const tiers = { small: { model: "gpt-4.1-mini" } };
 
       const result = await editSingleTier(ctx as never, tiers, "small");
       assert.ok(result, "should return updated tiers");
-      assert.equal(result.small, "gpt-5", "should have changed model");
-      assert.equal(typeof result.small, "string", "should still be a string");
+      assert.deepEqual(result.small, { model: "openai/gpt-5" });
+      assert.equal(ctx.ui.notify.mock.callCount(), 1);
     });
 
-    it("selects a model when no current model exists", async () => {
+    it("selects a thinking level without changing the model", async () => {
       const { editSingleTier } = await import("../src/workflows-models-command.js");
-      const ctx = {
-        ui: {
-          custom: mock.fn(async () => "openai/gpt-4.1-mini"),
-          notify: mock.fn(),
-        },
-      };
-      const tiers: Record<string, string> = {};
+      const ctx = editCtx(["Thinking → inherit", "high", "Save tier"]);
+      const tiers = { small: { model: "gpt-4.1-mini" } };
 
       const result = await editSingleTier(ctx as never, tiers, "small");
       assert.ok(result, "should return updated tiers");
-      assert.equal(result.small, "openai/gpt-4.1-mini");
+      assert.deepEqual(result.small, { model: "gpt-4.1-mini", thinkingLevel: "high" });
+    });
+
+    it("can clear an existing thinking level back to inherit", async () => {
+      const { editSingleTier } = await import("../src/workflows-models-command.js");
+      const ctx = editCtx(["Thinking → high", "Inherit session/default", "Save tier"]);
+      const tiers = { small: { model: "gpt-4.1-mini", thinkingLevel: "high" as const } };
+
+      const result = await editSingleTier(ctx as never, tiers, "small");
+      assert.ok(result, "should return updated tiers");
+      assert.deepEqual(result.small, { model: "gpt-4.1-mini" });
+    });
+
+    it("normalizes a legacy string tier when editing", async () => {
+      const { editSingleTier } = await import("../src/workflows-models-command.js");
+      const ctx = editCtx(["Thinking → inherit", "xhigh", "Save tier"]);
+      const tiers = { small: "gpt-4.1-mini" };
+
+      const result = await editSingleTier(ctx as never, tiers, "small");
+      assert.ok(result, "should return updated tiers");
+      assert.deepEqual(result.small, { model: "gpt-4.1-mini", thinkingLevel: "xhigh" });
     });
   });
 });

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -109,7 +109,10 @@ test("createWorktree falls back when target branch already exists", async () => 
     const wt = await createWorktreeLive(repo, name);
     assert.equal(wt.isolated, false);
     assert.equal(wt.cwd, repo);
-    assert.ok(/already exists/i.test(wt.reason ?? ""), `Expected 'already exists' error, got: ${wt.reason}`);
+    assert.ok(
+      /pi\/wf\/conflict-branch|conflict-branch/i.test(wt.reason ?? ""),
+      `Expected branch conflict error, got: ${wt.reason}`,
+    );
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }


### PR DESCRIPTION
 Adds workflow thinking-level support and richer live progress reporting.

 - Extends workflow model tiers to store both model and optional thinkingLevel, while preserving backward compatibility with legacy string-only configs.

 - Adds opts.thinkingLevel to agent() and applies tier/default thinking levels to subagent sessions.
 - Updates /workflows-models so each tier can edit model + thinking level (inherit, off, minimal, low, medium, high, xhigh).

 - Adds live token progress for running agents, including estimated tokens while streaming/thinking and finalized provider usage when available.
 - Enhances the workflow panel/navigator to show per-agent tokens, model + thinking level, aggregate cost, and live tok/s in detailed mode.

 - Updates README and expands unit coverage for tier normalization, thinking-level routing, token progress, persistence, and UI rendering.