### PR TITLE
feat: show cached token reads separately across workflow displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ return await agent('Synthesize and double-check these findings:\n' + findings.jo
 - **Journaled resume** — an interrupted run replays finished agents from a journal (no re-run, no tokens) and runs only what's left or what you changed.
 - **Git worktree isolation** — `isolation: "worktree"` gives an agent its own branch, so parallel agents can edit the same files without clobbering each other.
 - **Real token & cost accounting** — read from each subagent's session, not estimated. Runs have no default token cap; `tokenBudget`, phase budgets, and `budget` let you add explicit gates when you want them.
-- **Background by default** — the turn ends right away, a live "Workflows running" panel tracks runs, and each result is delivered back so the conversation auto-continues when it finishes. The panel is compact by default; `/workflows-progress detailed` expands it inline to per-phase/per-agent rows with tokens, cost, and a live tok/s rate (so a stalled agent shows as 0 tok/s) — no need to open `/workflows`.
+- **Background by default** — the turn ends right away, a live "Workflows running" panel tracks runs, and each result is delivered back so the conversation auto-continues when it finishes. The panel is compact by default; `/workflows-progress detailed` expands it inline to per-phase/per-agent rows with a fresh/cache token split, cost, and a live tok/s rate (so a stalled agent shows as 0 tok/s) — no need to open `/workflows`.
 - **Interactive `/workflows` TUI** — drill runs → phases → agents → detail; inspect per-agent failures and compact subagent history; pause, stop, restart, and save runs from the keyboard.
 - **Quality patterns built in** — `verify()`, `judgePanel()`, `loopUntilDry()`, and `completenessCheck()` for adversarial review, best-of-N, and exhaustive discovery.
 - **Ultracode** — `/ultracode` is a standing opt-in that auto-arms an exhaustive multi-agent workflow for every substantive message, the way Claude Code's ultracode does. `/effort high` is the lighter tier.
@@ -111,7 +111,7 @@ The same model — on Pi, plus the production pieces a real run needs:
                             is off (/workflows-trigger off); the run shows in the panel + /workflows.
 /workflows-progress compact|detailed|status
                             switch the live panel between the compact one-liner and the detailed
-                            per-phase/per-agent view (with tokens, cost, and a live tok/s rate)
+                            per-phase/per-agent view (with a fresh/cache token split, cost, and a live tok/s rate)
 /workflows-progress-max <N> cap agents shown per phase in detailed mode (1-1000, default 8)
 /workflows-models           map the small / medium / big tiers to real models, optionally with thinking levels
 /ultracode [off]            ultracode: auto-arm an exhaustive workflow for every substantive message

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -253,6 +253,28 @@ export interface AgentUsage {
   cost: number;
 }
 
+/**
+ * Map session stats to an AgentUsage, or undefined when the provider reported
+ * no usage at all (all-zero stats). Returning undefined — instead of a zero
+ * breakdown — lets displays fall back to their scalar token count, so setups
+ * on non-reporting providers render the same as before the split existed.
+ */
+export function usageFromStats(stats: {
+  tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+  cost: number;
+}): AgentUsage | undefined {
+  const { tokens, cost } = stats;
+  if (tokens.total <= 0 && cost <= 0) return undefined;
+  return {
+    input: tokens.input,
+    output: tokens.output,
+    cacheRead: tokens.cacheRead,
+    cacheWrite: tokens.cacheWrite,
+    total: tokens.total,
+    cost,
+  };
+}
+
 export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefined> {
   label?: string;
   /**
@@ -269,7 +291,8 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
   /**
    * Called once with this subagent's real usage, read from the session right
    * before disposal. Fires on both the success and error paths so partial
-   * usage is never lost. `total === 0` means the provider reported no usage.
+   * usage is never lost — but NOT when the provider reported no usage at all
+   * (all-zero stats), so consumers keep their scalar fallback.
    */
   onUsage?: (usage: AgentUsage) => void;
   /**
@@ -556,15 +579,8 @@ export class WorkflowAgent {
       // Read real usage before disposing — dispose tears down the session state.
       if (options.onUsage) {
         try {
-          const { tokens, cost } = session.getSessionStats();
-          options.onUsage({
-            input: tokens.input,
-            output: tokens.output,
-            cacheRead: tokens.cacheRead,
-            cacheWrite: tokens.cacheWrite,
-            total: tokens.total,
-            cost,
-          });
+          const usage = usageFromStats(session.getSessionStats());
+          if (usage) options.onUsage(usage);
         } catch {
           // Usage is best-effort; never let stats failure mask the real result/error.
         }

--- a/src/display.ts
+++ b/src/display.ts
@@ -68,21 +68,23 @@ export interface WorkflowDisplayOptions {
  * estimate. The token pipeline has two sources that don't always agree: the
  * provider-reported breakdown (input/output/cacheRead/cacheWrite) and a scalar
  * estimate (`total` at run level, `tokens` per agent) that keeps accruing even
- * when the provider reports nothing. Rule: `fresh` is the reported input+output,
- * but never less than what the estimate can account for after removing cache
- * reads/writes. That keeps estimate-only providers, cost-only providers
- * (billed but zero token counts), and mixed runs at the count the display
- * showed before the split existed, instead of a false "0 tok".
+ * when the provider reports nothing. Two rules:
+ * - `fresh` counts input+output+cacheWrite: cache writes are first-time
+ *   ingestion billed at full (or premium) price, so hiding them would
+ *   under-report real spend; only cacheRead is the cheap reuse shown apart.
+ * - `fresh` is never less than what the estimate can account for after
+ *   removing cache reads, so estimate-only providers, cost-only providers
+ *   (billed but zero token counts), and mixed runs keep the count the display
+ *   showed before the split existed, instead of a false "0 tok".
  */
 export function tokenFigures(
   usage: Partial<AgentUsage> | undefined,
   scalarTokens?: number,
 ): { fresh: number; cacheRead: number } {
   const cacheRead = usage?.cacheRead ?? 0;
-  const cacheWrite = usage?.cacheWrite ?? 0;
-  const reported = (usage?.input ?? 0) + (usage?.output ?? 0);
+  const reported = (usage?.input ?? 0) + (usage?.output ?? 0) + (usage?.cacheWrite ?? 0);
   const estimate = Math.max(scalarTokens ?? 0, usage?.total ?? 0);
-  return { fresh: Math.max(reported, estimate - cacheRead - cacheWrite), cacheRead };
+  return { fresh: Math.max(reported, estimate - cacheRead), cacheRead };
 }
 
 /** Sum a set of agents into fresh vs cacheRead totals, via {@link tokenFigures}. */
@@ -105,17 +107,30 @@ export function aggregateAgentUsage(agents: ReadonlyArray<Pick<WorkflowAgentSnap
  * "89K tok · 3.0M cached" when there were cache reads. The cache segment is shown
  * only when `cacheRead > 0`, so a non-caching provider (or a single-turn agent that
  * never re-reads its cache) reads as a plain "tok" rather than a bare, contextless
- * "fresh". `cacheWrite` (the one-time cache-creation premium) is intentionally left
- * out of both figures; its dollar impact already shows in the cost readout. `fmt`
- * adapts the number style per surface (compact in panels, full in the print view).
+ * "fresh". `fmt` adapts the number style per surface (compact in panels, full in
+ * the print view).
  */
 export function fmtTokenCount(fresh: number, cacheRead: number, fmt: (n: number) => string): string {
   const f = fmt(fresh) || "0";
   return cacheRead > 0 ? `${f} tok · ${fmt(cacheRead)} cached` : `${f} tok`;
 }
 
-/** "$1.23" from one cent up, four decimals below it — a real sub-cent cost never shows as "$0.00". */
+/**
+ * Like {@link fmtTokenCount}, but "" when nothing is known yet (both figures 0),
+ * so surfaces omit the segment instead of rendering a false "0 tok" — e.g. for a
+ * journal-replayed resume or a run whose agents were all skipped. Every surface
+ * should use this rather than re-implementing the zero guard.
+ */
+export function fmtTokenSegment(figures: { fresh: number; cacheRead: number }, fmt: (n: number) => string): string {
+  return figures.fresh + figures.cacheRead > 0 ? fmtTokenCount(figures.fresh, figures.cacheRead, fmt) : "";
+}
+
+/**
+ * "$1.23" from one cent up, four decimals below it, and "<$0.0001" for
+ * anything smaller — a real cost never rounds to a zero-looking "$0.00".
+ */
 export function fmtCost(cost: number): string {
+  if (cost > 0 && cost < 0.0001) return "<$0.0001";
   return `$${cost.toFixed(cost >= 0.01 ? 2 : 4)}`;
 }
 
@@ -230,9 +245,8 @@ const NO_THEME: ThemeLike = { fg: (_c, t) => t, bold: (t) => t };
 
 /** The bracketed per-agent token cell (" [89 tok · 3,000 cached]"), or "" when nothing is known yet. */
 function agentTokenCell(agent: WorkflowAgentSnapshot, theme: ThemeLike): string {
-  const { fresh, cacheRead } = tokenFigures(agent.tokenUsage, agent.tokens);
-  if (fresh + cacheRead <= 0) return "";
-  return theme.fg("dim", ` [${fmtTokenCount(fresh, cacheRead, fmtFull)}]`);
+  const segment = fmtTokenSegment(tokenFigures(agent.tokenUsage, agent.tokens), fmtFull);
+  return segment ? theme.fg("dim", ` [${segment}]`) : "";
 }
 
 export function renderWorkflowLines(
@@ -251,8 +265,8 @@ export function renderWorkflowLines(
   // Build header with token info (and cost when the provider reports it)
   const usage = snapshot.tokenUsage;
   const costInfo = usage?.cost ? ` · ${fmtCost(usage.cost)}` : "";
-  const figures = tokenFigures(usage);
-  const tokenInfo = usage ? ` · ${fmtTokenCount(figures.fresh, figures.cacheRead, fmtFull)}${costInfo}` : "";
+  const segment = fmtTokenSegment(tokenFigures(usage), fmtFull);
+  const tokenInfo = `${segment ? ` · ${segment}` : ""}${costInfo}`;
   const lines = [
     `${theme.bold(`◆ Workflow: ${snapshot.name}`)} (${snapshot.doneCount}/${snapshot.agentCount} done${state}${tokenInfo})`,
   ];

--- a/src/display.ts
+++ b/src/display.ts
@@ -134,7 +134,8 @@ export function fmtCost(cost: number): string {
   return `$${cost.toFixed(cost >= 0.01 ? 2 : 4)}`;
 }
 
-const fmtFull = (n: number): string => n.toLocaleString();
+/** Full (non-compact) number style for print/text surfaces: locale-grouped digits. */
+export const fmtFull = (n: number): string => n.toLocaleString();
 
 export function createWorkflowSnapshot(meta: WorkflowMeta): WorkflowSnapshot {
   return {

--- a/src/display.ts
+++ b/src/display.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import type { AgentUsage } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import type { WorkflowErrorCode } from "./errors.js";
 import type { WorkflowMeta } from "./workflow.js";
@@ -16,17 +17,10 @@ export interface WorkflowAgentSnapshot {
   errorCode?: WorkflowErrorCode;
   recoverable?: boolean;
   history?: AgentHistoryEntry[];
-  /** Tokens used by this agent. */
+  /** Tokens used by this agent (a scalar estimate when the provider reports no usage). */
   tokens?: number;
   /** Per-agent token usage breakdown (fresh input+output vs cached), when known. */
-  tokenUsage?: {
-    input: number;
-    output: number;
-    total: number;
-    cost: number;
-    cacheRead: number;
-    cacheWrite: number;
-  };
+  tokenUsage?: AgentUsage;
   /** The model this agent ran on (provider/id), when known. */
   model?: string;
 }
@@ -70,10 +64,28 @@ export interface WorkflowDisplayOptions {
 }
 
 /**
- * Sum a set of agents into fresh (input+output) vs cacheRead totals. Agents whose
- * provider reported no usage breakdown contribute their scalar `tokens` as fresh, so
- * a mixed run (some agents with a breakdown, some without) still aggregates sensibly.
+ * Displayable fresh/cached figures from a usage breakdown and/or a scalar
+ * estimate. The token pipeline has two sources that don't always agree: the
+ * provider-reported breakdown (input/output/cacheRead/cacheWrite) and a scalar
+ * estimate (`total` at run level, `tokens` per agent) that keeps accruing even
+ * when the provider reports nothing. Rule: `fresh` is the reported input+output,
+ * but never less than what the estimate can account for after removing cache
+ * reads/writes. That keeps estimate-only providers, cost-only providers
+ * (billed but zero token counts), and mixed runs at the count the display
+ * showed before the split existed, instead of a false "0 tok".
  */
+export function tokenFigures(
+  usage: Partial<AgentUsage> | undefined,
+  scalarTokens?: number,
+): { fresh: number; cacheRead: number } {
+  const cacheRead = usage?.cacheRead ?? 0;
+  const cacheWrite = usage?.cacheWrite ?? 0;
+  const reported = (usage?.input ?? 0) + (usage?.output ?? 0);
+  const estimate = Math.max(scalarTokens ?? 0, usage?.total ?? 0);
+  return { fresh: Math.max(reported, estimate - cacheRead - cacheWrite), cacheRead };
+}
+
+/** Sum a set of agents into fresh vs cacheRead totals, via {@link tokenFigures}. */
 export function aggregateAgentUsage(agents: ReadonlyArray<Pick<WorkflowAgentSnapshot, "tokens" | "tokenUsage">>): {
   fresh: number;
   cacheRead: number;
@@ -81,12 +93,9 @@ export function aggregateAgentUsage(agents: ReadonlyArray<Pick<WorkflowAgentSnap
   let fresh = 0;
   let cacheRead = 0;
   for (const a of agents) {
-    if (a.tokenUsage) {
-      fresh += a.tokenUsage.input + a.tokenUsage.output;
-      cacheRead += a.tokenUsage.cacheRead;
-    } else {
-      fresh += a.tokens ?? 0;
-    }
+    const f = tokenFigures(a.tokenUsage, a.tokens);
+    fresh += f.fresh;
+    cacheRead += f.cacheRead;
   }
   return { fresh, cacheRead };
 }
@@ -104,6 +113,13 @@ export function fmtTokenCount(fresh: number, cacheRead: number, fmt: (n: number)
   const f = fmt(fresh) || "0";
   return cacheRead > 0 ? `${f} tok · ${fmt(cacheRead)} cached` : `${f} tok`;
 }
+
+/** "$1.23" from one cent up, four decimals below it — a real sub-cent cost never shows as "$0.00". */
+export function fmtCost(cost: number): string {
+  return `$${cost.toFixed(cost >= 0.01 ? 2 : 4)}`;
+}
+
+const fmtFull = (n: number): string => n.toLocaleString();
 
 export function createWorkflowSnapshot(meta: WorkflowMeta): WorkflowSnapshot {
   return {
@@ -212,6 +228,13 @@ export interface ThemeLike {
 /** Identity passthrough for contexts where no theme is available (tool text output). */
 const NO_THEME: ThemeLike = { fg: (_c, t) => t, bold: (t) => t };
 
+/** The bracketed per-agent token cell (" [89 tok · 3,000 cached]"), or "" when nothing is known yet. */
+function agentTokenCell(agent: WorkflowAgentSnapshot, theme: ThemeLike): string {
+  const { fresh, cacheRead } = tokenFigures(agent.tokenUsage, agent.tokens);
+  if (fresh + cacheRead <= 0) return "";
+  return theme.fg("dim", ` [${fmtTokenCount(fresh, cacheRead, fmtFull)}]`);
+}
+
 export function renderWorkflowLines(
   snapshot: WorkflowSnapshot,
   options: WorkflowDisplayOptions = {},
@@ -227,10 +250,9 @@ export function renderWorkflowLines(
         : "";
   // Build header with token info (and cost when the provider reports it)
   const usage = snapshot.tokenUsage;
-  const costInfo = usage?.cost ? ` · $${usage.cost.toFixed(4)}` : "";
-  const tokenInfo = usage
-    ? ` · ${fmtTokenCount(usage.input + usage.output, usage.cacheRead ?? 0, (n) => n.toLocaleString())}${costInfo}`
-    : "";
+  const costInfo = usage?.cost ? ` · ${fmtCost(usage.cost)}` : "";
+  const figures = tokenFigures(usage);
+  const tokenInfo = usage ? ` · ${fmtTokenCount(figures.fresh, figures.cacheRead, fmtFull)}${costInfo}` : "";
   const lines = [
     `${theme.bold(`◆ Workflow: ${snapshot.name}`)} (${snapshot.doneCount}/${snapshot.agentCount} done${state}${tokenInfo})`,
   ];
@@ -261,17 +283,9 @@ export function renderWorkflowLines(
     for (const agent of visibleAgents) {
       const order = `[${agent.id}]`;
       const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
-      const agentTokens = agent.tokenUsage
-        ? theme.fg(
-            "dim",
-            ` [${fmtTokenCount(agent.tokenUsage.input + agent.tokenUsage.output, agent.tokenUsage.cacheRead, (n) =>
-              n.toLocaleString(),
-            )}]`,
-          )
-        : agent.tokens
-          ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`)
-          : "";
-      lines.push(`    ${order} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
+      lines.push(
+        `    ${order} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokenCell(agent, theme)}${result}`,
+      );
     }
     if (agents.length > visibleAgents.length)
       lines.push(theme.fg("dim", `    … ${agents.length - visibleAgents.length} earlier agents`));
@@ -282,17 +296,9 @@ export function renderWorkflowLines(
     lines.push(theme.fg("accent", "  Unphased"));
     for (const agent of unphased.slice(-maxAgents)) {
       const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
-      const agentTokens = agent.tokenUsage
-        ? theme.fg(
-            "dim",
-            ` [${fmtTokenCount(agent.tokenUsage.input + agent.tokenUsage.output, agent.tokenUsage.cacheRead, (n) =>
-              n.toLocaleString(),
-            )}]`,
-          )
-        : agent.tokens
-          ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`)
-          : "";
-      lines.push(`    [${agent.id}] ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
+      lines.push(
+        `    [${agent.id}] ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokenCell(agent, theme)}${result}`,
+      );
     }
   }
 

--- a/src/display.ts
+++ b/src/display.ts
@@ -18,6 +18,15 @@ export interface WorkflowAgentSnapshot {
   history?: AgentHistoryEntry[];
   /** Tokens used by this agent. */
   tokens?: number;
+  /** Per-agent token usage breakdown (fresh input+output vs cached), when known. */
+  tokenUsage?: {
+    input: number;
+    output: number;
+    total: number;
+    cost: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
   /** The model this agent ran on (provider/id), when known. */
   model?: string;
 }
@@ -214,7 +223,16 @@ export function renderWorkflowLines(
     for (const agent of visibleAgents) {
       const order = `[${agent.id}]`;
       const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
-      const agentTokens = agent.tokens ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`) : "";
+      const agentTokens = agent.tokenUsage
+        ? theme.fg(
+            "dim",
+            ` [${(agent.tokenUsage.input + agent.tokenUsage.output).toLocaleString()} fresh${
+              agent.tokenUsage.cacheRead > 0 ? ` · ${agent.tokenUsage.cacheRead.toLocaleString()} cache` : ""
+            }]`,
+          )
+        : agent.tokens
+          ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`)
+          : "";
       lines.push(`    ${order} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
     }
     if (agents.length > visibleAgents.length)
@@ -226,7 +244,16 @@ export function renderWorkflowLines(
     lines.push(theme.fg("accent", "  Unphased"));
     for (const agent of unphased.slice(-maxAgents)) {
       const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
-      const agentTokens = agent.tokens ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`) : "";
+      const agentTokens = agent.tokenUsage
+        ? theme.fg(
+            "dim",
+            ` [${(agent.tokenUsage.input + agent.tokenUsage.output).toLocaleString()} fresh${
+              agent.tokenUsage.cacheRead > 0 ? ` · ${agent.tokenUsage.cacheRead.toLocaleString()} cache` : ""
+            }]`,
+          )
+        : agent.tokens
+          ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`)
+          : "";
       lines.push(`    [${agent.id}] ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
     }
   }

--- a/src/display.ts
+++ b/src/display.ts
@@ -69,6 +69,42 @@ export interface WorkflowDisplayOptions {
   showResultPreviews?: boolean;
 }
 
+/**
+ * Sum a set of agents into fresh (input+output) vs cacheRead totals. Agents whose
+ * provider reported no usage breakdown contribute their scalar `tokens` as fresh, so
+ * a mixed run (some agents with a breakdown, some without) still aggregates sensibly.
+ */
+export function aggregateAgentUsage(agents: ReadonlyArray<Pick<WorkflowAgentSnapshot, "tokens" | "tokenUsage">>): {
+  fresh: number;
+  cacheRead: number;
+} {
+  let fresh = 0;
+  let cacheRead = 0;
+  for (const a of agents) {
+    if (a.tokenUsage) {
+      fresh += a.tokenUsage.input + a.tokenUsage.output;
+      cacheRead += a.tokenUsage.cacheRead;
+    } else {
+      fresh += a.tokens ?? 0;
+    }
+  }
+  return { fresh, cacheRead };
+}
+
+/**
+ * Format a token count for a display surface: "12.4K tok" on its own, or
+ * "89K tok · 3.0M cached" when there were cache reads. The cache segment is shown
+ * only when `cacheRead > 0`, so a non-caching provider (or a single-turn agent that
+ * never re-reads its cache) reads as a plain "tok" rather than a bare, contextless
+ * "fresh". `cacheWrite` (the one-time cache-creation premium) is intentionally left
+ * out of both figures; its dollar impact already shows in the cost readout. `fmt`
+ * adapts the number style per surface (compact in panels, full in the print view).
+ */
+export function fmtTokenCount(fresh: number, cacheRead: number, fmt: (n: number) => string): string {
+  const f = fmt(fresh) || "0";
+  return cacheRead > 0 ? `${f} tok · ${fmt(cacheRead)} cached` : `${f} tok`;
+}
+
 export function createWorkflowSnapshot(meta: WorkflowMeta): WorkflowSnapshot {
   return {
     name: meta.name,
@@ -192,7 +228,9 @@ export function renderWorkflowLines(
   // Build header with token info (and cost when the provider reports it)
   const usage = snapshot.tokenUsage;
   const costInfo = usage?.cost ? ` · $${usage.cost.toFixed(4)}` : "";
-  const tokenInfo = usage ? ` · ${usage.total.toLocaleString()} tokens${costInfo}` : "";
+  const tokenInfo = usage
+    ? ` · ${fmtTokenCount(usage.input + usage.output, usage.cacheRead ?? 0, (n) => n.toLocaleString())}${costInfo}`
+    : "";
   const lines = [
     `${theme.bold(`◆ Workflow: ${snapshot.name}`)} (${snapshot.doneCount}/${snapshot.agentCount} done${state}${tokenInfo})`,
   ];
@@ -226,9 +264,9 @@ export function renderWorkflowLines(
       const agentTokens = agent.tokenUsage
         ? theme.fg(
             "dim",
-            ` [${(agent.tokenUsage.input + agent.tokenUsage.output).toLocaleString()} fresh${
-              agent.tokenUsage.cacheRead > 0 ? ` · ${agent.tokenUsage.cacheRead.toLocaleString()} cache` : ""
-            }]`,
+            ` [${fmtTokenCount(agent.tokenUsage.input + agent.tokenUsage.output, agent.tokenUsage.cacheRead, (n) =>
+              n.toLocaleString(),
+            )}]`,
           )
         : agent.tokens
           ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`)
@@ -247,9 +285,9 @@ export function renderWorkflowLines(
       const agentTokens = agent.tokenUsage
         ? theme.fg(
             "dim",
-            ` [${(agent.tokenUsage.input + agent.tokenUsage.output).toLocaleString()} fresh${
-              agent.tokenUsage.cacheRead > 0 ? ` · ${agent.tokenUsage.cacheRead.toLocaleString()} cache` : ""
-            }]`,
+            ` [${fmtTokenCount(agent.tokenUsage.input + agent.tokenUsage.output, agent.tokenUsage.cacheRead, (n) =>
+              n.toLocaleString(),
+            )}]`,
           )
         : agent.tokens
           ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`)

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -4,6 +4,7 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { AgentUsage } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import type { WorkflowErrorCode } from "./errors.js";
 import { workflowProjectPaths } from "./workflow-paths.js";
@@ -23,6 +24,10 @@ export interface PersistedAgentState {
   history?: AgentHistoryEntry[];
   startedAt?: string;
   endedAt?: string;
+  /** Tokens used by this agent (a scalar estimate when the provider reports no usage). */
+  tokens?: number;
+  /** Per-agent token usage breakdown, when the provider reported one. */
+  tokenUsage?: AgentUsage;
   /** The model this agent ran on (provider/id), when known. */
   model?: string;
 }

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -12,7 +12,7 @@ import { type Component, type TUI, truncateToWidth, visibleWidth } from "@earend
 import {
   aggregateAgentUsage,
   fmtCost,
-  fmtTokenCount,
+  fmtTokenSegment,
   shorten,
   statusIcon,
   tokenFigures,
@@ -101,8 +101,8 @@ export function deliverText(run: ManagedRun, opts: { resultPath?: string; maxCha
   const summary = summarizeResult(run.result?.result, opts.maxChars);
   const tu = run.result?.tokenUsage;
   const cost = tu?.cost ? ` · ${fmtCost(tu.cost)}` : "";
-  const fig = tokenFigures(tu);
-  const tokens = tu ? ` · ${fmtTokenCount(fig.fresh, fig.cacheRead, fmtTokensShort)}${cost}` : "";
+  const segment = fmtTokenSegment(tokenFigures(tu), fmtTokensShort);
+  const tokens = `${segment ? ` · ${segment}` : ""}${cost}`;
   const agents = run.result?.agentCount ?? run.snapshot.agentCount;
   const duration = run.result?.durationMs ? ` · ${(run.result.durationMs / 1000).toFixed(1)}s` : "";
   const lines = [
@@ -322,14 +322,11 @@ function renderRunBody(
     const skipped = phaseAgents.filter((a) => a.status === "skipped").length;
     const complete = done + errors + skipped === phaseAgents.length;
     const marker = running > 0 || (!complete && snap.currentPhase === title) ? "▶" : complete ? "✓" : " ";
-    const phaseUsage = aggregateAgentUsage(phaseAgents);
     const phaseMeta = [
       `${done}/${phaseAgents.length} agents`,
       running ? `${running} running` : "",
       errors ? `${errors} errors` : "",
-      phaseUsage.fresh + phaseUsage.cacheRead > 0
-        ? fmtTokenCount(phaseUsage.fresh, phaseUsage.cacheRead, fmtTokensShort)
-        : "",
+      fmtTokenSegment(aggregateAgentUsage(phaseAgents), fmtTokensShort),
     ]
       .filter(Boolean)
       .join(" · ");
@@ -337,9 +334,8 @@ function renderRunBody(
 
     const visible = phaseAgents.slice(-maxAgents);
     for (const a of visible) {
-      const fig = tokenFigures(a.tokenUsage, a.tokens);
-      const tok =
-        fig.fresh + fig.cacheRead > 0 ? dim(` ${fmtTokenCount(fig.fresh, fig.cacheRead, fmtTokensShort)}`) : "";
+      const segment = fmtTokenSegment(tokenFigures(a.tokenUsage, a.tokens), fmtTokensShort);
+      const tok = segment ? dim(` ${segment}`) : "";
       const mdl = shortModel(a.model);
       const model = mdl ? dim(` · ${mdl}`) : "";
       lines.push(`    [${a.id}] ${statusIcon(a.status)} ${shorten(a.label, 40)}${tok}${model}`);
@@ -377,21 +373,20 @@ export function renderPanelDetailed(
     const icon = r.status === "paused" ? "⏸" : "◆";
     const usage = snap?.tokenUsage ?? r.tokenUsage;
     // The run-level tokenUsage aggregate is only finalized when the run ends, so
-    // it reads 0 for the whole live run. Per-agent `tokens` update on each agent
-    // completion, so sum those for a live total (and keep the header consistent
-    // with the per-phase subtotals). Note: tokens land at agent-completion
-    // granularity, so the rate reflects completion throughput — it decays to 0
-    // during a single long-running agent or a stall (which is the intended signal).
-    const total = agents.reduce((n, a) => n + (a.tokens ?? 0), 0);
-    // Sample the running total and derive the rolling token/s. Paused runs don't
-    // accrue tokens, so their rate is suppressed (a stalled rate would mislead).
-    sampleTokens(r.runId, total, now);
-    const rate = r.status === "running" ? tokensPerSecond(r.runId) : 0;
+    // it reads 0 for the whole live run; per-agent figures update on each agent
+    // completion, so aggregate those instead. The rate samples the same
+    // fresh+cacheRead sum the header displays, so tok/s tracks the visible
+    // figures. Tokens land at agent-completion granularity, so the rate reflects
+    // completion throughput — it decays to 0 during a single long-running agent
+    // or a stall (which is the intended signal). Paused runs don't accrue
+    // tokens, so their rate is suppressed (a stalled rate would mislead).
     const runUsage = aggregateAgentUsage(agents);
+    sampleTokens(r.runId, runUsage.fresh + runUsage.cacheRead, now);
+    const rate = r.status === "running" ? tokensPerSecond(r.runId) : 0;
     const meta = [
       `${done}/${agents.length} agents`,
       snap?.currentPhase || "",
-      runUsage.fresh + runUsage.cacheRead > 0 ? fmtTokenCount(runUsage.fresh, runUsage.cacheRead, fmtTokensShort) : "",
+      fmtTokenSegment(runUsage, fmtTokensShort),
       // (cost is only known once the run finalizes its usage.)
       usage?.cost ? fmtCost(usage.cost) : "",
       rate > 0 ? `${Math.round(rate)} tok/s` : "",

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -90,7 +90,9 @@ function fitLine(line: string, width?: number): string {
 
 export function deliverText(run: ManagedRun, opts: { resultPath?: string; maxChars?: number } = {}): string {
   const summary = summarizeResult(run.result?.result, opts.maxChars);
-  const tokens = run.result?.tokenUsage ? ` · ${run.result.tokenUsage.total.toLocaleString()} tokens` : "";
+  const tu = run.result?.tokenUsage;
+  const cost = tu?.cost ? ` · $${tu.cost.toFixed(tu.cost >= 0.01 ? 2 : 4)}` : "";
+  const tokens = tu ? ` · ${fmtFreshCache(tu.input, tu.output, tu.cacheRead ?? 0)}${cost}` : "";
   const agents = run.result?.agentCount ?? run.snapshot.agentCount;
   const duration = run.result?.durationMs ? ` · ${(run.result.durationMs / 1000).toFixed(1)}s` : "";
   const lines = [
@@ -277,6 +279,19 @@ function fmtTokensShort(n: number): string {
   return `${(n / 1_000_000).toFixed(1)}M`;
 }
 
+/**
+ * Format a fresh (input+output) vs cache (cacheRead) token split. The cache segment
+ * is omitted when there were no cache reads (e.g. a provider without prompt caching),
+ * so it reads "6.3M fresh" rather than a dangling "6.3M fresh ·  cache". cacheWrite (the
+ * one-time cache-creation premium) is intentionally excluded from both counts; its dollar
+ * impact already shows in the delivery line's $cost.
+ */
+function fmtFreshCache(input: number, output: number, cacheRead: number): string {
+  const fresh = fmtTokensShort(input + output) || "0";
+  const cache = fmtTokensShort(cacheRead);
+  return cache ? `${fresh} fresh · ${cache} cache` : `${fresh} fresh`;
+}
+
 /** Normalize the configured per-phase agent cap to a sane integer (default 8). */
 export function clampMaxAgents(value: number | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return 8;
@@ -323,7 +338,11 @@ function renderRunBody(
 
     const visible = phaseAgents.slice(-maxAgents);
     for (const a of visible) {
-      const tok = a.tokens ? dim(` ${fmtTokensShort(a.tokens)} tok`) : "";
+      const tok = a.tokenUsage
+        ? dim(` ${fmtFreshCache(a.tokenUsage.input, a.tokenUsage.output, a.tokenUsage.cacheRead)}`)
+        : a.tokens
+          ? dim(` ${fmtTokensShort(a.tokens)} tok`)
+          : "";
       const mdl = shortModel(a.model);
       const model = mdl ? dim(` · ${mdl}`) : "";
       lines.push(`    [${a.id}] ${statusIcon(a.status)} ${shorten(a.label, 40)}${tok}${model}`);

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -11,9 +11,11 @@ import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi
 import { type Component, type TUI, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import {
   aggregateAgentUsage,
+  fmtCost,
   fmtTokenCount,
   shorten,
   statusIcon,
+  tokenFigures,
   type WorkflowAgentSnapshot,
   type WorkflowSnapshot,
 } from "./display.js";
@@ -98,8 +100,9 @@ function fitLine(line: string, width?: number): string {
 export function deliverText(run: ManagedRun, opts: { resultPath?: string; maxChars?: number } = {}): string {
   const summary = summarizeResult(run.result?.result, opts.maxChars);
   const tu = run.result?.tokenUsage;
-  const cost = tu?.cost ? ` · $${tu.cost.toFixed(tu.cost >= 0.01 ? 2 : 4)}` : "";
-  const tokens = tu ? ` · ${fmtTokenCount(tu.input + tu.output, tu.cacheRead ?? 0, fmtTokensShort)}${cost}` : "";
+  const cost = tu?.cost ? ` · ${fmtCost(tu.cost)}` : "";
+  const fig = tokenFigures(tu);
+  const tokens = tu ? ` · ${fmtTokenCount(fig.fresh, fig.cacheRead, fmtTokensShort)}${cost}` : "";
   const agents = run.result?.agentCount ?? run.snapshot.agentCount;
   const duration = run.result?.durationMs ? ` · ${(run.result.durationMs / 1000).toFixed(1)}s` : "";
   const lines = [
@@ -334,11 +337,9 @@ function renderRunBody(
 
     const visible = phaseAgents.slice(-maxAgents);
     for (const a of visible) {
-      const tok = a.tokenUsage
-        ? dim(` ${fmtTokenCount(a.tokenUsage.input + a.tokenUsage.output, a.tokenUsage.cacheRead, fmtTokensShort)}`)
-        : a.tokens
-          ? dim(` ${fmtTokensShort(a.tokens)} tok`)
-          : "";
+      const fig = tokenFigures(a.tokenUsage, a.tokens);
+      const tok =
+        fig.fresh + fig.cacheRead > 0 ? dim(` ${fmtTokenCount(fig.fresh, fig.cacheRead, fmtTokensShort)}`) : "";
       const mdl = shortModel(a.model);
       const model = mdl ? dim(` · ${mdl}`) : "";
       lines.push(`    [${a.id}] ${statusIcon(a.status)} ${shorten(a.label, 40)}${tok}${model}`);
@@ -390,10 +391,9 @@ export function renderPanelDetailed(
     const meta = [
       `${done}/${agents.length} agents`,
       snap?.currentPhase || "",
-      total > 0 ? fmtTokenCount(runUsage.fresh, runUsage.cacheRead, fmtTokensShort) : "",
-      // 2 decimals for ≥1¢, 4 for sub-cent so a real cost never shows as "$0.00".
+      runUsage.fresh + runUsage.cacheRead > 0 ? fmtTokenCount(runUsage.fresh, runUsage.cacheRead, fmtTokensShort) : "",
       // (cost is only known once the run finalizes its usage.)
-      usage?.cost ? `$${usage.cost.toFixed(usage.cost >= 0.01 ? 2 : 4)}` : "",
+      usage?.cost ? fmtCost(usage.cost) : "",
       rate > 0 ? `${Math.round(rate)} tok/s` : "",
     ]
       .filter(Boolean)

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -9,7 +9,14 @@
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
 import { type Component, type TUI, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import { shorten, statusIcon, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
+import {
+  aggregateAgentUsage,
+  fmtTokenCount,
+  shorten,
+  statusIcon,
+  type WorkflowAgentSnapshot,
+  type WorkflowSnapshot,
+} from "./display.js";
 import type { ManagedRun, WorkflowManager } from "./workflow-manager.js";
 import type { WorkflowStorage } from "./workflow-saved.js";
 import type { WorkflowSettings } from "./workflow-settings.js";
@@ -92,7 +99,7 @@ export function deliverText(run: ManagedRun, opts: { resultPath?: string; maxCha
   const summary = summarizeResult(run.result?.result, opts.maxChars);
   const tu = run.result?.tokenUsage;
   const cost = tu?.cost ? ` · $${tu.cost.toFixed(tu.cost >= 0.01 ? 2 : 4)}` : "";
-  const tokens = tu ? ` · ${fmtFreshCache(tu.input, tu.output, tu.cacheRead ?? 0)}${cost}` : "";
+  const tokens = tu ? ` · ${fmtTokenCount(tu.input + tu.output, tu.cacheRead ?? 0, fmtTokensShort)}${cost}` : "";
   const agents = run.result?.agentCount ?? run.snapshot.agentCount;
   const duration = run.result?.durationMs ? ` · ${(run.result.durationMs / 1000).toFixed(1)}s` : "";
   const lines = [
@@ -279,19 +286,6 @@ function fmtTokensShort(n: number): string {
   return `${(n / 1_000_000).toFixed(1)}M`;
 }
 
-/**
- * Format a fresh (input+output) vs cache (cacheRead) token split. The cache segment
- * is omitted when there were no cache reads (e.g. a provider without prompt caching),
- * so it reads "6.3M fresh" rather than a dangling "6.3M fresh ·  cache". cacheWrite (the
- * one-time cache-creation premium) is intentionally excluded from both counts; its dollar
- * impact already shows in the delivery line's $cost.
- */
-function fmtFreshCache(input: number, output: number, cacheRead: number): string {
-  const fresh = fmtTokensShort(input + output) || "0";
-  const cache = fmtTokensShort(cacheRead);
-  return cache ? `${fresh} fresh · ${cache} cache` : `${fresh} fresh`;
-}
-
 /** Normalize the configured per-phase agent cap to a sane integer (default 8). */
 export function clampMaxAgents(value: number | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return 8;
@@ -325,12 +319,14 @@ function renderRunBody(
     const skipped = phaseAgents.filter((a) => a.status === "skipped").length;
     const complete = done + errors + skipped === phaseAgents.length;
     const marker = running > 0 || (!complete && snap.currentPhase === title) ? "▶" : complete ? "✓" : " ";
-    const phaseTokens = phaseAgents.reduce((n, a) => n + (a.tokens ?? 0), 0);
+    const phaseUsage = aggregateAgentUsage(phaseAgents);
     const phaseMeta = [
       `${done}/${phaseAgents.length} agents`,
       running ? `${running} running` : "",
       errors ? `${errors} errors` : "",
-      phaseTokens > 0 ? `${fmtTokensShort(phaseTokens)} tok` : "",
+      phaseUsage.fresh + phaseUsage.cacheRead > 0
+        ? fmtTokenCount(phaseUsage.fresh, phaseUsage.cacheRead, fmtTokensShort)
+        : "",
     ]
       .filter(Boolean)
       .join(" · ");
@@ -339,7 +335,7 @@ function renderRunBody(
     const visible = phaseAgents.slice(-maxAgents);
     for (const a of visible) {
       const tok = a.tokenUsage
-        ? dim(` ${fmtFreshCache(a.tokenUsage.input, a.tokenUsage.output, a.tokenUsage.cacheRead)}`)
+        ? dim(` ${fmtTokenCount(a.tokenUsage.input + a.tokenUsage.output, a.tokenUsage.cacheRead, fmtTokensShort)}`)
         : a.tokens
           ? dim(` ${fmtTokensShort(a.tokens)} tok`)
           : "";
@@ -390,10 +386,11 @@ export function renderPanelDetailed(
     // accrue tokens, so their rate is suppressed (a stalled rate would mislead).
     sampleTokens(r.runId, total, now);
     const rate = r.status === "running" ? tokensPerSecond(r.runId) : 0;
+    const runUsage = aggregateAgentUsage(agents);
     const meta = [
       `${done}/${agents.length} agents`,
       snap?.currentPhase || "",
-      total > 0 ? `${fmtTokensShort(total)} tok` : "",
+      total > 0 ? fmtTokenCount(runUsage.fresh, runUsage.cacheRead, fmtTokensShort) : "",
       // 2 decimals for ≥1¢, 4 for sub-cent so a real cost never shows as "$0.00".
       // (cost is only known once the run finalizes its usage.)
       usage?.cost ? `$${usage.cost.toFixed(usage.cost >= 0.01 ? 2 : 4)}` : "",

--- a/src/workflow-commands.ts
+++ b/src/workflow-commands.ts
@@ -5,6 +5,7 @@
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import {
+  fmtFull,
   fmtTokenSegment,
   recomputeWorkflowSnapshot,
   renderWorkflowText,
@@ -37,7 +38,7 @@ function summarizeRun(run: PersistedRunState): string {
   const icon = STATUS_ICON[run.status] ?? "?";
   const done = run.agents.filter((a) => a.status === "done").length;
   const total = run.agents.length;
-  const segment = fmtTokenSegment(tokenFigures(run.tokenUsage), (n) => n.toLocaleString());
+  const segment = fmtTokenSegment(tokenFigures(run.tokenUsage), fmtFull);
   const tokens = segment ? ` · ${segment}` : "";
   return `${icon} ${run.runId}  ${run.workflowName} [${run.status}] ${done}/${total} agents${tokens}`;
 }
@@ -104,7 +105,7 @@ function renderPersistedStatus(run: PersistedRunState): string {
       agent.status === "done" ? "✓" : agent.status === "error" ? "✗" : agent.status === "running" ? "◆" : "·";
     lines.push(`  ${icon} ${agent.label}`);
   }
-  const tokenSegment = fmtTokenSegment(tokenFigures(run.tokenUsage), (n) => n.toLocaleString());
+  const tokenSegment = fmtTokenSegment(tokenFigures(run.tokenUsage), fmtFull);
   if (tokenSegment) lines.push(`  tokens: ${tokenSegment}`);
   if (run.durationMs) lines.push(`  duration: ${(run.durationMs / 1000).toFixed(1)}s`);
   return lines.join("\n");

--- a/src/workflow-commands.ts
+++ b/src/workflow-commands.ts
@@ -4,7 +4,13 @@
  */
 
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
-import { recomputeWorkflowSnapshot, renderWorkflowText, type WorkflowSnapshot } from "./display.js";
+import {
+  fmtTokenSegment,
+  recomputeWorkflowSnapshot,
+  renderWorkflowText,
+  tokenFigures,
+  type WorkflowSnapshot,
+} from "./display.js";
 import { type EffortState, effortDirective } from "./effort-command.js";
 import type { PersistedRunState } from "./run-persistence.js";
 import { registerSavedWorkflow } from "./saved-commands.js";
@@ -31,7 +37,8 @@ function summarizeRun(run: PersistedRunState): string {
   const icon = STATUS_ICON[run.status] ?? "?";
   const done = run.agents.filter((a) => a.status === "done").length;
   const total = run.agents.length;
-  const tokens = run.tokenUsage ? ` · ${run.tokenUsage.total.toLocaleString()} tok` : "";
+  const segment = fmtTokenSegment(tokenFigures(run.tokenUsage), (n) => n.toLocaleString());
+  const tokens = segment ? ` · ${segment}` : "";
   return `${icon} ${run.runId}  ${run.workflowName} [${run.status}] ${done}/${total} agents${tokens}`;
 }
 
@@ -97,7 +104,8 @@ function renderPersistedStatus(run: PersistedRunState): string {
       agent.status === "done" ? "✓" : agent.status === "error" ? "✗" : agent.status === "running" ? "◆" : "·";
     lines.push(`  ${icon} ${agent.label}`);
   }
-  if (run.tokenUsage) lines.push(`  tokens: ${run.tokenUsage.total.toLocaleString()}`);
+  const tokenSegment = fmtTokenSegment(tokenFigures(run.tokenUsage), (n) => n.toLocaleString());
+  if (tokenSegment) lines.push(`  tokens: ${tokenSegment}`);
   if (run.durationMs) lines.push(`  duration: ${(run.durationMs / 1000).toFixed(1)}s`);
   return lines.join("\n");
 }

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -391,6 +391,7 @@ export class WorkflowManager extends EventEmitter {
             agent.errorCode = event.errorCode;
             agent.recoverable = event.recoverable;
             agent.tokens = event.tokens;
+            if (event.tokenUsage) agent.tokenUsage = event.tokenUsage;
             if (event.model) agent.model = event.model;
           }
           this.emit("agentEnd", { runId: managed.runId, ...event });

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -6,8 +6,11 @@ import { listAgentTypes, loadAgentRegistry } from "./agent-registry.js";
 import {
   createToolUpdateWorkflowDisplay,
   createWorkflowSnapshot,
+  fmtCost,
+  fmtTokenSegment,
   recomputeWorkflowSnapshot,
   renderWorkflowText,
+  tokenFigures,
   type WorkflowSnapshot,
 } from "./display.js";
 import { WorkflowError, WorkflowErrorCode } from "./errors.js";
@@ -287,10 +290,9 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       display.complete(snapshot);
 
       // Format token usage (include cost when the provider reports it)
-      const tokenInfo = result.tokenUsage
-        ? `\n\nToken usage: ${result.tokenUsage.total.toLocaleString()} tokens${
-            result.tokenUsage.cost ? ` ($${result.tokenUsage.cost.toFixed(4)})` : ""
-          }`
+      const tokenSegment = fmtTokenSegment(tokenFigures(result.tokenUsage), (n) => n.toLocaleString());
+      const tokenInfo = tokenSegment
+        ? `\n\nToken usage: ${tokenSegment}${result.tokenUsage?.cost ? ` (${fmtCost(result.tokenUsage.cost)})` : ""}`
         : "";
 
       const formattedResult =

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -7,6 +7,7 @@ import {
   createToolUpdateWorkflowDisplay,
   createWorkflowSnapshot,
   fmtCost,
+  fmtFull,
   fmtTokenSegment,
   recomputeWorkflowSnapshot,
   renderWorkflowText,
@@ -290,7 +291,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       display.complete(snapshot);
 
       // Format token usage (include cost when the provider reports it)
-      const tokenSegment = fmtTokenSegment(tokenFigures(result.tokenUsage), (n) => n.toLocaleString());
+      const tokenSegment = fmtTokenSegment(tokenFigures(result.tokenUsage), fmtFull);
       const tokenInfo = tokenSegment
         ? `\n\nToken usage: ${tokenSegment}${result.tokenUsage?.cost ? ` (${fmtCost(result.tokenUsage.cost)})` : ""}`
         : "";

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -18,7 +18,7 @@ import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
 import { parseKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentUsage } from "./agent.js";
 import type { WorkflowAgentSnapshot, WorkflowSnapshot } from "./display.js";
-import { aggregateAgentUsage, fmtCost, fmtTokenCount, fmtTokenSegment, tokenFigures } from "./display.js";
+import { aggregateAgentUsage, fmtCost, fmtTokenSegment, tokenFigures } from "./display.js";
 import type { PersistedRunState } from "./run-persistence.js";
 import { registerSavedWorkflow } from "./saved-commands.js";
 import type { WorkflowManager } from "./workflow-manager.js";

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -18,7 +18,7 @@ import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
 import { parseKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentUsage } from "./agent.js";
 import type { WorkflowAgentSnapshot, WorkflowSnapshot } from "./display.js";
-import { aggregateAgentUsage, fmtCost, fmtTokenCount, tokenFigures } from "./display.js";
+import { aggregateAgentUsage, fmtCost, fmtTokenCount, fmtTokenSegment, tokenFigures } from "./display.js";
 import type { PersistedRunState } from "./run-persistence.js";
 import { registerSavedWorkflow } from "./saved-commands.js";
 import type { WorkflowManager } from "./workflow-manager.js";
@@ -112,7 +112,14 @@ export class NavigatorModel {
       const live = this.manager.getRun(p.runId);
       const agents = (live?.snapshot.agents ?? p.agents) as WorkflowAgentSnapshot[];
       const usage = live?.snapshot.tokenUsage ?? p.tokenUsage;
-      const figures = tokenFigures(usage);
+      // The run-level aggregate is authoritative but only lands when the run
+      // ends; per-agent figures update live. Use whichever accounts for more
+      // tokens, so live runs show a count in the list (agreeing with the phase
+      // view) and finished/legacy runs keep the final aggregate.
+      const fromUsage = tokenFigures(usage);
+      const fromAgents = aggregateAgentUsage(agents);
+      const figures =
+        fromAgents.fresh + fromAgents.cacheRead > fromUsage.fresh + fromUsage.cacheRead ? fromAgents : fromUsage;
       return {
         runId: p.runId,
         name: live?.snapshot.name ?? p.workflowName,
@@ -471,8 +478,7 @@ function rightAgentRow(
   theme: ThemeLike,
 ): string {
   const dotColor = AGENT_DOT_COLOR[a.status] ?? "dim";
-  const fig = tokenFigures(a.tokenUsage, a.tokens);
-  const stats = fmtTokenCount(fig.fresh, fig.cacheRead, compactTokens);
+  const stats = fmtTokenSegment(tokenFigures(a.tokenUsage, a.tokens), compactTokens);
   const model = shortModel(a.model) ?? "";
 
   // Stable 2-cell marker so columns never shift on selection: "› " | "  ".
@@ -784,7 +790,7 @@ export function renderNavigator(
     // Render runs
     runs.forEach((r, i) => {
       const icon = STATUS_ICON[r.status] ?? "?";
-      const tok = r.fresh + r.cacheRead > 0 ? fmtTokenCount(r.fresh, r.cacheRead, pad) : "";
+      const tok = fmtTokenSegment(r, pad);
       const meta = [`${r.done}/${r.total}`, tok, r.cost > 0 ? fmtCost(r.cost) : ""].filter(Boolean).join(" · ");
       lines.push(sel(i, `${icon} ${r.name}  ${dim(`${r.runId} · ${r.status} · ${meta}`)}`));
     });
@@ -886,7 +892,8 @@ function twoPaneHeader(
   const line0 = theme.fg("accent", theme.bold(nameText));
 
   // Line 1 — left status, right summary.
-  const rightRaw = `${done}/${total} ${pluralize("agent", total)}${fresh + cacheRead > 0 ? ` · ${fmtTokenCount(fresh, cacheRead, compactTokens)}` : ""}`;
+  const headerSegment = fmtTokenSegment({ fresh, cacheRead }, compactTokens);
+  const rightRaw = `${done}/${total} ${pluralize("agent", total)}${headerSegment ? ` · ${headerSegment}` : ""}`;
   const rightW = visibleWidth(rightRaw);
   const gap = 2;
   let line1: string;

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -73,6 +73,14 @@ interface AgentRow {
   status: string;
   phase?: string;
   tokens?: number;
+  tokenUsage?: {
+    input: number;
+    output: number;
+    total: number;
+    cost: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
   model?: string;
 }
 
@@ -161,7 +169,15 @@ export class NavigatorModel {
     if (!snap) return [];
     return snap.agents
       .filter((a) => (a.phase ?? "(no phase)") === phase)
-      .map((a) => ({ id: a.id, label: a.label, status: a.status, phase: a.phase, tokens: a.tokens, model: a.model }));
+      .map((a) => ({
+        id: a.id,
+        label: a.label,
+        status: a.status,
+        phase: a.phase,
+        tokens: a.tokens,
+        tokenUsage: a.tokenUsage,
+        model: a.model,
+      }));
   }
 
   agentDetail(runId: string, agentId: number): WorkflowAgentSnapshot | undefined {
@@ -451,7 +467,11 @@ function rightAgentRow(
   theme: ThemeLike,
 ): string {
   const dotColor = AGENT_DOT_COLOR[a.status] ?? "dim";
-  const stats = `${compactTokens(a.tokens ?? 0)} tok`;
+  const stats = a.tokenUsage
+    ? `${compactTokens(a.tokenUsage.input + a.tokenUsage.output)} fresh${
+        a.tokenUsage.cacheRead > 0 ? ` · ${compactTokens(a.tokenUsage.cacheRead)} cache` : ""
+      }`
+    : `${compactTokens(a.tokens ?? 0)} tok`;
   const model = shortModel(a.model) ?? "";
 
   // Stable 2-cell marker so columns never shift on selection: "› " | "  ".

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -17,6 +17,7 @@ import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi
 import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
 import { parseKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { WorkflowAgentSnapshot, WorkflowSnapshot } from "./display.js";
+import { aggregateAgentUsage, fmtTokenCount } from "./display.js";
 import type { PersistedRunState } from "./run-persistence.js";
 import { registerSavedWorkflow } from "./saved-commands.js";
 import type { WorkflowManager } from "./workflow-manager.js";
@@ -59,6 +60,10 @@ interface RunRow {
   done: number;
   total: number;
   tokens: number;
+  /** Fresh (input+output) tokens for the whole run. */
+  fresh: number;
+  /** Cache-read tokens for the whole run. */
+  cacheRead: number;
   cost: number;
 }
 interface PhaseRow {
@@ -66,6 +71,10 @@ interface PhaseRow {
   done: number;
   total: number;
   tokens: number;
+  /** Fresh (input+output) tokens summed across the phase's agents. */
+  fresh: number;
+  /** Cache-read tokens summed across the phase's agents. */
+  cacheRead: number;
 }
 interface AgentRow {
   id: number;
@@ -110,14 +119,17 @@ export class NavigatorModel {
     return this.manager.listRuns().map((p) => {
       const live = this.manager.getRun(p.runId);
       const agents = (live?.snapshot.agents ?? p.agents) as WorkflowAgentSnapshot[];
+      const usage = live?.snapshot.tokenUsage ?? p.tokenUsage;
       return {
         runId: p.runId,
         name: live?.snapshot.name ?? p.workflowName,
         status: live?.status ?? p.status,
         done: agents.filter((a) => a.status === "done").length,
         total: agents.length,
-        tokens: (live?.snapshot.tokenUsage ?? p.tokenUsage)?.total ?? 0,
-        cost: (live?.snapshot.tokenUsage ?? p.tokenUsage)?.cost ?? 0,
+        tokens: usage?.total ?? 0,
+        fresh: (usage?.input ?? 0) + (usage?.output ?? 0),
+        cacheRead: usage?.cacheRead ?? 0,
+        cost: usage?.cost ?? 0,
       };
     });
   }
@@ -155,11 +167,14 @@ export class NavigatorModel {
     }
     return order.map((title) => {
       const agents = byPhase.get(title) ?? [];
+      const usage = aggregateAgentUsage(agents);
       return {
         title,
         done: agents.filter((a) => a.status === "done").length,
         total: agents.length,
         tokens: agents.reduce((n, a) => n + (a.tokens ?? 0), 0),
+        fresh: usage.fresh,
+        cacheRead: usage.cacheRead,
       };
     });
   }
@@ -468,9 +483,7 @@ function rightAgentRow(
 ): string {
   const dotColor = AGENT_DOT_COLOR[a.status] ?? "dim";
   const stats = a.tokenUsage
-    ? `${compactTokens(a.tokenUsage.input + a.tokenUsage.output)} fresh${
-        a.tokenUsage.cacheRead > 0 ? ` · ${compactTokens(a.tokenUsage.cacheRead)} cache` : ""
-      }`
+    ? fmtTokenCount(a.tokenUsage.input + a.tokenUsage.output, a.tokenUsage.cacheRead, compactTokens)
     : `${compactTokens(a.tokens ?? 0)} tok`;
   const model = shortModel(a.model) ?? "";
 
@@ -783,9 +796,10 @@ export function renderNavigator(
     // Render runs
     runs.forEach((r, i) => {
       const icon = STATUS_ICON[r.status] ?? "?";
-      const meta = [`${r.done}/${r.total}`, fmtTokens(r.tokens), r.cost > 0 ? `$${r.cost.toFixed(4)}` : ""]
-        .filter(Boolean)
-        .join(" · ");
+      // Prefer the fresh/cached split; fall back to the total for legacy
+      // persisted runs whose usage predates the breakdown.
+      const tok = r.fresh + r.cacheRead > 0 ? fmtTokenCount(r.fresh, r.cacheRead, pad) : fmtTokens(r.tokens);
+      const meta = [`${r.done}/${r.total}`, tok, r.cost > 0 ? `$${r.cost.toFixed(4)}` : ""].filter(Boolean).join(" · ");
       lines.push(sel(i, `${icon} ${r.name}  ${dim(`${r.runId} · ${r.status} · ${meta}`)}`));
     });
     // Render saved workflows after a separator
@@ -874,17 +888,21 @@ function twoPaneHeader(
   let done = 0;
   let total = 0;
   let tokens = 0;
+  let fresh = 0;
+  let cacheRead = 0;
   for (const p of phases) {
     done += p.done;
     total += p.total;
     tokens += p.tokens;
+    fresh += p.fresh;
+    cacheRead += p.cacheRead;
   }
   // Line 0 — name (accent + bold), truncated to width if needed.
   const nameText = truncateToWidth(name, width, ELLIPSIS, false);
   const line0 = theme.fg("accent", theme.bold(nameText));
 
   // Line 1 — left status, right summary.
-  const rightRaw = `${done}/${total} ${pluralize("agent", total)}${tokens > 0 ? ` · ${compactTokens(tokens)} tok` : ""}`;
+  const rightRaw = `${done}/${total} ${pluralize("agent", total)}${tokens > 0 ? ` · ${fmtTokenCount(fresh, cacheRead, compactTokens)}` : ""}`;
   const rightW = visibleWidth(rightRaw);
   const gap = 2;
   let line1: string;

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -16,8 +16,9 @@
 import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
 import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
 import { parseKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import type { AgentUsage } from "./agent.js";
 import type { WorkflowAgentSnapshot, WorkflowSnapshot } from "./display.js";
-import { aggregateAgentUsage, fmtTokenCount } from "./display.js";
+import { aggregateAgentUsage, fmtCost, fmtTokenCount, tokenFigures } from "./display.js";
 import type { PersistedRunState } from "./run-persistence.js";
 import { registerSavedWorkflow } from "./saved-commands.js";
 import type { WorkflowManager } from "./workflow-manager.js";
@@ -59,8 +60,7 @@ interface RunRow {
   status: string;
   done: number;
   total: number;
-  tokens: number;
-  /** Fresh (input+output) tokens for the whole run. */
+  /** Fresh tokens for the whole run (see tokenFigures for the fallback rule). */
   fresh: number;
   /** Cache-read tokens for the whole run. */
   cacheRead: number;
@@ -70,8 +70,7 @@ interface PhaseRow {
   title: string;
   done: number;
   total: number;
-  tokens: number;
-  /** Fresh (input+output) tokens summed across the phase's agents. */
+  /** Fresh tokens summed across the phase's agents. */
   fresh: number;
   /** Cache-read tokens summed across the phase's agents. */
   cacheRead: number;
@@ -82,14 +81,7 @@ interface AgentRow {
   status: string;
   phase?: string;
   tokens?: number;
-  tokenUsage?: {
-    input: number;
-    output: number;
-    total: number;
-    cost: number;
-    cacheRead: number;
-    cacheWrite: number;
-  };
+  tokenUsage?: AgentUsage;
   model?: string;
 }
 
@@ -120,15 +112,15 @@ export class NavigatorModel {
       const live = this.manager.getRun(p.runId);
       const agents = (live?.snapshot.agents ?? p.agents) as WorkflowAgentSnapshot[];
       const usage = live?.snapshot.tokenUsage ?? p.tokenUsage;
+      const figures = tokenFigures(usage);
       return {
         runId: p.runId,
         name: live?.snapshot.name ?? p.workflowName,
         status: live?.status ?? p.status,
         done: agents.filter((a) => a.status === "done").length,
         total: agents.length,
-        tokens: usage?.total ?? 0,
-        fresh: (usage?.input ?? 0) + (usage?.output ?? 0),
-        cacheRead: usage?.cacheRead ?? 0,
+        fresh: figures.fresh,
+        cacheRead: figures.cacheRead,
         cost: usage?.cost ?? 0,
       };
     });
@@ -172,7 +164,6 @@ export class NavigatorModel {
         title,
         done: agents.filter((a) => a.status === "done").length,
         total: agents.length,
-        tokens: agents.reduce((n, a) => n + (a.tokens ?? 0), 0),
         fresh: usage.fresh,
         cacheRead: usage.cacheRead,
       };
@@ -227,6 +218,8 @@ function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
       errorCode: a.errorCode,
       recoverable: a.recoverable,
       history: a.history,
+      tokens: a.tokens,
+      tokenUsage: a.tokenUsage,
       model: a.model,
     })),
     agentCount: p.agents.length,
@@ -358,10 +351,6 @@ function pad(n: number): string {
   return n.toLocaleString();
 }
 
-function fmtTokens(t: number): string {
-  return t > 0 ? `${pad(t)} tok` : "";
-}
-
 // ───────────────────────────────────────────────────────────────────────────
 // Two-pane (Phases | agents) renderer — Claude-Code parity.
 //
@@ -482,9 +471,8 @@ function rightAgentRow(
   theme: ThemeLike,
 ): string {
   const dotColor = AGENT_DOT_COLOR[a.status] ?? "dim";
-  const stats = a.tokenUsage
-    ? fmtTokenCount(a.tokenUsage.input + a.tokenUsage.output, a.tokenUsage.cacheRead, compactTokens)
-    : `${compactTokens(a.tokens ?? 0)} tok`;
+  const fig = tokenFigures(a.tokenUsage, a.tokens);
+  const stats = fmtTokenCount(fig.fresh, fig.cacheRead, compactTokens);
   const model = shortModel(a.model) ?? "";
 
   // Stable 2-cell marker so columns never shift on selection: "› " | "  ".
@@ -796,10 +784,8 @@ export function renderNavigator(
     // Render runs
     runs.forEach((r, i) => {
       const icon = STATUS_ICON[r.status] ?? "?";
-      // Prefer the fresh/cached split; fall back to the total for legacy
-      // persisted runs whose usage predates the breakdown.
-      const tok = r.fresh + r.cacheRead > 0 ? fmtTokenCount(r.fresh, r.cacheRead, pad) : fmtTokens(r.tokens);
-      const meta = [`${r.done}/${r.total}`, tok, r.cost > 0 ? `$${r.cost.toFixed(4)}` : ""].filter(Boolean).join(" · ");
+      const tok = r.fresh + r.cacheRead > 0 ? fmtTokenCount(r.fresh, r.cacheRead, pad) : "";
+      const meta = [`${r.done}/${r.total}`, tok, r.cost > 0 ? fmtCost(r.cost) : ""].filter(Boolean).join(" · ");
       lines.push(sel(i, `${icon} ${r.name}  ${dim(`${r.runId} · ${r.status} · ${meta}`)}`));
     });
     // Render saved workflows after a separator
@@ -887,13 +873,11 @@ function twoPaneHeader(
   const status = model.runStatus(runId);
   let done = 0;
   let total = 0;
-  let tokens = 0;
   let fresh = 0;
   let cacheRead = 0;
   for (const p of phases) {
     done += p.done;
     total += p.total;
-    tokens += p.tokens;
     fresh += p.fresh;
     cacheRead += p.cacheRead;
   }
@@ -902,7 +886,7 @@ function twoPaneHeader(
   const line0 = theme.fg("accent", theme.bold(nameText));
 
   // Line 1 — left status, right summary.
-  const rightRaw = `${done}/${total} ${pluralize("agent", total)}${tokens > 0 ? ` · ${fmtTokenCount(fresh, cacheRead, compactTokens)}` : ""}`;
+  const rightRaw = `${done}/${total} ${pluralize("agent", total)}${fresh + cacheRead > 0 ? ` · ${fmtTokenCount(fresh, cacheRead, compactTokens)}` : ""}`;
   const rightW = visibleWidth(rightRaw);
   const gap = 2;
   let line1: string;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -117,6 +117,7 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
     phase?: string;
     result: unknown;
     tokens?: number;
+    tokenUsage?: AgentUsage;
     worktree?: string;
     model?: string;
     error?: string;
@@ -550,6 +551,7 @@ export async function runWorkflow<T = unknown>(
               phase: assignedPhase,
               result,
               tokens,
+              tokenUsage: usage,
               worktree: runCwd,
               model: displayModel,
             });
@@ -573,6 +575,7 @@ export async function runWorkflow<T = unknown>(
               phase: assignedPhase,
               result: null,
               tokens,
+              tokenUsage: usage,
               worktree: runCwd,
               model: displayModel,
               error: workflowError.message,

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import type { AgentRunOptions, AgentUsage } from "../src/agent.js";
-import { listAvailableModelSpecs, resolveAgentModelSpec, WorkflowAgent } from "../src/agent.js";
+import { listAvailableModelSpecs, resolveAgentModelSpec, usageFromStats, WorkflowAgent } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { resolveModelSpecWithThinking } from "../src/model-spec.js";
 import type { ModelTierConfig } from "../src/model-tier-config.js";
@@ -784,4 +784,32 @@ test("agent() monitors agent count and calls onAgentStart/End for each", async (
   assert.equal(counts.length, 2);
   assert.ok(counts[0] > 0, "first agent tokens");
   assert.ok(counts[1] > 0, "second agent tokens");
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// usageFromStats — the guard between session stats and the onUsage callback.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("usageFromStats maps real stats to an AgentUsage", () => {
+  const usage = usageFromStats({
+    tokens: { input: 100, output: 50, cacheRead: 900, cacheWrite: 30, total: 1080 },
+    cost: 0.42,
+  });
+  assert.deepEqual(usage, { input: 100, output: 50, cacheRead: 900, cacheWrite: 30, total: 1080, cost: 0.42 });
+});
+
+test("usageFromStats returns undefined for all-zero stats (provider reported nothing)", () => {
+  const usage = usageFromStats({
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    cost: 0,
+  });
+  assert.equal(usage, undefined);
+});
+
+test("usageFromStats keeps cost-only stats (billed but tokens unreported)", () => {
+  const usage = usageFromStats({
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    cost: 0.01,
+  });
+  assert.equal(usage?.cost, 0.01);
 });

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -92,9 +92,9 @@ describe("installResultDelivery", () => {
     assert.ok(calls[0].content.includes("All tests passed"), "should contain All tests passed");
     assert.ok(calls[0].content.includes("test-workflow"), "should contain test-workflow");
     assert.ok(calls[0].content.includes("3 agents"), "should contain 3 agents");
-    // deliverText shows the fresh/cache split; the cache segment is omitted with no cache reads.
-    assert.ok(calls[0].content.includes("50.0K fresh"), "should show fresh tokens (input+output)");
-    assert.ok(!calls[0].content.includes("cache"), "omits the cache segment when cacheRead is 0");
+    // deliverText shows "N tok"; the cached segment is omitted with no cache reads.
+    assert.ok(calls[0].content.includes("50.0K tok"), "should show the token count (input+output)");
+    assert.ok(!calls[0].content.includes("cached"), "omits the cached segment when cacheRead is 0");
     assert.ok(calls[0].content.includes("1.5s"), "should contain 1.5s");
   });
 
@@ -116,8 +116,8 @@ describe("installResultDelivery", () => {
     manager.emit("complete", { runId: "test-run-1" });
 
     const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
-    assert.ok(content.includes("100.0K fresh"), `fresh should be input+output; got: ${content}`);
-    assert.ok(content.includes("6.0M cache"), `cache should be cacheRead; got: ${content}`);
+    assert.ok(content.includes("100.0K tok"), `fresh (input+output) should read as tok; got: ${content}`);
+    assert.ok(content.includes("6.0M cached"), `cacheRead should read as cached; got: ${content}`);
     assert.ok(content.includes("$6.70"), `cost should be shown; got: ${content}`);
   });
 
@@ -619,8 +619,8 @@ describe("renderPanelDetailed", () => {
     };
     const lines = renderPanelDetailed(manager as never, theme as never, undefined, 8, 1000);
     assert.ok(
-      lines.some((l) => l.includes("[1] ✓ cached_agent") && /100\.0K fresh/.test(l) && /3\.0M cache/.test(l)),
-      `expected a per-agent fresh/cache row, got:\n${lines.join("\n")}`,
+      lines.some((l) => l.includes("[1] ✓ cached_agent") && /100\.0K tok/.test(l) && /3\.0M cached/.test(l)),
+      `expected a per-agent tok/cached row, got:\n${lines.join("\n")}`,
     );
   });
 

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -121,6 +121,29 @@ describe("installResultDelivery", () => {
     assert.ok(content.includes("$6.70"), `cost should be shown; got: ${content}`);
   });
 
+  it("falls back to the estimated total when the provider reported no usage (#57 regression)", () => {
+    const pi = createMockPi();
+    // Estimate-only run: onUsage never fired, so the breakdown is all-zero while
+    // run-level `total` carries the scalar estimate.
+    const manager = createMockManager(
+      makeRun({
+        result: {
+          agentCount: 2,
+          durationMs: 1000,
+          tokenUsage: { input: 0, output: 0, total: 800, cacheRead: 0, cacheWrite: 0, cost: 0 },
+          result: { verdict: "done" },
+        },
+      }),
+    );
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.emit("complete", { runId: "test-run-1" });
+
+    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
+    assert.ok(content.includes("800 tok"), `the estimate should survive as the token count; got: ${content}`);
+    assert.ok(!/\b0 tok/.test(content), `must not render a zero breakdown; got: ${content}`);
+  });
+
   // ── deliverText: fallback chain ──
 
   it("falls back to report when verdict is absent", () => {
@@ -622,6 +645,52 @@ describe("renderPanelDetailed", () => {
       lines.some((l) => l.includes("[1] ✓ cached_agent") && /100\.0K tok/.test(l) && /3\.0M cached/.test(l)),
       `expected a per-agent tok/cached row, got:\n${lines.join("\n")}`,
     );
+  });
+
+  it("keeps the scalar estimate for cost-only agents instead of a zero breakdown (#57 regression)", async () => {
+    const { renderPanelDetailed, clearTokenSamples } = await import("../src/task-panel.js");
+    clearTokenSamples("r3");
+    const snapshot = {
+      name: "wf3",
+      phases: ["P"],
+      currentPhase: "P",
+      logs: [],
+      agents: [
+        {
+          id: 1,
+          label: "cost_only",
+          status: "done",
+          phase: "P",
+          tokens: 384,
+          // Provider billed cost but reported zero token counts.
+          tokenUsage: { input: 0, output: 0, total: 0, cacheRead: 0, cacheWrite: 0, cost: 0.02 },
+        },
+      ],
+      tokenUsage: { total: 0, input: 0, output: 0, cost: 0.02 },
+    };
+    const manager = {
+      listRuns: () => [
+        {
+          runId: "r3",
+          workflowName: "wf3",
+          status: "running",
+          agents: snapshot.agents,
+          tokenUsage: snapshot.tokenUsage,
+        },
+      ],
+      getRun: (id: string) => (id === "r3" ? { snapshot, status: "running" } : undefined),
+    };
+    const lines = renderPanelDetailed(manager as never, theme as never, undefined, 8, 1000);
+    assert.ok(
+      lines.some((l) => l.includes("[1] ✓ cost_only") && /384 tok/.test(l)),
+      `cost-only agent should show its scalar estimate, got:\n${lines.join("\n")}`,
+    );
+    // The run header guard must agree with the value it gates (no "0 tok" beside a real cost).
+    assert.ok(
+      lines.some((l) => /wf3/.test(l) && /384 tok/.test(l) && /\$0\.02/.test(l)),
+      `run header should show the estimate and the cost, got:\n${lines.join("\n")}`,
+    );
+    assert.ok(!lines.some((l) => /\b0 tok/.test(l)), `no zero breakdown anywhere:\n${lines.join("\n")}`);
   });
 
   it("renders aggregate tokens, cost, phases, and per-agent rows", async () => {

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -144,6 +144,28 @@ describe("installResultDelivery", () => {
     assert.ok(!/\b0 tok/.test(content), `must not render a zero breakdown; got: ${content}`);
   });
 
+  it("suppresses the token segment when the run-level aggregate is all-zero (#57 regression)", () => {
+    const pi = createMockPi();
+    // e.g. a fully journal-replayed resume: every agent came from cache, nothing accrued.
+    const manager = createMockManager(
+      makeRun({
+        result: {
+          agentCount: 3,
+          durationMs: 1500,
+          tokenUsage: { input: 0, output: 0, total: 0, cacheRead: 0, cacheWrite: 0, cost: 0 },
+          result: { verdict: "done" },
+        },
+      }),
+    );
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.emit("complete", { runId: "test-run-1" });
+
+    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
+    assert.ok(!/\b0 tok/.test(content), `an all-zero aggregate must not render "0 tok"; got: ${content}`);
+    assert.ok(content.includes("3 agents"), "the rest of the line is intact");
+  });
+
   // ── deliverText: fallback chain ──
 
   it("falls back to report when verdict is absent", () => {

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -92,9 +92,33 @@ describe("installResultDelivery", () => {
     assert.ok(calls[0].content.includes("All tests passed"), "should contain All tests passed");
     assert.ok(calls[0].content.includes("test-workflow"), "should contain test-workflow");
     assert.ok(calls[0].content.includes("3 agents"), "should contain 3 agents");
-    // locale may format the group separator as ',' / '.' / ' ' / none
-    assert.ok(/50[\s,.]?000/.test(calls[0].content), "should contain 50000 tokens formatted");
+    // deliverText shows the fresh/cache split; the cache segment is omitted with no cache reads.
+    assert.ok(calls[0].content.includes("50.0K fresh"), "should show fresh tokens (input+output)");
+    assert.ok(!calls[0].content.includes("cache"), "omits the cache segment when cacheRead is 0");
     assert.ok(calls[0].content.includes("1.5s"), "should contain 1.5s");
+  });
+
+  it("shows the fresh/cache split and cost in the delivery line", () => {
+    const pi = createMockPi();
+    // A caching model: little fresh input+output, most of the tokens are cheap cache reads.
+    const manager = createMockManager(
+      makeRun({
+        result: {
+          agentCount: 2,
+          durationMs: 1000,
+          tokenUsage: { input: 80000, output: 20000, total: 6100000, cacheRead: 6000000, cacheWrite: 0, cost: 6.7 },
+          result: { verdict: "done" },
+        },
+      }),
+    );
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.emit("complete", { runId: "test-run-1" });
+
+    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
+    assert.ok(content.includes("100.0K fresh"), `fresh should be input+output; got: ${content}`);
+    assert.ok(content.includes("6.0M cache"), `cache should be cacheRead; got: ${content}`);
+    assert.ok(content.includes("$6.70"), `cost should be shown; got: ${content}`);
   });
 
   // ── deliverText: fallback chain ──
@@ -559,6 +583,46 @@ describe("renderPanelDetailed", () => {
       getRun: (id: string) => (id === "r1" ? { snapshot, status } : undefined),
     };
   }
+
+  it("renders a per-agent fresh/cache split when tokenUsage is present", async () => {
+    const { renderPanelDetailed } = await import("../src/task-panel.js");
+    const snapshot = {
+      name: "wf",
+      phases: ["Scan"],
+      currentPhase: "Scan",
+      logs: [],
+      agents: [
+        {
+          id: 1,
+          label: "cached_agent",
+          status: "done",
+          phase: "Scan",
+          tokens: 3100000,
+          // Opus-style: little fresh input+output, most of it cheap cache reads.
+          tokenUsage: { input: 80000, output: 20000, total: 3100000, cacheRead: 3000000, cacheWrite: 0, cost: 0.4 },
+          model: "github-copilot/claude-opus-4.8",
+        },
+      ],
+      tokenUsage: { total: 0, input: 0, output: 0, cost: 0 },
+    };
+    const manager = {
+      listRuns: () => [
+        {
+          runId: "r2",
+          workflowName: "wf",
+          status: "running",
+          agents: snapshot.agents,
+          tokenUsage: snapshot.tokenUsage,
+        },
+      ],
+      getRun: (id: string) => (id === "r2" ? { snapshot, status: "running" } : undefined),
+    };
+    const lines = renderPanelDetailed(manager as never, theme as never, undefined, 8, 1000);
+    assert.ok(
+      lines.some((l) => l.includes("[1] ✓ cached_agent") && /100\.0K fresh/.test(l) && /3\.0M cache/.test(l)),
+      `expected a per-agent fresh/cache row, got:\n${lines.join("\n")}`,
+    );
+  });
 
   it("renders aggregate tokens, cost, phases, and per-agent rows", async () => {
     const { renderPanelDetailed, clearTokenSamples } = await import("../src/task-panel.js");

--- a/tests/workflow-display.test.ts
+++ b/tests/workflow-display.test.ts
@@ -30,7 +30,13 @@ function agent(
   label: string,
   status: "queued" | "running" | "done" | "error" | "skipped",
   phase?: string,
-  opts?: { resultPreview?: string; tokens?: number; model?: string; prompt?: string },
+  opts?: {
+    resultPreview?: string;
+    tokens?: number;
+    tokenUsage?: { input: number; output: number; total: number; cost: number; cacheRead: number; cacheWrite: number };
+    model?: string;
+    prompt?: string;
+  },
 ) {
   return {
     id,
@@ -40,6 +46,7 @@ function agent(
     prompt: opts?.prompt ?? `execute ${label}`,
     ...(opts?.resultPreview ? { resultPreview: opts.resultPreview } : {}),
     ...(opts?.tokens ? { tokens: opts.tokens } : {}),
+    ...(opts?.tokenUsage ? { tokenUsage: opts.tokenUsage } : {}),
     ...(opts?.model ? { model: opts.model } : {}),
   };
 }
@@ -170,6 +177,21 @@ describe("renderWorkflowText", () => {
     // toLocaleString() output depends on locale (UK/US uses commas, PL uses NBSP)
     // Check with a regex matching any thousands separator between 12 and 345
     assert.ok(/12[ ,.\u00a0]345/.test(text), "should show formatted token count");
+  });
+
+  it("shows a fresh/cache split for an agent with tokenUsage", async () => {
+    const { createWorkflowSnapshot, renderWorkflowLines } = await loadDisplay();
+    const snap = createWorkflowSnapshot(fakeMeta());
+    snap.agents = [
+      agent(1, "cached-agent", "done", "Research", {
+        tokens: 3_100_000,
+        tokenUsage: { input: 80_000, output: 20_000, total: 3_100_000, cacheRead: 3_000_000, cacheWrite: 0, cost: 0.4 },
+      }),
+    ] as never[];
+    const text = renderWorkflowLines(snap).join("\n");
+    // fresh = input+output = 100,000; cache = cacheRead = 3,000,000 (locale-flexible separators)
+    assert.ok(/100[ ,.\u00a0]000 fresh/.test(text), "shows fresh = input+output");
+    assert.ok(/3[ ,.\u00a0]000[ ,.\u00a0]000 cache/.test(text), "shows cache = cacheRead");
   });
 
   it("truncates long agent labels", async () => {
@@ -626,8 +648,8 @@ describe("deliverText", () => {
   it("includes token count when available", async () => {
     const { deliverText } = await loadTaskPanel();
     const text = deliverText(fakeManagedRun());
-    assert.ok(text.includes("150"), "should show token count");
-    assert.ok(text.includes("tokens"), "should mention tokens");
+    assert.ok(text.includes("150"), "should show fresh token count");
+    assert.ok(text.includes("fresh"), "should label fresh tokens");
   });
 
   it("includes agent count", async () => {

--- a/tests/workflow-display.test.ts
+++ b/tests/workflow-display.test.ts
@@ -140,7 +140,8 @@ describe("renderWorkflowText", () => {
     const snap = createWorkflowSnapshot(fakeMeta());
     snap.tokenUsage = { input: 1000, output: 500, total: 1500, cost: 0.042 };
     const text = renderWorkflowLines(snap).join("\n");
-    assert.ok(text.includes("$0.0420"), "should show cost");
+    // fmtCost: 2 decimals from one cent up, 4 below it (shared across all surfaces).
+    assert.ok(text.includes("$0.04"), "should show cost");
   });
 
   it("shows token info without cost when cost is absent", async () => {
@@ -192,6 +193,56 @@ describe("renderWorkflowText", () => {
     // fresh (input+output = 100,000) reads as "tok"; cacheRead (3,000,000) as "cached" (locale-flexible separators)
     assert.ok(/100[ ,.\u00a0]000 tok/.test(text), "shows fresh (input+output) as tok");
     assert.ok(/3[ ,.\u00a0]000[ ,.\u00a0]000 cached/.test(text), "shows cacheRead as cached");
+  });
+
+  it("tokenFigures uses the breakdown when it carries signal and the estimate otherwise", async () => {
+    const { tokenFigures } = await loadDisplay();
+    // Reporting provider: total = input+output+cacheRead+cacheWrite, both paths agree.
+    assert.deepEqual(tokenFigures({ input: 80, output: 20, total: 1100, cacheRead: 900, cacheWrite: 100 }), {
+      fresh: 100,
+      cacheRead: 900,
+    });
+    // Estimate-only (provider reported nothing): the scalar total survives as fresh.
+    assert.deepEqual(tokenFigures({ input: 0, output: 0, total: 800, cacheRead: 0, cacheWrite: 0 }), {
+      fresh: 800,
+      cacheRead: 0,
+    });
+    // Cost-only agent: all-zero breakdown, scalar estimate alongside.
+    assert.deepEqual(tokenFigures({ input: 0, output: 0, total: 0, cacheRead: 0, cacheWrite: 0, cost: 0.02 }, 384), {
+      fresh: 384,
+      cacheRead: 0,
+    });
+    // Mixed run: some agents reported (input+output=100), the rest only estimated into total.
+    assert.deepEqual(tokenFigures({ input: 70, output: 30, total: 900, cacheRead: 0, cacheWrite: 0 }), {
+      fresh: 900,
+      cacheRead: 0,
+    });
+    // No usage object at all.
+    assert.deepEqual(tokenFigures(undefined, 500), { fresh: 500, cacheRead: 0 });
+    assert.deepEqual(tokenFigures(undefined), { fresh: 0, cacheRead: 0 });
+  });
+
+  it("header falls back to the estimated total when the provider reported no usage (#57 regression)", async () => {
+    const { createWorkflowSnapshot, renderWorkflowLines } = await loadDisplay();
+    const snap = createWorkflowSnapshot(fakeMeta());
+    // onUsage never fired: breakdown is all-zero, total carries the estimate.
+    snap.tokenUsage = { input: 0, output: 0, total: 800 };
+    const text = renderWorkflowLines(snap).join("\n");
+    assert.ok(text.includes("800 tok"), `estimate should survive in the header; got: ${text}`);
+    assert.ok(!/\b0 tok/.test(text), `must not render a zero breakdown; got: ${text}`);
+  });
+
+  it("keeps the scalar estimate for a cost-only agent row (#57 regression)", async () => {
+    const { createWorkflowSnapshot, renderWorkflowLines } = await loadDisplay();
+    const snap = createWorkflowSnapshot(fakeMeta());
+    snap.agents = [
+      agent(1, "cost-only-agent", "done", "Research", {
+        tokens: 384,
+        tokenUsage: { input: 0, output: 0, total: 0, cacheRead: 0, cacheWrite: 0, cost: 0.02 },
+      }),
+    ] as never[];
+    const text = renderWorkflowLines(snap).join("\n");
+    assert.ok(/\[384 tok\]/.test(text), `cost-only agent should show its scalar estimate; got: ${text}`);
   });
 
   it("truncates long agent labels", async () => {

--- a/tests/workflow-display.test.ts
+++ b/tests/workflow-display.test.ts
@@ -198,9 +198,15 @@ describe("renderWorkflowText", () => {
   it("tokenFigures uses the breakdown when it carries signal and the estimate otherwise", async () => {
     const { tokenFigures } = await loadDisplay();
     // Reporting provider: total = input+output+cacheRead+cacheWrite, both paths agree.
+    // cacheWrite counts as fresh — it is first-time ingestion billed at full/premium price.
     assert.deepEqual(tokenFigures({ input: 80, output: 20, total: 1100, cacheRead: 900, cacheWrite: 100 }), {
-      fresh: 100,
+      fresh: 200,
       cacheRead: 900,
+    });
+    // Cache-creating first turn: the written prefix must not vanish from the count.
+    assert.deepEqual(tokenFigures({ input: 6000, output: 1000, total: 207000, cacheRead: 0, cacheWrite: 200000 }), {
+      fresh: 207000,
+      cacheRead: 0,
     });
     // Estimate-only (provider reported nothing): the scalar total survives as fresh.
     assert.deepEqual(tokenFigures({ input: 0, output: 0, total: 800, cacheRead: 0, cacheWrite: 0 }), {
@@ -243,6 +249,22 @@ describe("renderWorkflowText", () => {
     ] as never[];
     const text = renderWorkflowLines(snap).join("\n");
     assert.ok(/\[384 tok\]/.test(text), `cost-only agent should show its scalar estimate; got: ${text}`);
+  });
+
+  it("suppresses the header token segment for an all-zero usage aggregate (#57 regression)", async () => {
+    const { createWorkflowSnapshot, renderWorkflowLines } = await loadDisplay();
+    const snap = createWorkflowSnapshot(fakeMeta());
+    // e.g. a fully journal-replayed resume, or a run whose agents were all skipped.
+    snap.tokenUsage = { input: 0, output: 0, total: 0 };
+    const text = renderWorkflowLines(snap).join("\n");
+    assert.ok(!/\b0 tok/.test(text), `an all-zero aggregate must not render "0 tok"; got: ${text}`);
+  });
+
+  it("fmtCost never renders a real cost as a zero-looking figure", async () => {
+    const { fmtCost } = await loadDisplay();
+    assert.equal(fmtCost(6.7), "$6.70");
+    assert.equal(fmtCost(0.0042), "$0.0042");
+    assert.equal(fmtCost(0.00003), "<$0.0001");
   });
 
   it("truncates long agent labels", async () => {

--- a/tests/workflow-display.test.ts
+++ b/tests/workflow-display.test.ts
@@ -189,9 +189,9 @@ describe("renderWorkflowText", () => {
       }),
     ] as never[];
     const text = renderWorkflowLines(snap).join("\n");
-    // fresh = input+output = 100,000; cache = cacheRead = 3,000,000 (locale-flexible separators)
-    assert.ok(/100[ ,.\u00a0]000 fresh/.test(text), "shows fresh = input+output");
-    assert.ok(/3[ ,.\u00a0]000[ ,.\u00a0]000 cache/.test(text), "shows cache = cacheRead");
+    // fresh (input+output = 100,000) reads as "tok"; cacheRead (3,000,000) as "cached" (locale-flexible separators)
+    assert.ok(/100[ ,.\u00a0]000 tok/.test(text), "shows fresh (input+output) as tok");
+    assert.ok(/3[ ,.\u00a0]000[ ,.\u00a0]000 cached/.test(text), "shows cacheRead as cached");
   });
 
   it("truncates long agent labels", async () => {
@@ -648,8 +648,8 @@ describe("deliverText", () => {
   it("includes token count when available", async () => {
     const { deliverText } = await loadTaskPanel();
     const text = deliverText(fakeManagedRun());
-    assert.ok(text.includes("150"), "should show fresh token count");
-    assert.ok(text.includes("fresh"), "should label fresh tokens");
+    assert.ok(text.includes("150"), "should show the token count");
+    assert.ok(text.includes("tok"), "should label the token count");
   });
 
   it("includes agent count", async () => {

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -182,7 +182,6 @@ test("NavigatorModel reads runs, phases, agents, and detail", () => {
   assert.equal(runs.length, 1);
   assert.equal(runs[0].done, 2);
   assert.equal(runs[0].total, 3);
-  assert.equal(runs[0].tokens, 1050);
   assert.equal(runs[0].fresh, 150);
   assert.equal(runs[0].cacheRead, 900);
 
@@ -192,7 +191,7 @@ test("NavigatorModel reads runs, phases, agents, and detail", () => {
     ["Scan", "Report"],
   );
   assert.equal(phases[0].total, 2);
-  assert.equal(phases[0].tokens, 150);
+  assert.equal(phases[0].fresh, 150);
 
   const agents = model.agents("run-1", "Scan");
   assert.deepEqual(
@@ -226,11 +225,11 @@ test("NavigatorModel reads from persisted runs when no live snapshot", () => {
   assert.equal(runs[0].name, "old-run");
   assert.equal(runs[0].done, 1);
   assert.equal(runs[0].total, 1);
-  assert.equal(runs[0].tokens, 500);
-  assert.equal(runs[0].fresh, 0);
+  // Legacy total-only usage surfaces as fresh (tokenFigures fallback).
+  assert.equal(runs[0].fresh, 500);
   assert.equal(runs[0].cacheRead, 0);
 
-  // The runs list falls back to the plain total for legacy usage.
+  // The runs list surfaces legacy total-only usage as a plain count.
   const lines = renderNavigator(new NavigatorState(), model, 80);
   assert.match(lines.join("\n"), /1\/1 · 500 tok/);
 
@@ -671,4 +670,68 @@ test("renderNavigator footer hint changes based on item under cursor", () => {
   const savedText = renderNavigator(state, model, 80).join("\n");
   assert.notEqual(savedText.indexOf("x delete"), -1, "saved item should show x delete");
   assert.equal(savedText.indexOf("x stop"), -1, "saved item should NOT show x stop");
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #57 regressions — the split must survive persistence, and mixed or
+// estimate-only runs must never under-report vs the pre-split scalar.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("persisted runs keep the per-agent split across sessions (#57 regression)", () => {
+  const model = new NavigatorModel({
+    listRuns: () => [
+      {
+        runId: "r-split",
+        workflowName: "old-split",
+        status: "completed",
+        phases: ["Build"],
+        agents: [
+          {
+            id: 1,
+            label: "builder",
+            phase: "Build",
+            status: "done",
+            prompt: "build it",
+            result: "ok",
+            tokens: 1080,
+            tokenUsage: { input: 60, output: 20, total: 1080, cost: 0.01, cacheRead: 900, cacheWrite: 100 },
+          },
+        ],
+        logs: [],
+        tokenUsage: { input: 60, output: 20, total: 1080, cost: 0.01, cacheRead: 900, cacheWrite: 100 },
+      } as unknown as PersistedRunState,
+    ],
+    getRun: () => undefined,
+  });
+
+  // persistedToSnapshot must carry tokens/tokenUsage through to every view.
+  const agents = model.agents("r-split", "Build");
+  assert.equal(agents[0].tokenUsage?.cacheRead, 900);
+  const phases = model.phases("r-split");
+  assert.equal(phases[0].fresh, 80);
+  assert.equal(phases[0].cacheRead, 900);
+  const runs = model.runs();
+  assert.equal(runs[0].fresh, 80);
+  assert.equal(runs[0].cacheRead, 900);
+});
+
+test("runs list never under-reports mixed runs (reported + estimate-only agents) (#57 regression)", () => {
+  const model = new NavigatorModel({
+    listRuns: () => [
+      {
+        runId: "r-mixed",
+        workflowName: "mixed",
+        status: "completed",
+        phases: [],
+        agents: [],
+        logs: [],
+        // One agent reported input+output=100; the rest only estimated into total.
+        tokenUsage: { input: 70, output: 30, total: 900, cost: 0, cacheRead: 0, cacheWrite: 0 },
+      } as unknown as PersistedRunState,
+    ],
+    getRun: () => undefined,
+  });
+  assert.equal(model.runs()[0].fresh, 900);
+  const lines = renderNavigator(new NavigatorState(), model, 80);
+  assert.match(lines.join("\n"), /900 tok/);
 });

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -41,7 +41,7 @@ function fakeManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
     runningCount: 1,
     doneCount: 2,
     errorCount: 0,
-    tokenUsage: { input: 100, output: 50, total: 150, cost: 0 },
+    tokenUsage: { input: 100, output: 50, total: 1050, cost: 0, cacheRead: 900, cacheWrite: 0 },
   };
   return {
     listRuns: () => [
@@ -132,6 +132,8 @@ function persistedRunManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
         phases: ["Build"],
         agents: [{ id: 1, label: "builder", phase: "Build", status: "done", prompt: "build it", result: "ok" }],
         logs: ["done"],
+        // Legacy persisted usage: total only, no fresh/cache breakdown.
+        tokenUsage: { total: 500, cost: 0 },
       } as unknown as PersistedRunState,
     ],
     getRun: () => undefined,
@@ -180,7 +182,9 @@ test("NavigatorModel reads runs, phases, agents, and detail", () => {
   assert.equal(runs.length, 1);
   assert.equal(runs[0].done, 2);
   assert.equal(runs[0].total, 3);
-  assert.equal(runs[0].tokens, 150);
+  assert.equal(runs[0].tokens, 1050);
+  assert.equal(runs[0].fresh, 150);
+  assert.equal(runs[0].cacheRead, 900);
 
   const phases = model.phases("run-1");
   assert.deepEqual(
@@ -222,6 +226,13 @@ test("NavigatorModel reads from persisted runs when no live snapshot", () => {
   assert.equal(runs[0].name, "old-run");
   assert.equal(runs[0].done, 1);
   assert.equal(runs[0].total, 1);
+  assert.equal(runs[0].tokens, 500);
+  assert.equal(runs[0].fresh, 0);
+  assert.equal(runs[0].cacheRead, 0);
+
+  // The runs list falls back to the plain total for legacy usage.
+  const lines = renderNavigator(new NavigatorState(), model, 80);
+  assert.match(lines.join("\n"), /1\/1 · 500 tok/);
 
   const phases = model.phases("r-old");
   assert.equal(phases.length, 1);
@@ -399,6 +410,7 @@ test("renderNavigator shows runs view with selected row and footer hint", () => 
   const text = lines.join("\n");
   assert.match(text, /Workflows/);
   assert.match(text, /❯ ◆ audit/);
+  assert.match(text, /2\/3 · 150 tok · 900 cached/);
   assert.match(text, /enter open/);
 });
 

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -708,10 +708,11 @@ test("persisted runs keep the per-agent split across sessions (#57 regression)",
   const agents = model.agents("r-split", "Build");
   assert.equal(agents[0].tokenUsage?.cacheRead, 900);
   const phases = model.phases("r-split");
-  assert.equal(phases[0].fresh, 80);
+  // fresh = input+output+cacheWrite (cache writes are billed first-time ingestion).
+  assert.equal(phases[0].fresh, 180);
   assert.equal(phases[0].cacheRead, 900);
   const runs = model.runs();
-  assert.equal(runs[0].fresh, 80);
+  assert.equal(runs[0].fresh, 180);
   assert.equal(runs[0].cacheRead, 900);
 });
 
@@ -734,4 +735,40 @@ test("runs list never under-reports mixed runs (reported + estimate-only agents)
   assert.equal(model.runs()[0].fresh, 900);
   const lines = renderNavigator(new NavigatorState(), model, 80);
   assert.match(lines.join("\n"), /900 tok/);
+});
+
+test("runs list aggregates per-agent figures for live runs whose run-level usage has not landed (#57 regression)", () => {
+  const snapshot = {
+    name: "live-run",
+    phases: ["P"],
+    currentPhase: "P",
+    logs: [],
+    agents: [
+      { id: 1, label: "a", phase: "P", prompt: "x", status: "done", tokens: 1200 },
+      { id: 2, label: "b", phase: "P", prompt: "y", status: "running", tokens: 0 },
+    ],
+    agentCount: 2,
+    runningCount: 1,
+    doneCount: 1,
+    errorCount: 0,
+    // Run-level aggregate only lands at completion — absent while live.
+  } as unknown as WorkflowSnapshot;
+  const model = new NavigatorModel({
+    listRuns: () => [
+      {
+        runId: "r-live",
+        workflowName: "live-run",
+        status: "running",
+        phases: ["P"],
+        agents: snapshot.agents,
+        logs: [],
+      } as unknown as PersistedRunState,
+    ],
+    getRun: (id: string) =>
+      id === "r-live" ? ({ runId: "r-live", status: "running", snapshot } as unknown as ManagedRun) : undefined,
+  });
+  // The list must agree with the phase view (both aggregate per-agent figures).
+  assert.equal(model.runs()[0].fresh, 1200);
+  const lines = renderNavigator(new NavigatorState(), model, 80);
+  assert.match(lines.join("\n"), /1,200 tok|1[ .\u00a0]200 tok/);
 });


### PR DESCRIPTION
<!-- title: feat: show cached token reads separately across workflow displays -->

## What

The workflow token displays show a single scalar per agent — `input + output + cacheRead + cacheWrite` — which mixes real spend with cheap cache reads. For a ~95%-cached agent that reads as huge (e.g. "3.0M tok" when only ~100k was billed at full price); for a non-caching provider the same number is 100% real spend. Same unit, opposite meaning.

This splits it into `N tok · M cached` across every surface: live task panel, `/workflows` navigator (runs list, phase header, agent rows), status/print view, the `/workflows` text commands, the tool result, and the background-run delivery line.

**Before**
```
[1] ✓ paper-generation   3.0M tok    · claude-opus-4.8
[2] ✓ numeric-auditor    6.3M tok    · glm-5-2
```

**After**
```
[1] ✓ paper-generation   100K tok · 2.9M cached   · claude-opus-4.8
[2] ✓ numeric-auditor    6.3M tok                 · glm-5-2
```

`tok` = input + output + cacheWrite (cache writes are first-time ingestion billed at full or premium price, so they count as real spend); `cached` = cacheRead (cheap reuse), omitted when zero.

## What changed since #57 (and why it was closed)

#57 was closed because the split rendered inconsistently across setups: providers that don't report per-agent usage fell back to the old scalar, so the same workflow looked like two different features depending on the provider. This revision makes the degraded path first-class:

1. **The degraded mode is visually identical to the base format.** The wording changed from `N fresh · M cache` to `N tok · M cached`: an agent without cache data renders `N tok` — exactly the pre-existing scalar format. Cache data enriches the line when available and changes nothing when not.
2. **One fallback rule, one place.** `tokenFigures()` reconciles the two token sources the pipeline already had (the provider-reported breakdown, and the scalar estimate that keeps accruing when the provider reports nothing): fresh is the reported spend, but never less than what the estimate can account for after removing cache reads. Estimate-only providers, cost-only providers, and mixed runs all keep the count the display showed before the split.
3. **Zero never lies.** `usageFromStats()` skips `onUsage` for all-zero session stats, and `fmtTokenSegment()` centrally omits the token segment when nothing is known (e.g. a journal-replayed resume) — no surface can render a false "0 tok".
4. **The split survives persistence** — per-agent usage is carried through `persistedToSnapshot`, so cross-session runs render the same as live ones.

## Pre-existing display quirks this also fixes

Three small fixes ride along because the shared helpers make them free and they serve the same goal (truthful token accounting). Calling them out explicitly since they predate this PR:

- **Persisted runs never showed per-agent tokens** — `persistedToSnapshot` didn't copy them (this one is required for the split to work cross-session at all).
- **The `/workflows` runs list showed no token count for live runs** — the run-level aggregate only lands at completion; the list now uses whichever source (run aggregate vs per-agent figures) accounts for more tokens, so it agrees with the phase view.
- **A real but tiny cost could render as `$0.0000`** (`toFixed(4)`); `fmtCost` floors it at `<$0.0001`, and an all-zero usage aggregate no longer renders a literal `0 tokens`.

If you'd rather keep the PR minimal, I'm happy to split these into a follow-up.

## How

- Per-agent `AgentUsage` is read from `session.getSessionStats()` in a `finally` (fires on the error path too) and carried through `onAgentEnd` into `WorkflowAgentSnapshot.tokenUsage`.
- All surfaces render through shared helpers: `tokenFigures` (fallback rule) → `fmtTokenSegment` (blank-on-zero) → `fmtTokenCount` (format), plus `fmtCost` (unified cost format: 2 decimals ≥1¢, 4 below, `<$0.0001` floor).
- Backward compatible: snapshots without `tokenUsage` (including previously persisted runs) render the existing scalar count.

`feat:` because it adds public surface (`WorkflowAgentSnapshot.tokenUsage`, the `onAgentEnd` event's `tokenUsage`, and the display helpers). Display-only — nothing changes about what is sent to models or how much is spent. Two deliberate display-behavior changes ride along: the delivery line now includes the run cost, and cost formatting is unified across surfaces.

## Verification

`npm test` green on top of v2.13.1 (biome + tsc + 844 unit tests). The change went through two adversarial multi-agent review rounds; every finding is covered by a dedicated regression test: persisted-run split, estimate-only header/delivery, cost-only agents, mixed runs, all-zero aggregates, cache-write-heavy agents, live-run list aggregation, and the `tokenFigures`/`fmtCost` edge cases.

End-to-end on a real Pi install (dev-linked package) with a deliberately asymmetric setup — a vLLM gateway provider that reports usage but no caching, plus github-copilot/claude-opus-4.8 which caches heavily. A 2-agent demo run (screenshots below) renders the non-caching agent as a plain `N tok` (no dangling cache segment) next to a caching multi-turn agent with its `· N cached` split, and the runs-list row shows the aggregated split with cost. A separate 9-agent production run renders the header aggregate across six same-phase vLLM agents (plain counts) and cached Opus agents.

## Screenshots

<img width="1002" height="62" alt="two-pane-navigation" src="https://github.com/user-attachments/assets/6e705c94-3b7d-4cfe-83e4-5e4bdfb81e81" />
<img width="997" height="173" alt="detail-worflow" src="https://github.com/user-attachments/assets/2b793b2c-d3be-41c5-8481-fb2a49ccdfc5" />
