### PR TITLE
fix: persist running status when resuming workflows

### DIFF
--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -581,6 +581,9 @@ export class WorkflowManager extends EventEmitter {
       lease,
     };
     this.runs.set(runId, managed);
+    // Persist before notifying renderers: listRuns() is their source of truth for
+    // lifecycle status, while getRun() supplies the live in-memory snapshot.
+    this.persistRun(managed);
 
     const resumeJournal = new Map((persisted.journal ?? []).map((e) => [e.index, e] as const));
     this.emit("resumed", { runId });

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -1372,6 +1372,28 @@ test(
 // ─── Event tests ───────────────────────────────────────────────────────────────
 
 test(
+  "listRuns reflects running status immediately after resume",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, agent: da.runner });
+    manager.on("error", () => {});
+
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    manager.pause(runId);
+
+    const resumed = await manager.resume(runId);
+    const persisted = manager.listRuns().find((run) => run.runId === runId);
+
+    assert.equal(resumed, true);
+    assert.equal(persisted?.status, "running", "listRuns should show running status after resume");
+
+    da.resolve("done");
+    await promise.catch(() => {});
+  }),
+);
+
+test(
   "manager emits 'resumed' event on resume",
   withTempCwd(async (cwd) => {
     const da = deferredAgent();


### PR DESCRIPTION
## Context

I found this while running a background research workflow. A separate stale-context bug in the `pi-web-access` extension crashed my Pi session. After restarting, pi-dynamic-workflows correctly recovered the interrupted run as `paused`, and I resumed it with `/workflows resume`.

The workflow resumed and four agents started running, but the task panel still showed it as paused. The `pi-web-access` crash only exposed this bug; its stale-context issue is separate and is being fixed elsewhere.

## What changed

- Persist a resumed run's `running` status before notifying renderers.
- Add a regression test for the `resume()` to `listRuns()` boundary.

## Why

`resume()` changed the in-memory run to `running`, but left its persisted state as `paused`. The task panel reads lifecycle status through `listRuns()`, so it could show a paused workflow while agents were running. The status stayed stale until another journal or completion write.

## Testing

- `npm test` — 827 tests passed.
- Real Pi subagent session using `openai-codex/gpt-5.6-luna:xhigh` — the `resumed` listener observed `running`, the run completed, and the workflow returned `RESUME_OK`.
