### PR TITLE
feat: add 'max' thinking level support

### DIFF
--- a/src/model-spec.ts
+++ b/src/model-spec.ts
@@ -1,7 +1,7 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 
-export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
 export type ModelThinkingLevel = (typeof THINKING_LEVELS)[number];
 

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -43,7 +43,7 @@ export function modelRoutingGuideline(registry?: ModelRegistry | (() => ModelReg
     "Big tier: synthesis/judgment/decision agents spanning the full context.",
     "An agent with no opts.tier and no opts.model falls back to the user's medium tier; do not rely on that — tag agents explicitly so small/big are used where they fit.",
     "If the user named a specific model, use opts.model with that exact provider/id; opts.model always takes precedence over opts.tier.",
-    "Exact model specs may include Pi CLI-style thinking suffixes such as openai-codex/gpt-5.5:xhigh when the user requests a specific effort level.",
+    "Exact model specs may include Pi CLI-style thinking suffixes such as openai-codex/gpt-5.5:xhigh or anthropic/claude-fable-5:max when the user requests a specific effort level.",
     list,
   ].join(" ");
 }


### PR DESCRIPTION
Updates `THINKING_LEVELS` and documentation to support the `max` thinking level available in pi-coding-agent. This prevents the parser from rejecting `:max` suffixes in workflow tier configurations.