### PR TITLE
feat: point delivered results at the full persisted file with configurable truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ For larger or flakier fan-outs, the `workflow` tool also accepts `concurrency` (
 
 The live "Workflows running" panel is configured in the same `~/.pi/workflows/settings.json`: `"progressPanelMode"` is `"compact"` (default, one line per run) or `"detailed"` (per-phase/per-agent rows with tokens, cost, and a live tok/s rate), and `"progressPanelMaxAgents"` (default `8`, range `1`–`1000`) caps how many agents each phase shows in detailed mode before a `… N earlier agents` line. Toggle them live with `/workflows-progress compact|detailed` and `/workflows-progress-max <N>` — changes take effect on the next render without a restart.
 
+When a background run finishes, its result is delivered back into the conversation with a `↳ Full result: <path>` pointer to the persisted `~/.pi/workflows/projects/<project>/runs/<id>.json`, so nothing is lost even when the summary is shortened. Only the JSON-dump fallback (a result object without a `verdict`/`report`/`summary` string field) is truncated — at `"deliveredResultMaxChars"` characters (default `400`) in the same `~/.pi/workflows/settings.json` — and the dropped size is shown inline, e.g. `…(truncated 3.2 KB)`.
+
 Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()`, and `require`/`import`/`fs`/network are unavailable, so runs stay reproducible — which is what makes resume reliable.
 
 ## Default tier assignment

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -69,7 +69,9 @@ export default function extension(pi: ExtensionAPI) {
       // sessionManager may be unavailable in some contexts — fall back to global history.
     }
     // Deliver a background run's result into the conversation when it finishes.
-    installResultDelivery(pi, manager);
+    // The live settings loader lets `deliveredResultMaxChars` take effect without
+    // a restart.
+    installResultDelivery(pi, manager, { loadSettings: () => loadWorkflowSettings({ cwd }) });
     // Live "workflows running" panel below the input (focus + enter to open).
     // Pass a live settings loader so /workflows-progress (compact|detailed) takes
     // effect without a restart.

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -6,6 +6,7 @@
  *    conversation so the paused task continues with the outcome.
  */
 
+import { join } from "node:path";
 import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
 import { type Component, type TUI, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { shorten, statusIcon, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
@@ -43,12 +44,25 @@ export interface TaskPanelOptions {
   loadSettings?: () => WorkflowSettings;
 }
 
+/** Default cap on the JSON-dump fallback in a delivered result summary. Overridable
+ *  via the `deliveredResultMaxChars` setting in ~/.pi/workflows/settings.json. */
+const DEFAULT_DELIVERED_MAX_CHARS = 400;
+
+/** Human-readable byte size for the dropped-tail hint: 512 B, 3.2 KB, 1.4 MB. */
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 /**
  * Pick a clean human-readable summary from a workflow result, in order of
  * preference: a `verdict`/`report`/`summary` string field, a bare string
- * result, else a truncated JSON dump.
+ * result, else a JSON dump capped at `maxChars`. When the dump is truncated the
+ * dropped size is reported (the full result is still reachable via the pointer
+ * that {@link deliverText} appends).
  */
-function summarizeResult(result: unknown): string {
+function summarizeResult(result: unknown, maxChars: number = DEFAULT_DELIVERED_MAX_CHARS): string {
   if (typeof result === "string") return result;
   if (result == null) return "null";
   if (typeof result === "object") {
@@ -59,7 +73,12 @@ function summarizeResult(result: unknown): string {
     }
   }
   const json = JSON.stringify(result, null, 2);
-  return json.length > 400 ? `${json.slice(0, 400)}\n…(truncated)` : json;
+  if (json.length <= maxChars) return json;
+  // Slice once (the kept head); derive the dropped size by byte-length subtraction
+  // so we don't also allocate the (potentially large) truncated tail to measure it.
+  const kept = json.slice(0, maxChars);
+  const droppedBytes = Buffer.byteLength(json, "utf8") - Buffer.byteLength(kept, "utf8");
+  return `${kept}\n…(truncated ${formatBytes(droppedBytes)})`;
 }
 
 function fitLine(line: string, width?: number): string {
@@ -69,16 +88,40 @@ function fitLine(line: string, width?: number): string {
   return truncateToWidth(line, maxWidth);
 }
 
-export function deliverText(run: ManagedRun): string {
-  const summary = summarizeResult(run.result?.result);
+export function deliverText(run: ManagedRun, opts: { resultPath?: string; maxChars?: number } = {}): string {
+  const summary = summarizeResult(run.result?.result, opts.maxChars);
   const tokens = run.result?.tokenUsage ? ` · ${run.result.tokenUsage.total.toLocaleString()} tokens` : "";
   const agents = run.result?.agentCount ?? run.snapshot.agentCount;
   const duration = run.result?.durationMs ? ` · ${(run.result.durationMs / 1000).toFixed(1)}s` : "";
-  return [
+  const lines = [
     `✓ Background workflow "${run.snapshot.name}" finished (${agents} agents${tokens}${duration}).`,
     "",
     summary,
-  ].join("\n");
+  ];
+  // Always point at the full persisted result so the tail is never lost — even when
+  // the summary above is a complete verdict/summary field or an untruncated dump.
+  if (opts.resultPath) lines.push("", `↳ Full result: ${opts.resultPath}`);
+  return lines.join("\n");
+}
+
+/** Absolute path to a run's persisted result JSON. Undefined if the persistence
+ *  layer can't be resolved — delivery must never throw in the complete handler. */
+function persistedResultPath(manager: WorkflowManager, runId: string): string | undefined {
+  try {
+    return join(manager.getPersistence().getRunsDir(), `${runId}.json`);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Delivered JSON-dump truncation threshold from settings (already normalized),
+ *  defaulting to 400 when unset or unreadable. */
+function deliveredMaxChars(opts: { loadSettings?: () => WorkflowSettings }): number {
+  try {
+    return opts.loadSettings?.().deliveredResultMaxChars ?? DEFAULT_DELIVERED_MAX_CHARS;
+  } catch {
+    return DEFAULT_DELIVERED_MAX_CHARS;
+  }
 }
 
 /**
@@ -93,7 +136,11 @@ export function deliverText(run: ManagedRun): string {
  *
  * Set up once per extension; idempotent via an internal guard.
  */
-export function installResultDelivery(pi: ExtensionAPI, manager: WorkflowManager): void {
+export function installResultDelivery(
+  pi: ExtensionAPI,
+  manager: WorkflowManager,
+  opts: { loadSettings?: () => WorkflowSettings } = {},
+): void {
   // Mutable holder on manager so shared across re-calls (e.g. session_start after /reload).
   const m = manager as unknown as { __deliveryInstalled?: boolean; __holder?: { pi: ExtensionAPI } };
   if (m.__deliveryInstalled) {
@@ -123,7 +170,9 @@ export function installResultDelivery(pi: ExtensionAPI, manager: WorkflowManager
     const run = manager.getRun(runId);
     // Only background/resumed runs are delivered: a foreground (sync) run already
     // returns its result inline as the tool result, so re-delivering would dup it.
-    if (run?.background) deliver(deliverText(run));
+    if (run?.background) {
+      deliver(deliverText(run, { resultPath: persistedResultPath(manager, runId), maxChars: deliveredMaxChars(opts) }));
+    }
   });
   manager.on("error", ({ runId, error }: { runId: string; error?: { message?: string } }) => {
     if (!manager.getRun(runId)?.background) return;

--- a/src/workflow-settings.ts
+++ b/src/workflow-settings.ts
@@ -23,6 +23,11 @@ export interface WorkflowSettings {
   progressPanelMode?: "compact" | "detailed";
   /** Max agents shown per phase in detailed progress mode (default 8). */
   progressPanelMaxAgents?: number;
+  /**
+   * Character cap on a delivered background-run result's JSON-dump fallback before
+   * truncation (default 400). String/`verdict`/`summary` results are never truncated.
+   */
+  deliveredResultMaxChars?: number;
 }
 
 export interface WorkflowSettingsStore {
@@ -134,6 +139,8 @@ function normalizeSettings(value: unknown): WorkflowSettings {
   ) {
     settings.progressPanelMaxAgents = Math.min(1000, Math.floor(raw.progressPanelMaxAgents));
   }
+  const deliveredResultMaxChars = normalizeInteger(raw.deliveredResultMaxChars, 1, 1_000_000);
+  if (deliveredResultMaxChars !== undefined) settings.deliveredResultMaxChars = deliveredResultMaxChars;
   return settings;
 }
 

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -5,7 +5,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 
 type TaskPanelModule = {
-  installResultDelivery: (pi: ExtensionAPI, manager: unknown) => void;
+  installResultDelivery: (pi: ExtensionAPI, manager: unknown, opts?: unknown) => void;
   installTaskPanel: (pi: ExtensionAPI | null, manager: unknown, ui: unknown) => void;
 };
 
@@ -19,13 +19,15 @@ before(async () => {
 // ─── Pure-function tests (tested indirectly via installResultDelivery) ─────────
 
 describe("installResultDelivery", () => {
-  function createMockManager(run?: unknown) {
+  function createMockManager(run?: unknown, runsDir?: string) {
     const manager = new EventEmitter() as ReturnType<typeof EventEmitter> & {
       getRun: (...args: unknown[]) => unknown;
+      getPersistence?: () => { getRunsDir: () => string };
       __deliveryInstalled?: boolean;
       listRuns?: () => unknown[];
     };
     manager.getRun = () => run;
+    if (runsDir) manager.getPersistence = () => ({ getRunsDir: () => runsDir });
     return manager;
   }
 
@@ -143,7 +145,7 @@ describe("installResultDelivery", () => {
 
     const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
     assert.ok(calls[0].content.includes("foo"), "should contain foo");
-    assert.ok(calls[0].content.includes("…(truncated)"), "should contain …(truncated)");
+    assert.ok(/…\(truncated [\d.]+ (B|KB|MB)\)/.test(calls[0].content), "should note the dropped size on truncation");
   });
 
   it("falls back gracefully when result is nullish", () => {
@@ -158,6 +160,53 @@ describe("installResultDelivery", () => {
     const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
     assert.equal(calls.length, 1);
     assert.ok(calls[0].content.includes("null"), "should contain null for undefined result");
+  });
+
+  // ── Full-result pointer + configurable threshold ──
+
+  it("appends a Full result pointer to <runsDir>/<runId>.json when persistence exists", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun(), "/runs");
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.emit("complete", { runId: "test-run-1" });
+
+    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
+    assert.ok(content.includes("Full result:"), "should include the pointer label");
+    assert.ok(content.includes("/runs/test-run-1.json"), "should point at <runsDir>/<runId>.json");
+    // The verdict summary itself is unchanged apart from the appended pointer.
+    assert.ok(content.includes("All tests passed"), "verdict text preserved");
+  });
+
+  it("omits the pointer when the manager exposes no persistence layer", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun()); // no runsDir
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.emit("complete", { runId: "test-run-1" });
+
+    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    assert.equal(calls.length, 1, "the result is still delivered");
+    assert.ok(calls[0].content.includes("All tests passed"), "verdict body still intact");
+    assert.ok(!calls[0].content.includes("Full result:"), "no pointer without a persisted path");
+  });
+
+  it("honors deliveredResultMaxChars from loadSettings for the JSON-dump branch", () => {
+    const pi = createMockPi();
+    // ~216-char JSON dump: under the default 400, so it would NOT truncate by default
+    // — a truncation marker can therefore only come from the 50-char setting.
+    const run = makeRun({ result: { result: { note: "z".repeat(200) } } });
+    const manager = createMockManager(run, "/runs");
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager, {
+      loadSettings: () => ({ deliveredResultMaxChars: 50 }),
+    });
+    manager.emit("complete", { runId: "test-run-1" });
+
+    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
+    assert.ok(/…\(truncated [\d.]+ (B|KB|MB)\)/.test(content), "the 50-char setting truncates a sub-400 dump");
+    assert.ok(!content.includes("z".repeat(200)), "the body is cut at the configured threshold");
+    assert.ok(content.includes("/runs/test-run-1.json"), "pointer still appended");
   });
 
   // ── installResultDelivery: guard / stale ctx ──
@@ -644,5 +693,61 @@ describe("installTaskPanel mode selection", () => {
       lines.some((l) => /\[1\] ● a/.test(l)),
       "per-agent row in detailed mode",
     );
+  });
+});
+
+// ─── deliverText: pointer + truncation threshold ─────────────────────────────────
+
+describe("deliverText", () => {
+  function makeResult(result: unknown) {
+    return { snapshot: { name: "wf", agentCount: 1 }, result: { agentCount: 1, result } };
+  }
+
+  it("appends the Full result pointer to a verdict result without altering it", async () => {
+    const { deliverText } = await import("../src/task-panel.js");
+    // A verdict longer than the default cap must still pass through in full: the
+    // verdict branch is never subject to the JSON-dump truncation.
+    const verdict = "V".repeat(600);
+    const text = deliverText(makeResult({ verdict }) as never, { resultPath: "/r/x.json" });
+    assert.ok(text.includes(verdict), "long verdict passed through in full");
+    assert.ok(text.includes("↳ Full result: /r/x.json"), "pointer appended");
+    assert.ok(!/truncated/.test(text), "verdict branch bypasses truncation");
+  });
+
+  it("does not append a pointer when no resultPath is given", async () => {
+    const { deliverText } = await import("../src/task-panel.js");
+    const text = deliverText(makeResult("plain string") as never);
+    assert.ok(text.includes("plain string"), "string result passed through");
+    assert.ok(!text.includes("Full result:"), "no pointer without a resultPath");
+  });
+
+  it("leaves a small JSON dump untouched (no truncation marker)", async () => {
+    const { deliverText } = await import("../src/task-panel.js");
+    const text = deliverText(makeResult({ ok: true, changed: 2 }) as never, { resultPath: "/r/x.json" });
+    assert.ok(text.includes('"ok": true'), "full JSON shown");
+    assert.ok(!/truncated/.test(text), "no truncation under the threshold");
+    assert.ok(text.includes("↳ Full result: /r/x.json"), "pointer still appended");
+  });
+
+  it("truncates the JSON dump at maxChars and reports the dropped size", async () => {
+    const { deliverText } = await import("../src/task-panel.js");
+    const text = deliverText(makeResult({ note: "x".repeat(500) }) as never, {
+      resultPath: "/r/x.json",
+      maxChars: 100,
+    });
+    assert.ok(/…\(truncated [\d.]+ (B|KB|MB)\)/.test(text), "size hint present");
+    assert.ok(text.includes("↳ Full result: /r/x.json"), "pointer still appended");
+    // Body is capped near maxChars, so the 500-char tail is not delivered in full.
+    assert.ok(!text.includes("x".repeat(500)), "the full tail is not inlined");
+  });
+
+  it("defaults the JSON-dump threshold to 400 chars", async () => {
+    const { deliverText } = await import("../src/task-panel.js");
+    // JSON length is note length + 16, so 380 → 396 (under 400) and 390 → 406 (over),
+    // bracketing the default threshold tightly around 400.
+    const under = deliverText(makeResult({ note: "y".repeat(380) }) as never);
+    assert.ok(!/truncated/.test(under), "a 396-char dump is under the default 400");
+    const over = deliverText(makeResult({ note: "y".repeat(390) }) as never);
+    assert.ok(/…\(truncated/.test(over), "a 406-char dump exceeds the default 400");
   });
 });

--- a/tests/workflow-settings.test.ts
+++ b/tests/workflow-settings.test.ts
@@ -197,6 +197,24 @@ describe("workflow settings", () => {
     });
   });
 
+  it("clamps and floors deliveredResultMaxChars into [1, 1000000]", () => {
+    withSettingsPath((settingsPath) => {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+
+      writeFileSync(settingsPath, JSON.stringify({ deliveredResultMaxChars: 250.9 }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { deliveredResultMaxChars: 250 });
+
+      writeFileSync(settingsPath, JSON.stringify({ deliveredResultMaxChars: 5_000_000 }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { deliveredResultMaxChars: 1_000_000 });
+
+      writeFileSync(settingsPath, JSON.stringify({ deliveredResultMaxChars: 0 }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+
+      writeFileSync(settingsPath, JSON.stringify({ deliveredResultMaxChars: "400" }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+    });
+  });
+
   it("ignores corrupt or invalid settings", () => {
     withSettingsPath((settingsPath) => {
       mkdirSync(dirname(settingsPath), { recursive: true });


### PR DESCRIPTION
## What & why

Fixes #55. When a background workflow run finishes, `summarizeResult` / `deliverText`
(`src/task-panel.ts`) truncated the delivered result to 400 chars in the JSON-dump
branch — silently, with no size and no pointer to where the full result is persisted.

This PR:

- **Always appends a pointer** to the persisted result
  (`↳ Full result: ~/.pi/workflows/projects/<project>/runs/<id>.json`), even when
  nothing was truncated or a `verdict` / `report` / `summary` field is used.
- **Reports the dropped size** on truncation, e.g. `…(truncated 3.2 KB)`.
- **Makes the threshold configurable** via a new optional `deliveredResultMaxChars`
  setting in `~/.pi/workflows/settings.json` (default `400`, so existing behavior is
  unchanged). Only the JSON-dump fallback honors it; string / verdict / report /
  summary results are never truncated apart from the appended pointer.

## Notes

- Documented in `README.md` (settings paragraph, next to the existing knobs).
- `npm test` is green (biome + tsc + unit). Added unit tests for the pointer, the
  dropped-size marker, the configurable threshold, and settings normalization.
- This only affects the post-completion **delivery text**, not how agents actually
  run (retries / timeouts / routing / tokens / concurrency / resume), so a
  real-provider E2E run is not required — fake-agent unit tests cover it.