### PR TITLE
fix: enforce agentType policies on extension tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,13 @@ The full guide — every global, agent option, `agentType` definitions, structur
 | --- | --- |
 | `tier` | `"small"` \| `"medium"` \| `"big"` — coarse model routing (configure via `/workflows-models`; tiers may store `provider/modelId:thinking`). |
 | `model` | Exact `provider/modelId` or `provider/modelId:thinking` (always wins over `tier`). |
-| `agentType` | A named definition (`.pi/agents/<name>.md` project-level, or `~/.pi/agent/agents/<name>.md` user-level — `~/.pi/agents/<name>.md` still works as a deprecated fallback) binding tools + model + role prompt. |
+| `agentType` | A named definition (`.pi/agents/<name>.md` project-level, or `~/.pi/agent/agents/<name>.md` user-level — `~/.pi/agents/<name>.md` still works as a deprecated fallback) binding tools + model + role prompt. Its tool policy constrains Pi's final built-in/custom/extension registry; narrowed selectors such as `ext:pi-web-access/web_search` are supported. |
 | `isolation: "worktree"` | Run in a throwaway git worktree for conflict-free parallel edits. |
 | `schema` | JSON Schema → the subagent returns a validated object. |
 | `label` / `phase` / `timeoutMs` | Display label / phase override / optional per-agent hard timeout. Omit `timeoutMs` for no hard timeout. |
 | `retries` | Retry attempts after a recoverable failure (timeout, connection failure, empty output) for this agent. Overrides the run-level `agentRetries`. Default `0`. |
