### PR TITLE
fix(editor): support OMP editor constructor

### DIFF
--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -170,6 +170,26 @@ function isBackspace(data: string): boolean {
 }
 
 /**
+ * Pi's CustomEditor still forwards `(tui, theme, keybindings)` to the legacy
+ * pi-tui Editor constructor. OMP's CustomEditor has no constructor and extends
+ * the newer `Editor(theme)`. Select the argument layout from the base Editor's
+ * required parameter count so one extension can run in either host.
+ */
+function customEditorConstructorArgs(
+  tui: TUI,
+  theme: EditorTheme,
+  keybindings: ConstructorParameters<typeof CustomEditor>[2],
+): ConstructorParameters<typeof CustomEditor> {
+  const baseEditor = Object.getPrototypeOf(CustomEditor) as { readonly length: number };
+  if (baseEditor.length === 1) {
+    // The installed Pi types describe the legacy signature; OMP provides the
+    // runtime-only `(theme, keybindings)` signature.
+    return [theme, keybindings] as unknown as ConstructorParameters<typeof CustomEditor>;
+  }
+  return [tui, theme, keybindings];
+}
+
+/**
  * Editor that paints the trigger words and owns the on/off toggle. Reads/writes
  * `state.active` so the extension's `input` handler can decide whether to force a
  * workflow at submit time.
@@ -182,12 +202,12 @@ export class WorkflowEditor extends CustomEditor {
   private wasTriggered = false;
 
   constructor(
-    tui: TUI,
+    private readonly hostTui: TUI,
     theme: EditorTheme,
     keybindings: ConstructorParameters<typeof CustomEditor>[2],
     private readonly modeState: WorkflowModeState,
   ) {
-    super(tui, theme, keybindings);
+    super(...customEditorConstructorArgs(hostTui, theme, keybindings));
   }
 
   /** Highlighted/armed: a trigger is present and the user hasn't toggled it off. */
@@ -205,7 +225,7 @@ export class WorkflowEditor extends CustomEditor {
       this.disabled = true;
       this.modeState.suppressedKeywordText = this.getText().trim();
       this.syncState();
-      this.tui.requestRender();
+      this.hostTui.requestRender();
       return;
     }
     const before = this.getText();
