### PR TITLE
fix: remove model catalogue from workflow prompt

### DIFF
--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -165,10 +165,8 @@ export class WorkflowManager extends EventEmitter {
   }
 
   /**
-   * The host session's model registry, when set. Read lazily (e.g. by the
-   * workflow tool's model routing guideline) since `setModelRegistry` is called
-   * from `session_start`, which runs after the tool is created — a snapshot
-   * taken at tool-creation time would miss it.
+   * Expose the host session's model registry to integrations sharing this
+   * manager. Workflow execution reads the same registry internally.
    */
   getModelRegistry(): ModelRegistry | undefined {
     return this.modelRegistry;

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -1,7 +1,6 @@
-import { defineTool, type ModelRegistry, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { listAvailableModelSpecs } from "./agent.js";
 import { listAgentTypes, loadAgentRegistry } from "./agent-registry.js";
 import {
   createToolUpdateWorkflowDisplay,
@@ -23,18 +22,8 @@ import { loadWorkflowSettings } from "./workflow-settings.js";
  *
  * This string is injected into the workflow tool's promptGuidelines and
  * therefore appears in the LLM's system prompt for every workflow execution.
- *
- * `registry` is a live host-session ModelRegistry (or a getter reaching one),
- * e.g. from WorkflowManager.getModelRegistry(). A getter lets each call see
- * the registry as it stands at that moment — the manager's registry is set on
- * session_start, after the tool is created, so an early snapshot would miss it.
  */
-export function modelRoutingGuideline(registry?: ModelRegistry | (() => ModelRegistry | undefined)): string {
-  const resolvedRegistry = typeof registry === "function" ? registry() : registry;
-  const available = listAvailableModelSpecs(resolvedRegistry);
-  const list = available.length
-    ? `The user's currently available models (route only to these) are: ${available.join(", ")}.`
-    : "Use models the user has configured.";
+export function modelRoutingGuideline(): string {
   return [
     "For workflow, the user configures per-tier models (/workflows-models), so TAG EVERY agent with opts.tier by role so those models are actually used.",
     "opts.tier accepts 'small', 'medium', or 'big' and is enforced at runtime.",
@@ -42,9 +31,8 @@ export function modelRoutingGuideline(registry?: ModelRegistry | (() => ModelReg
     "Medium tier: balanced analysis agents.",
     "Big tier: synthesis/judgment/decision agents spanning the full context.",
     "An agent with no opts.tier and no opts.model falls back to the user's medium tier; do not rely on that — tag agents explicitly so small/big are used where they fit.",
-    "If the user named a specific model, use opts.model with that exact provider/id; opts.model always takes precedence over opts.tier.",
+    "Use opts.model only when the user names a specific model; pass that exact provider/id. opts.model always takes precedence over opts.tier.",
     "Exact model specs may include Pi CLI-style thinking suffixes such as openai-codex/gpt-5.5:xhigh or anthropic/claude-fable-5:max when the user requests a specific effort level.",
-    list,
   ].join(" ");
 }
 
@@ -164,10 +152,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
     promptSnippet:
       "Run a deterministic JavaScript workflow. Required script header: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }.",
     // Lazy accessor: the SDK re-reads definition.promptGuidelines on every
-    // tool-registry refresh, so each read sees the manager's registry as it
-    // stands then (setModelRegistry runs on session_start, after tool creation).
-    // Residual caveat: providers registered after the last refresh won't appear
-    // until the next one.
+    // tool-registry refresh, so changes to the agentType registry are reflected.
     get promptGuidelines() {
       return [
         "Use workflow only when the user explicitly asks for a workflow, workflows, fan-out, or multi-agent orchestration.",
@@ -189,7 +174,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
         "For workflow, the default quality shape for fan-out work is finder -> verify -> merge: run one agent per angle or work-unit (in parallel), pass each candidate finding through verify() and drop the unconfirmed, then a single synthesis agent that de-duplicates, ranks by confidence/severity, and caps the output. If nothing survives verification, return an empty result and say so rather than padding.",
         "For workflow, give each subagent a substantive, self-contained task: do not spawn an agent just to read one file or run one command, and do not use one agent only to check on another. Prefer fewer, higher-level agents over many trivial micro-tasks.",
         "For workflow, if agent() needs machine-readable output, pass a plain JSON Schema via opts.schema; agent() will return the validated object. Use JSON Schema syntax, not TypeScript or TypeBox constructors.",
-        modelRoutingGuideline(() => manager.getModelRegistry()),
+        modelRoutingGuideline(),
         agentTypeGuideline(),
         "For workflow, do not assume the parent assistant has repository code context inside subagents; include enough task context and relevant paths in each agent prompt.",
         "For workflow, runs are background by default: the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when the run finishes. Pass background: false only when you must use the result inline in this same turn (it will block).",

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -12,6 +12,8 @@ import {
 import { createWorkflowTool } from "../src/workflow-tool.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
+// Exact post-change measurements: ratchet only after reviewing a new accepted form.
+// The prompt baseline intentionally uses an empty agentType registry so user configuration cannot alter it.
 const RENDERED_PROMPT_BUDGET_BYTES = 6_500;
 const TOOL_DEFINITION_BUDGET_BYTES = 2_204;
 

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { createWorkflowTool } from "../src/workflow-tool.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+const RENDERED_PROMPT_BUDGET_BYTES = 6_500;
+const TOOL_DEFINITION_BUDGET_BYTES = 2_204;
+
+test("rendered workflow prompt contribution stays within its accepted size", async () => {
+  await withRenderedWorkflow(async ({ systemPrompt, promptLines }) => {
+    const expectedLines = new Set(promptLines);
+    const renderedLines = systemPrompt.split("\n").filter((line) => expectedLines.has(line));
+    assert.deepEqual(renderedLines, promptLines, "Pi should render each workflow prompt line exactly once");
+
+    const renderedContribution = renderedLines.join("\n");
+    const actualBytes = Buffer.byteLength(renderedContribution, "utf8");
+    assert.ok(
+      actualBytes <= RENDERED_PROMPT_BUDGET_BYTES,
+      `Rendered workflow prompt is ${actualBytes} bytes; budget is ${RENDERED_PROMPT_BUDGET_BYTES}.\n${renderedContribution}`,
+    );
+  });
+});
+
+test("provider-visible workflow tool definition stays within its accepted size", async () => {
+  await withRenderedWorkflow(async ({ wrappedWorkflow }) => {
+    const definitionJson = JSON.stringify({
+      name: wrappedWorkflow.name,
+      description: wrappedWorkflow.description,
+      parameters: wrappedWorkflow.parameters,
+    });
+    const actualBytes = Buffer.byteLength(definitionJson, "utf8");
+    const parameterBytes = Buffer.byteLength(JSON.stringify(wrappedWorkflow.parameters), "utf8");
+
+    assert.ok(
+      actualBytes <= TOOL_DEFINITION_BUDGET_BYTES,
+      `Workflow tool definition is ${actualBytes} bytes; budget is ${TOOL_DEFINITION_BUDGET_BYTES} (parameters: ${parameterBytes} bytes).\n${definitionJson}`,
+    );
+  });
+});
+
+async function withRenderedWorkflow(
+  inspect: (surface: {
+    systemPrompt: string;
+    promptLines: string[];
+    wrappedWorkflow: {
+      name: string;
+      description: string;
+      parameters: unknown;
+    };
+  }) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "workflow-prompt-budget-"));
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+  try {
+    process.env.PI_CODING_AGENT_DIR = root;
+    await withFakeHomeAsync(root, async () => {
+      const workflow = createWorkflowTool({ cwd: root });
+      const loader = new DefaultResourceLoader({
+        cwd: root,
+        agentDir: root,
+        appendSystemPromptOverride: () => [],
+      });
+      await loader.reload();
+
+      const { session } = await createAgentSession({
+        cwd: root,
+        agentDir: root,
+        tools: ["workflow"],
+        customTools: [workflow],
+        resourceLoader: loader,
+        sessionManager: SessionManager.inMemory(root),
+        settingsManager: SettingsManager.inMemory(),
+      });
+
+      try {
+        const wrappedWorkflow = session.agent.state.tools.find((tool) => tool.name === "workflow");
+        assert.ok(wrappedWorkflow, "Pi should expose the wrapped workflow tool");
+
+        await inspect({
+          systemPrompt: session.agent.state.systemPrompt,
+          promptLines: [
+            `- workflow: ${workflow.promptSnippet}`,
+            ...workflow.promptGuidelines.map((guideline) => `- ${guideline}`),
+          ],
+          wrappedWorkflow,
+        });
+      } finally {
+        session.dispose();
+      }
+    });
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -66,12 +66,13 @@ test("createWorkflowTool has promptGuidelines array", () => {
   assert.ok(tool.promptGuidelines.length > 5, "should have several guidelines");
 });
 
-test("createWorkflowTool promptGuidelines mention model routing", () => {
+test("createWorkflowTool routes normal work through tiers and reserves exact models for user requests", () => {
   const tool = createWorkflowTool();
   const all = tool.promptGuidelines.join(" ");
-  assert.ok(all.includes("opts.tier"), "should mention opts.tier");
-  assert.ok(all.includes("opts.model"), "should mention opts.model");
-  assert.ok(all.includes("small") || all.includes("medium") || all.includes("big"), "should mention tier names");
+
+  assert.match(all, /opts\.tier/);
+  assert.match(all, /small.+medium.+big/s);
+  assert.match(all, /opts\.model only when the user (names|supplies)/i);
 });
 
 test("createWorkflowTool promptGuidelines keep budget and timeout unbounded by default", () => {
@@ -132,17 +133,6 @@ test("modelRoutingGuideline explains tier vs model priority", () => {
   );
 });
 
-test("modelRoutingGuideline references the model scope (auth-independent)", () => {
-  const text = modelRoutingGuideline();
-  // With auth configured it lists the available models; on a fresh/CI machine
-  // with no models it falls back to a generic line. Accept either so the test
-  // doesn't depend on the runner's authenticated providers.
-  assert.ok(
-    text.includes("route only to these") || text.includes("models the user has configured"),
-    "should explain which models are in scope (listed or fallback)",
-  );
-});
-
 test("modelRoutingGuideline explains when to use each option", () => {
   const text = modelRoutingGuideline();
   assert.ok(/small.*(exploration|search|inventory|agents)/i.test(text), "small tier should mention light workloads");
@@ -164,53 +154,15 @@ test("createWorkflowTool with custom cwd creates tool", () => {
   assert.equal(tool.name, "workflow");
 });
 
-test("modelRoutingGuideline advertises models from an injected registry", () => {
-  const registry = fakeRegistry([{ provider: "router", id: "shared-model" }]);
-  const text = modelRoutingGuideline(registry);
-  assert.match(text, /route only to these/i);
-  assert.match(text, /router\/shared-model/);
-});
-
-test("modelRoutingGuideline accepts a getter and resolves it lazily at call time", () => {
-  // Empty registry (not undefined) so the getter path is exercised end-to-end
-  // rather than falling through to the disk-registry default.
-  let registry: any = fakeRegistry([]);
-  const text = modelRoutingGuideline(() => registry);
-  assert.doesNotMatch(text, /router\/late-model/);
-
-  // Registering after construction (simulating session_start running after the
-  // guideline string was first read) is reflected on the next call.
-  registry = fakeRegistry([{ provider: "router", id: "late-model" }]);
-  const later = modelRoutingGuideline(() => registry);
-  assert.match(later, /router\/late-model/);
-});
-
-test("createWorkflowTool advertises models from the manager's shared registry when set before creation", () => {
+test("createWorkflowTool does not add configured model IDs to promptGuidelines", () => {
   const manager = new WorkflowManager({ cwd: "/tmp" });
-  manager.setModelRegistry(fakeRegistry([{ provider: "router", id: "wired-model" }]));
+  manager.setModelRegistry(fakeRegistry([{ provider: "router", id: "private-model" }]));
   const tool = createWorkflowTool({ cwd: "/tmp", manager });
-  const all = tool.promptGuidelines.join(" ");
-  assert.match(all, /router\/wired-model/);
-});
 
-test("createWorkflowTool promptGuidelines reflect a registry set AFTER tool creation (lazy accessor)", () => {
-  // Mirrors the real ordering: createWorkflowTool() runs at extension load,
-  // setModelRegistry() runs later in session_start. The SDK re-reads
-  // definition.promptGuidelines on every tool-registry refresh, so a fresh
-  // property read must see the late-set registry.
-  const manager = new WorkflowManager({ cwd: "/tmp" });
-  manager.setModelRegistry(fakeRegistry([]));
-  const tool = createWorkflowTool({ cwd: "/tmp", manager });
-  assert.doesNotMatch(tool.promptGuidelines.join(" "), /router\/late-model/);
+  assert.doesNotMatch(tool.promptGuidelines.join(" "), /router\/private-model/);
 
-  manager.setModelRegistry(fakeRegistry([{ provider: "router", id: "late-model" }]));
-  assert.match(tool.promptGuidelines.join(" "), /router\/late-model/);
-
-  // Replacing the registry again is also reflected.
-  manager.setModelRegistry(fakeRegistry([{ provider: "router", id: "replacement-model" }]));
-  const latest = tool.promptGuidelines.join(" ");
-  assert.match(latest, /router\/replacement-model/);
-  assert.doesNotMatch(latest, /router\/late-model/);
+  manager.setModelRegistry(fakeRegistry([{ provider: "router", id: "later-private-model" }]));
+  assert.doesNotMatch(tool.promptGuidelines.join(" "), /router\/later-private-model/);
 });
 
 test("modelRoutingGuideline output is non-empty and well-formed", () => {

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -72,7 +72,7 @@ test("createWorkflowTool routes normal work through tiers and reserves exact mod
 
   assert.match(all, /opts\.tier/);
   assert.match(all, /small.+medium.+big/s);
-  assert.match(all, /opts\.model only when the user (names|supplies)/i);
+  assert.match(all, /opts\.model only when the user names/i);
 });
 
 test("createWorkflowTool promptGuidelines keep budget and timeout unbounded by default", () => {


### PR DESCRIPTION
## Summary

- remove the live available-model catalogue from `promptGuidelines`
- keep normal routing on `small` / `medium` / `big`, with `opts.model` only for a user-named exact model
- add regression budgets around the accepted rendered prompt and provider-visible tool definition

The limits were established after the focused prompt form was complete: **6,500 UTF-8 bytes** for the isolated rendered workflow prompt contribution and **2,204 UTF-8 bytes** for `JSON.stringify({ name, description, parameters })`. They are exact observed ratchets, not the more aggressive research targets. The prompt baseline deliberately uses an empty `agentType` registry because removing that catalogue is deferred.

The provider-visible definition is unchanged in this PR; its test records the accepted current form so future growth is deliberate.

## Validation

- `npm test` — 825 passing
- Pi SDK integration test renders the real workflow prompt and reads the wrapped tool from `session.agent.state.tools`
- configured model IDs are checked before and after registry replacement and never enter `promptGuidelines`

This changes parent-model guidance only; runtime tier resolution and subagent model execution are unchanged, so no real-provider routing run was required.

Part of #65.