+
+Workflow subagents deny recursive orchestration tools (`Agent`, `get_subagent_result`, `steer_subagent`, `workflow`, and the lowercase `agent` variant) by default so nested work cannot bypass the run's agent count, limiter, model routing, or accounting. A restrictive `agentType` tool allowlist is applied to Pi's final registry, including extension tools. To permit recursion deliberately, list the exact orchestration tool name in that agentType's `tools` allowlist.
 
 By default, workflows do not set a run-wide token budget or per-agent hard timeout. Use the `workflow` tool's `tokenBudget` / `agentTimeoutMs`, per-phase budgets, or per-agent `timeoutMs` only when you want an explicit cap. A global fallback timeout can also be set in `~/.pi/workflows/settings.json` as `{ "defaultAgentTimeoutMs": 600000 }`; set it to `null` or omit it for no default hard timeout.
 

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -183,18 +183,49 @@ export function resolveAgentType(name: string | undefined, registry: AgentRegist
 }
 
 /**
+ * Convert agent-definition tool selectors into Pi SDK tool names.
+ *
+ * Plain entries are already tool names. The shared pi-subagents definition
+ * format also supports a narrowed extension selector such as
+ * `ext:pi-web-access/web_search`; Pi's createAgentSession `tools` option needs
+ * the registered tool name (`web_search`), not that source-qualified selector.
+ * A bare `ext:package` selector cannot be resolved without enumerating the
+ * extension's registry, so it intentionally contributes no tool names here.
+ */
+export function normalizeToolPolicyNames(names: string[] | undefined): string[] | undefined {
+  if (names === undefined) return undefined;
+  const normalized: string[] = [];
+  for (const value of names) {
+    const name = value.trim();
+    if (!name) continue;
+    if (!name.startsWith("ext:")) {
+      normalized.push(name);
+      continue;
+    }
+    const slash = name.indexOf("/", "ext:".length);
+    if (slash === -1) continue;
+    const toolName = name.slice(slash + 1).trim();
+    if (toolName) normalized.push(toolName);
+  }
+  return [...new Set(normalized)];
+}
+
+/**
  * Apply a definition's tool policy to a tool list: keep only allowlisted names
- * (when an allowlist is given), then drop any denylisted names. Generic over any
- * object with a `name` so it is unit-testable without real ToolDefinitions.
+ * (when an allowlist is given), then drop any denylisted names. Narrowed `ext:`
+ * selectors are normalized to their registered Pi tool name first. Generic over
+ * any object with a `name` so it is unit-testable without real ToolDefinitions.
  */
 export function applyToolPolicy<T extends { name: string }>(tools: T[], allow?: string[], deny?: string[]): T[] {
   let out = tools;
-  if (allow?.length) {
-    const allowSet = new Set(allow);
+  const normalizedAllow = normalizeToolPolicyNames(allow);
+  const normalizedDeny = normalizeToolPolicyNames(deny);
+  if (normalizedAllow?.length) {
+    const allowSet = new Set(normalizedAllow);
     out = out.filter((t) => allowSet.has(t.name));
   }
-  if (deny?.length) {
-    const denySet = new Set(deny);
+  if (normalizedDeny?.length) {
+    const denySet = new Set(normalizedDeny);
     out = out.filter((t) => !denySet.has(t.name));
   }
   return out;

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -16,7 +16,7 @@ import {
 import type { Static, TSchema } from "typebox";
 import { Check, Convert } from "typebox/value";
 import { type AgentHistoryEntry, compactAgentHistory } from "./agent-history.js";
-import { applyToolPolicy } from "./agent-registry.js";
+import { applyToolPolicy, normalizeToolPolicyNames } from "./agent-registry.js";
 import { classifyProviderLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import { canonicalModelSpec, resolveModelSpecWithThinking } from "./model-spec.js";
 import { loadModelTierConfig, type ModelTierConfig, resolveTierModel } from "./model-tier-config.js";
@@ -296,13 +296,15 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
   /** Run this agent in a different working directory (e.g. an isolated worktree). */
   cwd?: string;
   /**
-   * Restrict the subagent's coding tools to these names (an agentType
-   * definition's `tools` allowlist). Undefined = all coding tools. The
-   * structured_output tool is always added after this filter, so a schema
-   * still works under a restrictive allowlist.
+   * Restrict the subagent's final Pi tool registry to these names (an agentType
+   * definition's `tools` allowlist), including extension tools. Narrowed
+   * `ext:package/tool` selectors are accepted. Undefined keeps the normal tool
+   * set, minus recursive orchestration tools. The structured_output tool is
+   * always added after this filter, so a schema still works under a restrictive
+   * allowlist.
    */
   toolNames?: string[];
-  /** Remove these coding-tool names after the allowlist (an agentType `disallowedTools` denylist). */
+  /** Remove these names from the final Pi tool registry after the allowlist. */
   disallowedToolNames?: string[];
   /**
    * With `schema`: how many extra repair turns to allow if the model finishes
@@ -330,6 +332,59 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
 export type AgentRunResult<TSchemaDef extends TSchema | undefined> = TSchemaDef extends TSchema
   ? Static<TSchemaDef>
   : string;
+
+/**
+ * Known Pi orchestration tools that can create or control work outside this
+ * workflow runtime's counters, limiter, model routing, and usage accounting.
+ * Workflow subagents deny these by default. An agentType/session allowlist may
+ * opt into an exact name deliberately; all other names stay denied.
+ */
+export const RECURSIVE_ORCHESTRATION_TOOL_NAMES = [
+  "Agent",
+  "agent",
+  "get_subagent_result",
+  "steer_subagent",
+  "workflow",
+] as const;
+
+function uniqueToolNames(names: Iterable<string>): string[] {
+  return [...new Set([...names].filter(Boolean))];
+}
+
+/** Build the Pi SDK policy that gates built-in, custom, and extension tools. */
+function buildSessionToolPolicy(
+  options: Pick<AgentRunOptions<any>, "toolNames" | "disallowedToolNames">,
+  sessionOptions: Partial<CreateAgentSessionOptions>,
+  alwaysAllowedToolNames: string[],
+): Pick<CreateAgentSessionOptions, "tools" | "excludeTools"> {
+  // An agentType allowlist is authoritative over a constructor-level session
+  // allowlist. Both forms may use narrowed ext:package/tool selectors.
+  const policyAllow = normalizeToolPolicyNames(options.toolNames);
+  const sessionAllow = normalizeToolPolicyNames(sessionOptions.tools);
+  const explicitAllow = policyAllow ?? sessionAllow;
+  const explicitlyAllowed = new Set(explicitAllow ?? []);
+
+  const denied = new Set([
+    ...(normalizeToolPolicyNames(sessionOptions.excludeTools) ?? []),
+    ...(normalizeToolPolicyNames(options.disallowedToolNames) ?? []),
+  ]);
+  for (const toolName of RECURSIVE_ORCHESTRATION_TOOL_NAMES) {
+    if (!explicitlyAllowed.has(toolName)) denied.add(toolName);
+  }
+
+  // Runtime-owned system/schema tools intentionally bypass agentType policy.
+  for (const toolName of alwaysAllowedToolNames) denied.delete(toolName);
+
+  if (explicitAllow !== undefined) {
+    const tools = uniqueToolNames([
+      ...explicitAllow.filter((toolName) => !denied.has(toolName)),
+      ...alwaysAllowedToolNames,
+    ]);
+    return { tools, excludeTools: [...denied] };
+  }
+
+  return { excludeTools: [...denied] };
+}
 
 export class WorkflowAgent {
   private readonly cwd: string;
@@ -437,6 +492,14 @@ export class WorkflowAgent {
       customTools.push(createStructuredOutputTool({ schema: options.schema, capture }) as unknown as ToolDefinition);
     }
 
+    const alwaysAllowedToolNames = uniqueToolNames([
+      ...(options.systemTools ?? []).map((tool) => tool.name),
+      ...(options.schema ? ["structured_output"] : []),
+    ]);
+    // Crucially, pass Pi's own tools/excludeTools policy. Filtering customTools
+    // alone does not constrain tools registered by globally loaded extensions.
+    const sessionToolPolicy = buildSessionToolPolicy(options, this.sessionOptions, alwaysAllowedToolNames);
+
     // Resolve the model spec (explicit model > tier > session default). This
     // composes with phase-based routing in workflow.ts, which only supplies
     // options.model when a phase pattern matches — so an explicit model wins.
@@ -484,6 +547,9 @@ export class WorkflowAgent {
         ? { modelRegistry: options.modelRegistry ?? this.sharedRegistry }
         : {}),
       ...this.sessionOptions,
+      // Final policy wins over sessionOptions so an agentType allowlist cannot
+      // be bypassed by extension/custom tools loaded during session creation.
+      ...sessionToolPolicy,
       // Per-call model/thinking wins over any sessionOptions defaults.
       ...(resolvedModel ? { model: resolvedModel } : {}),
       ...(resolvedThinkingLevel ? { thinkingLevel: resolvedThinkingLevel } : {}),

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -12,6 +12,7 @@ import {
   applyToolPolicy,
   listAgentTypes,
   loadAgentRegistry,
+  normalizeToolPolicyNames,
   parseAgentDefinition,
   resolveAgentType,
 } from "../src/agent-registry.js";
@@ -303,6 +304,20 @@ describe("applyToolPolicy", () => {
       applyToolPolicy(tools, ["read", "write"], ["write"]).map((t) => t.name),
       ["read"],
     );
+  });
+  it("normalizes narrowed extension selectors to Pi tool names", () => {
+    const withExtensionTool = [...tools, { name: "web_search" }];
+    assert.deepEqual(
+      applyToolPolicy(withExtensionTool, ["read", "ext:pi-web-access/web_search"]).map((t) => t.name),
+      ["read", "web_search"],
+    );
+    assert.deepEqual(normalizeToolPolicyNames(["ext:pi-web-access/web_search", "read", "read"]), [
+      "web_search",
+      "read",
+    ]);
+  });
+  it("does not guess tool names from a bare extension selector", () => {
+    assert.deepEqual(normalizeToolPolicyNames(["ext:pi-web-access"]), []);
   });
 });
 

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -3,6 +3,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
+import { DefaultResourceLoader, defineTool, SessionManager, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
 import type { AgentRunOptions, AgentUsage } from "../src/agent.js";
 import { listAvailableModelSpecs, resolveAgentModelSpec, WorkflowAgent } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
@@ -249,6 +251,90 @@ test("WorkflowAgent.getRegistry: per-run registry wins, then constructor's share
 
   const bareAgent = new WorkflowAgent({ cwd: "/tmp" });
   assert.doesNotThrow(() => (bareAgent as any).getRegistry());
+});
+
+function probeTool(name: string) {
+  return defineTool({
+    name,
+    label: name,
+    description: name,
+    parameters: Type.Object({}),
+    execute: async () => ({ content: [{ type: "text" as const, text: "ok" }], details: {} }),
+  });
+}
+
+async function captureWorkflowAgentActiveTools(
+  runOptions: Pick<AgentRunOptions<any>, "toolNames" | "disallowedToolNames">,
+): Promise<string[]> {
+  const root = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-tool-policy-"));
+  try {
+    let activeTools: string[] = [];
+    const settingsManager = SettingsManager.inMemory();
+    const resourceLoader = new DefaultResourceLoader({
+      cwd: root,
+      agentDir: join(root, "agent"),
+      settingsManager,
+      noSkills: true,
+      noPromptTemplates: true,
+      noThemes: true,
+      noContextFiles: true,
+      extensionFactories: [
+        (pi) => {
+          for (const name of ["Agent", "get_subagent_result", "steer_subagent", "workflow", "web_search"]) {
+            pi.registerTool(probeTool(name));
+          }
+          // Capture the final active registry without making a provider request.
+          pi.on("input", () => {
+            activeTools = pi.getActiveTools();
+            return { action: "handled" as const };
+          });
+        },
+      ],
+    });
+    await resourceLoader.reload();
+
+    const agent = new WorkflowAgent({
+      cwd: root,
+      tools: [probeTool("read")],
+      session: {
+        resourceLoader,
+        settingsManager,
+        sessionManager: SessionManager.inMemory(root),
+      },
+    });
+    await assert.rejects(
+      () => agent.run("capture active tools", { label: "tool policy probe", ...runOptions }),
+      /no assistant output/i,
+    );
+    return activeTools;
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("WorkflowAgent applies agentType allowlists to the final extension tool registry", async () => {
+  const active = await captureWorkflowAgentActiveTools({
+    toolNames: ["read", "ext:pi-web-access/web_search"],
+  });
+  assert.deepEqual(active.sort(), ["read", "web_search"]);
+});
+
+test("WorkflowAgent denies recursive orchestration tools by default but keeps normal extensions", async () => {
+  const active = await captureWorkflowAgentActiveTools({});
+  assert.ok(active.includes("web_search"), "ordinary extension tools remain available without an agentType allowlist");
+  for (const forbidden of ["Agent", "get_subagent_result", "steer_subagent", "workflow"]) {
+    assert.ok(!active.includes(forbidden), `${forbidden} must be denied by default`);
+  }
+});
+
+test("WorkflowAgent applies agentType denylists to extension tools", async () => {
+  const active = await captureWorkflowAgentActiveTools({ disallowedToolNames: ["web_search"] });
+  assert.ok(!active.includes("web_search"));
+});
+
+test("WorkflowAgent permits an orchestration tool only when it is explicitly allowlisted", async () => {
+  const active = await captureWorkflowAgentActiveTools({ toolNames: ["Agent"] });
+  assert.deepEqual(active, ["Agent"]);
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- apply `agentType` allow/deny policies to Pi's final built-in, SDK-custom, and extension tool registry
- deny recursive orchestration tools (`Agent`, `agent`, `get_subagent_result`, `steer_subagent`, `workflow`) in workflow subagents unless an exact name is deliberately allowlisted
- normalize narrowed shared-agent selectors such as `ext:pi-web-access/web_search` to the registered Pi tool name while preserving runtime-owned schema/store tools

## Why

`WorkflowAgent` previously filtered only the `customTools` array and then called `createAgentSession()` without Pi's `tools` or `excludeTools` options. Pi consequently kept globally registered extension tools active. A workflow agent with a restrictive `agentType` could still launch hidden manual subagents, bypassing the workflow's `maxAgents`, concurrency limiter, model tier, progress view, and accounting.

## Tests

- regression tests create a real Pi `AgentSession` with inline extension tools and inspect its active registry without a provider request
- verifies narrowed web tools remain available
- verifies recursive tools are absent by default
- verifies extension denylists apply
- verifies explicit opt-in can re-enable an exact orchestration tool
- focused branch validation: 88 tests passed + TypeScript build
- combined branch validation: `npm test`, 837 tests passed