@@ -261,7 +281,7 @@ export class WorkflowEditor extends CustomEditor {
     if (shouldRun && !this.timer) {
       this.timer = setInterval(() => {
         this.tick = (this.tick + 1) % (RAINBOW.length * 6);
-        this.tui.requestRender();
+        this.hostTui.requestRender();
       }, 90);
       // Don't keep the process alive for the animation.
       (this.timer as { unref?: () => void }).unref?.();

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -169,22 +169,48 @@ function isBackspace(data: string): boolean {
   return data === "\x7f" || data === "\b";
 }
 
+/** Emitted at most once per process so a noisy host doesn't spam the log. */
+let warnedUnexpectedArity = false;
+
 /**
  * Pi's CustomEditor still forwards `(tui, theme, keybindings)` to the legacy
  * pi-tui Editor constructor. OMP's CustomEditor has no constructor and extends
  * the newer `Editor(theme)`. Select the argument layout from the base Editor's
  * required parameter count so one extension can run in either host.
+ *
+ * `baseEditorCtor` defaults to the real `Editor` class (via
+ * `Object.getPrototypeOf(CustomEditor)`) and is only overridable so unit tests
+ * can exercise both branches without depending on which host's `CustomEditor`
+ * happens to be installed (see `tests/workflow-editor.test.ts`).
  */
-function customEditorConstructorArgs(
+export function customEditorConstructorArgs(
   tui: TUI,
   theme: EditorTheme,
   keybindings: ConstructorParameters<typeof CustomEditor>[2],
+  baseEditorCtor: { readonly length: number } = Object.getPrototypeOf(CustomEditor) as { readonly length: number },
 ): ConstructorParameters<typeof CustomEditor> {
-  const baseEditor = Object.getPrototypeOf(CustomEditor) as { readonly length: number };
-  if (baseEditor.length === 1) {
+  if (baseEditorCtor.length === 1) {
     // The installed Pi types describe the legacy signature; OMP provides the
     // runtime-only `(theme, keybindings)` signature.
     return [theme, keybindings] as unknown as ConstructorParameters<typeof CustomEditor>;
+  }
+  // INTENTIONAL: any arity other than exactly 1 is treated as the legacy
+  // 3-arg `(tui, theme, keybindings)` layout — this includes the expected
+  // legacy case (2: pi-tui's `Editor(tui, theme, options)`), but also any
+  // *unexpected* arity (0, 3, ...) from a host we haven't seen yet. That's a
+  // deliberate choice: legacy is the layout we've actually verified against
+  // real Pi releases, so it's the safer default. If a third host signature
+  // ever shows up, this heuristic needs a new branch — the warning below is
+  // meant to surface that instead of silently misconstructing the editor
+  // (see https://github.com/QuintinShaw/pi-dynamic-workflows/issues/72).
+  if (baseEditorCtor.length !== 2 && !warnedUnexpectedArity) {
+    warnedUnexpectedArity = true;
+    console.warn(
+      `[pi-dynamic-workflows] WorkflowEditor: base editor constructor takes ${baseEditorCtor.length} required ` +
+        "argument(s), which is neither the known OMP layout (1) nor the known legacy Pi layout (2). Falling back " +
+        "to the legacy (tui, theme, keybindings) call — the editor may fail to render on this host. Please report " +
+        "this at https://github.com/QuintinShaw/pi-dynamic-workflows/issues/72.",
+    );
   }
   return [tui, theme, keybindings];
 }
@@ -249,19 +275,85 @@ export class WorkflowEditor extends CustomEditor {
   }
 
   override render(width: number): string[] {
-    const lines = super.render(width);
+    // Defensive layer for issue #72: on some hosts a base-editor/pi-tui
+    // version mismatch can leave the base `Editor`'s internal render state
+    // uninitialized, making `super.render()` throw on every single render —
+    // including the very first one, before the user has typed anything —
+    // which crashes the whole app at launch with no way to recover (short of
+    // disabling the extension). We can't fix a broken host from here, but we
+    // CAN make sure this extension degrades to a plain, unstyled editor
+    // instead of hard-crashing Pi/OMP.
+    let lines: string[];
+    let usingFallback = false;
+    try {
+      lines = super.render(width);
+    } catch (err) {
+      usingFallback = true;
+      if (!WorkflowEditor.warnedRenderFallback) {
+        WorkflowEditor.warnedRenderFallback = true;
+        console.warn(
+          "[pi-dynamic-workflows] WorkflowEditor: base editor render() threw; degrading to a minimal, unstyled " +
+            "rendering so the app doesn't crash. Workflows-mode highlighting will be unavailable this session. " +
+            `Original error: ${err instanceof Error ? (err.stack ?? err.message) : String(err)} ` +
+            "Please report this at https://github.com/QuintinShaw/pi-dynamic-workflows/issues/72.",
+        );
+      }
+      lines = this.safeFallbackLines(width);
+    }
+
     // Keep the shared state current even for non-keystroke changes (history
     // recall, programmatic setText) so the submit hook reads the right value.
-    this.syncState();
-    this.reconcileAnimation();
-    if (!this.isActive() || lines.length === 0) return lines;
-    // First and last lines are the editor's horizontal borders; only the text
-    // lines in between are colorized.
-    return lines.map((ln, i) =>
-      i === 0 || i === lines.length - 1
-        ? ln
-        : colorizeWorkflow(ln, this.tick, RAINBOW, this.modeState.keywordTriggerWord),
-    );
+    // Guarded: this bookkeeping must never itself throw — including against
+    // the fallback lines above — or a broken host would still crash the app.
+    try {
+      this.syncState();
+      this.reconcileAnimation();
+    } catch {
+      // Best-effort; rendering must proceed even if bookkeeping fails.
+    }
+
+    let active = false;
+    try {
+      active = this.isActive();
+    } catch {
+      active = false;
+    }
+    if (usingFallback || !active || lines.length === 0) return lines;
+
+    try {
+      // First and last lines are the editor's horizontal borders; only the text
+      // lines in between are colorized.
+      return lines.map((ln, i) =>
+        i === 0 || i === lines.length - 1
+          ? ln
+          : colorizeWorkflow(ln, this.tick, RAINBOW, this.modeState.keywordTriggerWord),
+      );
+    } catch {
+      // Colorizing is cosmetic; never let it turn a working render into a crash.
+      return lines;
+    }
+  }
+
+  /** Emitted at most once per process so a broken host doesn't spam the log every render. */
+  private static warnedRenderFallback = false;
+
+  /**
+   * Minimal, defensive rendering used only when the base editor's render()
+   * throws (see issue #72). Deliberately avoids calling any other overridden
+   * or state-dependent method that might share the same broken internal
+   * state; falls back to an empty array if even plain text access fails.
+   * Not pretty (no borders, no wrapping beyond a hard slice) — the goal is
+   * "the app still launches", not "the editor still looks nice".
+   */
+  private safeFallbackLines(width: number): string[] {
+    try {
+      const text = this.getText();
+      const raw = text.length > 0 ? text.split("\n") : [""];
+      const safeWidth = Number.isFinite(width) && width > 0 ? Math.floor(width) : 80;
+      return raw.map((line) => (line.length > safeWidth ? line.slice(0, safeWidth) : line));
+    } catch {
+      return [];
+    }
   }
 
   /** Absolute text before the cursor, used to detect "right after the word". */

--- a/tests/workflow-editor.test.ts
+++ b/tests/workflow-editor.test.ts
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import { before, describe, it } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { CustomEditor, type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { type Terminal, TUI } from "@earendil-works/pi-tui";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -38,6 +38,20 @@ function makeMockTerminal(): Terminal {
 /** Create a TUI instance safe for test usage (no real terminal I/O). */
 function createMockTui(): TUI {
   return new TUI(makeMockTerminal(), false);
+}
+
+/**
+ * The base `Editor` class that `WorkflowEditor` actually renders through at
+ * runtime, resolved the same way `customEditorConstructorArgs` resolves it
+ * (`Object.getPrototypeOf(CustomEditor)`). This is NOT necessarily the same
+ * module instance as a direct `import { Editor } from "@earendil-works/pi-tui"`
+ * in this file — `pi-coding-agent` ships its own nested copy of `pi-tui`
+ * (`node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui`),
+ * so a top-level import resolves to a *different* `Editor` class object than
+ * the one `CustomEditor` actually extends. Patching the wrong one is a no-op.
+ */
+function getBaseEditorClass(): { prototype: { render: (width: number) => string[] } } {
+  return Object.getPrototypeOf(CustomEditor) as { prototype: { render: (width: number) => string[] } };
 }
 
 /** Editor theme stub. */
@@ -345,6 +359,58 @@ describe("RAINBOW", () => {
   });
 });
 
+// PR #64 / issue #72: the editor must construct the base `CustomEditor` with
+// the argument layout the *actual host's* base `Editor` expects — vanilla Pi
+// forwards `(tui, theme, keybindings)`, while some hosts (e.g. OMP) expose a
+// base `Editor` whose constructor only takes `(theme)`. `baseEditorCtor` is
+// injected here purely for testability (see the function's doc comment).
+describe("customEditorConstructorArgs", () => {
+  it("returns [theme, keybindings] when the base editor takes exactly 1 required arg", async () => {
+    const { customEditorConstructorArgs } = await load();
+    const tui = createMockTui();
+    const theme = makeTheme();
+    const keybindings = {} as unknown as Parameters<typeof customEditorConstructorArgs>[2];
+
+    const result = customEditorConstructorArgs(tui, theme, keybindings, { length: 1 });
+
+    assert.deepEqual(result, [theme, keybindings]);
+  });
+
+  it("returns [tui, theme, keybindings] when the base editor's arity is 2 (the known legacy Pi layout)", async () => {
+    const { customEditorConstructorArgs } = await load();
+    const tui = createMockTui();
+    const theme = makeTheme();
+    const keybindings = {} as unknown as Parameters<typeof customEditorConstructorArgs>[2];
+
+    const result = customEditorConstructorArgs(tui, theme, keybindings, { length: 2 });
+
+    assert.deepEqual(result, [tui, theme, keybindings]);
+  });
+
+  it("falls back to [tui, theme, keybindings] for any arity other than 1 (0, 3, ... unseen hosts too)", async () => {
+    const { customEditorConstructorArgs } = await load();
+    const tui = createMockTui();
+    const theme = makeTheme();
+    const keybindings = {} as unknown as Parameters<typeof customEditorConstructorArgs>[2];
+
+    for (const length of [0, 3, 4]) {
+      assert.deepEqual(customEditorConstructorArgs(tui, theme, keybindings, { length }), [tui, theme, keybindings]);
+    }
+  });
+
+  it("defaults to the real installed CustomEditor's base arity when no override is given", async () => {
+    const { customEditorConstructorArgs } = await load();
+    const tui = createMockTui();
+    const theme = makeTheme();
+    const keybindings = {} as unknown as Parameters<typeof customEditorConstructorArgs>[2];
+
+    // The installed pi-coding-agent/pi-tui devDependencies ship the legacy
+    // `Editor(tui, theme, options)` signature (2 required params), so the
+    // default resolution must produce the legacy 3-arg call layout.
+    assert.deepEqual(customEditorConstructorArgs(tui, theme, keybindings), [tui, theme, keybindings]);
+  });
+});
+
 describe("WorkflowEditor", () => {
   type KBManagerClass = {
     new (
@@ -420,6 +486,72 @@ describe("WorkflowEditor", () => {
     for (const ln of lines) {
       assert.equal(typeof ln, "string", "each line should be a string");
     }
+  });
+
+  // Issue #72: a broken/mismatched host can make the base Editor's render()
+  // throw on every render, including the very first one — crashing the whole
+  // app at launch. WorkflowEditor.render() must degrade instead of crashing.
+  describe("render() defensive fallback (issue #72)", () => {
+    it("degrades to plain text instead of throwing when the base render() throws", () => {
+      const { editor } = createEditor();
+      editor.setText("run a workflow test");
+
+      const BaseEditor = getBaseEditorClass();
+      const original = BaseEditor.prototype.render;
+      BaseEditor.prototype.render = () => {
+        throw new Error("simulated host render() crash");
+      };
+      try {
+        assert.doesNotThrow(() => editor.render(80), "render() must not propagate the base editor's crash");
+        const lines = editor.render(80);
+        assert.deepEqual(lines, ["run a workflow test"], "should fall back to the raw, unstyled text");
+      } finally {
+        BaseEditor.prototype.render = original;
+      }
+    });
+
+    it("does not colorize the fallback lines even when workflows mode is active", () => {
+      const { editor, state } = createEditor();
+      editor.setText("run a workflow test");
+
+      const BaseEditor = getBaseEditorClass();
+      const original = BaseEditor.prototype.render;
+      BaseEditor.prototype.render = () => {
+        throw new Error("simulated host render() crash");
+      };
+      try {
+        const lines = editor.render(80);
+        for (const ln of lines) {
+          assert.equal(ln.includes("\x1b["), false, "fallback lines should contain no ANSI color codes");
+        }
+        // Bookkeeping should still be best-effort attempted (guarded, not skipped).
+        assert.equal(typeof state.active, "boolean");
+      } finally {
+        BaseEditor.prototype.render = original;
+      }
+    });
+
+    it("recovers on the next render once the base editor stops throwing", () => {
+      const { editor } = createEditor();
+      editor.setText("hello");
+
+      const BaseEditor = getBaseEditorClass();
+      const original = BaseEditor.prototype.render;
+      BaseEditor.prototype.render = () => {
+        throw new Error("simulated host render() crash");
+      };
+      let crashedLines: string[] = [];
+      try {
+        crashedLines = editor.render(80);
+      } finally {
+        BaseEditor.prototype.render = original;
+      }
+      assert.deepEqual(crashedLines, ["hello"]);
+
+      const recoveredLines = editor.render(80);
+      assert.ok(Array.isArray(recoveredLines) && recoveredLines.length > 0, "should render normally again");
+      assert.notDeepEqual(recoveredLines, ["hello"], "a real render includes borders, unlike the plain fallback");
+    });
   });
 
   it("isActive() returns true when trigger text is present", () => {


### PR DESCRIPTION
## Summary

Fix the launch crash when this extension is loaded by OMP 16.4.6.

Legacy Pi's `CustomEditor` expects `(tui, theme, keybindings)`, while OMP's `CustomEditor` inherits the newer `Editor(theme)` constructor. Passing the legacy argument list under OMP stored the TUI instance as the editor theme, so the initial render failed while reading `theme.symbols.boxRound`.

The editor now selects the constructor argument layout from the base editor's required parameter count. It also retains the host TUI explicitly for render requests because OMP's newer editor does not expose the legacy `tui` field.

## Compatibility

- Preserves the legacy Pi constructor path.
- Supports OMP's theme-only editor base.
- Does not change the extension's public API or workflow behavior.

## Verification

- `npm run build`
- `npx tsx --test tests/workflow-editor.test.ts`
- `npx biome check src/workflow-editor.ts`
- `omp --no-session -e extensions/workflow.ts`

All automated checks passed. Before the change, the OMP smoke test crashed during initial rendering with `TypeError: undefined is not an object (evaluating 'this.#j.symbols.boxRound')`. After the change, OMP rendered the interactive editor and remained running until the deliberate smoke-test timeout.