### PR TITLE
feat: show a fresh vs cached token split in the workflow displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ return await agent('Synthesize and double-check these findings:\n' + findings.jo
 - **Journaled resume** — an interrupted run replays finished agents from a journal (no re-run, no tokens) and runs only what's left or what you changed.
 - **Git worktree isolation** — `isolation: "worktree"` gives an agent its own branch, so parallel agents can edit the same files without clobbering each other.
 - **Real token & cost accounting** — read from each subagent's session, not estimated. Runs have no default token cap; `tokenBudget`, phase budgets, and `budget` let you add explicit gates when you want them.
-- **Background by default** — the turn ends right away, a live "Workflows running" panel tracks runs, and each result is delivered back so the conversation auto-continues when it finishes. The panel is compact by default; `/workflows-progress detailed` expands it inline to per-phase/per-agent rows with tokens, cost, and a live tok/s rate (so a stalled agent shows as 0 tok/s) — no need to open `/workflows`.
+- **Background by default** — the turn ends right away, a live "Workflows running" panel tracks runs, and each result is delivered back so the conversation auto-continues when it finishes. The panel is compact by default; `/workflows-progress detailed` expands it inline to per-phase/per-agent rows with a fresh/cache token split, cost, and a live tok/s rate (so a stalled agent shows as 0 tok/s) — no need to open `/workflows`.
 - **Interactive `/workflows` TUI** — drill runs → phases → agents → detail; inspect per-agent failures and compact subagent history; pause, stop, restart, and save runs from the keyboard.
 - **Quality patterns built in** — `verify()`, `judgePanel()`, `loopUntilDry()`, and `completenessCheck()` for adversarial review, best-of-N, and exhaustive discovery.
 - **Ultracode** — `/ultracode` is a standing opt-in that auto-arms an exhaustive multi-agent workflow for every substantive message, the way Claude Code's ultracode does. `/effort high` is the lighter tier.
@@ -111,7 +111,7 @@ The same model — on Pi, plus the production pieces a real run needs:
                             is off (/workflows-trigger off); the run shows in the panel + /workflows.
 /workflows-progress compact|detailed|status
                             switch the live panel between the compact one-liner and the detailed
-                            per-phase/per-agent view (with tokens, cost, and a live tok/s rate)
+                            per-phase/per-agent view (with a fresh/cache token split, cost, and a live tok/s rate)
 /workflows-progress-max <N> cap agents shown per phase in detailed mode (1-1000, default 8)
 /workflows-models           map the small / medium / big tiers to real models
 /ultracode [off]            ultracode: auto-arm an exhaustive workflow for every substantive message

--- a/src/display.ts
+++ b/src/display.ts
@@ -18,6 +18,15 @@ export interface WorkflowAgentSnapshot {
   history?: AgentHistoryEntry[];
   /** Tokens used by this agent. */
   tokens?: number;
+  /** Per-agent token usage breakdown (fresh input+output vs cached), when known. */
+  tokenUsage?: {
+    input: number;
+    output: number;
+    total: number;
+    cost: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
   /** The model this agent ran on (provider/id), when known. */
   model?: string;
 }
@@ -214,7 +223,16 @@ export function renderWorkflowLines(
     for (const agent of visibleAgents) {
       const order = `[${agent.id}]`;
       const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
-      const agentTokens = agent.tokens ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`) : "";
+      const agentTokens = agent.tokenUsage
+        ? theme.fg(
+            "dim",
+            ` [${(agent.tokenUsage.input + agent.tokenUsage.output).toLocaleString()} fresh${
+              agent.tokenUsage.cacheRead > 0 ? ` · ${agent.tokenUsage.cacheRead.toLocaleString()} cache` : ""
+            }]`,
+          )
+        : agent.tokens
+          ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`)
+          : "";
       lines.push(`    ${order} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
     }
     if (agents.length > visibleAgents.length)
@@ -226,7 +244,16 @@ export function renderWorkflowLines(
     lines.push(theme.fg("accent", "  Unphased"));
     for (const agent of unphased.slice(-maxAgents)) {
       const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
-      const agentTokens = agent.tokens ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`) : "";
+      const agentTokens = agent.tokenUsage
+        ? theme.fg(
+            "dim",
+            ` [${(agent.tokenUsage.input + agent.tokenUsage.output).toLocaleString()} fresh${
+              agent.tokenUsage.cacheRead > 0 ? ` · ${agent.tokenUsage.cacheRead.toLocaleString()} cache` : ""
+            }]`,
+          )
+        : agent.tokens
+          ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`)
+          : "";
       lines.push(`    [${agent.id}] ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
     }
   }

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -71,7 +71,9 @@ function fitLine(line: string, width?: number): string {
 
 export function deliverText(run: ManagedRun): string {
   const summary = summarizeResult(run.result?.result);
-  const tokens = run.result?.tokenUsage ? ` · ${run.result.tokenUsage.total.toLocaleString()} tokens` : "";
+  const tu = run.result?.tokenUsage;
+  const cost = tu?.cost ? ` · $${tu.cost.toFixed(tu.cost >= 0.01 ? 2 : 4)}` : "";
+  const tokens = tu ? ` · ${fmtFreshCache(tu.input, tu.output, tu.cacheRead ?? 0)}${cost}` : "";
   const agents = run.result?.agentCount ?? run.snapshot.agentCount;
   const duration = run.result?.durationMs ? ` · ${(run.result.durationMs / 1000).toFixed(1)}s` : "";
   return [
@@ -228,6 +230,19 @@ function fmtTokensShort(n: number): string {
   return `${(n / 1_000_000).toFixed(1)}M`;
 }
 
+/**
+ * Format a fresh (input+output) vs cache (cacheRead) token split. The cache segment
+ * is omitted when there were no cache reads (e.g. a provider without prompt caching),
+ * so it reads "6.3M fresh" rather than a dangling "6.3M fresh ·  cache". cacheWrite (the
+ * one-time cache-creation premium) is intentionally excluded from both counts; its dollar
+ * impact already shows in the delivery line's $cost.
+ */
+function fmtFreshCache(input: number, output: number, cacheRead: number): string {
+  const fresh = fmtTokensShort(input + output) || "0";
+  const cache = fmtTokensShort(cacheRead);
+  return cache ? `${fresh} fresh · ${cache} cache` : `${fresh} fresh`;
+}
+
 /** Normalize the configured per-phase agent cap to a sane integer (default 8). */
 export function clampMaxAgents(value: number | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return 8;
@@ -274,7 +289,11 @@ function renderRunBody(
 
     const visible = phaseAgents.slice(-maxAgents);
     for (const a of visible) {
-      const tok = a.tokens ? dim(` ${fmtTokensShort(a.tokens)} tok`) : "";
+      const tok = a.tokenUsage
+        ? dim(` ${fmtFreshCache(a.tokenUsage.input, a.tokenUsage.output, a.tokenUsage.cacheRead)}`)
+        : a.tokens
+          ? dim(` ${fmtTokensShort(a.tokens)} tok`)
+          : "";
       const mdl = shortModel(a.model);
       const model = mdl ? dim(` · ${mdl}`) : "";
       lines.push(`    [${a.id}] ${statusIcon(a.status)} ${shorten(a.label, 40)}${tok}${model}`);

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -368,6 +368,7 @@ export class WorkflowManager extends EventEmitter {
             agent.errorCode = event.errorCode;
             agent.recoverable = event.recoverable;
             agent.tokens = event.tokens;
+            if (event.tokenUsage) agent.tokenUsage = event.tokenUsage;
             if (event.model) agent.model = event.model;
           }
           this.emit("agentEnd", { runId: managed.runId, ...event });

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -73,6 +73,14 @@ interface AgentRow {
   status: string;
   phase?: string;
   tokens?: number;
+  tokenUsage?: {
+    input: number;
+    output: number;
+    total: number;
+    cost: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
   model?: string;
 }
 
@@ -161,7 +169,15 @@ export class NavigatorModel {
     if (!snap) return [];
     return snap.agents
       .filter((a) => (a.phase ?? "(no phase)") === phase)
-      .map((a) => ({ id: a.id, label: a.label, status: a.status, phase: a.phase, tokens: a.tokens, model: a.model }));
+      .map((a) => ({
+        id: a.id,
+        label: a.label,
+        status: a.status,
+        phase: a.phase,
+        tokens: a.tokens,
+        tokenUsage: a.tokenUsage,
+        model: a.model,
+      }));
   }
 
   agentDetail(runId: string, agentId: number): WorkflowAgentSnapshot | undefined {
@@ -451,7 +467,11 @@ function rightAgentRow(
   theme: ThemeLike,
 ): string {
   const dotColor = AGENT_DOT_COLOR[a.status] ?? "dim";
-  const stats = `${compactTokens(a.tokens ?? 0)} tok`;
+  const stats = a.tokenUsage
+    ? `${compactTokens(a.tokenUsage.input + a.tokenUsage.output)} fresh${
+        a.tokenUsage.cacheRead > 0 ? ` · ${compactTokens(a.tokenUsage.cacheRead)} cache` : ""
+      }`
+    : `${compactTokens(a.tokens ?? 0)} tok`;
   const model = shortModel(a.model) ?? "";
 
   // Stable 2-cell marker so columns never shift on selection: "› " | "  ".

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -116,6 +116,7 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
     phase?: string;
     result: unknown;
     tokens?: number;
+    tokenUsage?: AgentUsage;
     worktree?: string;
     model?: string;
     error?: string;
@@ -547,6 +548,7 @@ export async function runWorkflow<T = unknown>(
               phase: assignedPhase,
               result,
               tokens,
+              tokenUsage: usage,
               worktree: runCwd,
               model: displayModel,
             });
@@ -570,6 +572,7 @@ export async function runWorkflow<T = unknown>(
               phase: assignedPhase,
               result: null,
               tokens,
+              tokenUsage: usage,
               worktree: runCwd,
               model: displayModel,
               error: workflowError.message,

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -90,9 +90,33 @@ describe("installResultDelivery", () => {
     assert.ok(calls[0].content.includes("All tests passed"), "should contain All tests passed");
     assert.ok(calls[0].content.includes("test-workflow"), "should contain test-workflow");
     assert.ok(calls[0].content.includes("3 agents"), "should contain 3 agents");
-    // locale may format the group separator as ',' / '.' / ' ' / none
-    assert.ok(/50[\s,.]?000/.test(calls[0].content), "should contain 50000 tokens formatted");
+    // deliverText shows the fresh/cache split; the cache segment is omitted with no cache reads.
+    assert.ok(calls[0].content.includes("50.0K fresh"), "should show fresh tokens (input+output)");
+    assert.ok(!calls[0].content.includes("cache"), "omits the cache segment when cacheRead is 0");
     assert.ok(calls[0].content.includes("1.5s"), "should contain 1.5s");
+  });
+
+  it("shows the fresh/cache split and cost in the delivery line", () => {
+    const pi = createMockPi();
+    // A caching model: little fresh input+output, most of the tokens are cheap cache reads.
+    const manager = createMockManager(
+      makeRun({
+        result: {
+          agentCount: 2,
+          durationMs: 1000,
+          tokenUsage: { input: 80000, output: 20000, total: 6100000, cacheRead: 6000000, cacheWrite: 0, cost: 6.7 },
+          result: { verdict: "done" },
+        },
+      }),
+    );
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.emit("complete", { runId: "test-run-1" });
+
+    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
+    assert.ok(content.includes("100.0K fresh"), `fresh should be input+output; got: ${content}`);
+    assert.ok(content.includes("6.0M cache"), `cache should be cacheRead; got: ${content}`);
+    assert.ok(content.includes("$6.70"), `cost should be shown; got: ${content}`);
   });
 
   // ── deliverText: fallback chain ──
@@ -510,6 +534,46 @@ describe("renderPanelDetailed", () => {
       getRun: (id: string) => (id === "r1" ? { snapshot, status } : undefined),
     };
   }
+
+  it("renders a per-agent fresh/cache split when tokenUsage is present", async () => {
+    const { renderPanelDetailed } = await import("../src/task-panel.js");
+    const snapshot = {
+      name: "wf",
+      phases: ["Scan"],
+      currentPhase: "Scan",
+      logs: [],
+      agents: [
+        {
+          id: 1,
+          label: "cached_agent",
+          status: "done",
+          phase: "Scan",
+          tokens: 3100000,
+          // Opus-style: little fresh input+output, most of it cheap cache reads.
+          tokenUsage: { input: 80000, output: 20000, total: 3100000, cacheRead: 3000000, cacheWrite: 0, cost: 0.4 },
+          model: "github-copilot/claude-opus-4.8",
+        },
+      ],
+      tokenUsage: { total: 0, input: 0, output: 0, cost: 0 },
+    };
+    const manager = {
+      listRuns: () => [
+        {
+          runId: "r2",
+          workflowName: "wf",
+          status: "running",
+          agents: snapshot.agents,
+          tokenUsage: snapshot.tokenUsage,
+        },
+      ],
+      getRun: (id: string) => (id === "r2" ? { snapshot, status: "running" } : undefined),
+    };
+    const lines = renderPanelDetailed(manager as never, theme as never, undefined, 8, 1000);
+    assert.ok(
+      lines.some((l) => l.includes("[1] ✓ cached_agent") && /100\.0K fresh/.test(l) && /3\.0M cache/.test(l)),
+      `expected a per-agent fresh/cache row, got:\n${lines.join("\n")}`,
+    );
+  });
 
   it("renders aggregate tokens, cost, phases, and per-agent rows", async () => {
     const { renderPanelDetailed, clearTokenSamples } = await import("../src/task-panel.js");

--- a/tests/workflow-display.test.ts
+++ b/tests/workflow-display.test.ts
@@ -30,7 +30,13 @@ function agent(
   label: string,
   status: "queued" | "running" | "done" | "error" | "skipped",
   phase?: string,
-  opts?: { resultPreview?: string; tokens?: number; model?: string; prompt?: string },
+  opts?: {
+    resultPreview?: string;
+    tokens?: number;
+    tokenUsage?: { input: number; output: number; total: number; cost: number; cacheRead: number; cacheWrite: number };
+    model?: string;
+    prompt?: string;
+  },
 ) {
   return {
     id,
@@ -40,6 +46,7 @@ function agent(
     prompt: opts?.prompt ?? `execute ${label}`,
     ...(opts?.resultPreview ? { resultPreview: opts.resultPreview } : {}),
     ...(opts?.tokens ? { tokens: opts.tokens } : {}),
+    ...(opts?.tokenUsage ? { tokenUsage: opts.tokenUsage } : {}),
     ...(opts?.model ? { model: opts.model } : {}),
   };
 }
@@ -170,6 +177,21 @@ describe("renderWorkflowText", () => {
     // toLocaleString() output depends on locale (UK/US uses commas, PL uses NBSP)
     // Check with a regex matching any thousands separator between 12 and 345
     assert.ok(/12[ ,.\u00a0]345/.test(text), "should show formatted token count");
+  });
+
+  it("shows a fresh/cache split for an agent with tokenUsage", async () => {
+    const { createWorkflowSnapshot, renderWorkflowLines } = await loadDisplay();
+    const snap = createWorkflowSnapshot(fakeMeta());
+    snap.agents = [
+      agent(1, "cached-agent", "done", "Research", {
+        tokens: 3_100_000,
+        tokenUsage: { input: 80_000, output: 20_000, total: 3_100_000, cacheRead: 3_000_000, cacheWrite: 0, cost: 0.4 },
+      }),
+    ] as never[];
+    const text = renderWorkflowLines(snap).join("\n");
+    // fresh = input+output = 100,000; cache = cacheRead = 3,000,000 (locale-flexible separators)
+    assert.ok(/100[ ,.\u00a0]000 fresh/.test(text), "shows fresh = input+output");
+    assert.ok(/3[ ,.\u00a0]000[ ,.\u00a0]000 cache/.test(text), "shows cache = cacheRead");
   });
 
   it("truncates long agent labels", async () => {
@@ -626,8 +648,8 @@ describe("deliverText", () => {
   it("includes token count when available", async () => {
     const { deliverText } = await loadTaskPanel();
     const text = deliverText(fakeManagedRun());
-    assert.ok(text.includes("150"), "should show token count");
-    assert.ok(text.includes("tokens"), "should mention tokens");
+    assert.ok(text.includes("150"), "should show fresh token count");
+    assert.ok(text.includes("fresh"), "should label fresh tokens");
   });
 
   it("includes agent count", async () => {


### PR DESCRIPTION
## What

The workflow token displays show a single scalar per agent — `input + output + cacheRead + cacheWrite` — which mixes real spend with cheap cache reads. For a ~95%-cached Opus agent that reads as huge (e.g. "3.0M tok" when only ~89k was actually fresh); for a non-caching provider it's 100% fresh. Same unit, opposite meaning — it's easy to misread which agents actually cost you.

This surfaces the split the SDK already computes (`AgentUsage`), which the workflow layer was collapsing to a scalar.

**Before**
```
[1] ✓ paper-generation   3.0M tok    · claude-opus-4.8
[2] ✓ numeric-auditor    6.3M tok    · glm-5-2
```

**After**
```
[1] ✓ paper-generation   89K fresh · 3.0M cache   · claude-opus-4.8
[2] ✓ numeric-auditor    6.3M fresh               · glm-5-2
```
Delivery line: `✓ … finished (11 agents · 18.0M fresh · 6.0M cache · $6.70 · 51.9s)`.

`fresh = input + output` (real spend), `cache = cacheRead` (cheap reuse). The cache segment is omitted when there were no cache reads, so a non-caching run reads cleanly as `6.3M fresh`. `cacheWrite` is excluded from both counts (its cost is reflected in `$cost` on the delivery line).

## How

- Carry the per-agent `AgentUsage` (already captured via `onUsage`) through the existing `onAgentEnd` event into `WorkflowAgentSnapshot.tokenUsage` — it was being dropped.
- Render the split across **all** per-agent token surfaces for consistency: the live detailed panel (`task-panel.ts`), the `/workflows` navigator (`workflow-ui.ts`), the status/print command (`display.ts`), and the background-run delivery line.
- Backward compatible: agents without a `tokenUsage` breakdown fall back to the existing `N tok` scalar.

`feat:` because it adds public surface (`WorkflowAgentSnapshot.tokenUsage` and the `onAgentEnd` event's `tokenUsage`). Display-only — nothing changes about what's sent to models or how much is spent.

## Verification

`npm test` green (biome check + tsc build + 790 unit tests). Added coverage in `task-panel.test.ts` (per-agent split, delivery-line cache+cost, cache-omitted-when-`cacheRead=0`) and `workflow-display.test.ts` (status-command split).

**End-to-end against a real Pi subagent session** (per CONTRIBUTING's "token accounting" rule): verified on a live install carrying the same change. Real runs on `forge/glm-5-2` (parallel fan-out) + `github-copilot/claude-opus-4.8` confirm the per-agent `tokenUsage` populates from the real `createAgentSession` — the run-level aggregate was `input+output ≈ 18.0M`, `cacheRead ≈ 6.03M`, `cacheWrite ≈ 234k`, and the `cacheRead` is entirely attributable to the copilot/Opus agents (the forge/GLM provider reports no cache reads). So the panel renders the Opus agents with a large `cache` segment and the GLM agents as `fresh`-only, exactly as intended. Happy to share the raw run stats if useful.
