### PR TITLE
feat: make workflow runs observable and resumable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,16 @@ If you add a `workflow` tool parameter or a `~/.pi/workflows/settings.json` sett
 
 Fake-agent unit tests are necessary but not sufficient. Any change to how agents actually run — retries, timeouts, model routing, token accounting, concurrency, resume — must also be verified **end-to-end against a real Pi subagent session** (real `createAgentSession` → real model), because the real SDK path behaves differently than a mock. If you don't have a real-provider environment, say so in the PR and a maintainer will run it before merge.
 
-A throwaway harness for this should live in the repo root (not `/tmp`, whose symlink breaks relative imports), import from `./src`, and be deleted before commit — don't commit harnesses.
+A throwaway harness for this should live in the repo root (not `/tmp`, whose symlink breaks relative imports), import from `./src`, and be deleted before commit — don't commit harnesses, credentials, or provider output. Record the provider/model and observed results in the PR instead.
+
+For workflow runtime reliability changes, exercise every affected item in this real-provider checklist:
+
+1. **Safe typing:** Submit ordinary prompts containing `workflow`, `workflows`, mixed case, punctuation, paths, and slash commands. With fresh/default settings, none may rewrite the prompt or emit a forced-tool message. Explicit `/workflows-trigger on` must restore only word-bounded activation.
+2. **Autonomous management:** Let Pi start a background run with `workflow`, then have Pi use `workflow_control` to `list`, inspect `status`, `pause`, `resume`, and `stop` it without asking the user to type `/workflows` commands.
+3. **Active fleet:** Start 42 independent agents with Pi selecting `concurrency: 8`. Confirm no more than eight run simultaneously, all active labels appear in `Running now (N/8)`, and remaining work is shown as queued.
+4. **Live usage:** Run a multi-turn child. Confirm `~N tok` moves during streaming, exact tokens replace the estimate at assistant-message boundaries, and terminal reconciliation remains exact.
+5. **Restart/resume:** Interrupt after at least 27 completed calls, restart Pi, and resume the same run. Confirm completed agents retain status and tokens, aggregate usage remains monotonic, no rows duplicate, and the original concurrency/options remain in effect. Repeat with an older run artifact when changing persistence migration.
+6. **Human compatibility:** Confirm `/workflows` commands, navigator pause/stop/restart, `q` close, `x` stop, trigger opt-in, saved workflows, and stale-run recovery still work.
 
 ## Style
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Built for **codebase-wide audits, multi-perspective review, large refactors, and
 pi install npm:@quintinshaw/pi-dynamic-workflows
 ```
 
-Then `/reload` in Pi. You get the `workflow` tool plus the `/workflows`, `/deep-research`, and `/adversarial-review` commands.
+Then `/reload` in Pi. You get the `workflow` start tool, the `workflow_control` management tool, plus the `/workflows`, `/deep-research`, and `/adversarial-review` commands.
 
 ## Try it
 
@@ -32,11 +32,13 @@ Ask in plain language:
 Run a workflow to audit every route under src/routes/ for missing auth checks.
 ```
 
-Pi writes the script and runs it in the background — your turn ends immediately and a live panel tracks progress while you keep working. Or just type **workflow** or **workflows** in any message to force one. To force one explicitly — even with the keyword trigger off — run `/workflows run <prompt>`. If that causes false triggers, set a custom trigger such as `pi-workflow` with `/workflows-trigger set pi-workflow` or by adding `{ "keywordTriggerWord": "pi-workflow" }` to `~/.pi/workflows/settings.json`. With that setting, only `pi-workflow` auto-arms workflows mode. If you only want to discuss workflows without triggering one, run `/workflows-trigger off`; preferences are saved for new sessions. Check the current state with `/workflows-trigger status`, and turn it back on with `/workflows-trigger on`.
+Pi writes the script and runs it in the background — your turn ends immediately and a live panel tracks progress while you keep working. Keyword activation is **off by default**, so ordinary mentions of `workflow` or `workflows` are never rewritten. To enable it, run `/workflows-trigger on`; enabled triggers are case-insensitive, word-bounded literal terms and do not match paths, slash commands, or identifier-like text. You can choose a custom term with `/workflows-trigger set pi-workflow`, restore `workflow`/`workflows` with `/workflows-trigger reset`, inspect it with `/workflows-trigger status`, or disable it again with `/workflows-trigger off`. Preferences are saved for new sessions.
+
+To force a workflow without enabling keyword activation, run `/workflows run <prompt>`. This explicit command always works.
 
 ![Workflows mode in the input box](https://raw.githubusercontent.com/QuintinShaw/pi-dynamic-workflows/main/docs/media/workflows-mode.jpg)
 
-If another Pi extension has already installed a custom editor component, pi-dynamic-workflows leaves it in place and keeps the submit-time workflow trigger active. In that compatibility mode, the animated keyword highlight and Backspace one-shot disarm affordance are skipped because the existing editor remains responsible for rendering and input handling; use `/workflows-trigger off` or `/workflows-trigger set <word>` when you need to discuss workflow/workflows without auto-triggering, including in future sessions. Editor composition is load-order dependent: whichever extension installs a visual editor last owns the editor surface, while pi-dynamic-workflows still keeps its submit-time hook registered.
+If another Pi extension has already installed a custom editor component, pi-dynamic-workflows leaves it in place. The default-off submit hook leaves input and active tools untouched. When keyword activation is explicitly enabled, submit-time detection still works in compatibility mode, but the animated highlight and Backspace one-shot disarm affordance are unavailable because the existing editor owns rendering and input handling. Editor composition is load-order dependent: whichever extension installs a visual editor last owns the editor surface.
 
 ## What a workflow looks like
 
@@ -67,13 +69,13 @@ return await agent('Synthesize and double-check these findings:\n' + findings.jo
 
 ## Highlights
 
-- **Fan-out orchestration** — `agent()`, `parallel()`, `pipeline()`, `phase()` in a sandboxed script. Up to 16 concurrent / 1000 total subagents; intermediate results stay in variables, not the chat.
+- **Fan-out orchestration** — `agent()`, `parallel()`, `pipeline()`, `phase()` in a sandboxed script. Pi can select 1–16 concurrent agents for each run independently of the 1000-agent whole-run cap; intermediate results stay in variables, not the chat.
 - **Real model routing** — `small` / `medium` / `big` tiers (or an exact `model`) per agent. It actually switches the subagent's model — cheap work on a light one, hard synthesis on a big one.
-- **Journaled resume** — an interrupted run replays finished agents from a journal (no re-run, no tokens) and runs only what's left or what you changed.
+- **Durable journaled resume** — an interrupted run preserves completed agent identities and exact usage, replays finished agents without charging them twice, and resumes unfinished work with the original run controls.
 - **Git worktree isolation** — `isolation: "worktree"` gives an agent its own branch, so parallel agents can edit the same files without clobbering each other.
-- **Real token & cost accounting** — read from each subagent's session, not estimated. Runs have no default token cap; `tokenBudget`, phase budgets, and `budget` let you add explicit gates when you want them.
-- **Background by default** — the turn ends right away, a live "Workflows running" panel tracks runs, and each result is delivered back so the conversation auto-continues when it finishes. The panel is compact by default; `/workflows-progress detailed` expands it inline to per-phase/per-agent rows with tokens, cost, and a live tok/s rate (so a stalled agent shows as 0 tok/s) — no need to open `/workflows`.
-- **Interactive `/workflows` TUI** — drill runs → phases → agents → detail; inspect per-agent failures and compact subagent history; pause, stop, restart, and save runs from the keyboard.
+- **Live token & cost accounting** — `~N tok` marks a streaming, display-only estimate; exact cumulative usage replaces it at each assistant-message boundary and is reconciled from the subagent session at completion. Runs have no default token cap; `tokenBudget`, phase budgets, and `budget` use exact usage for explicit gates.
+- **Background by default** — the turn ends right away, a live "Workflows running" panel tracks runs, and each result is delivered back so the conversation auto-continues when it finishes. Queued and running counts are separate, and `Running now (N/M)` names every active agent against the run's concurrency cap. The panel is compact by default; `/workflows-progress detailed` expands it inline to per-phase/per-agent rows with live usage — no need to open `/workflows`.
+- **Interactive `/workflows` TUI** — drill runs → phases → agents → detail; inspect queued/running/done/error/skipped state, per-agent usage, failures, and compact history; pause, stop, restart, and save runs from the keyboard.
 - **Quality patterns built in** — `verify()`, `judgePanel()`, `loopUntilDry()`, and `completenessCheck()` for adversarial review, best-of-N, and exhaustive discovery.
 - **Ultracode** — `/ultracode` is a standing opt-in that auto-arms an exhaustive multi-agent workflow for every substantive message, the way Claude Code's ultracode does. `/effort high` is the lighter tier.
 - **Bundled `/deep-research` + `/adversarial-review` + `/code-review`** — real web search, source cross-checking, cited reports, and a 7-angle parallel code review with a verify pass.
@@ -86,13 +88,38 @@ The same model — on Pi, plus the production pieces a real run needs:
 | Claude Code dynamic workflows | pi-dynamic-workflows (on Pi) |
 | --- | --- |
 | Code-mode orchestration — the model writes a script that drives subagents | A JS `workflow` tool running `agent()` / `parallel()` / `pipeline()` / `phase()` in a vm sandbox |
-| Subagents with isolated context | Fresh in-memory Pi sessions; results held in script variables, not the chat |
+| Subagents with isolated context | Private Pi sessions outside `/resume`; results held in script variables, not the chat |
 | Structured outputs | JSON-Schema `schema` → a validated object, with bounded repair if the model misses |
-| Background runs | Non-blocking by default, a live task panel, and auto-continue delivery |
-| Resume | **Journaled + replayable** — survives restarts and replays the unchanged prefix |
+| Background runs | Non-blocking by default, a live task panel, autonomous `workflow_control`, and auto-continue delivery |
+| Resume | **Durable, journaled, and replayable** — survives restarts with completed status/usage and run controls intact |
 | Model selection | **Per-agent / per-phase routing** across any provider Pi is authenticated for |
 | Ultracode (standing maximal-effort opt-in) | **`/ultracode`** (or `/effort ultra`) — auto-arms an exhaustive workflow for every substantive message |
 | — | **Git worktree isolation**, **real cost accounting**, **`/deep-research`**, and a **quality-pattern stdlib** |
+
+## Pi tools
+
+Pi starts work with `workflow`, then manages background runs directly with `workflow_control`; it does not need to ask you to type a slash command. `workflow_control` supports `list`, `status`, `set_concurrency`, `pause`, `resume`, `stop`, `restart`, and `remove`. Every action except `list` requires the canonical `runId` returned by `workflow` or `workflow_control list`.
+
+For example, you can ask Pi:
+
+```text
+Start a background workflow with concurrency 8, then list its status.
+Pause that run, resume it when I say continue, and stop it if I say quit.
+```
+
+Pi can make the corresponding calls itself:
+
+```json
+{ "action": "list" }
+{ "action": "status", "runId": "<canonical-run-id>" }
+{ "action": "pause", "runId": "<canonical-run-id>" }
+{ "action": "resume", "runId": "<canonical-run-id>" }
+{ "action": "stop", "runId": "<canonical-run-id>" }
+{ "action": "restart", "runId": "<canonical-run-id>" }
+{ "action": "remove", "runId": "<canonical-run-id>" }
+```
+
+`stop` means terminate/quit the run. In the navigator, `x` also stops the selected run, while `q` only closes the navigator.
 
 ## Commands
 
@@ -102,10 +129,10 @@ The same model — on Pi, plus the production pieces a real run needs:
 /workflows save <name>      save the latest run's script as a reusable /<name> command
 /workflows pause|resume|stop|rm <id>
 /workflows-trigger off|on|status
-                            persistently disable, restore, or inspect keyword triggering
+                            persistently disable, enable, or inspect keyword triggering (off by default)
 /workflows-trigger set <word>|reset
-                            customize or reset the keyword trigger word (default "workflow",
-                            also matches "workflows"; custom words match exactly, case-insensitive)
+                            customize or reset the word-bounded trigger (default "workflow",
+                            also matches "workflows"; all trigger words are literal and case-insensitive)
 /workflows run <prompt>     force a dynamic workflow from <prompt> on demand — the explicit
                             twin of the keyword trigger. Works even when the keyword trigger
                             is off (/workflows-trigger off); the run shows in the panel + /workflows.
@@ -148,7 +175,7 @@ The same model — on Pi, plus the production pieces a real run needs:
 
 It fans out 7 finder agents in parallel — 3 on correctness (line-by-line scan, removed-behavior audit, cross-file call-site tracing), 3 on cleanup (reuse, simplification, efficiency), and 1 on abstraction-level fit — dedupes their candidates, verifies each one, and returns a ranked markdown report (correctness first, cleanup next, abstraction last, capped at the top 10). A diff over ~200k characters is truncated with a clear notice rather than silently cut or blowing up the prompt.
 
-In the navigator: `↑/↓` select · `enter`/`→` open · `esc`/`←` back · `p` pause · `x` stop · `r` restart · `s` save · `q` quit. Each agent shows the model it ran on; the detail view shows its prompt, result, error diagnostics, and compact message/tool history.
+In the navigator: `↑/↓` select · `enter`/`→` open · `esc`/`←` back · `p` pause · `x` stop run · `r` restart · `s` save · `q` close. `q` never terminates a run. Each agent shows its explicit state and model; the detail view shows its prompt, live or exact token usage, result, error diagnostics, and compact message/tool history.
 
 ## Storage
 
@@ -168,15 +195,16 @@ Workflow state is stored under `~/.pi/workflows` so projects do not accumulate e
 
 Use `/workflows-models` to edit these in the TUI: choose the base model first, then choose `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or the session default.
 
-To avoid accidental keyword triggers, configure a custom trigger word in `~/.pi/workflows/settings.json`:
+Keyword triggering is disabled when `keywordTriggerEnabled` is missing or `false`. To opt in with a custom term, configure `~/.pi/workflows/settings.json`:
 
 ```json
 {
+  "keywordTriggerEnabled": true,
   "keywordTriggerWord": "pi-workflow"
 }
 ```
 
-The default `"workflow"` preserves the legacy behavior and also matches `"workflows"`. Custom trigger words are literal, case-insensitive terms with no spaces and no leading slash; for example, `"pi-workflow"` does not match `"workflow"`, `"workflows"`, or `"pi-workflows"`.
+The built-in `"workflow"` trigger also matches `"workflows"`. All trigger words are literal, case-insensitive, and word-bounded, with no spaces or leading slash; they do not activate inside paths, slash commands, or identifiers. For example, `"pi-workflow"` does not match `"workflow"`, `"workflows"`, or `"pi-workflows"`.
 
 ## Reference
 
@@ -205,15 +233,19 @@ The full guide — every global, agent option, `agentType` definitions, structur
 
 By default, workflows do not set a run-wide token budget or per-agent hard timeout. Use the `workflow` tool's `tokenBudget` / `agentTimeoutMs`, per-phase budgets, or per-agent `timeoutMs` only when you want an explicit cap. A global fallback timeout can also be set in `~/.pi/workflows/settings.json` as `{ "defaultAgentTimeoutMs": 600000 }`; set it to `null` or omit it for no default hard timeout.
 
-For larger or flakier fan-outs, the `workflow` tool also accepts `concurrency` (max agents running at once, clamped to the runtime maximum of `16`) and `agentRetries` (retry attempts after a recoverable agent failure such as a timeout, connection failure, or empty output). Both can be defaulted in `~/.pi/workflows/settings.json` as `{ "defaultConcurrency": 4, "defaultAgentRetries": 2 }`; a per-run tool value overrides the default, and a per-agent `retries` overrides `agentRetries`. Retries default to `0` (off) unless configured or passed, and only recoverable failures retry — nonrecoverable errors still abort the run.
+For larger or flakier fan-outs, Pi may set the `workflow` tool's per-run positive-integer `concurrency` based on independent task count and provider stability. The plugin imposes no hard concurrency cap. If omitted, `defaultConcurrency` from `~/.pi/workflows/settings.json` is used; the runtime fallback is `16`. The selected requested/effective concurrency is persisted and reused on resume. Resize a running or paused run with `workflow_control set_concurrency` or `/workflows concurrency <runId> <n>`. Increasing the limit releases queued agents immediately; decreasing it lets already-running agents finish and starts no replacements until activity falls below the new limit. `concurrency` only limits simultaneous agents; `maxAgents` separately limits the whole-run total (default `1000`), so provider capacity and `maxAgents` remain the practical ceilings.
 
-By default, each workflow subagent runs in an in-memory session: the full transcript is discarded when the run ends, and only a compacted excerpt survives inside the run JSON. Set `{ "persistAgentSessions": true }` in `~/.pi/workflows/settings.json` (or a project-level override, which wins) to persist every subagent transcript as a real pi session file in the standard sessions directory for the project (`~/.pi/agent/sessions/<encoded-cwd>/`), named `workflow:<runId> <agent label>` so it's identifiable in `/resume` and other session tooling. Sessions are keyed by the project cwd even when an agent runs in a temporary git worktree. Default is `false` (current behavior). Caveat: large fan-out runs create one session file per agent, which can clutter session pickers. Caveat: unlike the compacted run JSON, the persisted transcript is full and untruncated, so anything a subagent reads into context — including secrets — lands on disk when this is enabled. If a session can't be created or written (permissions, disk full), that agent silently falls back to an in-memory session rather than aborting the run.
+The tool also accepts `agentRetries` for recoverable failures such as a timeout, connection failure, or empty assistant output. Defaults can be set as `{ "defaultConcurrency": 4, "defaultAgentRetries": 2 }`; a per-run tool value overrides the configured default, and a per-agent `retries` overrides `agentRetries`. Retries default to `0` (off) unless configured or passed, and nonrecoverable errors still abort the run.
 
-The live "Workflows running" panel is configured in the same `~/.pi/workflows/settings.json`: `"progressPanelMode"` is `"compact"` (default, one line per run) or `"detailed"` (per-phase/per-agent rows with tokens, cost, and a live tok/s rate), and `"progressPanelMaxAgents"` (default `8`, range `1`–`1000`) caps how many agents each phase shows in detailed mode before a `… N earlier agents` line. Toggle them live with `/workflows-progress compact|detailed` and `/workflows-progress-max <N>` — changes take effect on the next render without a restart.
+By default, each workflow subagent uses a file-backed Pi session under the workflow project's private state directory (`~/.pi/workflows/projects/<project>/agent-sessions/`), named `workflow:<runId> <agent label>`. These child sessions are intentionally outside Pi's standard session directory, so they do not clutter the normal `/resume` picker; the run artifact links each agent to its transcript for workflow-specific analysis and turn-boundary resume. A paused or crash-interrupted agent can reopen its transcript and continue from the last durable assistant-message/tool-result boundary instead of restarting the whole agent. Sessions are keyed by the project cwd, and an isolated agent's worktree is preserved while paused so its coding tools reopen in the same cwd. Set `{ "persistAgentSessions": false }` in `~/.pi/workflows/settings.json` (or a project override) to opt out; interrupted agents then fall back to a fresh session. Large fan-outs create one session file per agent and full transcripts can contain sensitive context. If a saved session is missing, corrupt, or unwritable, only that agent restarts fresh and the fallback is shown in workflow logs/UI.
+
+The live "Workflows running" panel is configured in the same `~/.pi/workflows/settings.json`: `"progressPanelMode"` is `"compact"` (default, one summary per run) or `"detailed"`, and `"progressPanelMaxAgents"` (default `8`, range `1`–`1000`) caps rows per phase. Both views separately show finished agents, `paused mid-run` agents, and queued agents that have `not started`; paused rows say whether a child session was saved or a fresh restart is required. Active labels remain listed as `Running now (N/M)`. Token text prefixed with `~` is an in-progress estimate; exact cumulative usage replaces it at message boundaries and terminal reconciliation. Estimates are display-only and are not persisted or charged to budgets.
 
 When a background run finishes, its result is delivered back into the conversation with a `↳ Full result: <path>` pointer to the persisted `~/.pi/workflows/projects/<project>/runs/<id>.json`, so nothing is lost even when the summary is shortened. Only the JSON-dump fallback (a result object without a `verdict`/`report`/`summary` string field) is truncated — at `"deliveredResultMaxChars"` characters (default `400`) in the same `~/.pi/workflows/settings.json` — and the dropped size is shown inline, e.g. `…(truncated 3.2 KB)`.
 
-Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()`, and `require`/`import`/`fs`/network are unavailable, so runs stay reproducible — which is what makes resume reliable.
+Run artifacts are versioned. On Pi restart, completed agents keep their stable identities, status, history, usage, and results; agents that had started are recovered as `paused` with their child-session/worktree checkpoint, while agents that never entered the runner remain `queued`. Runs do not auto-resume. `/workflows resume <id>` or `workflow_control resume` replays completed journal entries, reopens paused child sessions, and starts never-started work fresh with the persisted concurrency, limits, retries, timeout, and token budget. A provider stream cannot resume mid-token, and a tool interrupted before its result was durably recorded is inherently uncertain; the continuation prompt tells the agent to inspect existing state and avoid repeating completed side effects. Older artifacts are migrated defensively, and missing/corrupt child sessions fall back per-agent to a fresh restart.
+
+Workflows run in a Node `vm` sandbox; `Date.now()`, `Math.random()`, `new Date()`, and `require`/`import`/`fs`/network are unavailable, so runs stay reproducible — which is what makes durable replay reliable.
 
 ## Default tier assignment
 

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -15,6 +15,7 @@ import {
   saveWorkflowSettingsForCwd,
   WorkflowManager,
 } from "../src/index.js";
+import { createWorkflowControlTool } from "../src/workflow-control-tool.js";
 
 export default function extension(pi: ExtensionAPI) {
   // Single manager/storage shared by the workflow tool and the /workflows command,
@@ -32,7 +33,9 @@ export default function extension(pi: ExtensionAPI) {
   });
 
   const workflowTool = createWorkflowTool({ cwd, manager, storage });
+  const workflowControlTool = createWorkflowControlTool({ manager });
   pi.registerTool(workflowTool);
+  pi.registerTool(workflowControlTool);
   // Standing /effort opt-in (off|high|ultra): auto-arms a workflow for substantive
   // messages, like CC's ultracode. Shared with the editor's input hook below and
   // with the explicit /workflows run <prompt> manual trigger.
@@ -58,9 +61,9 @@ export default function extension(pi: ExtensionAPI) {
     // advertise the shared registry's models.
     manager.setModelRegistry(ctx.modelRegistry);
     const active = pi.getActiveTools();
-    if (!active.includes(workflowTool.name)) {
-      pi.setActiveTools([...active, workflowTool.name]);
-    }
+    const workflowTools = [workflowTool.name, workflowControlTool.name];
+    const missing = workflowTools.filter((name) => !active.includes(name));
+    if (missing.length) pi.setActiveTools([...active, ...missing]);
     // Scope the /workflows history to this session: runs persist on disk across
     // sessions, but the navigator/task panel show only the current session's runs.
     // Switching back to a previous session re-shows that session's runs.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
-import { unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AssistantMessage, Model, TextContent } from "@earendil-works/pi-ai";
 import {
+  type AgentSessionEvent,
   AuthStorage,
   type CreateAgentSessionOptions,
   createAgentSession,
@@ -21,6 +22,7 @@ import { classifyProviderLimit, WorkflowError, WorkflowErrorCode } from "./error
 import { canonicalModelSpec, resolveModelSpecWithThinking } from "./model-spec.js";
 import { loadModelTierConfig, type ModelTierConfig, resolveTierModel } from "./model-tier-config.js";
 import { createStructuredOutputTool, type StructuredOutputCapture } from "./structured-output.js";
+import { workflowProjectPaths } from "./workflow-paths.js";
 
 /**
  * Find a JSON object/array in free-form text: a fenced ```json block if present,
@@ -215,9 +217,8 @@ export interface WorkflowAgentOptions {
    */
   modelRegistry?: ModelRegistry;
   /**
-   * Persist each subagent transcript as a real pi session file under the
-   * standard sessions directory (keyed by the runner's project cwd), instead
-   * of the default in-memory session that is discarded when the run ends.
+   * Persist each subagent transcript as a private pi session file under the
+   * workflow project's state directory, outside Pi's normal /resume picker.
    * Default: false (current behavior).
    */
   persistAgentSessions?: boolean;
@@ -243,7 +244,7 @@ export function listAvailableModelSpecs(registry?: ModelRegistry): string[] {
   }
 }
 
-/** Real token/cost usage for a single subagent run, read from the SDK session. */
+/** Token/cost usage for a single subagent run. */
 export interface AgentUsage {
   input: number;
   output: number;
@@ -251,6 +252,69 @@ export interface AgentUsage {
   cacheWrite: number;
   total: number;
   cost: number;
+  /** True only for an in-progress output-token estimate. */
+  estimated?: boolean;
+}
+
+/**
+ * Convert session events into absolute cumulative usage. Exact message usage is
+ * emitted at message_end; throttled message_update events add only a temporary
+ * output estimate, which the next exact event replaces.
+ */
+export function createAgentUsageEventHandler(
+  onUsage: (usage: AgentUsage) => void,
+  now: () => number = Date.now,
+): (event: AgentSessionEvent) => void {
+  const exact: AgentUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 };
+  const endedMessages = new WeakSet<object>();
+  let lastEstimateEmit = Number.NEGATIVE_INFINITY;
+  const emit = (usage: AgentUsage) => {
+    try {
+      onUsage(usage);
+    } catch {
+      // Telemetry is best-effort; never interrupt the child session.
+    }
+  };
+
+  return (event) => {
+    if (event.type === "message_end" && event.message.role === "assistant") {
+      if (endedMessages.has(event.message)) return;
+      endedMessages.add(event.message);
+      const usage = event.message.usage;
+      exact.input += usage.input;
+      exact.output += usage.output;
+      exact.cacheRead += usage.cacheRead;
+      exact.cacheWrite += usage.cacheWrite;
+      exact.total += usage.totalTokens;
+      exact.cost += usage.cost.total;
+      lastEstimateEmit = Number.NEGATIVE_INFINITY;
+      emit({ ...exact, estimated: false });
+      return;
+    }
+
+    if (event.type !== "message_update" || event.message.role !== "assistant") return;
+    const timestamp = now();
+    if (timestamp - lastEstimateEmit < 250) return;
+    lastEstimateEmit = timestamp;
+    const text = event.message.content
+      .map((part) => (part.type === "text" ? part.text : part.type === "thinking" ? part.thinking : ""))
+      .join("");
+    const estimatedOutput = Math.ceil(text.length / 4);
+    if (estimatedOutput <= 0) return;
+    emit({
+      ...exact,
+      output: exact.output + estimatedOutput,
+      total: exact.total + estimatedOutput,
+      estimated: true,
+    });
+  };
+}
+
+export interface AgentSessionCheckpoint {
+  /** File-backed Pi child session. Undefined means this invocation cannot resume in-place. */
+  sessionFile?: string;
+  /** True when the existing session was reopened rather than created fresh. */
+  resumed: boolean;
 }
 
 export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefined> {
@@ -267,11 +331,15 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
   instructions?: string;
   signal?: AbortSignal;
   /**
-   * Called once with this subagent's real usage, read from the session right
-   * before disposal. Fires on both the success and error paths so partial
-   * usage is never lost. `total === 0` means the provider reported no usage.
+   * Called with absolute cumulative usage during the run and once more with
+   * authoritative session totals before disposal. Streaming estimates have
+   * `estimated: true`; message-boundary and terminal updates are exact.
    */
   onUsage?: (usage: AgentUsage) => void;
+  /** Reopen this persisted Pi child session and continue from its last durable turn boundary. */
+  resumeSessionFile?: string;
+  /** Called before prompting so workflow persistence can durably link the invocation to its child session. */
+  onSession?: (checkpoint: AgentSessionCheckpoint) => void;
   /**
    * Model spec for this subagent: either `provider/modelId` (unambiguous) or a
    * bare `modelId`. When it can't be resolved, the session default is used and
@@ -376,9 +444,9 @@ export class WorkflowAgent {
   }
 
   /**
-   * Session manager for one subagent run. File-backed (persisted under the
-   * standard sessions dir, keyed by the runner's project cwd — never a
-   * per-call worktree cwd) when persistAgentSessions is on; in-memory otherwise.
+   * Session manager for one subagent run. File-backed in the workflow project's
+   * private agent-sessions directory (never the normal Pi /resume directory and
+   * never a per-call worktree cwd) when persistence is on; in-memory otherwise.
    *
    * SessionManager.create() only creates the session directory — the SDK writes
    * the session file lazily (synchronous fs calls, uncaught) on the first
@@ -391,7 +459,7 @@ export class WorkflowAgent {
   private createSessionManager(): SessionManager {
     if (!this.persistAgentSessions) return SessionManager.inMemory();
     try {
-      const manager = SessionManager.create(this.cwd);
+      const manager = SessionManager.create(this.cwd, workflowProjectPaths(this.cwd).agentSessionsDir);
       this.assertSessionDirWritable(manager.getSessionDir());
       return manager;
     } catch (error) {
@@ -402,6 +470,28 @@ export class WorkflowAgent {
       );
       return SessionManager.inMemory();
     }
+  }
+
+  /** Reopen a durable child session when possible; otherwise create the configured fresh session. */
+  private resolveSessionManager(
+    resumeSessionFile: string | undefined,
+    runCwd: string,
+  ): {
+    manager: SessionManager;
+    resumed: boolean;
+  } {
+    if (resumeSessionFile && existsSync(resumeSessionFile)) {
+      try {
+        return { manager: SessionManager.open(resumeSessionFile, undefined, runCwd), resumed: true };
+      } catch (error) {
+        console.warn(
+          `[workflow] could not reopen child session ${resumeSessionFile} (${
+            error instanceof Error ? error.message : String(error)
+          }); restarting this agent from a fresh session`,
+        );
+      }
+    }
+    return { manager: this.createSessionManager(), resumed: false };
   }
 
   /** Best-effort write probe: throws if the session directory isn't actually writable. */
@@ -463,11 +553,13 @@ export class WorkflowAgent {
     }
 
     const agentDir = getAgentDir();
-    // Key persisted sessions by the runner's project cwd (this.cwd), NOT the
-    // per-call runCwd: agents working in short-lived git worktrees should still
-    // group under the project's session dir instead of scattering across
-    // temporary worktree paths.
-    const sessionManager = this.createSessionManager();
+    // Key new persisted sessions by the runner's project cwd (this.cwd), NOT the
+    // per-call runCwd. A resumed session is reopened with runCwd as its cwd override
+    // so coding tools continue in the same shared tree or preserved worktree.
+    const resolvedSession = this.sessionOptions.sessionManager
+      ? { manager: this.sessionOptions.sessionManager, resumed: false }
+      : this.resolveSessionManager(options.resumeSessionFile, runCwd);
+    const sessionManager = resolvedSession.manager;
     const { session } = await createAgentSession({
       cwd: runCwd,
       agentDir,
@@ -489,9 +581,21 @@ export class WorkflowAgent {
       ...(resolvedThinkingLevel ? { thinkingLevel: resolvedThinkingLevel } : {}),
     });
 
-    // Name the persisted session so it's identifiable in session pickers.
-    // Skip when an injected session.sessionManager override won (tests/embedders).
-    if (this.persistAgentSessions && !this.sessionOptions.sessionManager && options.sessionName) {
+    // Persist the child-session link before the model starts, so a crash can recover it.
+    try {
+      options.onSession?.({ sessionFile: sessionManager.getSessionFile(), resumed: resolvedSession.resumed });
+    } catch {
+      // Session-link telemetry is best-effort; never block the child.
+    }
+
+    // Name a newly persisted session so it's identifiable in session pickers.
+    // Skip reopened sessions and injected managers to avoid duplicate session_info entries.
+    if (
+      this.persistAgentSessions &&
+      !resolvedSession.resumed &&
+      !this.sessionOptions.sessionManager &&
+      options.sessionName
+    ) {
       try {
         sessionManager.appendSessionInfo(options.sessionName);
       } catch {
@@ -499,8 +603,9 @@ export class WorkflowAgent {
       }
     }
 
+    const initialStats = resolvedSession.resumed ? session.getSessionStats() : undefined;
     let removeAbortListener: (() => void) | undefined;
-    let removeHistoryListener: (() => void) | undefined;
+    let removeSessionListener: (() => void) | undefined;
     let lastHistoryEmit = 0;
     const emitHistory = () => options.onHistory?.(compactAgentHistory(session.messages));
     const maybeEmitHistory = () => {
@@ -510,6 +615,7 @@ export class WorkflowAgent {
       lastHistoryEmit = now;
       emitHistory();
     };
+    const handleUsageEvent = options.onUsage ? createAgentUsageEventHandler(options.onUsage) : undefined;
     try {
       if (options.signal?.aborted) throw new Error("Subagent was aborted");
       if (options.signal) {
@@ -517,11 +623,18 @@ export class WorkflowAgent {
         options.signal.addEventListener("abort", onAbort, { once: true });
         removeAbortListener = () => options.signal?.removeEventListener("abort", onAbort);
       }
-      if (options.onHistory) {
-        removeHistoryListener = session.subscribe(() => maybeEmitHistory());
+      if (options.onHistory || handleUsageEvent) {
+        removeSessionListener = session.subscribe((event) => {
+          maybeEmitHistory();
+          handleUsageEvent?.(event);
+        });
       }
 
-      await session.prompt(this.buildPrompt(prompt, options as AgentRunOptions<any>, Boolean(options.schema)));
+      await session.prompt(
+        resolvedSession.resumed
+          ? this.buildResumePrompt(Boolean(options.schema))
+          : this.buildPrompt(prompt, options as AgentRunOptions<any>, Boolean(options.schema)),
+      );
 
       if (options.signal?.aborted) throw new Error("Subagent was aborted");
 
@@ -547,7 +660,7 @@ export class WorkflowAgent {
       return text as AgentRunResult<TSchemaDef>;
     } finally {
       removeAbortListener?.();
-      removeHistoryListener?.();
+      removeSessionListener?.();
       try {
         emitHistory();
       } catch {
@@ -558,12 +671,13 @@ export class WorkflowAgent {
         try {
           const { tokens, cost } = session.getSessionStats();
           options.onUsage({
-            input: tokens.input,
-            output: tokens.output,
-            cacheRead: tokens.cacheRead,
-            cacheWrite: tokens.cacheWrite,
-            total: tokens.total,
-            cost,
+            input: Math.max(0, tokens.input - (initialStats?.tokens.input ?? 0)),
+            output: Math.max(0, tokens.output - (initialStats?.tokens.output ?? 0)),
+            cacheRead: Math.max(0, tokens.cacheRead - (initialStats?.tokens.cacheRead ?? 0)),
+            cacheWrite: Math.max(0, tokens.cacheWrite - (initialStats?.tokens.cacheWrite ?? 0)),
+            total: Math.max(0, tokens.total - (initialStats?.tokens.total ?? 0)),
+            cost: Math.max(0, cost - (initialStats?.cost ?? 0)),
+            estimated: false,
           });
         } catch {
           // Usage is best-effort; never let stats failure mask the real result/error.
@@ -571,6 +685,20 @@ export class WorkflowAgent {
       }
       session.dispose();
     }
+  }
+
+  private buildResumePrompt(structured: boolean): string {
+    const parts = [
+      "Continue the interrupted task from the existing session at the last durable message/tool-result boundary.",
+      "Review the prior messages and current filesystem state before acting. Do not repeat completed side effects.",
+      "Finish the original task and return its requested final result.",
+    ];
+    if (structured) {
+      parts.push(
+        "When finished, call structured_output with the required schema, even if it was called before interruption.",
+      );
+    }
+    return parts.join("\n\n");
   }
 
   private buildPrompt(prompt: string, options: AgentRunOptions<any>, structured: boolean): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,8 +8,8 @@ export const MAX_AGENTS_PER_RUN = 1000;
 /** Default timeout for a single agent in milliseconds. null means no hard timeout. */
 export const DEFAULT_AGENT_TIMEOUT_MS = null;
 
-/** Maximum concurrent agents (matches Claude Code limit). */
-export const MAX_CONCURRENCY = 16;
+/** Concurrent agents used when a run does not specify a limit. */
+export const DEFAULT_CONCURRENCY = 16;
 
 /** Maximum automatic retry attempts after a recoverable agent failure. */
 export const MAX_AGENT_RETRIES = 3;

--- a/src/display.ts
+++ b/src/display.ts
@@ -2,11 +2,15 @@ import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import type { WorkflowErrorCode } from "./errors.js";
 import type { WorkflowMeta } from "./workflow.js";
+import type { Worktree } from "./worktree.js";
 
-export type WorkflowAgentStatus = "queued" | "running" | "done" | "error" | "skipped";
+export type WorkflowAgentStatus = "queued" | "running" | "paused" | "done" | "error" | "skipped";
 
 export interface WorkflowAgentSnapshot {
   id: number;
+  /** Stable runtime identity (`runId:callIndex`). */
+  executionId?: string;
+  callIndex?: number;
   label: string;
   phase?: string;
   prompt: string;
@@ -18,8 +22,26 @@ export interface WorkflowAgentSnapshot {
   history?: AgentHistoryEntry[];
   /** Tokens used by this agent. */
   tokens?: number;
+  /** Whether tokens is a live streaming estimate. */
+  tokensEstimated?: boolean;
+  startedAt?: string;
+  endedAt?: string;
+  /** Absolute cumulative usage for this invocation. */
+  usage?: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+    cost: number;
+    estimated?: boolean;
+  };
   /** The model this agent ran on (provider/id), when known. */
   model?: string;
+  /** File-backed Pi child session used to continue this invocation after pause/restart. */
+  sessionFile?: string;
+  /** Preserved isolated cwd required by a resumed child session. */
+  worktree?: Worktree;
 }
 
 export interface WorkflowSnapshot {
@@ -44,6 +66,8 @@ export interface WorkflowSnapshot {
     cacheWrite?: number;
   };
   runId?: string;
+  requestedConcurrency?: number;
+  effectiveConcurrency?: number;
 }
 
 export interface WorkflowDisplay {
@@ -174,19 +198,37 @@ export function renderWorkflowLines(
 ): string[] {
   const maxAgents = options.maxAgents ?? 8;
   const showResultPreviews = options.showResultPreviews ?? false;
-  const state =
-    snapshot.errorCount > 0
-      ? `, ${snapshot.errorCount} errors`
-      : snapshot.runningCount > 0
-        ? `, ${snapshot.runningCount} running`
-        : "";
-  // Build header with token info (and cost when the provider reports it)
+  const queuedCount = snapshot.agents.filter((agent) => agent.status === "queued").length;
+  const pausedAgents = snapshot.agents.filter((agent) => agent.status === "paused");
+  const skippedCount = snapshot.agents.filter((agent) => agent.status === "skipped").length;
   const usage = snapshot.tokenUsage;
   const costInfo = usage?.cost ? ` · $${usage.cost.toFixed(4)}` : "";
   const tokenInfo = usage ? ` · ${usage.total.toLocaleString()} tokens${costInfo}` : "";
+  const state = [
+    snapshot.runningCount ? `${snapshot.runningCount} running` : "",
+    pausedAgents.length ? `${pausedAgents.length} paused mid-run` : "",
+    queuedCount ? `${queuedCount} not started` : "",
+    snapshot.errorCount ? `${snapshot.errorCount} errors` : "",
+    skippedCount ? `${skippedCount} skipped` : "",
+  ]
+    .filter(Boolean)
+    .join(", ");
   const lines = [
-    `${theme.bold(`◆ Workflow: ${snapshot.name}`)} (${snapshot.doneCount}/${snapshot.agentCount} done${state}${tokenInfo})`,
+    `${theme.bold(`◆ Workflow: ${snapshot.name}`)} (${snapshot.doneCount}/${snapshot.agentCount} done${state ? `, ${state}` : ""}${tokenInfo})`,
   ];
+  const activeLabels = snapshot.agents.filter((agent) => agent.status === "running").map((agent) => agent.label);
+  if (activeLabels.length) {
+    lines.push(
+      `  Running now (${activeLabels.length}/${snapshot.effectiveConcurrency ?? activeLabels.length}): ${activeLabels.join(", ")}`,
+    );
+  }
+  if (pausedAgents.length) {
+    lines.push(
+      `  Paused mid-run (${pausedAgents.length}): ${pausedAgents
+        .map((agent) => `${agent.label}${agent.sessionFile ? " (session saved)" : " (fresh restart)"}`)
+        .join(", ")}`,
+    );
+  }
 
   const phaseNames = snapshot.phases.length
     ? snapshot.phases
@@ -198,15 +240,18 @@ export function renderWorkflowLines(
     for (const agent of agents) rendered.add(agent);
     const done = agents.filter((agent) => agent.status === "done").length;
     const running = agents.filter((agent) => agent.status === "running").length;
+    const paused = agents.filter((agent) => agent.status === "paused").length;
+    const queued = agents.filter((agent) => agent.status === "queued").length;
     const errors = agents.filter((agent) => agent.status === "error").length;
     const skipped = agents.filter((agent) => agent.status === "skipped").length;
     const complete = agents.length > 0 && done + errors + skipped === agents.length;
-    const marker = running > 0 || (!complete && snapshot.currentPhase === phase) ? "▶" : complete ? "✓" : " ";
+    const marker =
+      paused > 0 ? "⏸" : running > 0 || (!complete && snapshot.currentPhase === phase) ? "▶" : complete ? "✓" : " ";
     lines.push(
       theme.fg("accent", `  ${marker} ${phase}`) +
         theme.fg(
           "dim",
-          ` ${done}/${agents.length}${running ? ` · ${running} running` : ""}${errors ? ` · ${errors} errors` : ""}${skipped ? ` · ${skipped} skipped` : ""}`,
+          ` ${done}/${agents.length}${running ? ` · ${running} running` : ""}${paused ? ` · ${paused} paused` : ""}${queued ? ` · ${queued} not started` : ""}${errors ? ` · ${errors} errors` : ""}${skipped ? ` · ${skipped} skipped` : ""}`,
         ),
     );
 
@@ -214,8 +259,10 @@ export function renderWorkflowLines(
     for (const agent of visibleAgents) {
       const order = `[${agent.id}]`;
       const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
-      const agentTokens = agent.tokens ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`) : "";
-      lines.push(`    ${order} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
+      const agentTokens = formatAgentTokens(agent, theme);
+      lines.push(
+        `    ${order} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens} · ${agentStatusLabel(agent)}${result}`,
+      );
     }
     if (agents.length > visibleAgents.length)
       lines.push(theme.fg("dim", `    … ${agents.length - visibleAgents.length} earlier agents`));
@@ -226,12 +273,24 @@ export function renderWorkflowLines(
     lines.push(theme.fg("accent", "  Unphased"));
     for (const agent of unphased.slice(-maxAgents)) {
       const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
-      const agentTokens = agent.tokens ? theme.fg("dim", ` [${agent.tokens.toLocaleString()} tok]`) : "";
-      lines.push(`    [${agent.id}] ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
+      const agentTokens = formatAgentTokens(agent, theme);
+      lines.push(
+        `    [${agent.id}] ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens} · ${agentStatusLabel(agent)}${result}`,
+      );
     }
   }
 
   return lines;
+}
+
+function agentStatusLabel(agent: WorkflowAgentSnapshot): string {
+  if (agent.status !== "paused") return agent.status;
+  return agent.sessionFile ? "paused mid-run (session saved)" : "paused mid-run (fresh restart)";
+}
+
+function formatAgentTokens(agent: WorkflowAgentSnapshot, theme: ThemeLike): string {
+  if (!agent.tokens) return "";
+  return theme.fg("dim", ` [${agent.tokensEstimated ? "~" : ""}${agent.tokens.toLocaleString()} tok]`);
 }
 
 export function renderWorkflowText(snapshot: WorkflowSnapshot, completed = false): string {
@@ -243,6 +302,9 @@ function statusLine(snapshot: WorkflowSnapshot, completed: boolean): string {
   if (completed) return `workflow ✓ ${snapshot.name}: ${snapshot.doneCount}/${snapshot.agentCount}`;
   if (snapshot.runningCount > 0)
     return `workflow ${snapshot.name}: ${snapshot.runningCount} running, ${snapshot.doneCount}/${snapshot.agentCount} done`;
+  const paused = snapshot.agents.filter((agent) => agent.status === "paused").length;
+  if (paused > 0)
+    return `workflow ${snapshot.name}: ${paused} paused mid-run, ${snapshot.doneCount}/${snapshot.agentCount} done`;
   return `workflow ${snapshot.name}: ${snapshot.doneCount}/${snapshot.agentCount} done`;
 }
 
@@ -252,6 +314,8 @@ export function statusIcon(status: WorkflowAgentStatus): string {
       return "○";
     case "running":
       return "●";
+    case "paused":
+      return "⏸";
     case "done":
       return "✓";
     case "error":

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export type { AdversarialReviewConfig } from "./adversarial-review.js";
 export { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
-export type { AgentRunOptions, AgentRunResult, WorkflowAgentOptions } from "./agent.js";
+export type { AgentRunOptions, AgentRunResult, AgentSessionCheckpoint, WorkflowAgentOptions } from "./agent.js";
 export { listAvailableModelSpecs, WorkflowAgent } from "./agent.js";
 export type { AgentHistoryEntry, AgentHistoryKind, AgentHistoryRole } from "./agent-history.js";
 export { compactAgentHistory } from "./agent-history.js";
@@ -80,14 +80,17 @@ export { createWebFetchTool, createWebSearchTool, createWebTools } from "./web-t
 export type {
   AgentOptions,
   JournalEntry,
+  ResumeAgentState,
   SharedRuntime,
+  WorkflowConcurrencyLimiter,
   WorkflowMeta,
   WorkflowMetaPhase,
   WorkflowRunOptions,
   WorkflowRunResult,
 } from "./workflow.js";
-export { parseWorkflowScript, runWorkflow } from "./workflow.js";
+export { createConcurrencyLimiter, parseWorkflowScript, runWorkflow } from "./workflow.js";
 export { registerWorkflowCommands } from "./workflow-commands.js";
+export { createWorkflowControlTool } from "./workflow-control-tool.js";
 export {
   buildForcedWorkflowPrompt,
   colorizeWorkflow,
@@ -102,7 +105,7 @@ export {
   WorkflowEditor,
   type WorkflowModeState,
 } from "./workflow-editor.js";
-export type { ManagedRun, WorkflowManagerOptions } from "./workflow-manager.js";
+export type { ConcurrencyUpdate, ManagedRun, WorkflowManagerOptions } from "./workflow-manager.js";
 export { WorkflowManager } from "./workflow-manager.js";
 export type { WorkflowProjectPaths } from "./workflow-paths.js";
 export {

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -4,32 +4,55 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { AgentUsage } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import type { WorkflowErrorCode } from "./errors.js";
+import type { JournalEntry } from "./workflow.js";
 import { workflowProjectPaths } from "./workflow-paths.js";
+import type { Worktree } from "./worktree.js";
+
+export const RUN_STATE_VERSION = 3;
 
 export type RunStatus = "pending" | "running" | "paused" | "completed" | "failed" | "aborted";
 
 export interface PersistedAgentState {
   id: number;
+  /** Stable runtime identity (`runId:callIndex`). Optional for legacy save callers. */
+  executionId?: string;
+  callIndex?: number;
   label: string;
   phase?: string;
   prompt: string;
-  status: "queued" | "running" | "done" | "error" | "skipped";
+  status: "queued" | "running" | "paused" | "done" | "error" | "skipped";
   result?: unknown;
+  resultPreview?: string;
   error?: string;
   errorCode?: WorkflowErrorCode;
   recoverable?: boolean;
   history?: AgentHistoryEntry[];
+  /** Exact cumulative usage. Streaming estimates are never persisted. */
+  usage?: AgentUsage;
+  tokens?: number;
   startedAt?: string;
   endedAt?: string;
   /** The model this agent ran on (provider/id), when known. */
   model?: string;
+  /** File-backed Pi child session used for turn-boundary continuation. */
+  sessionFile?: string;
+  /** Preserved isolated cwd for a paused child session. */
+  worktree?: Worktree;
+}
+
+export interface LoadedPersistedAgentState extends PersistedAgentState {
+  executionId: string;
+  callIndex: number;
 }
 
 export interface PersistedRunState {
+  version?: number;
   runId: string;
   workflowName: string;
+  workflowDescription?: string;
   script: string;
   args?: unknown;
   /** The pi session this run belongs to. Runs persist on disk across sessions but
@@ -49,6 +72,13 @@ export interface PersistedRunState {
   updatedAt: string;
   completedAt?: string;
   durationMs?: number;
+  /** Run controls required to resume with equivalent execution behavior. */
+  requestedConcurrency?: number;
+  effectiveConcurrency?: number;
+  maxAgents?: number;
+  agentRetries?: number;
+  agentTimeoutMs?: number | null;
+  tokenBudget?: number | null;
   tokenUsage?: {
     input: number;
     output: number;
@@ -58,15 +88,20 @@ export interface PersistedRunState {
     cacheWrite?: number;
   };
   /** Cached agent results for resume, keyed by deterministic call index. */
-  journal?: Array<{ index: number; hash: string; result: unknown }>;
+  journal?: JournalEntry[];
+}
+
+export interface LoadedPersistedRunState extends Omit<PersistedRunState, "version" | "agents"> {
+  version: number;
+  agents: LoadedPersistedAgentState[];
 }
 
 export interface RunPersistence {
   /** Save current run state. */
   save(state: PersistedRunState): void;
-  /** Load a persisted run by ID. */
+  /** Load a persisted run by ID. Built-in persistence returns normalized state. */
   load(runId: string): PersistedRunState | null;
-  /** List all persisted runs. */
+  /** List persisted runs. Built-in persistence returns normalized state. */
   list(): PersistedRunState[];
   /** Delete a persisted run. */
   delete(runId: string): boolean;
@@ -86,12 +121,241 @@ export interface RunLease {
   token: string;
 }
 
+interface NormalizedRunPersistence extends RunPersistence {
+  load(runId: string): LoadedPersistedRunState | null;
+  list(): LoadedPersistedRunState[];
+}
+
 interface LockFile {
   runId: string;
   runPath: string;
   pid: number;
   startedAt: string;
   token: string;
+}
+
+const RUN_STATUSES = new Set<RunStatus>(["pending", "running", "paused", "completed", "failed", "aborted"]);
+const AGENT_STATUSES = new Set<PersistedAgentState["status"]>([
+  "queued",
+  "running",
+  "paused",
+  "done",
+  "error",
+  "skipped",
+]);
+const warnedMigrationSources = new Set<string>();
+
+function warnMigrationOnce(source: string, message: string): void {
+  if (warnedMigrationSources.has(source)) return;
+  warnedMigrationSources.add(source);
+  console.warn(message);
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function exactUsage(value: unknown): AgentUsage | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const usage = value as Record<string, unknown>;
+  return {
+    input: finiteNumber(usage.input) ?? 0,
+    output: finiteNumber(usage.output) ?? 0,
+    cacheRead: finiteNumber(usage.cacheRead) ?? 0,
+    cacheWrite: finiteNumber(usage.cacheWrite) ?? 0,
+    total: finiteNumber(usage.total) ?? 0,
+    cost: finiteNumber(usage.cost) ?? 0,
+    estimated: false,
+  };
+}
+
+function migrateWorktree(value: unknown): Worktree | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const worktree = value as Record<string, unknown>;
+  if (typeof worktree.cwd !== "string" || typeof worktree.isolated !== "boolean") return undefined;
+  return {
+    cwd: worktree.cwd,
+    isolated: worktree.isolated,
+    branch: typeof worktree.branch === "string" ? worktree.branch : undefined,
+    repoRoot: typeof worktree.repoRoot === "string" ? worktree.repoRoot : undefined,
+    reason: typeof worktree.reason === "string" ? worktree.reason : undefined,
+  };
+}
+
+function migrateAgent(
+  raw: unknown,
+  runId: string,
+  fallbackIndex: number,
+  legacyIdentity: boolean,
+): LoadedPersistedAgentState | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const agent = raw as Record<string, unknown>;
+  const persistedId = finiteNumber(agent.id);
+  const callIndex = Math.max(0, Math.floor(finiteNumber(agent.callIndex) ?? (persistedId ?? fallbackIndex + 1) - 1));
+  const id = Math.max(1, Math.floor(persistedId ?? callIndex + 1));
+  const status = AGENT_STATUSES.has(agent.status as PersistedAgentState["status"])
+    ? (agent.status as PersistedAgentState["status"])
+    : "queued";
+  const usage = exactUsage(agent.usage);
+  return {
+    id,
+    executionId: !legacyIdentity && typeof agent.executionId === "string" ? agent.executionId : `${runId}:${callIndex}`,
+    callIndex,
+    label: typeof agent.label === "string" ? agent.label : `agent-${id}`,
+    phase: typeof agent.phase === "string" ? agent.phase : undefined,
+    prompt: typeof agent.prompt === "string" ? agent.prompt : "",
+    status,
+    result: agent.result,
+    resultPreview: typeof agent.resultPreview === "string" ? agent.resultPreview : undefined,
+    error: typeof agent.error === "string" ? agent.error : undefined,
+    errorCode: typeof agent.errorCode === "string" ? (agent.errorCode as WorkflowErrorCode) : undefined,
+    recoverable: typeof agent.recoverable === "boolean" ? agent.recoverable : undefined,
+    history: Array.isArray(agent.history) ? (agent.history as AgentHistoryEntry[]) : undefined,
+    usage,
+    tokens: finiteNumber(agent.tokens) ?? usage?.total,
+    startedAt: typeof agent.startedAt === "string" ? agent.startedAt : undefined,
+    endedAt: typeof agent.endedAt === "string" ? agent.endedAt : undefined,
+    model: typeof agent.model === "string" ? agent.model : undefined,
+    sessionFile: typeof agent.sessionFile === "string" ? agent.sessionFile : undefined,
+    worktree: migrateWorktree(agent.worktree),
+  };
+}
+
+function migrateRunState(raw: unknown, source: string): LoadedPersistedRunState | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const state = raw as Record<string, unknown>;
+  if (typeof state.runId !== "string" || !state.runId) return null;
+  const runId = state.runId;
+  const now = new Date().toISOString();
+  const legacyIdentity =
+    state.version === undefined || finiteNumber(state.version) === undefined || Number(state.version) < 2;
+  let malformedNested = false;
+  const malformedUsage = (value: unknown): boolean => {
+    if (value === undefined) return false;
+    if (!value || typeof value !== "object" || Array.isArray(value)) return true;
+    const usage = value as Record<string, unknown>;
+    return ["input", "output", "cacheRead", "cacheWrite", "total", "cost"].some(
+      (field) => usage[field] !== undefined && finiteNumber(usage[field]) === undefined,
+    );
+  };
+  const agents = Array.isArray(state.agents)
+    ? state.agents.flatMap((agent, index) => {
+        if (!agent || typeof agent !== "object" || Array.isArray(agent)) {
+          malformedNested = true;
+          return [];
+        }
+        const agentRecord = agent as Record<string, unknown>;
+        if (malformedUsage(agentRecord.usage)) malformedNested = true;
+        if (agentRecord.sessionFile !== undefined && typeof agentRecord.sessionFile !== "string")
+          malformedNested = true;
+        if (agentRecord.worktree !== undefined && !migrateWorktree(agentRecord.worktree)) malformedNested = true;
+        const migrated = migrateAgent(agent, runId, index, legacyIdentity);
+        return migrated ? [migrated] : [];
+      })
+    : [];
+  const journal = Array.isArray(state.journal)
+    ? state.journal.flatMap((rawEntry) => {
+        if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
+          malformedNested = true;
+          return [];
+        }
+        const entry = rawEntry as Record<string, unknown>;
+        const index = finiteNumber(entry.index);
+        if (index === undefined || typeof entry.hash !== "string") {
+          malformedNested = true;
+          return [];
+        }
+        if (
+          (!legacyIdentity && typeof entry.executionId !== "string") ||
+          malformedUsage(entry.usage) ||
+          (entry.storeDelta !== undefined &&
+            (!entry.storeDelta || typeof entry.storeDelta !== "object" || Array.isArray(entry.storeDelta)))
+        ) {
+          malformedNested = true;
+        }
+        const usage = exactUsage(entry.usage);
+        return [
+          {
+            index: Math.floor(index),
+            executionId:
+              !legacyIdentity && typeof entry.executionId === "string"
+                ? entry.executionId
+                : `${runId}:${Math.floor(index)}`,
+            hash: entry.hash,
+            result: entry.result,
+            usage,
+            storeDelta:
+              entry.storeDelta && typeof entry.storeDelta === "object" && !Array.isArray(entry.storeDelta)
+                ? (entry.storeDelta as Record<string, unknown>)
+                : undefined,
+          },
+        ];
+      })
+    : undefined;
+  const rawTokenUsage =
+    state.tokenUsage && typeof state.tokenUsage === "object" && !Array.isArray(state.tokenUsage)
+      ? (state.tokenUsage as Record<string, unknown>)
+      : undefined;
+  const tokenUsage = rawTokenUsage
+    ? {
+        input: finiteNumber(rawTokenUsage.input) ?? 0,
+        output: finiteNumber(rawTokenUsage.output) ?? 0,
+        total: finiteNumber(rawTokenUsage.total) ?? 0,
+        ...(finiteNumber(rawTokenUsage.cost) !== undefined ? { cost: finiteNumber(rawTokenUsage.cost) } : {}),
+        ...(finiteNumber(rawTokenUsage.cacheRead) !== undefined
+          ? { cacheRead: finiteNumber(rawTokenUsage.cacheRead) }
+          : {}),
+        ...(finiteNumber(rawTokenUsage.cacheWrite) !== undefined
+          ? { cacheWrite: finiteNumber(rawTokenUsage.cacheWrite) }
+          : {}),
+      }
+    : undefined;
+  const status = RUN_STATUSES.has(state.status as RunStatus) ? (state.status as RunStatus) : "paused";
+  const malformed =
+    (state.phases !== undefined && !Array.isArray(state.phases)) ||
+    (Array.isArray(state.phases) && state.phases.some((phase) => typeof phase !== "string")) ||
+    (state.agents !== undefined && !Array.isArray(state.agents)) ||
+    (state.logs !== undefined && !Array.isArray(state.logs)) ||
+    (Array.isArray(state.logs) && state.logs.some((log) => typeof log !== "string")) ||
+    malformedNested ||
+    (state.requestedConcurrency !== undefined && finiteNumber(state.requestedConcurrency) === undefined) ||
+    (state.tokenBudget !== undefined && state.tokenBudget !== null && finiteNumber(state.tokenBudget) === undefined);
+  if (state.version !== RUN_STATE_VERSION) {
+    warnMigrationOnce(source, `[run-persistence] Migrated legacy workflow run ${runId} from ${source}`);
+  } else if (malformed) {
+    warnMigrationOnce(source, `[run-persistence] Ignored malformed fields in workflow run ${runId} from ${source}`);
+  }
+  return {
+    version: RUN_STATE_VERSION,
+    runId,
+    workflowName: typeof state.workflowName === "string" ? state.workflowName : runId,
+    workflowDescription: typeof state.workflowDescription === "string" ? state.workflowDescription : undefined,
+    script: typeof state.script === "string" ? state.script : "",
+    args: state.args,
+    sessionId: typeof state.sessionId === "string" ? state.sessionId : undefined,
+    status,
+    pauseReason: typeof state.pauseReason === "string" ? state.pauseReason : undefined,
+    resetHint: typeof state.resetHint === "string" ? state.resetHint : undefined,
+    phases: Array.isArray(state.phases)
+      ? state.phases.filter((phase): phase is string => typeof phase === "string")
+      : [],
+    currentPhase: typeof state.currentPhase === "string" ? state.currentPhase : undefined,
+    agents,
+    logs: Array.isArray(state.logs) ? state.logs.filter((log): log is string => typeof log === "string") : [],
+    result: state.result,
+    startedAt: typeof state.startedAt === "string" ? state.startedAt : now,
+    updatedAt: typeof state.updatedAt === "string" ? state.updatedAt : now,
+    completedAt: typeof state.completedAt === "string" ? state.completedAt : undefined,
+    durationMs: finiteNumber(state.durationMs),
+    requestedConcurrency: finiteNumber(state.requestedConcurrency),
+    effectiveConcurrency: finiteNumber(state.effectiveConcurrency),
+    maxAgents: finiteNumber(state.maxAgents),
+    agentRetries: finiteNumber(state.agentRetries),
+    agentTimeoutMs: state.agentTimeoutMs === null ? null : finiteNumber(state.agentTimeoutMs),
+    tokenBudget: state.tokenBudget === null ? null : finiteNumber(state.tokenBudget),
+    tokenUsage,
+    journal,
+  };
 }
 
 /**
@@ -108,7 +372,7 @@ export type FsLayer = {
   writeFileSync: typeof writeFileSync;
 };
 
-export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>): RunPersistence {
+export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>): NormalizedRunPersistence {
   const _existsSync = fsOverride?.existsSync ?? existsSync;
   const _mkdirSync = fsOverride?.mkdirSync ?? mkdirSync;
   const _readdirSync = fsOverride?.readdirSync ?? readdirSync;
@@ -171,6 +435,7 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
   return {
     save(state: PersistedRunState) {
       ensureDir();
+      state.version = RUN_STATE_VERSION;
       state.updatedAt = new Date().toISOString();
       const path = primaryRunPath(state.runId);
       const json = JSON.stringify(state, null, 2);
@@ -186,13 +451,14 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
       }
     },
 
-    load(runId: string): PersistedRunState | null {
+    load(runId: string): LoadedPersistedRunState | null {
       // Try the primary, then the .bak — so a corrupt primary doesn't lose the run.
       for (const path of candidateRunPaths(runId)) {
         for (const candidate of [path, `${path}.bak`]) {
           try {
             if (!_existsSync(candidate)) continue;
-            return JSON.parse(_readFileSync(candidate, "utf-8")) as PersistedRunState;
+            const migrated = migrateRunState(JSON.parse(_readFileSync(candidate, "utf-8")), candidate);
+            if (migrated) return migrated;
           } catch {
             // corrupt candidate -> fall through to the next candidate
           }
@@ -201,16 +467,17 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
       return null;
     },
 
-    list(): PersistedRunState[] {
-      const byRunId = new Map<string, PersistedRunState>();
+    list(): LoadedPersistedRunState[] {
+      const byRunId = new Map<string, LoadedPersistedRunState>();
       for (const dir of [runsDir, legacyRunsDir]) {
         try {
           if (!_existsSync(dir)) continue;
           const files = _readdirSync(dir).filter((f) => f.endsWith(".json"));
           for (const file of files) {
             try {
-              const state = JSON.parse(_readFileSync(join(dir, file), "utf-8")) as PersistedRunState;
-              if (!byRunId.has(state.runId)) byRunId.set(state.runId, state);
+              const path = join(dir, file);
+              const state = migrateRunState(JSON.parse(_readFileSync(path, "utf-8")), path);
+              if (state && !byRunId.has(state.runId)) byRunId.set(state.runId, state);
             } catch {
               // Skip corrupted files
             }
@@ -226,9 +493,9 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
       let deleted = false;
       try {
         for (const path of candidateRunPaths(runId)) {
-          const dir = path === primaryRunPath(runId) ? runsDir : legacyRunsDir;
-          // Best-effort cleanup of the sidecar files alongside the primary.
-          for (const sidecar of [`${path}.bak`, `${path}.tmp`, lockPath(dir, runId)]) {
+          // Lease files are ownership records, not artifact sidecars. Only the
+          // lease owner may remove them through releaseRunLease().
+          for (const sidecar of [`${path}.bak`, `${path}.tmp`]) {
             try {
               if (_existsSync(sidecar)) _unlinkSync(sidecar);
             } catch {

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -8,7 +8,7 @@
 
 import { join } from "node:path";
 import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
-import { type Component, type TUI, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { type Component, type TUI, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import { shorten, statusIcon, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
 import type { ManagedRun, WorkflowManager } from "./workflow-manager.js";
 import type { WorkflowStorage } from "./workflow-saved.js";
@@ -19,11 +19,16 @@ import { shortModel } from "./workflow-ui.js";
 // as tokens accrue (not only on agent start/end). It is harmless in compact mode —
 // it redraws identical content.
 const RUN_EVENTS = [
+  "agentQueued",
+  "agentSession",
   "agentStart",
+  "agentUsage",
+  "agentHistory",
   "agentEnd",
   "phase",
   "log",
   "tokenUsage",
+  "concurrencyChanged",
   "complete",
   "error",
   "stopped",
@@ -86,6 +91,11 @@ function fitLine(line: string, width?: number): string {
   const maxWidth = Math.max(0, Math.floor(width));
   if (visibleWidth(line) <= maxWidth) return line;
   return truncateToWidth(line, maxWidth);
+}
+
+function wrapLine(line: string, width?: number): string[] {
+  if (typeof width !== "number" || !Number.isFinite(width) || visibleWidth(line) <= width) return [line];
+  return wrapTextWithAnsi(line, Math.max(1, Math.floor(width)));
 }
 
 export function deliverText(run: ManagedRun, opts: { resultPath?: string; maxChars?: number } = {}): string {
@@ -211,13 +221,34 @@ export function renderPanel(manager: WorkflowManager, theme: Theme, width?: numb
   const all = manager.listRuns();
   const active = all.filter((r) => r.status === "running" || r.status === "paused");
   if (!active.length) return [];
-  const rows = active.map((r) => {
+  const rows = active.flatMap((r) => {
     const live = manager.getRun(r.runId);
     const agents = live?.snapshot.agents ?? r.agents;
     const done = agents.filter((a) => a.status === "done").length;
+    const running = agents.filter((a) => a.status === "running");
+    const paused = agents.filter((a) => a.status === "paused");
+    const queued = agents.filter((a) => a.status === "queued").length;
     const icon = r.status === "paused" ? "⏸" : "◆";
     const phase = live?.snapshot.currentPhase ? ` · ${live.snapshot.currentPhase}` : "";
-    return `  ${icon} ${r.workflowName}  ${done}/${agents.length} agents${phase}`;
+    const summary = `  ${icon} ${r.workflowName}  ${done}/${agents.length} agents · ${running.length} running · ${paused.length} paused · ${queued} not started${phase}`;
+    const pausedLines = paused.length
+      ? wrapLine(
+          `    Paused mid-run (${paused.length}): ${paused
+            .map((agent) => `${agent.label}${agent.sessionFile ? " (session saved)" : " (fresh restart)"}`)
+            .join(", ")}`,
+          width,
+        )
+      : [];
+    if (!running.length) return [summary, ...pausedLines];
+    const cap = live?.execution?.effectiveConcurrency ?? r.effectiveConcurrency ?? running.length;
+    return [
+      summary,
+      ...wrapLine(
+        `    Running now (${running.length}/${cap}): ${running.map((agent) => agent.label).join(", ")}`,
+        width,
+      ),
+      ...pausedLines,
+    ];
   });
   // Finished runs leave this live panel but are kept in the navigator. Tell the
   // user so a completed run doesn't look like it vanished.
@@ -235,38 +266,46 @@ export function renderPanel(manager: WorkflowManager, theme: Theme, width?: numb
 
 /** Rolling window for the token/s rate. Older samples age out so a stall decays to 0. */
 const RATE_WINDOW_MS = 10_000;
-/** Per-run (timestamp, cumulative total) samples, keyed by the persisted runId so
- *  the rolling rate survives pause→resume. Cleared when a run ends. */
-const tokenSamples = new Map<string, Array<{ ts: number; total: number }>>();
+/** Per-invocation samples grouped by run. Stable execution IDs prevent duplicate
+ * labels from sharing a token-rate series. */
+const tokenSamples = new Map<string, Map<string, Array<{ ts: number; total: number }>>>();
+const RUN_TOTAL_SAMPLE = "__run__";
 
-/** Record a token-total sample for `runId` at time `now` (ms). */
-export function sampleTokens(runId: string, total: number, now: number): void {
-  const samples = tokenSamples.get(runId) ?? [];
+/** Record a token-total sample for one invocation (or the run aggregate by default). */
+export function sampleTokens(runId: string, total: number, now: number, executionId = RUN_TOTAL_SAMPLE): void {
+  const byAgent = tokenSamples.get(runId) ?? new Map<string, Array<{ ts: number; total: number }>>();
+  const samples = byAgent.get(executionId) ?? [];
   const last = samples[samples.length - 1];
-  // Collapse repeat renders within the same instant (e.g. width recalcs).
   if (last && last.ts === now && last.total === total) return;
   samples.push({ ts: now, total });
-  // Drop samples beyond the rolling window, always keeping ≥2 so a rate is computable.
   while (samples.length > 2 && now - samples[0].ts > RATE_WINDOW_MS) samples.shift();
-  tokenSamples.set(runId, samples);
+  byAgent.set(executionId, samples);
+  tokenSamples.set(runId, byAgent);
 }
 
-/** Tokens/second over the rolling window; 0 when too few samples or totals plateau. */
-export function tokensPerSecond(runId: string): number {
-  const samples = tokenSamples.get(runId);
+function sampleRate(samples: Array<{ ts: number; total: number }> | undefined): number {
   if (!samples || samples.length < 2) return 0;
   const oldest = samples[0];
   const newest = samples[samples.length - 1];
   const elapsedMs = newest.ts - oldest.ts;
-  if (elapsedMs <= 0) return 0;
   const delta = newest.total - oldest.total;
-  if (delta <= 0) return 0;
-  return (delta / elapsedMs) * 1000;
+  return elapsedMs > 0 && delta > 0 ? (delta / elapsedMs) * 1000 : 0;
 }
 
-/** Forget a run's samples (call when it finishes) so the map can't grow unbounded. */
-export function clearTokenSamples(runId: string): void {
-  tokenSamples.delete(runId);
+/** Tokens/second for one invocation, or the aggregate compatibility series. */
+export function tokensPerSecond(runId: string, executionId = RUN_TOTAL_SAMPLE): number {
+  return sampleRate(tokenSamples.get(runId)?.get(executionId));
+}
+
+/** Forget a run or one terminal invocation's samples. */
+export function clearTokenSamples(runId: string, executionId?: string): void {
+  if (!executionId) {
+    tokenSamples.delete(runId);
+    return;
+  }
+  const byAgent = tokenSamples.get(runId);
+  byAgent?.delete(executionId);
+  if (byAgent?.size === 0) tokenSamples.delete(runId);
 }
 
 /** Compact token count for the space-constrained panel: 980, 12.4K, 1.3M. */
@@ -306,14 +345,19 @@ function renderRunBody(
     if (!phaseAgents.length) continue;
     const done = phaseAgents.filter((a) => a.status === "done").length;
     const running = phaseAgents.filter((a) => a.status === "running").length;
+    const paused = phaseAgents.filter((a) => a.status === "paused").length;
+    const queued = phaseAgents.filter((a) => a.status === "queued").length;
     const errors = phaseAgents.filter((a) => a.status === "error").length;
     const skipped = phaseAgents.filter((a) => a.status === "skipped").length;
     const complete = done + errors + skipped === phaseAgents.length;
-    const marker = running > 0 || (!complete && snap.currentPhase === title) ? "▶" : complete ? "✓" : " ";
+    const marker =
+      paused > 0 ? "⏸" : running > 0 || (!complete && snap.currentPhase === title) ? "▶" : complete ? "✓" : " ";
     const phaseTokens = phaseAgents.reduce((n, a) => n + (a.tokens ?? 0), 0);
     const phaseMeta = [
       `${done}/${phaseAgents.length} agents`,
       running ? `${running} running` : "",
+      paused ? `${paused} paused` : "",
+      queued ? `${queued} not started` : "",
       errors ? `${errors} errors` : "",
       phaseTokens > 0 ? `${fmtTokensShort(phaseTokens)} tok` : "",
     ]
@@ -323,10 +367,12 @@ function renderRunBody(
 
     const visible = phaseAgents.slice(-maxAgents);
     for (const a of visible) {
-      const tok = a.tokens ? dim(` ${fmtTokensShort(a.tokens)} tok`) : "";
+      const tok = a.tokens ? dim(` ${a.tokensEstimated ? "~" : ""}${fmtTokensShort(a.tokens)} tok`) : "";
       const mdl = shortModel(a.model);
       const model = mdl ? dim(` · ${mdl}`) : "";
-      lines.push(`    [${a.id}] ${statusIcon(a.status)} ${shorten(a.label, 40)}${tok}${model}`);
+      const state =
+        a.status === "paused" ? `paused mid-run (${a.sessionFile ? "session saved" : "fresh restart"})` : a.status;
+      lines.push(`    [${a.id}] ${statusIcon(a.status)} ${shorten(a.label, 40)}${tok}${model}${dim(` · ${state}`)}`);
     }
     if (phaseAgents.length > visible.length) {
       lines.push(dim(`    … ${phaseAgents.length - visible.length} earlier agents`));
@@ -349,6 +395,10 @@ export function renderPanelDetailed(
 ): string[] {
   const all = manager.listRuns();
   const active = all.filter((r) => r.status === "running" || r.status === "paused");
+  const knownRunIds = new Set(all.map((run) => run.runId));
+  for (const sampledRunId of tokenSamples.keys()) {
+    if (!knownRunIds.has(sampledRunId)) tokenSamples.delete(sampledRunId);
+  }
   if (!active.length) return [];
   const dim = (t: string) => theme.fg("dim", t);
   const out: string[] = [theme.bold(`Workflows running (${active.length}):`)];
@@ -358,23 +408,27 @@ export function renderPanelDetailed(
     const snap = live?.snapshot;
     const agents = (snap?.agents ?? r.agents) as WorkflowAgentSnapshot[];
     const done = agents.filter((a) => a.status === "done").length;
+    const running = agents.filter((a) => a.status === "running");
+    const paused = agents.filter((a) => a.status === "paused");
+    const queued = agents.filter((a) => a.status === "queued").length;
     const icon = r.status === "paused" ? "⏸" : "◆";
     const usage = snap?.tokenUsage ?? r.tokenUsage;
-    // The run-level tokenUsage aggregate is only finalized when the run ends, so
-    // it reads 0 for the whole live run. Per-agent `tokens` update on each agent
-    // completion, so sum those for a live total (and keep the header consistent
-    // with the per-phase subtotals). Note: tokens land at agent-completion
-    // granularity, so the rate reflects completion throughput — it decays to 0
-    // during a single long-running agent or a stall (which is the intended signal).
     const total = agents.reduce((n, a) => n + (a.tokens ?? 0), 0);
-    // Sample the running total and derive the rolling token/s. Paused runs don't
-    // accrue tokens, so their rate is suppressed (a stalled rate would mislead).
-    sampleTokens(r.runId, total, now);
-    const rate = r.status === "running" ? tokensPerSecond(r.runId) : 0;
+    const estimated = agents.some((agent) => agent.tokensEstimated && (agent.tokens ?? 0) > 0);
+    let rate = 0;
+    for (const agent of running) {
+      const executionId = agent.executionId ?? `${r.runId}:${agent.callIndex ?? agent.id - 1}`;
+      sampleTokens(r.runId, agent.tokens ?? 0, now, executionId);
+      rate += tokensPerSecond(r.runId, executionId);
+    }
+    if (r.status !== "running") rate = 0;
     const meta = [
       `${done}/${agents.length} agents`,
+      `${running.length} running`,
+      `${paused.length} paused`,
+      `${queued} not started`,
       snap?.currentPhase || "",
-      total > 0 ? `${fmtTokensShort(total)} tok` : "",
+      total > 0 ? `${estimated ? "~" : ""}${fmtTokensShort(total)} tok` : "",
       // 2 decimals for ≥1¢, 4 for sub-cent so a real cost never shows as "$0.00".
       // (cost is only known once the run finalizes its usage.)
       usage?.cost ? `$${usage.cost.toFixed(usage.cost >= 0.01 ? 2 : 4)}` : "",
@@ -383,6 +437,28 @@ export function renderPanelDetailed(
       .filter(Boolean)
       .join(" · ");
     out.push(`  ${icon} ${theme.bold(r.workflowName)}  ${dim(meta)}`);
+    if (running.length) {
+      const cap = live?.execution?.effectiveConcurrency ?? r.effectiveConcurrency ?? running.length;
+      out.push(
+        ...wrapLine(
+          dim(`    Running now (${running.length}/${cap}): ${running.map((agent) => agent.label).join(", ")}`),
+          width,
+        ),
+      );
+    }
+    if (paused.length) {
+      out.push(
+        ...wrapLine(
+          theme.fg(
+            "warning",
+            `    Paused mid-run (${paused.length}): ${paused
+              .map((agent) => `${agent.label}${agent.sessionFile ? " (session saved)" : " (fresh restart)"}`)
+              .join(", ")}`,
+          ),
+          width,
+        ),
+      );
+    }
     if (snap) out.push(...renderRunBody(snap, agents, maxAgents, theme));
   }
 
@@ -433,6 +509,9 @@ export function installTaskPanel(
     (tui: TUI, theme: Theme) => {
       const onEvent = () => tui.requestRender();
       for (const ev of RUN_EVENTS) manager.on(ev, onEvent);
+      const onAgentEnd = ({ runId, executionId }: { runId: string; executionId: string }) =>
+        clearTokenSamples(runId, executionId);
+      manager.on("agentEnd", onAgentEnd);
       const onRunEnd = ({ runId }: { runId: string }) => clearTokenSamples(runId);
       for (const ev of RUN_END_EVENTS) manager.on(ev, onRunEnd);
       // In detailed mode, force a redraw every 2s while a run is active so the
@@ -456,6 +535,7 @@ export function installTaskPanel(
         dispose: () => {
           clearInterval(timer);
           for (const ev of RUN_EVENTS) manager.off(ev, onEvent);
+          manager.off("agentEnd", onAgentEnd);
           for (const ev of RUN_END_EVENTS) manager.off(ev, onRunEnd);
         },
       };

--- a/src/workflow-commands.ts
+++ b/src/workflow-commands.ts
@@ -23,7 +23,7 @@ const STATUS_ICON: Record<string, string> = {
 };
 
 const USAGE =
-  "Usage: /workflows [list] | run <prompt> | status <id> | watch <id> | stop <id> | pause <id> | resume <id> | rm <id> | save <name> [runId]";
+  "Usage: /workflows [list] | run <prompt> | status <id> | watch <id> | concurrency <id> <n> | stop <id> | pause <id> | resume <id> | rm <id> | save <name> [runId]";
 
 const RUN_USAGE = "Usage: /workflows run <prompt> — force a dynamic workflow from the prompt";
 
@@ -65,7 +65,7 @@ function watchRun(manager: WorkflowManager, pi: ExtensionAPI, ctx: ExtensionComm
     if (!e || e.runId === id) update();
   };
   let settled = false;
-  const progressEvents = ["agentStart", "agentEnd", "phase", "log"];
+  const progressEvents = ["agentStart", "agentEnd", "phase", "log", "concurrencyChanged"];
   const finalEvents = ["complete", "error", "stopped", "paused"];
   const finish = (e: { runId?: string }) => {
     if (e && e.runId !== id) return;
@@ -126,7 +126,7 @@ export function registerWorkflowCommands(
 
   pi.registerCommand("workflows", {
     description:
-      "Manage workflow runs — no args (opens navigator) | run <prompt> | status/stop/pause/resume <id> | rm <id> | save <name> [runId]",
+      "Manage workflow runs — no args (opens navigator) | run <prompt> | status/stop/pause/resume <id> | concurrency <id> <n> | rm <id> | save <name> [runId]",
     async handler(args: string, ctx: ExtensionCommandContext) {
       const parts = args.trim().split(/\s+/).filter(Boolean);
       const sub = (parts[0] ?? "list").toLowerCase();
@@ -212,6 +212,21 @@ export function registerWorkflowCommands(
           await print(renderPersistedStatus(run));
           return;
         }
+        case "concurrency": {
+          const concurrency = Number(parts[2]);
+          if (!id || !Number.isInteger(concurrency) || concurrency < 1) {
+            ctx.ui.notify("Usage: /workflows concurrency <id> <positive integer>", "warning");
+            return;
+          }
+          const updated = manager.setConcurrency(id, concurrency);
+          ctx.ui.notify(
+            updated
+              ? `Concurrency for ${id}: ${updated.previousConcurrency ?? "-"} → ${updated.effectiveConcurrency}`
+              : `Cannot change concurrency for ${id}`,
+            updated ? "info" : "warning",
+          );
+          return;
+        }
         case "stop": {
           if (!id) return ctx.ui.notify(USAGE, "warning");
           ctx.ui.notify(
@@ -233,7 +248,13 @@ export function registerWorkflowCommands(
         }
         case "rm": {
           if (!id) return ctx.ui.notify(USAGE, "warning");
-          ctx.ui.notify(manager.deleteRun(id) ? `Removed ${id}` : `No run ${id}`, "info");
+          const run = manager.listRuns().find((candidate) => candidate.runId === id);
+          if (run?.status === "running" || run?.status === "paused") {
+            ctx.ui.notify(`Cannot remove ${id} while ${run.status}; stop it first`, "warning");
+            return;
+          }
+          const removed = manager.deleteRun(id);
+          ctx.ui.notify(removed ? `Removed ${id}` : `No run ${id}`, removed ? "info" : "warning");
           return;
         }
         case "save": {

--- a/src/workflow-control-tool.ts
+++ b/src/workflow-control-tool.ts
@@ -1,0 +1,243 @@
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { type Static, Type } from "typebox";
+import type { WorkflowAgentSnapshot, WorkflowSnapshot } from "./display.js";
+import type { PersistedRunState, RunStatus } from "./run-persistence.js";
+import type { WorkflowManager } from "./workflow-manager.js";
+
+const runActionSchema = Type.Union([
+  Type.Literal("status"),
+  Type.Literal("pause"),
+  Type.Literal("resume"),
+  Type.Literal("stop"),
+  Type.Literal("restart"),
+  Type.Literal("remove"),
+]);
+
+const workflowControlSchema = Type.Union([
+  Type.Object(
+    { action: Type.Literal("list", { description: "List workflow runs." }) },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      action: runActionSchema,
+      runId: Type.String({ minLength: 1, description: "Canonical workflow run ID." }),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      action: Type.Literal("set_concurrency", { description: "Resize a live or resumable workflow." }),
+      runId: Type.String({ minLength: 1, description: "Canonical workflow run ID." }),
+      concurrency: Type.Integer({ minimum: 1, description: "New positive-integer concurrency limit." }),
+    },
+    { additionalProperties: false },
+  ),
+]);
+
+export type WorkflowControlInput = Static<typeof workflowControlSchema>;
+
+export interface WorkflowControlToolOptions {
+  manager: WorkflowManager;
+}
+
+type ControlResult = {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+};
+
+export function createWorkflowControlTool(
+  options: WorkflowControlToolOptions,
+): ToolDefinition<typeof workflowControlSchema, Record<string, unknown>> {
+  const manager = options.manager;
+  return defineTool({
+    name: "workflow_control",
+    label: "Workflow Control",
+    description:
+      "List and inspect workflow runs, resize live concurrency, or pause, resume, stop (terminate/quit), restart, and remove them without asking the user to run slash commands.",
+    promptSnippet: "Manage workflow runs directly by canonical run ID.",
+    promptGuidelines: [
+      "Use workflow_control for workflow lifecycle management; do not ask the user to type /workflows when this tool can perform the action.",
+      "Use stop to terminate or quit a run. Navigator q only closes the navigator and does not stop a run.",
+      "Use set_concurrency to resize a running workflow without restarting it. Increasing releases queued agents immediately; decreasing never aborts agents already running.",
+    ],
+    parameters: workflowControlSchema,
+    prepareArguments: normalizeInput,
+    async execute(_toolCallId, params) {
+      if (params.action === "list") {
+        const runs = manager.listRuns();
+        return result(
+          runs.length
+            ? `action=list result=ok runs=${runs.length}\n${runs.map((run) => formatRun(run, manager.getSnapshot(run.runId))).join("\n")}`
+            : "action=list result=ok runs=0",
+          { action: "list", result: "ok", runIds: runs.map((run) => run.runId) },
+        );
+      }
+
+      const run = findRun(manager, params.runId);
+      if (!run) return controlError(params.action, params.runId, "run not found", ["list"]);
+
+      switch (params.action) {
+        case "status":
+          return result(`action=status result=ok ${formatRun(run, manager.getSnapshot(run.runId))}`, {
+            action: "status",
+            result: "ok",
+            runId: run.runId,
+          });
+        case "set_concurrency": {
+          const updated = manager.setConcurrency(run.runId, params.concurrency);
+          if (!updated) return invalidTransition("set_concurrency", run);
+          const current = currentRun(manager, run);
+          return result(
+            `action=set_concurrency result=updated previous=${updated.previousConcurrency ?? "-"} ${formatRun(current, manager.getSnapshot(run.runId))}`,
+            { action: "set_concurrency", result: "updated", runId: run.runId, ...updated },
+          );
+        }
+        case "pause":
+          if (!manager.pause(run.runId)) return invalidTransition("pause", run);
+          return actionSuccess("pause", "paused", currentRun(manager, run));
+        case "resume":
+          if (!(await manager.resume(run.runId))) return invalidTransition("resume", run);
+          return actionSuccess("resume", "resumed", currentRun(manager, run));
+        case "stop":
+          if (!manager.stop(run.runId)) return invalidTransition("stop", run);
+          return actionSuccess("stop", "stopped", currentRun(manager, run));
+        case "restart": {
+          if (run.status === "running") {
+            return controlError("restart", run.runId, "cannot restart a running run", [
+              "status",
+              "set_concurrency",
+              "pause",
+              "stop",
+            ]);
+          }
+          if (!run.script)
+            return controlError("restart", run.runId, "run has no saved script", allowedActions(run.status));
+          const restarted = manager.restart(run.runId);
+          if (!restarted)
+            return controlError("restart", run.runId, "run could not be restarted", allowedActions(run.status));
+          const next = findRun(manager, restarted.runId);
+          return result(
+            `action=restart result=restarted sourceRunId=${run.runId} ${next ? formatRun(next, manager.getSnapshot(next.runId)) : `runId=${restarted.runId} status=running`}`,
+            { action: "restart", result: "restarted", sourceRunId: run.runId, runId: restarted.runId },
+          );
+        }
+        case "remove":
+          if (run.status === "running" || run.status === "paused") {
+            return controlError("remove", run.runId, `cannot remove a ${run.status} run; stop it first`, [
+              "status",
+              "stop",
+            ]);
+          }
+          if (!manager.deleteRun(run.runId))
+            return controlError("remove", run.runId, "run could not be removed", ["list"]);
+          return result(`action=remove result=removed runId=${run.runId}`, {
+            action: "remove",
+            result: "removed",
+            runId: run.runId,
+          });
+      }
+    },
+  });
+}
+
+function normalizeInput(value: unknown): WorkflowControlInput {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("workflow_control requires an object argument");
+  }
+  const input = value as Record<string, unknown>;
+  const actions = new Set(["list", "status", "set_concurrency", "pause", "resume", "stop", "restart", "remove"]);
+  if (typeof input.action !== "string" || !actions.has(input.action)) {
+    throw new Error("workflow_control requires action: list|status|set_concurrency|pause|resume|stop|restart|remove");
+  }
+  if (input.action !== "list" && (typeof input.runId !== "string" || !input.runId.trim())) {
+    throw new Error(`workflow_control action "${input.action}" requires runId`);
+  }
+  if (
+    input.action === "set_concurrency" &&
+    (typeof input.concurrency !== "number" || !Number.isInteger(input.concurrency) || input.concurrency < 1)
+  ) {
+    throw new Error('workflow_control action "set_concurrency" requires a positive integer concurrency');
+  }
+  return input as WorkflowControlInput;
+}
+
+function result(text: string, details: Record<string, unknown>): ControlResult {
+  return { content: [{ type: "text", text }], details };
+}
+
+function findRun(manager: WorkflowManager, runId: string): PersistedRunState | undefined {
+  return manager.listRuns().find((candidate) => candidate.runId === runId);
+}
+
+function currentRun(manager: WorkflowManager, fallback: PersistedRunState): PersistedRunState {
+  return findRun(manager, fallback.runId) ?? fallback;
+}
+
+function actionSuccess(action: string, actionResult: string, run: PersistedRunState): ControlResult {
+  return result(`action=${action} result=${actionResult} ${formatRun(run)}`, {
+    action,
+    result: actionResult,
+    runId: run.runId,
+  });
+}
+
+function invalidTransition(action: string, run: PersistedRunState): ControlResult {
+  return controlError(action, run.runId, `cannot ${action} run with status ${run.status}`, allowedActions(run.status));
+}
+
+function controlError(action: string, runId: string, message: string, allowed: string[]): ControlResult {
+  return result(
+    `action=${action} result=error runId=${runId} error=${message} allowed=${allowed.join(",") || "none"}`,
+    { action, result: "error", runId, error: message, allowedActions: allowed },
+  );
+}
+
+function allowedActions(status: RunStatus): string[] {
+  switch (status) {
+    case "running":
+      return ["status", "set_concurrency", "pause", "stop"];
+    case "paused":
+      return ["status", "set_concurrency", "resume", "stop", "restart"];
+    case "failed":
+      return ["status", "set_concurrency", "resume", "restart", "remove"];
+    case "completed":
+    case "aborted":
+      return ["status", "restart", "remove"];
+    case "pending":
+      return ["status", "set_concurrency", "resume", "restart", "remove"];
+  }
+}
+
+function formatRun(run: PersistedRunState, live?: WorkflowSnapshot | null): string {
+  const agents = live?.agents ?? run.agents;
+  const counts = countAgents(agents);
+  const phase = live?.currentPhase ?? run.currentPhase ?? "-";
+  const active = agents.filter((agent) => agent.status === "running").map((agent) => agent.label);
+  const paused = agents
+    .filter((agent) => agent.status === "paused")
+    .map((agent) => `${agent.label} (${agent.sessionFile ? "session saved" : "fresh restart"})`);
+  const concurrency = run.effectiveConcurrency ?? "-";
+  const tokens = live?.tokenUsage?.total ?? run.tokenUsage?.total ?? 0;
+  return `runId=${run.runId} status=${run.status} phase=${quote(phase)} done=${counts.done} running=${counts.running} paused=${counts.paused} queued=${counts.queued} error=${counts.error} active=${quote(active.join(",") || "-")} pausedAgents=${quote(paused.join(",") || "-")} concurrency=${concurrency} tokens=${tokens}`;
+}
+
+function countAgents(agents: Array<Pick<WorkflowAgentSnapshot, "status">>): {
+  done: number;
+  running: number;
+  paused: number;
+  queued: number;
+  error: number;
+} {
+  return {
+    done: agents.filter((agent) => agent.status === "done").length,
+    running: agents.filter((agent) => agent.status === "running").length,
+    paused: agents.filter((agent) => agent.status === "paused").length,
+    queued: agents.filter((agent) => agent.status === "queued").length,
+    error: agents.filter((agent) => agent.status === "error").length,
+  };
+}
+
+function quote(value: string): string {
+  return JSON.stringify(value);
+}

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -1,8 +1,9 @@
 /**
  * "Workflows mode" input affordance, à la a smart input box:
  *
- *  - While the editor text contains the word `workflow`/`workflows`, those letters
- *    render as a flowing rainbow, signalling that submitting will engage a workflow.
+ *  - When explicitly enabled, editor text containing the bounded word
+ *    `workflow`/`workflows` renders as a flowing rainbow, signalling that
+ *    submitting will engage a workflow.
  *  - Pressing Backspace immediately after such a word toggles the highlight OFF
  *    (the word stays, but turns plain white) — a non-destructive "don't run a
  *    workflow after all". Re-typing a fresh trigger word turns it back on.
@@ -32,21 +33,20 @@ import {
   type WorkflowSettingsStore,
 } from "./workflow-settings.js";
 
-// A keyword trigger is a configured literal term. The default `workflow`
-// trigger keeps legacy substring behavior and plural support (`workflows`) while
-// custom trigger words match only that exact term. Slash commands like
-// `/workflows` or `/pi-workflow` are left alone (not colored, not armed).
+// A keyword trigger is a configured literal term. All trigger words use token
+// boundaries so slash commands, paths, and identifier-like text stay untouched.
+// The default `workflow` trigger additionally supports the plural `workflows`.
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function triggerSource(triggerWord: string): string {
   const escaped = escapeRegExp(triggerWord);
-  if (triggerWord.toLowerCase() === DEFAULT_KEYWORD_TRIGGER_WORD) return `(?<!\\/)${escaped}s?`;
-  return `(?<![/A-Za-z0-9_-])${escaped}(?![A-Za-z0-9_-])`;
+  const plural = triggerWord.toLowerCase() === DEFAULT_KEYWORD_TRIGGER_WORD ? "s?" : "";
+  return `(?<![/\\p{ID_Continue}$-])(?<!\\\\)${escaped}${plural}(?![/\\p{ID_Continue}$-])(?!\\\\)`;
 }
 
-function triggerRegex(triggerWord = DEFAULT_KEYWORD_TRIGGER_WORD, flags = "i", atEnd = false): RegExp {
+function triggerRegex(triggerWord = DEFAULT_KEYWORD_TRIGGER_WORD, flags = "iu", atEnd = false): RegExp {
   const word = normalizeKeywordTriggerWord(triggerWord) ?? DEFAULT_KEYWORD_TRIGGER_WORD;
   return new RegExp(`${triggerSource(word)}${atEnd ? "$" : ""}`, flags);
 }
@@ -62,7 +62,7 @@ export function hasTrigger(text: string, triggerWord = DEFAULT_KEYWORD_TRIGGER_W
 }
 
 export function endsWithTrigger(textBeforeCursor: string, triggerWord = DEFAULT_KEYWORD_TRIGGER_WORD): boolean {
-  return triggerRegex(triggerWord, "i", true).test(textBeforeCursor);
+  return triggerRegex(triggerWord, "iu", true).test(textBeforeCursor);
 }
 
 /** Shared, mutable view of whether "workflows mode" is currently armed. */
@@ -138,7 +138,7 @@ export function colorizeWorkflow(
   if (!hasTrigger(visible, triggerWord)) return line;
 
   const ranges: Array<[number, number]> = [];
-  const globalTrigger = triggerRegex(triggerWord, "gi");
+  const globalTrigger = triggerRegex(triggerWord, "giu");
   for (let m = globalTrigger.exec(visible); m; m = globalTrigger.exec(visible)) {
     ranges.push([m.index, m.index + m[0].length]);
   }
@@ -448,7 +448,7 @@ export function installWorkflowEditor(
   const initialSettings = loadInitialWorkflowSettings(settingsStore);
   const state: WorkflowModeState = {
     active: false,
-    keywordTriggerEnabled: initialSettings.keywordTriggerEnabled ?? true,
+    keywordTriggerEnabled: initialSettings.keywordTriggerEnabled ?? false,
     keywordTriggerWord: initialSettings.keywordTriggerWord ?? DEFAULT_KEYWORD_TRIGGER_WORD,
   };
 
@@ -474,12 +474,15 @@ export function installWorkflowEditor(
   // BEFORE the input event fires (the actual prompt processing is async).
   pi.on("input", (event: { source?: string; text?: string }) => {
     if (event.source !== "interactive" || !event.text) return { action: "continue" } as const;
-    // Arm either when the user typed the "workflow(s)" trigger, or when standing
+    // Arm either when the user opted into the keyword trigger, or when standing
     // effort mode is on and the message is a substantive request.
-    const normalizedText = event.text.trim();
-    const suppressed = state.suppressedKeywordText === normalizedText;
-    if (suppressed) state.suppressedKeywordText = undefined;
-    const triggered = state.keywordTriggerEnabled && !suppressed && hasTrigger(event.text, state.keywordTriggerWord);
+    let triggered = false;
+    if (state.keywordTriggerEnabled) {
+      const normalizedText = event.text.trim();
+      const suppressed = state.suppressedKeywordText === normalizedText;
+      if (suppressed) state.suppressedKeywordText = undefined;
+      triggered = !suppressed && hasTrigger(event.text, state.keywordTriggerWord);
+    }
     const byEffort = !triggered && !!effort && effort.level !== "off" && isSubstantive(event.text);
     if (!triggered && !byEffort) return { action: "continue" } as const;
     try {
@@ -526,7 +529,7 @@ function loadInitialWorkflowSettings(settingsStore: WorkflowSettingsStore): Work
       keywordTriggerWord: normalizeKeywordTriggerWord(settings.keywordTriggerWord) ?? DEFAULT_KEYWORD_TRIGGER_WORD,
     };
   } catch {
-    return { keywordTriggerEnabled: true, keywordTriggerWord: DEFAULT_KEYWORD_TRIGGER_WORD };
+    return { keywordTriggerEnabled: false, keywordTriggerWord: DEFAULT_KEYWORD_TRIGGER_WORD };
   }
 }
 

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -4,18 +4,51 @@
 
 import { EventEmitter } from "node:events";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
-import type { WorkflowAgent } from "./agent.js";
-import { preview, type WorkflowSnapshot } from "./display.js";
+import type { AgentUsage, WorkflowAgent } from "./agent.js";
+import { DEFAULT_CONCURRENCY, MAX_AGENTS_PER_RUN } from "./config.js";
+import { preview, recomputeWorkflowSnapshot, type WorkflowSnapshot } from "./display.js";
 import { WorkflowError, WorkflowErrorCode } from "./errors.js";
 import {
   createRunPersistence,
   generateRunId,
-  type PersistedRunState,
+  type LoadedPersistedRunState,
   type RunLease,
   type RunPersistence,
   type RunStatus,
 } from "./run-persistence.js";
-import { type JournalEntry, parseWorkflowScript, runWorkflow, type WorkflowRunResult } from "./workflow.js";
+import {
+  createConcurrencyLimiter,
+  type JournalEntry,
+  parseWorkflowScript,
+  type ResumeAgentState,
+  runWorkflow,
+  WORKFLOW_PAUSE_ABORT_REASON,
+  type WorkflowConcurrencyLimiter,
+  type WorkflowRunResult,
+} from "./workflow.js";
+import { removeWorktree, type Worktree } from "./worktree.js";
+
+interface DurableAgentMetadata {
+  result?: unknown;
+  usage?: AgentUsage;
+  startedAt?: string;
+  endedAt?: string;
+}
+
+interface DurableExecutionControls {
+  requestedConcurrency: number;
+  effectiveConcurrency: number;
+  maxAgents: number;
+  agentRetries: number;
+  agentTimeoutMs: number | null;
+  tokenBudget: number | null;
+}
+
+export interface ConcurrencyUpdate {
+  previousConcurrency?: number;
+  requestedConcurrency: number;
+  effectiveConcurrency: number;
+}
 
 export interface ManagedRun {
   runId: string;
@@ -30,6 +63,20 @@ export interface ManagedRun {
   args?: unknown;
   /** Accumulated agent results for resume (deterministic call index -> result). */
   journal: JournalEntry[];
+  /** Serializable execution controls retained across resume. */
+  execution: DurableExecutionControls;
+  /** Exact usage already consumed before a cold resume. */
+  usageBaseline: NonNullable<WorkflowSnapshot["tokenUsage"]>;
+  /** Result, exact usage, and timestamps not carried by the display snapshot. */
+  durableAgents: Map<string, DurableAgentMetadata>;
+  sessionId?: string;
+  persistTimer?: ReturnType<typeof setTimeout>;
+  /** Current execution settlement, retained across pause so resume can serialize behind it. */
+  executionPromise?: Promise<WorkflowRunResult>;
+  /** Mutable gate shared by this execution and all nested workflows. */
+  concurrencyLimiter: WorkflowConcurrencyLimiter;
+  /** Prevent a stopped run that is still unwinding from recreating its deleted artifact. */
+  deleted?: boolean;
   /** Cross-process execution lease for this run, when it is actively executing. */
   lease?: RunLease;
   /**
@@ -43,8 +90,10 @@ export interface ManagedRun {
 
 /** Per-execution options shared by sync, background, and resume runs. */
 export interface ExecOptions {
-  /** Replay these journaled agent results for the unchanged prefix (resume). */
-  resumeJournal?: Map<number, JournalEntry>;
+  /** Replay these journaled results for the unchanged prefix (resume). */
+  resumeJournal?: ReadonlyMap<string | number, JournalEntry>;
+  /** Reopen incomplete Pi child sessions instead of starting those invocations fresh. */
+  resumeAgents?: ReadonlyMap<string, ResumeAgentState>;
   /** Cap on total agents for this run. */
   maxAgents?: number;
   /** Per-agent timeout in milliseconds. null/omitted means no hard timeout. */
@@ -61,6 +110,10 @@ export interface ExecOptions {
   agentRetries?: number;
   /** Resolve a checkpoint() question with a human reply (only for UI-bearing runs). */
   confirm?: (promptText: string, options: unknown) => Promise<unknown>;
+}
+
+function isConcurrencyMutableStatus(status: RunStatus): boolean {
+  return status === "running" || status === "paused" || status === "failed" || status === "pending";
 }
 
 export interface WorkflowManagerOptions {
@@ -85,15 +138,15 @@ export interface WorkflowManagerOptions {
   /** Default retry attempts after recoverable agent failures. */
   defaultAgentRetries?: number;
   /**
-   * Persist each subagent transcript as a real pi session file under the
-   * standard sessions directory. Default false (in-memory, discarded).
+   * Persist each subagent transcript under the workflow project's private
+   * agent-sessions directory. Default true for turn-boundary resume.
    */
   persistAgentSessions?: boolean;
 }
 
 export class WorkflowManager extends EventEmitter {
   private runs = new Map<string, ManagedRun>();
-  private persistence: RunPersistence;
+  private persistence: ReturnType<typeof createRunPersistence>;
   private cwd: string;
   private concurrency: number;
   private loadSavedWorkflow?: (name: string) => string | undefined;
@@ -111,7 +164,7 @@ export class WorkflowManager extends EventEmitter {
   constructor(options: WorkflowManagerOptions = {}) {
     super();
     this.cwd = options.cwd ?? process.cwd();
-    this.concurrency = options.concurrency ?? 8;
+    this.concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
     this.loadSavedWorkflow = options.loadSavedWorkflow;
     this.agent = options.agent;
     this.mainModel = options.mainModel;
@@ -119,7 +172,7 @@ export class WorkflowManager extends EventEmitter {
     this.sessionId = options.sessionId;
     this.defaultAgentTimeoutMs = options.defaultAgentTimeoutMs ?? null;
     this.defaultAgentRetries = options.defaultAgentRetries ?? 0;
-    this.persistAgentSessions = options.persistAgentSessions ?? false;
+    this.persistAgentSessions = options.persistAgentSessions ?? true;
     this.persistence = createRunPersistence(this.cwd);
     this.recoverStaleRuns();
   }
@@ -130,27 +183,51 @@ export class WorkflowManager extends EventEmitter {
     this.sessionId = id;
   }
 
-  /**
-   * On startup, any persisted run still marked "running" belongs to a process
-   * that died mid-run (this fresh manager has it nowhere in memory). Reconcile it
-   * to "paused" — never "failed" — so its journal is preserved and resume() can
-   * replay the completed prefix and finish the rest.
-   */
+  /** Reconcile persisted work not owned by a live process into restart-safe rows. */
   private recoverStaleRuns(): void {
+    let persistedRuns: LoadedPersistedRunState[];
     try {
-      for (const p of this.listAllRuns()) {
-        if (p.status === "running" && !this.runs.has(p.runId)) {
-          const lease = this.persistence.acquireRunLease(p.runId);
-          if (!lease) continue;
-          try {
-            this.persistence.save({ ...p, status: "paused" });
-          } finally {
-            this.persistence.releaseRunLease(lease);
-          }
-        }
-      }
+      persistedRuns = this.listAllRuns();
     } catch {
-      // Recovery is best-effort; never let it block manager construction.
+      return;
+    }
+
+    for (const persisted of persistedRuns) {
+      if (this.runs.has(persisted.runId)) continue;
+      let lease: RunLease | null = null;
+      try {
+        lease = this.persistence.acquireRunLease(persisted.runId);
+        if (!lease) continue;
+        const current = this.persistence.load(persisted.runId) ?? persisted;
+        const status = current.status === "running" ? "paused" : current.status;
+        const resumable = status === "pending" || status === "paused" || status === "failed";
+        const agents = current.agents.map((agent) => {
+          if (agent.status !== "running") return agent;
+          return resumable
+            ? { ...agent, status: "paused" as const, endedAt: undefined }
+            : {
+                ...agent,
+                status: "skipped" as const,
+                endedAt: agent.endedAt ?? current.completedAt ?? current.updatedAt,
+              };
+        });
+        if (status !== current.status || agents.some((agent, index) => agent !== current.agents[index])) {
+          this.persistence.save({ ...current, status, agents });
+        }
+      } catch {
+        // Recovery is best-effort per run; one bad artifact must not block the rest.
+      } finally {
+        if (lease) this.persistence.releaseRunLease(lease);
+      }
+    }
+  }
+
+  private cleanupWorktrees(worktrees: Array<Worktree | undefined>): void {
+    const seen = new Set<string>();
+    for (const worktree of worktrees) {
+      if (!worktree?.isolated || seen.has(worktree.cwd)) continue;
+      seen.add(worktree.cwd);
+      void removeWorktree(worktree);
     }
   }
 
@@ -195,6 +272,7 @@ export class WorkflowManager extends EventEmitter {
     const controller = new AbortController();
     const lease = this.persistence.acquireRunLease(runId);
     if (!lease) throw new Error(`Could not acquire workflow run lease for ${runId}`);
+    const controls = this.resolveExecutionControls(exec);
 
     const managed: ManagedRun = {
       runId,
@@ -209,12 +287,19 @@ export class WorkflowManager extends EventEmitter {
         runningCount: 0,
         doneCount: 0,
         errorCount: 0,
+        requestedConcurrency: controls.requestedConcurrency,
+        effectiveConcurrency: controls.effectiveConcurrency,
       },
       controller,
       startedAt: new Date(),
       script,
       args,
       journal: [],
+      execution: controls,
+      concurrencyLimiter: createConcurrencyLimiter(controls.effectiveConcurrency),
+      usageBaseline: this.zeroUsage(),
+      durableAgents: new Map(),
+      sessionId: this.sessionId,
       background: true,
       lease,
     };
@@ -222,20 +307,7 @@ export class WorkflowManager extends EventEmitter {
     this.runs.set(runId, managed);
 
     try {
-      // Persist initial state
-      this.persistence.save({
-        runId,
-        workflowName: parsed.meta.name,
-        script,
-        args,
-        sessionId: this.sessionId,
-        status: "running",
-        phases: managed.snapshot.phases,
-        agents: [],
-        logs: [],
-        startedAt: managed.startedAt.toISOString(),
-        updatedAt: managed.startedAt.toISOString(),
-      });
+      this.persistRun(managed);
     } catch (err) {
       this.releaseRunLease(managed);
       this.runs.delete(runId);
@@ -247,7 +319,7 @@ export class WorkflowManager extends EventEmitter {
     // when a workflow is aborted/paused/stopped — executeRun()'s catch block
     // already records status/event/persist, but the promise still rejects.
     // The original promise is returned so callers can await it in try/catch.
-    const promise = this.executeRun(managed, script, args, exec);
+    const promise = this.beginExecution(managed, script, args, exec);
     promise.catch(() => {});
 
     return { runId, promise };
@@ -260,7 +332,7 @@ export class WorkflowManager extends EventEmitter {
    * a caller (e.g. the workflow tool) drive its own inline display.
    */
   async runSync(script: string, args?: unknown, exec: ExecOptions = {}): Promise<WorkflowRunResult> {
-    const managed = this.createManaged(script, args);
+    const managed = this.createManaged(script, args, exec);
     const lease = this.persistence.acquireRunLease(managed.runId);
     if (!lease) throw new Error(`Could not acquire workflow run lease for ${managed.runId}`);
     managed.lease = lease;
@@ -268,11 +340,30 @@ export class WorkflowManager extends EventEmitter {
     // Persist the initial state immediately so listRuns()/the task panel can see
     // the run the moment it starts, not only after the first agent journals.
     this.persistRun(managed);
-    return this.executeRun(managed, script, args, exec);
+    return this.beginExecution(managed, script, args, exec);
+  }
+
+  private beginExecution(
+    managed: ManagedRun,
+    script: string,
+    args?: unknown,
+    exec: ExecOptions = {},
+  ): Promise<WorkflowRunResult> {
+    const promise = this.executeRun(managed, script, args, exec);
+    managed.executionPromise = promise;
+    void promise.then(
+      () => {
+        if (managed.executionPromise === promise) managed.executionPromise = undefined;
+      },
+      () => {
+        if (managed.executionPromise === promise) managed.executionPromise = undefined;
+      },
+    );
+    return promise;
   }
 
   /** Build a fresh managed run with an empty snapshot. */
-  private createManaged(script: string, args?: unknown): ManagedRun {
+  private createManaged(script: string, args?: unknown, exec: ExecOptions = {}): ManagedRun {
     const parsed = parseWorkflowScript(script);
     const slug = parsed.meta.name
       ? parsed.meta.name
@@ -282,6 +373,7 @@ export class WorkflowManager extends EventEmitter {
           .slice(0, 40) || "workflow"
       : "";
     const runId = slug ? `${slug}-${generateRunId()}` : generateRunId();
+    const controls = this.resolveExecutionControls(exec);
     return {
       runId,
       status: "running",
@@ -295,13 +387,50 @@ export class WorkflowManager extends EventEmitter {
         runningCount: 0,
         doneCount: 0,
         errorCount: 0,
+        requestedConcurrency: controls.requestedConcurrency,
+        effectiveConcurrency: controls.effectiveConcurrency,
       },
       controller: new AbortController(),
       startedAt: new Date(),
       script,
       args,
       journal: [],
+      execution: controls,
+      concurrencyLimiter: createConcurrencyLimiter(controls.effectiveConcurrency),
+      usageBaseline: this.zeroUsage(),
+      durableAgents: new Map(),
+      sessionId: this.sessionId,
       background: false,
+    };
+  }
+
+  private zeroUsage(): NonNullable<WorkflowSnapshot["tokenUsage"]> {
+    return { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 };
+  }
+
+  private addUsage(left: AgentUsage | undefined, right: AgentUsage): AgentUsage {
+    return {
+      input: (left?.input ?? 0) + right.input,
+      output: (left?.output ?? 0) + right.output,
+      cacheRead: (left?.cacheRead ?? 0) + right.cacheRead,
+      cacheWrite: (left?.cacheWrite ?? 0) + right.cacheWrite,
+      total: (left?.total ?? 0) + right.total,
+      cost: (left?.cost ?? 0) + right.cost,
+      estimated: right.estimated === true,
+    };
+  }
+
+  private resolveExecutionControls(exec: ExecOptions): DurableExecutionControls {
+    const requestedConcurrency = exec.concurrency ?? this.concurrency;
+    const effectiveConcurrency =
+      !Number.isFinite(requestedConcurrency) || requestedConcurrency < 1 ? 1 : Math.floor(requestedConcurrency);
+    return {
+      requestedConcurrency,
+      effectiveConcurrency,
+      maxAgents: exec.maxAgents ?? MAX_AGENTS_PER_RUN,
+      agentRetries: exec.agentRetries ?? this.defaultAgentRetries,
+      agentTimeoutMs: exec.agentTimeoutMs !== undefined ? exec.agentTimeoutMs : this.defaultAgentTimeoutMs,
+      tokenBudget: exec.tokenBudget ?? null,
     };
   }
 
@@ -311,21 +440,28 @@ export class WorkflowManager extends EventEmitter {
     args?: unknown,
     exec: ExecOptions = {},
   ): Promise<WorkflowRunResult> {
-    const {
-      resumeJournal,
-      maxAgents,
-      agentTimeoutMs,
-      externalSignal,
-      onProgress,
-      tokenBudget,
-      concurrency,
-      agentRetries,
-      confirm,
-    } = exec;
-    const resolvedAgentTimeoutMs = agentTimeoutMs !== undefined ? agentTimeoutMs : this.defaultAgentTimeoutMs;
-    const resolvedConcurrency = concurrency ?? this.concurrency;
-    const resolvedAgentRetries = agentRetries ?? this.defaultAgentRetries;
+    const { resumeJournal, resumeAgents, externalSignal, onProgress, confirm } = exec;
+    const controls = managed.execution;
+    const runtimeTokenBudget =
+      resumeJournal && controls.tokenBudget !== null
+        ? Math.max(0, controls.tokenBudget - managed.usageBaseline.total)
+        : controls.tokenBudget;
     const progress = () => onProgress?.(managed.snapshot);
+    const refresh = () => {
+      managed.snapshot = recomputeWorkflowSnapshot(managed.snapshot);
+      progress();
+    };
+    const findAgent = (executionId: string) =>
+      managed.snapshot.agents.find((agent) => agent.executionId === executionId);
+    const invocationBaselines = new Map(
+      managed.snapshot.agents.flatMap((agent) => {
+        const usage =
+          agent.executionId && agent.status !== "done"
+            ? managed.durableAgents.get(agent.executionId)?.usage
+            : undefined;
+        return agent.executionId && usage ? [[agent.executionId, { ...usage, estimated: false }] as const] : [];
+      }),
+    );
     // Let a host abort (e.g. Esc during a blocking tool call) cancel this run.
     if (externalSignal) {
       if (externalSignal.aborted) managed.controller.abort();
@@ -339,21 +475,40 @@ export class WorkflowManager extends EventEmitter {
         mainModel: this.mainModel,
         modelRegistry: this.modelRegistry,
         persistAgentSessions: this.persistAgentSessions,
+        concurrencyLimiter: managed.concurrencyLimiter,
         signal: managed.controller.signal,
-        concurrency: resolvedConcurrency,
-        agentRetries: resolvedAgentRetries,
-        maxAgents,
-        agentTimeoutMs: resolvedAgentTimeoutMs,
-        tokenBudget,
+        runId: managed.runId,
+        concurrency: controls.effectiveConcurrency,
+        agentRetries: controls.agentRetries,
+        maxAgents: controls.maxAgents,
+        agentTimeoutMs: controls.agentTimeoutMs,
+        tokenBudget: runtimeTokenBudget,
         confirm,
         loadSavedWorkflow: this.loadSavedWorkflow,
         resumeJournal,
         resumeFromRunId: resumeJournal ? managed.runId : undefined,
+        resumeAgents,
         onAgentJournal: (entry) => {
-          // Append (crash-safe-ish): keep the latest entry per index, then persist.
-          managed.journal = managed.journal.filter((e) => e.index !== entry.index);
-          managed.journal.push(entry);
-          this.persistRun(managed);
+          const baseline = entry.executionId ? invocationBaselines.get(entry.executionId) : undefined;
+          const usage = entry.usage
+            ? entry.usage.estimated
+              ? baseline
+              : this.addUsage(baseline, entry.usage)
+            : baseline;
+          const reconciled = { ...entry, usage: usage ? { ...usage, estimated: false } : undefined };
+          managed.journal = managed.journal.filter(
+            (existing) =>
+              (existing.executionId ?? `${managed.runId}:${existing.index}`) !==
+              (reconciled.executionId ?? `${managed.runId}:${reconciled.index}`),
+          );
+          managed.journal.push(reconciled);
+          managed.journal.sort(
+            (left, right) =>
+              left.index - right.index || (left.executionId ?? "").localeCompare(right.executionId ?? ""),
+          );
+          // Agent journals are followed synchronously by onAgentEnd, which saves
+          // the row and journal together. Checkpoints have no agent row callback.
+          if (entry.source === "checkpoint") this.persistRun(managed);
         },
         onLog: (message) => {
           managed.snapshot.logs.push(message);
@@ -368,60 +523,156 @@ export class WorkflowManager extends EventEmitter {
           this.emit("phase", { runId: managed.runId, title });
           progress();
         },
+        onAgentQueued: (event) => {
+          let agent = findAgent(event.executionId);
+          if (!agent) {
+            agent = {
+              id: managed.snapshot.agents.length + 1,
+              executionId: event.executionId,
+              callIndex: event.callIndex,
+              label: event.label,
+              phase: event.phase,
+              prompt: event.prompt,
+              status: "queued",
+              model: event.model,
+            };
+            managed.snapshot.agents.push(agent);
+          } else if (!event.replayed) {
+            agent.status = "queued";
+            agent.label = event.label;
+            agent.phase = event.phase;
+            agent.prompt = event.prompt;
+            agent.resultPreview = undefined;
+            agent.error = undefined;
+            agent.errorCode = undefined;
+            agent.recoverable = undefined;
+            if (!event.resuming) {
+              agent.tokens = undefined;
+              agent.tokensEstimated = false;
+              agent.usage = undefined;
+              agent.sessionFile = undefined;
+              agent.worktree = undefined;
+              managed.durableAgents.set(event.executionId, {});
+            }
+            if (event.model) agent.model = event.model;
+          }
+          this.schedulePersist(managed);
+          this.emit("agentQueued", { runId: managed.runId, ...event });
+          refresh();
+        },
+        onAgentSession: (event) => {
+          const agent = findAgent(event.executionId);
+          if (agent) {
+            agent.sessionFile = event.sessionFile;
+            agent.worktree = event.worktree;
+          }
+          this.persistRun(managed);
+          this.emit("agentSession", { runId: managed.runId, ...event });
+          refresh();
+        },
         onAgentStart: (event) => {
-          managed.snapshot.agents.push({
-            id: managed.snapshot.agents.length + 1,
-            label: event.label,
-            phase: event.phase,
-            prompt: event.prompt,
-            status: "running",
-            model: event.model,
-          });
+          const agent = findAgent(event.executionId);
+          if (agent && !event.replayed) {
+            agent.status = "running";
+            if (event.model) agent.model = event.model;
+            const metadata = managed.durableAgents.get(event.executionId) ?? {};
+            metadata.startedAt = new Date().toISOString();
+            metadata.endedAt = undefined;
+            managed.durableAgents.set(event.executionId, metadata);
+          }
+          this.schedulePersist(managed);
           this.emit("agentStart", { runId: managed.runId, ...event });
+          refresh();
+        },
+        onAgentUsage: (event) => {
+          const usage = this.addUsage(invocationBaselines.get(event.executionId), event.usage);
+          const agent = findAgent(event.executionId);
+          if (agent) {
+            agent.usage = usage;
+            agent.tokens = usage.total;
+            agent.tokensEstimated = usage.estimated === true;
+            if (!usage.estimated) {
+              const metadata = managed.durableAgents.get(event.executionId) ?? {};
+              metadata.usage = { ...usage, estimated: false };
+              managed.durableAgents.set(event.executionId, metadata);
+              this.schedulePersist(managed);
+            }
+          }
+          this.emit("agentUsage", { runId: managed.runId, ...event, usage });
           progress();
         },
         onAgentEnd: (event) => {
-          const agent = [...managed.snapshot.agents]
-            .reverse()
-            .find((a) => a.label === event.label && a.status === "running");
+          const agent = findAgent(event.executionId);
+          const baseline = invocationBaselines.get(event.executionId);
+          const usage = event.usage ? this.addUsage(baseline, event.usage) : baseline;
           if (agent) {
-            agent.status = event.result === null ? "error" : "done";
+            const alreadyCompleted = agent.status === "done";
+            agent.status = event.status;
             agent.resultPreview = preview(event.result);
             agent.error = event.error;
             agent.errorCode = event.errorCode;
             agent.recoverable = event.recoverable;
-            agent.tokens = event.tokens;
+            if (!alreadyCompleted || usage) agent.tokens = usage?.total ?? event.tokens;
+            agent.tokensEstimated = usage?.estimated === true;
+            if (usage) agent.usage = usage;
             if (event.model) agent.model = event.model;
+            agent.worktree = event.status === "paused" ? (event.worktree ?? agent.worktree) : undefined;
+            const metadata = managed.durableAgents.get(event.executionId) ?? {};
+            metadata.result = event.result;
+            if (event.status === "paused") metadata.endedAt = undefined;
+            else metadata.endedAt ??= new Date().toISOString();
+            if (usage && !usage.estimated) metadata.usage = { ...usage, estimated: false };
+            managed.durableAgents.set(event.executionId, metadata);
           }
-          this.emit("agentEnd", { runId: managed.runId, ...event });
-          progress();
+          this.persistRun(managed);
+          this.emit("agentEnd", { runId: managed.runId, ...event, usage });
+          refresh();
         },
         onAgentHistory: (event) => {
-          const agent = [...managed.snapshot.agents]
-            .reverse()
-            .find((a) => a.label === event.label && a.status === "running");
-          if (agent) {
-            agent.history = event.history;
-          }
+          const agent = findAgent(event.executionId);
+          if (agent) agent.history = event.history;
           this.emit("agentHistory", { runId: managed.runId, ...event });
           progress();
         },
         onTokenUsage: (usage) => {
-          managed.snapshot.tokenUsage = usage;
-          this.emit("tokenUsage", { runId: managed.runId, usage });
+          const baseline = managed.usageBaseline;
+          managed.snapshot.tokenUsage = {
+            input: baseline.input + usage.input,
+            output: baseline.output + usage.output,
+            total: baseline.total + usage.total,
+            cost: (baseline.cost ?? 0) + usage.cost,
+            cacheRead: (baseline.cacheRead ?? 0) + (usage.cacheRead ?? 0),
+            cacheWrite: (baseline.cacheWrite ?? 0) + (usage.cacheWrite ?? 0),
+          };
+          this.emit("tokenUsage", { runId: managed.runId, usage: managed.snapshot.tokenUsage });
           progress();
         },
       });
 
       managed.status = "completed";
-      managed.result = result;
-      this.emit("complete", { runId: managed.runId, result });
+      const finalUsage = managed.snapshot.tokenUsage;
+      const completedResult: WorkflowRunResult = {
+        ...result,
+        tokenUsage: finalUsage
+          ? {
+              input: finalUsage.input,
+              output: finalUsage.output,
+              total: finalUsage.total,
+              cost: finalUsage.cost ?? 0,
+              cacheRead: finalUsage.cacheRead,
+              cacheWrite: finalUsage.cacheWrite,
+            }
+          : result.tokenUsage,
+      };
+      managed.result = completedResult;
+      managed.snapshot.result = result.result;
+      managed.snapshot.durationMs = result.durationMs;
+      this.emit("complete", { runId: managed.runId, result: managed.result });
 
-      // Persist final state
       this.persistRun(managed);
       this.releaseRunLease(managed);
 
-      return result;
+      return completedResult;
     } catch (error) {
       const workflowError =
         error instanceof WorkflowError
@@ -432,6 +683,8 @@ export class WorkflowManager extends EventEmitter {
               { recoverable: true },
             );
 
+      const lifecycleAbort =
+        managed.controller.signal.aborted && (managed.status === "paused" || managed.status === "aborted");
       const usageLimitPaused =
         !managed.controller.signal.aborted && workflowError.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT;
       if (managed.controller.signal.aborted) {
@@ -455,7 +708,9 @@ export class WorkflowManager extends EventEmitter {
           error: workflowError,
           resetHint: workflowError.resetHint,
         });
-      } else {
+      } else if (!lifecycleAbort && this.listenerCount("error") > 0) {
+        // pause()/stop() already emitted their lifecycle event. Only unexpected
+        // failures and external aborts reach the error channel.
         this.emit("error", { runId: managed.runId, error: workflowError });
       }
 
@@ -473,20 +728,34 @@ export class WorkflowManager extends EventEmitter {
     managed.lease = undefined;
   }
 
-  private persistRun(managed: ManagedRun) {
+  private schedulePersist(managed: ManagedRun): void {
+    if (managed.deleted || managed.persistTimer) return;
+    managed.persistTimer = setTimeout(() => this.persistRun(managed), 100);
+  }
+
+  private persistRun(managed: ManagedRun): void {
+    if (managed.persistTimer) {
+      clearTimeout(managed.persistTimer);
+      managed.persistTimer = undefined;
+    }
+    if (managed.deleted) return;
     try {
       this.persistence.save({
         runId: managed.runId,
         workflowName: managed.snapshot.name,
-        // Persist the real script + journal so the run can be resumed. Runs live
-        // in workflow run storage — protect via directory permissions, not blanking.
+        workflowDescription: managed.snapshot.description,
         script: managed.script,
         args: managed.args,
-        sessionId: this.sessionId,
-        journal: managed.journal,
+        sessionId: managed.sessionId,
+        journal: managed.journal.map((entry) => ({
+          index: entry.index,
+          executionId: entry.executionId,
+          hash: entry.hash,
+          result: entry.result,
+          usage: entry.usage ? { ...entry.usage, estimated: false } : undefined,
+          storeDelta: entry.storeDelta,
+        })),
         status: managed.status,
-        // Why a usage-limit pause happened, so the navigator / a future cold start
-        // can show it and (eventually) re-arm resume after the budget refills.
         pauseReason:
           managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
             ? "usage_limit"
@@ -495,14 +764,35 @@ export class WorkflowManager extends EventEmitter {
           managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
             ? managed.error.resetHint
             : undefined,
-        phases: managed.snapshot.phases,
+        phases: [...managed.snapshot.phases],
         currentPhase: managed.snapshot.currentPhase,
-        agents: managed.snapshot.agents.map((a) => ({
-          ...a,
-          startedAt: managed.startedAt.toISOString(),
-          endedAt: new Date().toISOString(),
-        })),
-        logs: managed.snapshot.logs,
+        agents: managed.snapshot.agents.map((agent) => {
+          const executionId = agent.executionId ?? `${managed.runId}:${agent.callIndex ?? agent.id - 1}`;
+          const metadata = managed.durableAgents.get(executionId);
+          return {
+            id: agent.id,
+            executionId,
+            callIndex: agent.callIndex ?? agent.id - 1,
+            label: agent.label,
+            phase: agent.phase,
+            prompt: agent.prompt,
+            status: agent.status,
+            result: metadata?.result,
+            resultPreview: agent.resultPreview,
+            error: agent.error,
+            errorCode: agent.errorCode,
+            recoverable: agent.recoverable,
+            history: agent.history,
+            usage: metadata?.usage ? { ...metadata.usage, estimated: false } : undefined,
+            tokens: metadata?.usage?.total ?? (agent.tokensEstimated ? undefined : agent.tokens),
+            startedAt: metadata?.startedAt,
+            endedAt: metadata?.endedAt,
+            model: agent.model,
+            sessionFile: agent.sessionFile,
+            worktree: agent.worktree,
+          };
+        }),
+        logs: [...managed.snapshot.logs],
         result: managed.result?.result,
         tokenUsage: managed.snapshot.tokenUsage
           ? {
@@ -518,13 +808,50 @@ export class WorkflowManager extends EventEmitter {
         updatedAt: new Date().toISOString(),
         completedAt: managed.status === "completed" ? new Date().toISOString() : undefined,
         durationMs: managed.result?.durationMs,
+        requestedConcurrency: managed.execution.requestedConcurrency,
+        effectiveConcurrency: managed.execution.effectiveConcurrency,
+        maxAgents: managed.execution.maxAgents,
+        agentRetries: managed.execution.agentRetries,
+        agentTimeoutMs: managed.execution.agentTimeoutMs,
+        tokenBudget: managed.execution.tokenBudget,
       });
     } catch (err) {
-      // Persistence is best-effort: the run is still healthy in memory.
-      // Log so an operator debugging state-loss has a lead, but never crash
-      // the workflow over a disk-full situation.
       console.warn("[workflow-manager] Persist run failed:", err);
     }
+  }
+
+  /** Resize a running limiter, or update the persisted limit used by a later resume. */
+  setConcurrency(runId: string, concurrency: number): ConcurrencyUpdate | null {
+    if (!Number.isFinite(concurrency) || !Number.isInteger(concurrency) || concurrency < 1) return null;
+    const managed = this.runs.get(runId);
+    if (managed) {
+      if (!isConcurrencyMutableStatus(managed.status)) return null;
+      const previousConcurrency = managed.execution.effectiveConcurrency;
+      managed.execution.requestedConcurrency = concurrency;
+      managed.execution.effectiveConcurrency = concurrency;
+      managed.snapshot.requestedConcurrency = concurrency;
+      managed.snapshot.effectiveConcurrency = concurrency;
+      if (managed.status === "running") managed.concurrencyLimiter.setLimit(concurrency);
+      this.persistRun(managed);
+      const update = { previousConcurrency, requestedConcurrency: concurrency, effectiveConcurrency: concurrency };
+      this.emit("concurrencyChanged", { runId, ...update });
+      return update;
+    }
+
+    const persisted = this.persistence.load(runId);
+    if (!persisted || !isConcurrencyMutableStatus(persisted.status)) return null;
+    const update = {
+      previousConcurrency: persisted.effectiveConcurrency,
+      requestedConcurrency: concurrency,
+      effectiveConcurrency: concurrency,
+    };
+    this.persistence.save({
+      ...persisted,
+      requestedConcurrency: concurrency,
+      effectiveConcurrency: concurrency,
+    });
+    this.emit("concurrencyChanged", { runId, ...update });
+    return update;
   }
 
   /**
@@ -534,11 +861,14 @@ export class WorkflowManager extends EventEmitter {
     const managed = this.runs.get(runId);
     if (managed?.status !== "running") return false;
 
-    managed.controller.abort();
     managed.status = "paused";
+    for (const agent of managed.snapshot.agents) {
+      if (agent.status === "running") agent.status = "paused";
+    }
+    managed.snapshot = recomputeWorkflowSnapshot(managed.snapshot);
+    managed.controller.abort(WORKFLOW_PAUSE_ABORT_REASON);
     this.emit("paused", { runId });
     this.persistRun(managed);
-    this.releaseRunLease(managed);
     return true;
   }
 
@@ -552,44 +882,134 @@ export class WorkflowManager extends EventEmitter {
     const active = this.runs.get(runId);
     if (active?.status === "running") return false;
     if (active?.status === "aborted") return false;
+    if (active?.executionPromise) await active.executionPromise.catch(() => {});
 
+    const settled = this.runs.get(runId);
+    if (settled?.status === "running" || settled?.status === "aborted") return false;
     const persisted = this.persistence.load(runId);
     if (!persisted?.script || persisted.status === "completed" || persisted.status === "aborted") return false;
     const lease = this.persistence.acquireRunLease(runId);
     if (!lease) return false;
 
-    const controller = new AbortController();
+    const controls = this.resolveExecutionControls({
+      concurrency: persisted.requestedConcurrency ?? persisted.effectiveConcurrency,
+      maxAgents: persisted.maxAgents,
+      agentRetries: persisted.agentRetries,
+      agentTimeoutMs: persisted.agentTimeoutMs !== undefined ? persisted.agentTimeoutMs : this.defaultAgentTimeoutMs,
+      tokenBudget: persisted.tokenBudget !== undefined ? persisted.tokenBudget : null,
+    });
+    const agents = persisted.agents.map((agent) => ({
+      id: agent.id,
+      executionId: agent.executionId,
+      callIndex: agent.callIndex,
+      label: agent.label,
+      phase: agent.phase,
+      prompt: agent.prompt,
+      status: agent.status === "running" ? ("paused" as const) : agent.status,
+      resultPreview: agent.resultPreview ?? (agent.result !== undefined ? preview(agent.result) : undefined),
+      error: agent.error,
+      errorCode: agent.errorCode,
+      recoverable: agent.recoverable,
+      history: agent.history,
+      tokens: agent.usage?.total ?? agent.tokens,
+      tokensEstimated: false,
+      usage: agent.usage ? { ...agent.usage, estimated: false } : undefined,
+      model: agent.model,
+      sessionFile: agent.sessionFile,
+      worktree: agent.worktree,
+    }));
+    const aggregateUsage = agents.reduce((total, agent) => {
+      const usage = agent.usage;
+      if (usage) {
+        total.input += usage.input;
+        total.output += usage.output;
+        total.total += usage.total;
+        total.cost = (total.cost ?? 0) + usage.cost;
+        total.cacheRead = (total.cacheRead ?? 0) + usage.cacheRead;
+        total.cacheWrite = (total.cacheWrite ?? 0) + usage.cacheWrite;
+      } else if (agent.status === "done" && agent.tokens !== undefined) {
+        // v1 rows carried only a terminal token total.
+        total.total += agent.tokens;
+      }
+      return total;
+    }, this.zeroUsage());
+    const usageBaseline = persisted.tokenUsage ? { ...persisted.tokenUsage } : aggregateUsage;
+    const startedAt = new Date(persisted.startedAt);
     const managed: ManagedRun = {
       runId,
       status: "running",
-      snapshot: {
+      snapshot: recomputeWorkflowSnapshot({
         name: persisted.workflowName,
-        phases: persisted.phases ?? [],
-        logs: persisted.logs ?? [],
-        agents: [],
-        agentCount: 0,
+        description: persisted.workflowDescription,
+        phases: [...persisted.phases],
+        currentPhase: persisted.currentPhase,
+        logs: [...persisted.logs],
+        agents,
+        agentCount: agents.length,
         runningCount: 0,
         doneCount: 0,
         errorCount: 0,
-      },
-      controller,
-      startedAt: new Date(),
+        result: persisted.result,
+        durationMs: persisted.durationMs,
+        tokenUsage: usageBaseline,
+        runId,
+        requestedConcurrency: controls.requestedConcurrency,
+        effectiveConcurrency: controls.effectiveConcurrency,
+      }),
+      controller: new AbortController(),
+      startedAt: Number.isNaN(startedAt.getTime()) ? new Date() : startedAt,
       script: persisted.script,
       args: persisted.args,
       journal: persisted.journal ?? [],
+      execution: controls,
+      concurrencyLimiter: createConcurrencyLimiter(controls.effectiveConcurrency),
+      usageBaseline,
+      durableAgents: new Map(
+        persisted.agents.map((agent) => [
+          agent.executionId,
+          {
+            result: agent.result,
+            usage: agent.usage ? { ...agent.usage, estimated: false } : undefined,
+            startedAt: agent.startedAt,
+            endedAt: agent.status === "running" || agent.status === "paused" ? undefined : agent.endedAt,
+          },
+        ]),
+      ),
+      sessionId: persisted.sessionId,
       background: true,
       lease,
     };
     this.runs.set(runId, managed);
-    // Persist before notifying renderers: listRuns() is their source of truth for
-    // lifecycle status, while getRun() supplies the live in-memory snapshot.
     this.persistRun(managed);
 
-    const resumeJournal = new Map((persisted.journal ?? []).map((e) => [e.index, e] as const));
+    const resumeJournal = new Map(managed.journal.map((entry) => [entry.executionId ?? entry.index, entry] as const));
+    const resumeAgents = new Map<string, ResumeAgentState>(
+      persisted.agents.flatMap((agent) =>
+        agent.status === "paused" && agent.sessionFile
+          ? [[agent.executionId, { sessionFile: agent.sessionFile, worktree: agent.worktree }] as const]
+          : [],
+      ),
+    );
     this.emit("resumed", { runId });
     // Run in the background; executeRun records status/errors on the managed run.
-    void this.executeRun(managed, persisted.script, persisted.args, { resumeJournal }).catch(() => {});
+    void this.beginExecution(managed, persisted.script, persisted.args, { resumeJournal, resumeAgents }).catch(
+      () => {},
+    );
     return true;
+  }
+
+  /** Restart a saved run with the same durable execution controls. */
+  restart(runId: string): { runId: string; promise: Promise<WorkflowRunResult> } | null {
+    const active = this.runs.get(runId);
+    const persisted = this.persistence.load(runId);
+    if (active?.status === "running" || persisted?.status === "running" || !persisted?.script) return null;
+    return this.startInBackground(persisted.script, persisted.args, {
+      concurrency: persisted.requestedConcurrency ?? persisted.effectiveConcurrency,
+      maxAgents: persisted.maxAgents,
+      agentRetries: persisted.agentRetries,
+      agentTimeoutMs: persisted.agentTimeoutMs !== undefined ? persisted.agentTimeoutMs : this.defaultAgentTimeoutMs,
+      tokenBudget: persisted.tokenBudget !== undefined ? persisted.tokenBudget : null,
+    });
   }
 
   /**
@@ -597,14 +1017,64 @@ export class WorkflowManager extends EventEmitter {
    */
   stop(runId: string): boolean {
     const managed = this.runs.get(runId);
-    if (!managed || (managed.status !== "running" && managed.status !== "paused")) return false;
+    if (managed) {
+      if (managed.status !== "running" && managed.status !== "paused") return false;
+      const preservedWorktrees = managed.snapshot.agents
+        .filter((agent) => agent.status === "paused")
+        .map((agent) => agent.worktree);
+      const endedAt = new Date().toISOString();
+      for (const agent of managed.snapshot.agents) {
+        if (agent.status !== "queued" && agent.status !== "running" && agent.status !== "paused") continue;
+        agent.status = "skipped";
+        agent.worktree = undefined;
+        const executionId = agent.executionId;
+        if (executionId) {
+          const metadata = managed.durableAgents.get(executionId) ?? {};
+          metadata.endedAt ??= endedAt;
+          managed.durableAgents.set(executionId, metadata);
+        }
+      }
+      managed.snapshot = recomputeWorkflowSnapshot(managed.snapshot);
+      managed.status = "aborted";
+      managed.controller.abort();
+      this.emit("stopped", { runId });
+      this.persistRun(managed);
+      this.cleanupWorktrees(preservedWorktrees);
+      return true;
+    }
 
-    managed.controller.abort();
-    managed.status = "aborted";
-    this.emit("stopped", { runId });
-    this.persistRun(managed);
-    this.releaseRunLease(managed);
-    return true;
+    const persisted = this.persistence.load(runId);
+    if (!persisted || (persisted.status !== "running" && persisted.status !== "paused")) return false;
+    const lease = this.persistence.acquireRunLease(runId);
+    if (!lease) return false;
+    try {
+      const current = this.persistence.load(runId);
+      if (!current || (current.status !== "running" && current.status !== "paused")) return false;
+      const preservedWorktrees = current.agents
+        .filter((agent) => agent.status === "paused")
+        .map((agent) => agent.worktree);
+      this.persistence.save({
+        ...current,
+        status: "aborted",
+        pauseReason: undefined,
+        resetHint: undefined,
+        agents: current.agents.map((agent) =>
+          agent.status === "queued" || agent.status === "running" || agent.status === "paused"
+            ? {
+                ...agent,
+                status: "skipped" as const,
+                endedAt: agent.endedAt ?? new Date().toISOString(),
+                worktree: undefined,
+              }
+            : agent,
+        ),
+      });
+      this.cleanupWorktrees(preservedWorktrees);
+      this.emit("stopped", { runId });
+      return true;
+    } finally {
+      this.persistence.releaseRunLease(lease);
+    }
   }
 
   /**
@@ -622,13 +1092,13 @@ export class WorkflowManager extends EventEmitter {
    * that session's runs are returned — runs from other sessions stay on disk and
    * reappear when you switch back. Unbound (tests/legacy) returns everything.
    */
-  listRuns(): PersistedRunState[] {
+  listRuns(): LoadedPersistedRunState[] {
     const all = this.persistence.list();
     return this.sessionId ? all.filter((r) => r.sessionId === this.sessionId) : all;
   }
 
   /** All persisted runs regardless of session (used by cross-session recovery). */
-  listAllRuns(): PersistedRunState[] {
+  listAllRuns(): LoadedPersistedRunState[] {
     return this.persistence.list();
   }
 
@@ -639,14 +1109,40 @@ export class WorkflowManager extends EventEmitter {
     return this.runs.get(runId)?.snapshot ?? null;
   }
 
-  /**
-   * Delete a persisted run.
-   */
+  /** Delete a terminal persisted run. Running and paused work must be stopped first. */
   deleteRun(runId: string): boolean {
     const managed = this.runs.get(runId);
-    if (managed) this.releaseRunLease(managed);
-    this.runs.delete(runId);
-    return this.persistence.delete(runId);
+    const persisted = this.persistence.load(runId);
+    const status = managed?.status ?? persisted?.status;
+    if (status === "running" || status === "paused" || (!managed && !persisted)) return false;
+
+    const acquiredLease = managed?.lease ? null : this.persistence.acquireRunLease(runId);
+    const lease = managed?.lease ?? acquiredLease;
+    if (!lease) return false;
+
+    try {
+      const current = this.persistence.load(runId);
+      const currentStatus = managed?.status ?? current?.status;
+      if (currentStatus === "running" || currentStatus === "paused" || (!managed && !current)) return false;
+
+      if (managed) {
+        managed.deleted = true;
+        if (managed.persistTimer) {
+          clearTimeout(managed.persistTimer);
+          managed.persistTimer = undefined;
+        }
+      }
+      const deleted = this.persistence.delete(runId);
+      if (!deleted) {
+        if (managed) managed.deleted = false;
+        return false;
+      }
+      this.runs.delete(runId);
+      if (managed?.lease?.token === lease.token) this.releaseRunLease(managed);
+      return true;
+    } finally {
+      if (acquiredLease) this.persistence.releaseRunLease(acquiredLease);
+    }
   }
 
   /**

--- a/src/workflow-paths.ts
+++ b/src/workflow-paths.ts
@@ -19,6 +19,8 @@ export interface WorkflowProjectPaths {
   rootDir: string;
   runsDir: string;
   savedDir: string;
+  /** Private child-session storage; intentionally outside Pi's /resume session index. */
+  agentSessionsDir: string;
   settingsPath: string;
   legacyRunsDir: string;
   legacySavedDir: string;
@@ -47,6 +49,7 @@ export function workflowProjectPaths(cwd: string): WorkflowProjectPaths {
     rootDir,
     runsDir: join(rootDir, "runs"),
     savedDir: join(rootDir, "saved"),
+    agentSessionsDir: join(rootDir, "agent-sessions"),
     settingsPath: join(rootDir, "settings.json"),
     legacyRunsDir: resolve(cwd, WORKFLOW_RUNS_DIR),
     legacySavedDir: resolve(cwd, WORKFLOW_SAVED_DIR),

--- a/src/workflow-settings.ts
+++ b/src/workflow-settings.ts
@@ -7,10 +7,11 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { MAX_AGENT_RETRIES, MAX_CONCURRENCY, normalizeKeywordTriggerWord } from "./config.js";
+import { MAX_AGENT_RETRIES, normalizeKeywordTriggerWord } from "./config.js";
 import { workflowHomeDir, workflowProjectPaths } from "./workflow-paths.js";
 
 export interface WorkflowSettings {
+  /** Opt-in keyword activation. Missing values default to false. */
   keywordTriggerEnabled?: boolean;
   /** Literal keyword that arms workflows mode from interactive input. */
   keywordTriggerWord?: string;
@@ -24,10 +25,10 @@ export interface WorkflowSettings {
   /** Max agents shown per phase in detailed progress mode (default 8). */
   progressPanelMaxAgents?: number;
   /**
-   * Persist each workflow subagent transcript as a real pi session file under
-   * the standard sessions directory (~/.pi/agent/sessions/<encoded-cwd>/),
-   * keyed by the project cwd. Default false: subagent sessions stay in-memory
-   * and only the compacted history embedded in the run JSON survives.
+   * Persist each workflow subagent transcript under the workflow project's
+   * private agent-sessions directory (outside Pi's /resume picker), keyed by
+   * the project cwd. Default true so paused agents can continue from
+   * their last durable message/tool-result boundary. Set false to opt out.
    */
   persistAgentSessions?: boolean;
   /**
@@ -132,7 +133,7 @@ function normalizeSettings(value: unknown): WorkflowSettings {
   ) {
     settings.defaultAgentTimeoutMs = raw.defaultAgentTimeoutMs;
   }
-  const defaultConcurrency = normalizeInteger(raw.defaultConcurrency, 1, MAX_CONCURRENCY);
+  const defaultConcurrency = normalizeInteger(raw.defaultConcurrency, 1);
   if (defaultConcurrency !== undefined) settings.defaultConcurrency = defaultConcurrency;
   const defaultAgentRetries = normalizeInteger(raw.defaultAgentRetries, 0, MAX_AGENT_RETRIES);
   if (defaultAgentRetries !== undefined) settings.defaultAgentRetries = defaultAgentRetries;
@@ -154,9 +155,10 @@ function normalizeSettings(value: unknown): WorkflowSettings {
   return settings;
 }
 
-function normalizeInteger(value: unknown, min: number, max: number): number | undefined {
+function normalizeInteger(value: unknown, min: number, max?: number): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value) || value < min) return undefined;
-  return Math.min(max, Math.floor(value));
+  const normalized = Math.floor(value);
+  return max === undefined ? normalized : Math.min(max, normalized);
 }
 
 function readObject(path: string): Record<string, unknown> {

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -3,6 +3,7 @@ import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { listAvailableModelSpecs } from "./agent.js";
 import { listAgentTypes, loadAgentRegistry } from "./agent-registry.js";
+import { DEFAULT_CONCURRENCY } from "./config.js";
 import {
   createToolUpdateWorkflowDisplay,
   createWorkflowSnapshot,
@@ -85,13 +86,14 @@ const workflowToolSchema = Type.Object({
   ),
   maxAgents: Type.Optional(
     Type.Number({
-      description: "Maximum number of agents allowed in this run. Default: 1000.",
+      description:
+        "Maximum total number of agents allowed across the whole run. Default: 1000. This is separate from concurrency, which limits how many run simultaneously.",
     }),
   ),
   concurrency: Type.Optional(
-    Type.Number({
-      description:
-        "Maximum concurrent agents for this run. Clamped to the runtime maximum. Use when provider/transport stability matters.",
+    Type.Integer({
+      minimum: 1,
+      description: `Maximum concurrent agents allowed to run simultaneously (positive integer, no plugin hard cap). Choose it based on independent task count and provider stability; omission uses the configured default (${DEFAULT_CONCURRENCY} unless overridden). This does not change maxAgents, the whole-run total.`,
     }),
   ),
   agentRetries: Type.Optional(
@@ -183,7 +185,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
         "For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.",
         "For workflow, pipeline(items, ...stages) runs each item through stages sequentially, while different items may run concurrently. Each stage receives (previousValue, originalItem, index).",
         "For workflow, every agent() call should include a unique short label option, 2-5 words, such as { label: 'repo inventory' } or { label: 'source modules' }; unique labels make live status and error reporting readable.",
-        "For workflow, use low concurrency and agentRetries for unstable provider/transport fan-out runs; retries apply only to recoverable agent failures and still require explicit null handling after exhaustion.",
+        `For workflow, choose any positive-integer concurrency per run based on the number of independent tasks and provider stability; the plugin has no hard concurrency cap, and omission uses the configured default (${DEFAULT_CONCURRENCY} unless overridden). For example, 24 independent tasks can use concurrency: 24 while maxAgents: 24 limits the whole-run total. Use low concurrency and agentRetries for unstable provider/transport fan-out runs; retries apply only to recoverable agent failures and still require explicit null handling after exhaustion.`,
         "For workflow, failed agent(), parallel(), or pipeline() branches return null and log the failure unless the workflow is aborted. Check for nulls before synthesizing conclusions.",
         "For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.",
         "For workflow, the default quality shape for fan-out work is finder -> verify -> merge: run one agent per angle or work-unit (in parallel), pass each candidate finding through verify() and drop the unconfirmed, then a single synthesis agent that de-duplicates, ranks by confidence/severity, and caps the output. If nothing survives verification, return an empty result and say so rather than padding.",
@@ -203,6 +205,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
       const script = normalizeWorkflowScript(params.script);
       const parsed = parseWorkflowScript(script);
+      const concurrency = requestedConcurrency(params.concurrency);
 
       // checkpoint() reaches the human only on a UI-bearing foreground run; a
       // background run is detached, so checkpoint() falls back to its headless
@@ -228,8 +231,13 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
           tokenBudget: params.tokenBudget,
         });
         return {
-          content: [{ type: "text", text: backgroundStartedText(parsed.meta.name, runId) }],
-          details: { runId, background: true },
+          content: [{ type: "text", text: backgroundStartedText(parsed.meta.name, runId, concurrency) }],
+          details: {
+            runId,
+            background: true,
+            requestedConcurrency: concurrency?.requested,
+            effectiveConcurrency: concurrency?.effective,
+          },
         };
       }
 
@@ -295,12 +303,13 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
 
       const formattedResult =
         result.result !== undefined ? `\n\`\`\`json\n${JSON.stringify(result.result, null, 2)}\n\`\`\`` : "";
+      const concurrencyInfo = concurrency ? `\n\n${formatConcurrency(concurrency)}` : "";
 
       return {
         content: [
           {
             type: "text",
-            text: `Workflow **${result.meta.name}** completed with **${result.agentCount}** agent(s).${tokenInfo}\n\n## Result${formattedResult}`,
+            text: `Workflow **${result.meta.name}** completed with **${result.agentCount}** agent(s).${tokenInfo}${concurrencyInfo}\n\n## Result${formattedResult}`,
           },
         ],
         details: {
@@ -312,6 +321,8 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
           durationMs: result.durationMs,
           tokenUsage: result.tokenUsage,
           runId: result.runId,
+          requestedConcurrency: concurrency?.requested,
+          effectiveConcurrency: concurrency?.effective,
         },
       };
     },
@@ -360,17 +371,34 @@ function resolveWorkflowToolDefaults(
  * own and the conversation will resume automatically when it finishes, so the
  * user can just wait here (or go do something else).
  */
-export function backgroundStartedText(name: string, runId: string): string {
+export function backgroundStartedText(
+  name: string,
+  runId: string,
+  concurrency?: { requested: number; effective: number },
+): string {
   return [
     `Workflow "${name}" started in the background.`,
     `Run ID: ${runId}`,
+    concurrency ? formatConcurrency(concurrency) : undefined,
     "It keeps running on its own. When it finishes, the result is delivered back",
     "here and the conversation continues automatically — the user does not need to",
     "do anything. Tell the user they can simply wait here for it to finish (it will",
     "resume the conversation by itself), or keep chatting / working on other things",
     "in the meantime; either way the result will come back to this conversation.",
     `They can also track or cancel it with /workflows status ${runId} or /workflows stop ${runId}.`,
-  ].join("\n");
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join("\n");
+}
+
+function requestedConcurrency(requested: number | undefined): { requested: number; effective: number } | undefined {
+  if (requested === undefined) return undefined;
+  const effective = !Number.isFinite(requested) || requested < 1 ? 1 : Math.floor(requested);
+  return { requested, effective };
+}
+
+function formatConcurrency(concurrency: { requested: number; effective: number }): string {
+  return `Concurrency: requested ${concurrency.requested}; effective ${concurrency.effective}.`;
 }
 
 function normalizeWorkflowToolArgs(args: unknown): WorkflowToolInput {

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -6,8 +6,8 @@
  *        ◀── (saved items in runs view) ──enter──▶ saved detail
  *
  * Keys: ↑/↓ (or j/k) select · enter/→ drill in · esc/← back (esc at top closes)
- *       On runs: p pause · x stop · r restart · s save · q quit
- *       On saved: x delete · q quit
+ *       On runs: p pause · x stop · r restart · s save · q close
+ *       On saved: x delete · q close
  *
  * The state machine and line rendering are pure and unit-tested; the pi-tui
  * Component shell (openWorkflowNavigator) wires them to live manager events.
@@ -57,6 +57,9 @@ interface RunRow {
   name: string;
   status: string;
   done: number;
+  running: number;
+  paused: number;
+  queued: number;
   total: number;
   tokens: number;
   cost: number;
@@ -64,16 +67,22 @@ interface RunRow {
 interface PhaseRow {
   title: string;
   done: number;
+  running: number;
+  paused: number;
+  queued: number;
   total: number;
   tokens: number;
 }
 interface AgentRow {
   id: number;
+  executionId?: string;
   label: string;
   status: string;
   phase?: string;
   tokens?: number;
+  tokensEstimated?: boolean;
   model?: string;
+  sessionFile?: string;
 }
 
 /** Short, human-friendly model label: drop the provider prefix for display. */
@@ -92,7 +101,16 @@ export class NavigatorModel {
 
   private snapshot(runId: string): { snapshot: WorkflowSnapshot; status: string } | undefined {
     const live = this.manager.getRun(runId);
-    if (live) return { snapshot: live.snapshot, status: live.status };
+    if (live) {
+      return {
+        snapshot: {
+          ...live.snapshot,
+          requestedConcurrency: live.execution?.requestedConcurrency,
+          effectiveConcurrency: live.execution?.effectiveConcurrency,
+        },
+        status: live.status,
+      };
+    }
     const p = this.manager.listRuns().find((r) => r.runId === runId);
     if (!p) return undefined;
     return { snapshot: persistedToSnapshot(p), status: p.status };
@@ -107,6 +125,9 @@ export class NavigatorModel {
         name: live?.snapshot.name ?? p.workflowName,
         status: live?.status ?? p.status,
         done: agents.filter((a) => a.status === "done").length,
+        running: agents.filter((a) => a.status === "running").length,
+        paused: agents.filter((a) => a.status === "paused").length,
+        queued: agents.filter((a) => a.status === "queued").length,
         total: agents.length,
         tokens: (live?.snapshot.tokenUsage ?? p.tokenUsage)?.total ?? 0,
         cost: (live?.snapshot.tokenUsage ?? p.tokenUsage)?.cost ?? 0,
@@ -150,6 +171,9 @@ export class NavigatorModel {
       return {
         title,
         done: agents.filter((a) => a.status === "done").length,
+        running: agents.filter((a) => a.status === "running").length,
+        paused: agents.filter((a) => a.status === "paused").length,
+        queued: agents.filter((a) => a.status === "queued").length,
         total: agents.length,
         tokens: agents.reduce((n, a) => n + (a.tokens ?? 0), 0),
       };
@@ -161,7 +185,51 @@ export class NavigatorModel {
     if (!snap) return [];
     return snap.agents
       .filter((a) => (a.phase ?? "(no phase)") === phase)
-      .map((a) => ({ id: a.id, label: a.label, status: a.status, phase: a.phase, tokens: a.tokens, model: a.model }));
+      .map((a) => ({
+        id: a.id,
+        executionId: a.executionId,
+        label: a.label,
+        status: a.status,
+        phase: a.phase,
+        tokens: a.tokens,
+        tokensEstimated: a.tokensEstimated,
+        model: a.model,
+        sessionFile: a.sessionFile,
+      }));
+  }
+
+  activity(runId: string): { running: AgentRow[]; paused: AgentRow[]; queued: number; effectiveConcurrency?: number } {
+    const snap = this.snapshot(runId)?.snapshot;
+    if (!snap) return { running: [], paused: [], queued: 0 };
+    return {
+      running: snap.agents
+        .filter((agent) => agent.status === "running")
+        .map((agent) => ({
+          id: agent.id,
+          executionId: agent.executionId,
+          label: agent.label,
+          status: agent.status,
+          phase: agent.phase,
+          tokens: agent.tokens,
+          tokensEstimated: agent.tokensEstimated,
+          model: agent.model,
+        })),
+      paused: snap.agents
+        .filter((agent) => agent.status === "paused")
+        .map((agent) => ({
+          id: agent.id,
+          executionId: agent.executionId,
+          label: agent.label,
+          status: agent.status,
+          phase: agent.phase,
+          tokens: agent.tokens,
+          tokensEstimated: agent.tokensEstimated,
+          model: agent.model,
+          sessionFile: agent.sessionFile,
+        })),
+      queued: snap.agents.filter((agent) => agent.status === "queued").length,
+      effectiveConcurrency: snap.effectiveConcurrency,
+    };
   }
 
   agentDetail(runId: string, agentId: number): WorkflowAgentSnapshot | undefined {
@@ -186,17 +254,27 @@ function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
     logs: p.logs,
     agents: p.agents.map((a) => ({
       id: a.id,
+      executionId: a.executionId,
+      callIndex: a.callIndex,
       label: a.label,
       phase: a.phase,
       prompt: a.prompt,
       status: a.status,
       resultPreview:
-        a.result == null ? undefined : String(typeof a.result === "string" ? a.result : JSON.stringify(a.result)),
+        a.resultPreview ??
+        (a.result == null ? undefined : String(typeof a.result === "string" ? a.result : JSON.stringify(a.result))),
       error: a.error,
       errorCode: a.errorCode,
       recoverable: a.recoverable,
       history: a.history,
+      tokens: a.usage?.total ?? a.tokens,
+      tokensEstimated: false,
+      usage: a.usage ? { ...a.usage, estimated: false } : undefined,
+      startedAt: a.startedAt,
+      endedAt: a.endedAt,
       model: a.model,
+      sessionFile: a.sessionFile,
+      worktree: a.worktree,
     })),
     agentCount: p.agents.length,
     runningCount: p.agents.filter((a) => a.status === "running").length,
@@ -204,6 +282,8 @@ function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
     errorCount: p.agents.filter((a) => a.status === "error").length,
     tokenUsage: p.tokenUsage ? { ...p.tokenUsage } : undefined,
     runId: p.runId,
+    requestedConcurrency: p.requestedConcurrency,
+    effectiveConcurrency: p.effectiveConcurrency,
   };
 }
 
@@ -375,7 +455,7 @@ function pluralize(word: string, n: number): string {
 /** Aggregate phase status precedence: ERR > RUN > all-done(OK) > PEND. */
 function phaseStatusColor(p: { done: number; total: number }, agents: AgentRow[]): string {
   if (agents.some((a) => a.status === "error" || a.status === "failed")) return "error";
-  if (agents.some((a) => a.status === "running")) return "warning";
+  if (agents.some((a) => a.status === "running" || a.status === "paused")) return "warning";
   if (p.total > 0 && p.done === p.total) return "success";
   return "dim";
 }
@@ -384,7 +464,7 @@ const AGENT_DOT_COLOR: Record<string, string> = {
   running: "warning",
   queued: "dim",
   pending: "dim",
-  paused: "dim",
+  paused: "warning",
   done: "success",
   completed: "success",
   error: "error",
@@ -451,7 +531,9 @@ function rightAgentRow(
   theme: ThemeLike,
 ): string {
   const dotColor = AGENT_DOT_COLOR[a.status] ?? "dim";
-  const stats = `${compactTokens(a.tokens ?? 0)} tok`;
+  const status =
+    a.status === "paused" ? `paused mid-run (${a.sessionFile ? "session saved" : "fresh restart"})` : a.status;
+  const stats = `${a.tokensEstimated ? "~" : ""}${compactTokens(a.tokens ?? 0)} tok · ${status}`;
   const model = shortModel(a.model) ?? "";
 
   // Stable 2-cell marker so columns never shift on selection: "› " | "  ".
@@ -486,7 +568,7 @@ function rightAgentRow(
   const statsStyled = theme.fg("dim", stats);
 
   // Assemble with explicit cell padding (visibleWidth-driven gaps).
-  let out = marker + dot + " " + nameStyled;
+  let out = `${marker + dot} ${nameStyled}`;
   const afterName = nameStart + visibleWidth(nameOut);
   if (modelOut) {
     out += " ".repeat(Math.max(0, modelStart - afterName)) + modelStyled;
@@ -763,7 +845,14 @@ export function renderNavigator(
     // Render runs
     runs.forEach((r, i) => {
       const icon = STATUS_ICON[r.status] ?? "?";
-      const meta = [`${r.done}/${r.total}`, fmtTokens(r.tokens), r.cost > 0 ? `$${r.cost.toFixed(4)}` : ""]
+      const meta = [
+        `${r.done}/${r.total}`,
+        `${r.running} running`,
+        r.paused ? `${r.paused} paused mid-run` : "",
+        `${r.queued} not started`,
+        fmtTokens(r.tokens),
+        r.cost > 0 ? `$${r.cost.toFixed(4)}` : "",
+      ]
         .filter(Boolean)
         .join(" · ");
       lines.push(sel(i, `${icon} ${r.name}  ${dim(`${r.runId} · ${r.status} · ${meta}`)}`));
@@ -781,17 +870,18 @@ export function renderNavigator(
   } else if (state.kind === "phases" && state.runId) {
     const phases = model.phases(state.runId);
     state.clamp(phases.length);
-    // Two-line header (name + description/status) then the combined frame.
-    lines.push(...twoPaneHeader(model, state.runId, phases, width, theme));
-    // Body cap: total height minus 2 header + 2 frame rules + blank + footer.
-    const bodyCap = Math.max(1, viewportRows - 2 /*header*/ - 2 /*rules*/ - 2 /*blank+footer*/);
+    // Header (name, counts, wrapped active inventory) then the combined frame.
+    const header = twoPaneHeader(model, state.runId, phases, width, theme);
+    lines.push(...header);
+    const bodyCap = Math.max(1, viewportRows - header.length - 2 /*rules*/ - 2 /*blank+footer*/);
     lines.push(...renderPhasesAgents(state, model, state.runId, width, theme, bodyCap));
   } else if (state.kind === "agents" && state.runId && state.phase) {
     const agents = model.agents(state.runId, state.phase);
     state.clamp(agents.length);
     const phases = model.phases(state.runId);
-    lines.push(...twoPaneHeader(model, state.runId, phases, width, theme));
-    const bodyCap = Math.max(1, viewportRows - 2 - 2 - 2);
+    const header = twoPaneHeader(model, state.runId, phases, width, theme);
+    lines.push(...header);
+    const bodyCap = Math.max(1, viewportRows - header.length - 2 - 2);
     lines.push(...renderPhasesAgents(state, model, state.runId, width, theme, bodyCap));
   } else if (state.kind === "detail" && state.runId && state.agentId != null) {
     const a = model.agentDetail(state.runId, state.agentId);
@@ -800,6 +890,10 @@ export function renderNavigator(
       const body: string[] = [];
       body.push(dim("Status: ") + (a.status ?? ""));
       if (a.model) body.push(dim("Model: ") + (shortModel(a.model) ?? ""));
+      if (a.tokens) body.push(`${dim("Tokens: ")}${a.tokensEstimated ? "~" : ""}${pad(a.tokens)} tok`);
+      if (a.status === "paused") {
+        body.push(dim("Resume: ") + (a.sessionFile ? "continue saved child session" : "restart agent fresh"));
+      }
       if (a.error) body.push(dim("Error: ") + a.error);
       if (a.errorCode) body.push(`${dim("Error code: ")}${a.errorCode}${a.recoverable ? " (recoverable)" : ""}`);
       body.push("", dim("Prompt:"));
@@ -836,9 +930,10 @@ export function renderNavigator(
 }
 
 /**
- * Two-line header above the Phases | agents frame (spec §1):
+ * Header above the Phases | agents frame (spec §1):
  *   line 0: <name>                          (ACCENT_BOLD)
- *   line 1: <status>            <done>/<total> agent[s] · <tokens>   (DIM)
+ *   line 1: <status>  <done>/<total> · <running> running · <queued> queued · <tokens>
+ *   line 2+: Running now (N/M): <all active labels>, wrapped as needed
  * Right segment is built first and never truncated; the left segment is
  * truncated to the remaining width with an ellipsis.
  */
@@ -852,10 +947,16 @@ function twoPaneHeader(
   const name = model.runName(runId);
   const status = model.runStatus(runId);
   let done = 0;
+  let running = 0;
+  let paused = 0;
+  let queued = 0;
   let total = 0;
   let tokens = 0;
   for (const p of phases) {
     done += p.done;
+    running += p.running;
+    paused += p.paused;
+    queued += p.queued;
     total += p.total;
     tokens += p.tokens;
   }
@@ -864,7 +965,7 @@ function twoPaneHeader(
   const line0 = theme.fg("accent", theme.bold(nameText));
 
   // Line 1 — left status, right summary.
-  const rightRaw = `${done}/${total} ${pluralize("agent", total)}${tokens > 0 ? ` · ${compactTokens(tokens)} tok` : ""}`;
+  const rightRaw = `${done}/${total} ${pluralize("agent", total)} · ${running} running · ${paused} paused · ${queued} not started${tokens > 0 ? ` · ${compactTokens(tokens)} tok` : ""}`;
   const rightW = visibleWidth(rightRaw);
   const gap = 2;
   let line1: string;
@@ -878,7 +979,21 @@ function twoPaneHeader(
     const fill = " ".repeat(Math.max(gap, width - leftW - rightW));
     line1 = theme.fg("dim", leftText) + fill + theme.fg("dim", rightRaw);
   }
-  return [line0, line1];
+  const activity = model.activity(runId);
+  const cap = activity.effectiveConcurrency ?? activity.running.length;
+  const activityText = activity.running.length
+    ? `Running now (${activity.running.length}/${cap}): ${activity.running.map((agent) => agent.label).join(", ")}`
+    : `Running now (0/${cap || 0}): none`;
+  const activityLines = wrapTextWithAnsi(activityText, Math.max(1, width)).map((line) => theme.fg("dim", line));
+  const pausedText = activity.paused.length
+    ? `Paused mid-run (${activity.paused.length}): ${activity.paused
+        .map((agent) => `${agent.label}${agent.sessionFile ? " (session saved)" : " (fresh restart)"}`)
+        .join(", ")}`
+    : undefined;
+  const pausedLines = pausedText
+    ? wrapTextWithAnsi(pausedText, Math.max(1, width)).map((line) => theme.fg("warning", line))
+    : [];
+  return [line0, line1, ...activityLines, ...pausedLines];
 }
 
 function historyLabel(entry: NonNullable<WorkflowAgentSnapshot["history"]>[number]): string {
@@ -901,15 +1016,15 @@ function footerHint(state: NavigatorState, model: NavigatorModel, theme: ThemeLi
       const itemKind = model.saved().length > 0 ? state.itemKindAt(model, state.cursor) : "run";
       parts.push("↑/↓ select", "enter open", "esc back");
       if (itemKind === "run") {
-        parts.push("p pause", "x stop", "r restart", "s save");
+        parts.push("p pause", "x stop run", "r restart", "s save");
       } else {
         parts.push("x delete");
       }
-      parts.push("q quit");
+      parts.push("q close");
       break;
     }
     default:
-      parts.push("↑/↓ select", "enter open", "esc back", "q quit");
+      parts.push("↑/↓ select", "enter open", "esc back", "q close");
   }
   return theme.fg("dim", parts.join(" · "));
 }
@@ -999,7 +1114,22 @@ export function openWorkflowNavigator(
   return ui.custom<void>(
     (tui: TUI, theme: Theme, _keybindings, done: (r: undefined) => void) => {
       const rerender = () => tui.requestRender();
-      const events = ["agentStart", "agentEnd", "phase", "log", "complete", "error", "stopped", "paused", "resumed"];
+      const events = [
+        "agentQueued",
+        "agentStart",
+        "agentUsage",
+        "agentHistory",
+        "agentEnd",
+        "tokenUsage",
+        "phase",
+        "log",
+        "complete",
+        "error",
+        "stopped",
+        "paused",
+        "resumed",
+        "concurrencyChanged",
+      ];
       const onEvent = () => rerender();
       for (const ev of events) manager.on(ev, onEvent);
       const cleanup = () => {
@@ -1055,12 +1185,17 @@ export function openWorkflowNavigator(
           case "restart": {
             const id = state.activeRunId(model);
             const run = id ? manager.listRuns().find((r) => r.runId === id) : undefined;
-            if (!run?.script) {
+            if (!id || !run?.script) {
               ui.notify(id ? `Cannot restart ${id} (no script saved)` : "No run selected to restart", "warning");
               break;
             }
-            const { runId: newId } = manager.startInBackground(run.script, run.args);
-            ui.notify(`Restarted ${run.workflowName || "workflow"} as ${newId}`, "info");
+            const restarted = manager.restart(id);
+            ui.notify(
+              restarted
+                ? `Restarted ${run.workflowName || "workflow"} as ${restarted.runId}`
+                : `Cannot restart ${id} while it is running`,
+              restarted ? "info" : "warning",
+            );
             break;
           }
           case "save": {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import vm from "node:vm";
 import type { Node } from "acorn";
 import { parse } from "acorn";
@@ -13,12 +14,15 @@ import {
   loadAgentRegistry,
   resolveAgentType,
 } from "./agent-registry.js";
-import { DEFAULT_AGENT_TIMEOUT_MS, MAX_AGENT_RETRIES, MAX_AGENTS_PER_RUN, MAX_CONCURRENCY } from "./config.js";
+import { DEFAULT_AGENT_TIMEOUT_MS, DEFAULT_CONCURRENCY, MAX_AGENT_RETRIES, MAX_AGENTS_PER_RUN } from "./config.js";
 import { WorkflowError, WorkflowErrorCode, wrapError } from "./errors.js";
 import { createWorkflowLogger } from "./logger.js";
 import { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.js";
 import { createAgentStoreTools, SharedStore } from "./shared-store.js";
 import { createWorktree, removeWorktree, type Worktree } from "./worktree.js";
+
+/** AbortSignal reason used for a resumable workflow pause (distinct from stop/Esc). */
+export const WORKFLOW_PAUSE_ABORT_REASON = "workflow-paused";
 
 export interface WorkflowMetaPhase {
   title: string;
@@ -37,9 +41,15 @@ export interface WorkflowMeta {
 /** One cached agent() result, keyed by its deterministic call index. */
 export interface JournalEntry {
   index: number;
+  /** Stable invocation identity (`runId:index`). */
+  executionId?: string;
+  /** Runtime-only origin; checkpoints have no following agent-end persistence callback. */
+  source?: "agent" | "checkpoint";
   /** sha256 of the call's identity (prompt + model + phase + agentType + schema). */
   hash: string;
   result: unknown;
+  /** Exact cumulative usage for the completed invocation, when available. */
+  usage?: AgentUsage;
   /**
    * Per-agent write delta (keys set by this agent) for additive replay on resume.
    * Replaces the former full-map snapshot to fix parallel-agent ordering: applying
@@ -49,17 +59,32 @@ export interface JournalEntry {
   storeDelta?: Record<string, unknown>;
 }
 
+/** FIFO concurrency gate shared by a run and any nested workflows. */
+export interface WorkflowConcurrencyLimiter {
+  <T>(fn: () => Promise<T>): Promise<T>;
+  setLimit(limit: number): void;
+  getLimit(): number;
+  getActive(): number;
+  getQueued(): number;
+}
+
 /**
- * Global resources shared across a run and any workflow() nested inside it, so
- * the 16-concurrent / 1000-total caps and the token budget hold across nesting
- * instead of each level getting its own limiter and counters.
+ * Global resources shared across a run and any nested workflow() call, so live
+ * concurrency changes, maxAgents, and token budgets apply to the whole tree.
  */
 export interface SharedRuntime {
-  limiter: <T>(fn: () => Promise<T>) => Promise<T>;
+  limiter: WorkflowConcurrencyLimiter;
   agentCount: number;
   spent: number;
   tokenUsage: { input: number; output: number; total: number; cost: number; cacheRead: number; cacheWrite: number };
   depth: number;
+  /** Shared resume boundary: after any parent/child miss, all later scoped calls run live. */
+  resumeMissed?: boolean;
+}
+
+export interface ResumeAgentState {
+  sessionFile: string;
+  worktree?: Worktree;
 }
 
 export interface WorkflowRunOptions extends WorkflowAgentOptions {
@@ -87,14 +112,18 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   persistLogs?: boolean;
   /** Run ID for persistence. Auto-generated if not provided. */
   runId?: string;
-  /** Resume: cached agent results keyed by deterministic call index. */
-  resumeJournal?: Map<number, JournalEntry>;
+  /** Resume: cached results keyed by scoped execution ID (numeric keys remain supported for legacy callers). */
+  resumeJournal?: ReadonlyMap<string | number, JournalEntry>;
   /** Resume: the run being resumed (informational; enables resume mode). */
   resumeFromRunId?: string;
+  /** Incomplete invocations that can reopen their persisted Pi child sessions. */
+  resumeAgents?: ReadonlyMap<string, ResumeAgentState>;
   /** Called after each live agent completes so the caller can persist the journal. */
   onAgentJournal?: (entry: JournalEntry) => void;
   /** Internal: shared runtime inherited by a nested workflow() call. */
   sharedRuntime?: SharedRuntime;
+  /** Internal: manager-owned limiter, enabling live concurrency changes. */
+  concurrencyLimiter?: WorkflowConcurrencyLimiter;
   /**
    * Shared store for this run. One instance is created per top-level run and
    * propagated into nested workflow() calls. Pass an existing instance to share
@@ -111,19 +140,70 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   confirm?: (promptText: string, options: CheckpointOptions) => Promise<unknown>;
   onLog?: (message: string) => void;
   onPhase?: (title: string) => void;
-  onAgentStart?: (event: { label: string; phase?: string; prompt: string; model?: string }) => void;
+  onAgentQueued?: (event: {
+    executionId: string;
+    callIndex: number;
+    label: string;
+    phase?: string;
+    prompt: string;
+    model?: string;
+    /** True when this invocation will reopen an interrupted child session. */
+    resuming?: boolean;
+    /** True only when this callback represents a journal cache hit. */
+    replayed?: boolean;
+  }) => void;
+  onAgentStart?: (event: {
+    executionId: string;
+    callIndex: number;
+    label: string;
+    phase?: string;
+    prompt: string;
+    model?: string;
+    resuming?: boolean;
+    /** True only when this callback represents a journal cache hit. */
+    replayed?: boolean;
+  }) => void;
+  /** Persist the child-session checkpoint before model execution starts. */
+  onAgentSession?: (event: {
+    executionId: string;
+    callIndex: number;
+    label: string;
+    phase?: string;
+    sessionFile?: string;
+    resumed: boolean;
+    worktree?: Worktree;
+  }) => void;
   onAgentEnd?: (event: {
+    executionId: string;
+    callIndex: number;
     label: string;
     phase?: string;
     result: unknown;
+    status: "done" | "error" | "skipped" | "paused";
     tokens?: number;
-    worktree?: string;
+    usage?: AgentUsage;
+    worktree?: Worktree;
     model?: string;
     error?: string;
     errorCode?: WorkflowErrorCode;
     recoverable?: boolean;
+    /** True only when this callback represents a journal cache hit. */
+    replayed?: boolean;
   }) => void;
-  onAgentHistory?: (event: { label: string; phase?: string; history: AgentHistoryEntry[] }) => void;
+  onAgentHistory?: (event: {
+    executionId: string;
+    callIndex: number;
+    label: string;
+    phase?: string;
+    history: AgentHistoryEntry[];
+  }) => void;
+  onAgentUsage?: (event: {
+    executionId: string;
+    callIndex: number;
+    label: string;
+    phase?: string;
+    usage: AgentUsage;
+  }) => void;
   onTokenUsage?: (usage: {
     input: number;
     output: number;
@@ -219,6 +299,8 @@ interface RuntimeState {
    * callIndex < firstMiss; once a call misses, it AND everything after run live.
    */
   firstMiss: number;
+  /** Deterministic nested workflow invocation sequence within this script. */
+  nestedSeq: number;
 }
 
 type AnyNode = Node & { [key: string]: any; start: number; end: number };
@@ -293,19 +375,19 @@ export async function runWorkflow<T = unknown>(
     phaseBudgets: new Map(),
     callSeq: 0,
     firstMiss: Number.POSITIVE_INFINITY,
+    nestedSeq: 0,
   };
 
   const agentRunner = options.agent ?? new WorkflowAgent(options);
-  const concurrency = normalizeConcurrency(
-    options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2),
-  );
-  // Global caps + budget are shared with any nested workflow() so they hold across nesting.
+  const concurrency = normalizeConcurrency(options.concurrency ?? DEFAULT_CONCURRENCY);
+  // Global controls are shared with any nested workflow() so they hold across nesting.
   const shared: SharedRuntime = options.sharedRuntime ?? {
-    limiter: createLimiter(concurrency),
+    limiter: options.concurrencyLimiter ?? createConcurrencyLimiter(concurrency),
     agentCount: 0,
     spent: 0,
     tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
     depth: 0,
+    resumeMissed: false,
   };
   const limiter = shared.limiter;
 
@@ -343,6 +425,12 @@ export async function runWorkflow<T = unknown>(
     }
   };
 
+  const cachedJournalEntry = (executionId: string, callIndex: number): JournalEntry | undefined => {
+    const scoped = options.resumeJournal?.get(executionId);
+    if (scoped) return scoped;
+    return options.resumeJournal?.get(callIndex);
+  };
+
   const agent = async (prompt: string, agentOptions: AgentOptions = {}) => {
     throwIfAborted();
 
@@ -355,35 +443,7 @@ export async function runWorkflow<T = unknown>(
       );
     }
 
-    if (budget.total !== null && budget.remaining() <= 0) {
-      throw new WorkflowError("workflow token budget exhausted", WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED, {
-        recoverable: false,
-      });
-    }
-
     const assignedPhase = agentOptions.phase ?? state.currentPhase;
-
-    // Per-phase soft sub-budget gate: a noisy phase can exhaust its own ceiling
-    // without touching the run's overall budget. Soft (spent accrues post-agent),
-    // warns once at ~80%, throws at 100%. Scripts can try/catch around a phase's
-    // work so later phases still proceed.
-    if (assignedPhase) {
-      const pb = state.phaseBudgets.get(assignedPhase);
-      if (pb) {
-        const phaseSpent = shared.spent - pb.startSpent;
-        if (phaseSpent >= pb.budget) {
-          throw new WorkflowError(
-            `phase "${assignedPhase}" token sub-budget exhausted (${pb.budget})`,
-            WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED,
-            { recoverable: false },
-          );
-        }
-        if (!pb.warned && phaseSpent >= pb.budget * 0.8) {
-          pb.warned = true;
-          log(`phase "${assignedPhase}" at ${Math.round((phaseSpent / pb.budget) * 100)}% of its token sub-budget`);
-        }
-      }
-    }
 
     const requestedLabel = agentOptions.label?.trim();
 
@@ -415,45 +475,87 @@ export async function runWorkflow<T = unknown>(
     // running nested-run agent can both get callIndex 0 and collide in
     // SharedStore.agentDeltas — whichever commits last steals/overwrites the
     // other's journaled delta. Composing the run's own runId (unique per
-    // top-level run AND per nested run, see `${runId}-nested${shared.depth}`
-    // below) with callIndex makes the key unique across the whole store.
-    const deltaKey = `${runId}:${callIndex}`;
+    // top-level and deterministic nested invocation) with callIndex makes the
+    // key unique across the whole store.
+    const executionId = `${runId}:${callIndex}`;
+    const deltaKey = executionId;
 
-    // Reserve the agent slot synchronously — atomic with the limit/budget gate
-    // above (no await in between) — so a parallel() fan-out can't all observe the
-    // same agentCount and overshoot maxAgents. (Token budget stays a soft gate:
-    // spent accrues after each agent, matching Claude Code; in-flight agents may
-    // push slightly past total, then further agent() calls throw.)
-    shared.agentCount++;
-    const label = requestedLabel || defaultAgentLabel(assignedPhase, shared.agentCount);
+    const label = requestedLabel || defaultAgentLabel(assignedPhase, shared.agentCount + 1);
+    const invocation = { executionId, callIndex, label, phase: assignedPhase };
+    const resumeAgent = options.resumeAgents?.get(executionId);
 
-    // Longest-unchanged-prefix resume: replay a cached result only while the
-    // prefix is still intact — this call's index is before the first changed/new
-    // call. Once any call misses, it AND everything after it run live (matching
-    // Claude Code's contract), so an edited upstream call never leaves stale
-    // downstream results served from the journal.
-    const cached = options.resumeJournal?.get(callIndex);
+    // Longest-unchanged-prefix resume: replay a cached result before live-work
+    // budget gates. Historical work is free even when the remaining budget is 0.
+    const cached = cachedJournalEntry(executionId, callIndex);
     const hashMatches = cached != null && cached.hash === callHash;
     const cachedEmptyOutput = hashMatches && isEmptyTextAgentResult(cached.result, agentOptions.schema);
-    if (hashMatches && !cachedEmptyOutput && callIndex < state.firstMiss) {
-      options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
-      options.onAgentEnd?.({ label, phase: assignedPhase, result: cached.result, tokens: 0, model: displayModel });
-      // Apply this agent's write delta so live agents later in the run see a
-      // consistent store. Additive apply preserves parallel-agent writes that
-      // came from higher-callIndex agents finishing before this one.
+    if (hashMatches && !cachedEmptyOutput && !shared.resumeMissed && callIndex < state.firstMiss) {
+      shared.agentCount++;
+      options.onAgentQueued?.({ ...invocation, prompt, model: displayModel, replayed: true });
+      options.onAgentStart?.({ ...invocation, prompt, model: displayModel, replayed: true });
+      if (cached.usage) options.onAgentUsage?.({ ...invocation, usage: { ...cached.usage, estimated: false } });
+      options.onAgentEnd?.({
+        ...invocation,
+        result: cached.result,
+        status: "done",
+        tokens: cached.usage?.total ?? 0,
+        usage: cached.usage,
+        model: displayModel,
+        replayed: true,
+      });
       if (cached.storeDelta) store.applyDelta(cached.storeDelta);
       return cached.result;
     }
-    // A genuine miss (no journal entry, or the hash changed) marks where the
-    // unchanged prefix ends; this call and every later one then run live.
-    if (!hashMatches || cachedEmptyOutput) state.firstMiss = Math.min(state.firstMiss, callIndex);
+    if (!hashMatches || cachedEmptyOutput) {
+      state.firstMiss = Math.min(state.firstMiss, callIndex);
+      shared.resumeMissed = true;
+    }
+
+    if (budget.total !== null && budget.remaining() <= 0) {
+      throw new WorkflowError("workflow token budget exhausted", WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED, {
+        recoverable: false,
+      });
+    }
+    if (assignedPhase) {
+      const pb = state.phaseBudgets.get(assignedPhase);
+      if (pb) {
+        const phaseSpent = shared.spent - pb.startSpent;
+        if (phaseSpent >= pb.budget) {
+          throw new WorkflowError(
+            `phase "${assignedPhase}" token sub-budget exhausted (${pb.budget})`,
+            WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED,
+            { recoverable: false },
+          );
+        }
+        if (!pb.warned && phaseSpent >= pb.budget * 0.8) {
+          pb.warned = true;
+          log(`phase "${assignedPhase}" at ${Math.round((phaseSpent / pb.budget) * 100)}% of its token sub-budget`);
+        }
+      }
+    }
+
+    // Reserve synchronously before the limiter so parallel fan-out cannot exceed maxAgents.
+    shared.agentCount++;
+    options.onAgentQueued?.({
+      ...invocation,
+      prompt,
+      model: displayModel,
+      resuming: Boolean(resumeAgent?.sessionFile),
+    });
 
     return limiter(async () => {
+      // Calls that never entered the limiter before pause remain visibly queued.
+      throwIfAborted();
       const timeout = agentOptions.timeoutMs !== undefined ? agentOptions.timeoutMs : agentTimeoutMs;
       const retryAttempts = normalizeAgentRetries(agentOptions.retries ?? options.agentRetries ?? 0);
       const maxAttempts = retryAttempts + 1;
 
-      options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
+      options.onAgentStart?.({
+        ...invocation,
+        prompt,
+        model: displayModel,
+        resuming: Boolean(resumeAgent?.sessionFile),
+      });
 
       // Optional per-agent worktree isolation (deterministic name -> stable resume keys).
       // Precedence: explicit call-site isolation > agentDef isolation.
@@ -463,32 +565,94 @@ export async function runWorkflow<T = unknown>(
       let worktree: Worktree | undefined;
       const resolvedIsolation = agentOptions.isolation ?? agentDef?.isolation;
       if (resolvedIsolation === "worktree") {
-        worktree = await createWorktree(baseCwd, `${runId}-${callIndex}-${label}`);
-        if (!worktree.isolated) log(`isolation ignored for "${label}" (${worktree.reason})`);
+        const saved = resumeAgent?.worktree;
+        if (saved?.isolated && existsSync(saved.cwd)) {
+          worktree = saved;
+        } else {
+          if (saved?.isolated) await removeWorktree(saved);
+          worktree = await createWorktree(baseCwd, `${runId}-${callIndex}-${label}`);
+          if (!worktree.isolated) log(`isolation ignored for "${label}" (${worktree.reason})`);
+        }
       }
       const runCwd = worktree?.isolated ? worktree.cwd : undefined;
+      let activeSessionFile: string | undefined;
+      let preserveWorktree = false;
 
-      // Captured from the subagent's real session usage; falls back to an
-      // estimate when the provider reports no usage (total === 0). Usage is reset
-      // per retry attempt so a failed attempt does not double-count the next one.
-      let usage: AgentUsage | undefined;
-      const recordTokens = (result: unknown): number => {
-        const tokens = usage && usage.total > 0 ? usage.total : estimateTokens(result) + estimateTokens(prompt);
-        if (usage) {
-          shared.tokenUsage.input += usage.input;
-          shared.tokenUsage.output += usage.output;
-          shared.tokenUsage.cost += usage.cost;
-          shared.tokenUsage.cacheRead += usage.cacheRead;
-          shared.tokenUsage.cacheWrite += usage.cacheWrite;
+      // Provider callbacks are absolute within an attempt. Only exact callbacks
+      // enter durable/run accounting; estimates are provisional display values.
+      const zeroUsage = (): AgentUsage => ({
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+        cost: 0,
+        estimated: false,
+      });
+      const addUsage = (left: AgentUsage, right: AgentUsage): AgentUsage => ({
+        input: left.input + right.input,
+        output: left.output + right.output,
+        cacheRead: left.cacheRead + right.cacheRead,
+        cacheWrite: left.cacheWrite + right.cacheWrite,
+        total: left.total + right.total,
+        cost: left.cost + right.cost,
+        estimated: left.estimated === true || right.estimated === true,
+      });
+      let completedExactUsage = zeroUsage();
+      let attemptExactUsage: AgentUsage | undefined;
+      let accountedUsage = zeroUsage();
+      const emitUsage = (usage: AgentUsage) => options.onAgentUsage?.({ ...invocation, usage });
+      const applyExactUsage = (usage: AgentUsage) => {
+        const input = usage.input - accountedUsage.input;
+        const output = usage.output - accountedUsage.output;
+        const cacheRead = usage.cacheRead - accountedUsage.cacheRead;
+        const cacheWrite = usage.cacheWrite - accountedUsage.cacheWrite;
+        const total = usage.total - accountedUsage.total;
+        const cost = usage.cost - accountedUsage.cost;
+        shared.tokenUsage.input += input;
+        shared.tokenUsage.output += output;
+        shared.tokenUsage.cacheRead += cacheRead;
+        shared.tokenUsage.cacheWrite += cacheWrite;
+        shared.tokenUsage.total += total;
+        shared.tokenUsage.cost += cost;
+        shared.spent += total;
+        accountedUsage = { ...usage, estimated: false };
+        if (input || output || cacheRead || cacheWrite || total || cost) options.onTokenUsage?.(shared.tokenUsage);
+      };
+      const receiveUsage = (usage: AgentUsage) => {
+        if (usage.estimated) {
+          emitUsage(addUsage(completedExactUsage, { ...usage, estimated: true }));
+          return;
         }
-        shared.tokenUsage.total += tokens;
-        shared.spent += tokens;
-        return tokens;
+        attemptExactUsage = { ...usage, estimated: false };
+        const cumulative = addUsage(completedExactUsage, attemptExactUsage);
+        emitUsage(cumulative);
+        applyExactUsage(cumulative);
+      };
+      const finishAttempt = (result: unknown, allowEstimate = true): { display?: AgentUsage; exact?: AgentUsage } => {
+        if (attemptExactUsage) {
+          completedExactUsage = addUsage(completedExactUsage, attemptExactUsage);
+          completedExactUsage.estimated = false;
+          emitUsage(completedExactUsage);
+          applyExactUsage(completedExactUsage);
+          attemptExactUsage = undefined;
+          return { display: completedExactUsage, exact: completedExactUsage };
+        }
+        if (!allowEstimate) return { exact: completedExactUsage.total > 0 ? completedExactUsage : undefined };
+        const display = addUsage(completedExactUsage, {
+          ...zeroUsage(),
+          total: estimateTokens(result) + estimateTokens(prompt),
+          estimated: true,
+        });
+        emitUsage(display);
+        return { display, exact: completedExactUsage.total > 0 ? completedExactUsage : undefined };
       };
 
+      let activeAttempt = 0;
       try {
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-          usage = undefined;
+          activeAttempt = attempt;
+          attemptExactUsage = undefined;
           try {
             throwIfAborted();
 
@@ -498,6 +662,14 @@ export async function runWorkflow<T = unknown>(
                 label,
                 // Identifiable name for persisted sessions (persistAgentSessions).
                 sessionName: `workflow:${runId} ${label}`,
+                resumeSessionFile: resumeAgent?.sessionFile,
+                onSession: ({ sessionFile, resumed }) => {
+                  activeSessionFile = sessionFile;
+                  options.onAgentSession?.({ ...invocation, sessionFile, resumed, worktree });
+                  if (resumeAgent?.sessionFile && !resumed) {
+                    log(`${label}: persisted child session unavailable — restarting this agent fresh`);
+                  }
+                },
                 schema: agentOptions.schema,
                 signal: options.signal,
                 instructions: buildAgentInstructions(assignedPhase, agentOptions, agentDef, resolvedIsolation),
@@ -519,11 +691,11 @@ export async function runWorkflow<T = unknown>(
                   // Make the silent degrade visible in /workflows, not just console.
                   log(`${label}: model "${spec}" unavailable — using the session default`);
                 },
-                onUsage: (u: AgentUsage) => {
-                  usage = u;
+                onUsage: (usage: AgentUsage) => {
+                  if (activeAttempt === attempt) receiveUsage(usage);
                 },
                 onHistory: (history: AgentHistoryEntry[]) => {
-                  options.onAgentHistory?.({ label, phase: assignedPhase, history });
+                  options.onAgentHistory?.({ ...invocation, history });
                 },
               }),
               timeout,
@@ -538,28 +710,52 @@ export async function runWorkflow<T = unknown>(
               });
             }
 
-            const tokens = recordTokens(result);
+            const usage = finishAttempt(result);
+            activeAttempt = 0;
             options.onAgentJournal?.({
               index: callIndex,
+              executionId,
+              source: "agent",
               hash: callHash,
               result,
+              usage: usage.exact,
               storeDelta: store.commitDelta(deltaKey),
             });
             options.onAgentEnd?.({
-              label,
-              phase: assignedPhase,
+              ...invocation,
               result,
-              tokens,
-              worktree: runCwd,
+              status: "done",
+              tokens: usage.display?.total ?? 0,
+              usage: usage.display,
+              worktree,
               model: displayModel,
             });
             return result;
           } catch (error) {
-            if (options.signal?.aborted) throw error;
+            if (options.signal?.aborted) {
+              const usage = finishAttempt(null, false);
+              activeAttempt = 0;
+              const paused = options.signal.reason === WORKFLOW_PAUSE_ABORT_REASON;
+              preserveWorktree = paused && Boolean(activeSessionFile);
+              options.onAgentEnd?.({
+                ...invocation,
+                result: null,
+                status: paused ? "paused" : "skipped",
+                tokens: usage.display?.total ?? usage.exact?.total ?? 0,
+                usage: usage.display ?? usage.exact,
+                worktree,
+                model: displayModel,
+                error: paused ? "Subagent paused at its last durable session boundary" : "Subagent was aborted",
+                errorCode: WorkflowErrorCode.WORKFLOW_ABORTED,
+                recoverable: true,
+              });
+              throw error;
+            }
 
             const workflowError = wrapError(error, { agentLabel: label });
             logger.error(`agent ${label} attempt ${attempt}/${maxAttempts} failed: ${workflowError.message}`);
-            const tokens = recordTokens(null);
+            const usage = finishAttempt(null);
+            activeAttempt = 0;
 
             if (workflowError.recoverable && attempt < maxAttempts) {
               log(
@@ -568,18 +764,22 @@ export async function runWorkflow<T = unknown>(
               continue;
             }
 
+            const providerPaused = workflowError.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT;
+            preserveWorktree = providerPaused && Boolean(activeSessionFile);
             options.onAgentEnd?.({
-              label,
-              phase: assignedPhase,
+              ...invocation,
               result: null,
-              tokens,
-              worktree: runCwd,
+              status: providerPaused ? "paused" : "error",
+              tokens: usage.display?.total ?? usage.exact?.total ?? 0,
+              usage: usage.display ?? usage.exact,
+              worktree,
               model: displayModel,
               error: workflowError.message,
               errorCode: workflowError.code,
               recoverable: workflowError.recoverable,
             });
 
+            if (providerPaused) throw workflowError;
             if (workflowError.recoverable) {
               log(
                 `agent "${label}" exhausted ${maxAttempts} attempt${maxAttempts === 1 ? "" : "s"}: ${workflowError.code} ${workflowError.message}`,
@@ -591,8 +791,8 @@ export async function runWorkflow<T = unknown>(
         }
         return null;
       } finally {
-        // Always tear down the worktree, even on timeout/abort.
-        if (worktree?.isolated) await removeWorktree(worktree);
+        // Paused agents keep their worktree so the reopened child session has the same cwd.
+        if (worktree?.isolated && !preserveWorktree) await removeWorktree(worktree);
       }
     });
   };
@@ -663,6 +863,7 @@ export async function runWorkflow<T = unknown>(
     }
     const resolved = options.loadSavedWorkflow?.(String(nameOrScript));
     const childScript = resolved ?? String(nameOrScript);
+    const childRunId = `${runId}-nested${state.nestedSeq++}`;
     shared.depth++;
     try {
       const child = await runWorkflow(childScript, {
@@ -671,10 +872,10 @@ export async function runWorkflow<T = unknown>(
         sharedRuntime: shared,
         // Propagate the parent's store so nested agents share the same key-value space.
         sharedStore: store,
-        // A nested run is its own script; never reuse the parent's resume journal.
-        resumeJournal: undefined,
-        resumeFromRunId: undefined,
-        runId: `${runId}-nested${shared.depth}`,
+        // Scoped execution IDs let parent and child replay from one durable journal.
+        resumeJournal: options.resumeJournal,
+        resumeFromRunId: options.resumeFromRunId,
+        runId: childRunId,
         persistLogs: false,
       });
       return child.result;
@@ -853,13 +1054,17 @@ export async function runWorkflow<T = unknown>(
       );
     }
     const callIndex = state.callSeq++;
+    const executionId = `${runId}:${callIndex}`;
     const callHash = hashCheckpoint(promptText, checkpointOptions);
-    const cached = options.resumeJournal?.get(callIndex);
-    if (cached != null && cached.hash === callHash && callIndex < state.firstMiss) {
+    const cached = cachedJournalEntry(executionId, callIndex);
+    if (cached != null && cached.hash === callHash && !shared.resumeMissed && callIndex < state.firstMiss) {
       shared.agentCount++;
       return cached.result; // replay the journaled human reply
     }
-    if (cached == null || cached.hash !== callHash) state.firstMiss = Math.min(state.firstMiss, callIndex);
+    if (cached == null || cached.hash !== callHash) {
+      state.firstMiss = Math.min(state.firstMiss, callIndex);
+      shared.resumeMissed = true;
+    }
     shared.agentCount++;
 
     let reply: unknown;
@@ -875,7 +1080,13 @@ export async function runWorkflow<T = unknown>(
       reply = checkpointOptions.default ?? true;
     }
     throwIfAborted();
-    options.onAgentJournal?.({ index: callIndex, hash: callHash, result: reply });
+    options.onAgentJournal?.({
+      index: callIndex,
+      executionId,
+      source: "checkpoint",
+      hash: callHash,
+      result: reply,
+    });
     return reply;
   };
 
@@ -1063,22 +1274,36 @@ function validateMeta(meta: unknown): asserts meta is WorkflowMeta {
   }
 }
 
-function createLimiter(limit: number) {
+export function createConcurrencyLimiter(initialLimit: number): WorkflowConcurrencyLimiter {
+  let limit = normalizeConcurrency(initialLimit);
   let active = 0;
   const queue: Array<() => void> = [];
-  const next = () => {
-    active--;
-    queue.shift()?.();
+  const drain = () => {
+    while (active < limit && queue.length > 0) {
+      active++;
+      queue.shift()?.();
+    }
   };
-  return async <T>(fn: () => Promise<T>): Promise<T> => {
-    if (active >= limit) await new Promise<void>((resolve) => queue.push(resolve));
-    active++;
+  const limiter = (async <T>(fn: () => Promise<T>): Promise<T> => {
+    await new Promise<void>((resolve) => {
+      queue.push(resolve);
+      drain();
+    });
     try {
       return await fn();
     } finally {
-      next();
+      active--;
+      drain();
     }
+  }) as WorkflowConcurrencyLimiter;
+  limiter.setLimit = (value: number) => {
+    limit = normalizeConcurrency(value);
+    drain();
   };
+  limiter.getLimit = () => limit;
+  limiter.getActive = () => active;
+  limiter.getQueued = () => queue.length;
+  return limiter;
 }
 
 function defaultAgentLabel(phase: string | undefined, index: number): string {
@@ -1145,7 +1370,7 @@ function estimateTokens(value: unknown): number {
 
 function normalizeConcurrency(value: unknown): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 1) return 1;
-  return Math.min(MAX_CONCURRENCY, Math.floor(value));
+  return Math.floor(value);
 }
 
 function normalizeAgentRetries(value: unknown): number {

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -16,6 +16,7 @@ import {
   resolveAgentType,
 } from "../src/agent-registry.js";
 import { runWorkflow } from "../src/workflow.js";
+import { withFakeHome } from "./helpers/fake-home.js";
 
 // ── parseAgentDefinition ───────────────────────────────────────────────────
 
@@ -146,23 +147,21 @@ describe("loadAgentRegistry", () => {
 
   it("default userDir resolution uses getAgentDir() (~/.pi/agent/agents) with no injected opts", () => {
     const tmpHome = mkdtempSync(join(tmpdir(), "pi-home-"));
-    const originalHome = process.env.HOME;
     const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
     delete process.env.PI_CODING_AGENT_DIR;
-    process.env.HOME = tmpHome;
     try {
-      const expectedUserDir = join(getAgentDir(), "agents");
-      assert.equal(expectedUserDir, join(tmpHome, ".pi", "agent", "agents"), "sanity: HOME override took effect");
-      writeDef(expectedUserDir, "scout.md", "---\nname: scout\n---\nUser-level scout.");
+      withFakeHome(tmpHome, () => {
+        const expectedUserDir = join(getAgentDir(), "agents");
+        assert.equal(expectedUserDir, join(tmpHome, ".pi", "agent", "agents"), "sanity: home override took effect");
+        writeDef(expectedUserDir, "scout.md", "---\nname: scout\n---\nUser-level scout.");
 
-      const cwd = mkdtempSync(join(tmpdir(), "pi-cwd-"));
-      const reg = loadAgentRegistry(cwd);
-      assert.equal(reg.get("scout")?.source, "user");
-      assert.equal(reg.get("scout")?.prompt, "User-level scout.");
-      rmSync(cwd, { recursive: true, force: true });
+        const cwd = mkdtempSync(join(tmpdir(), "pi-cwd-"));
+        const reg = loadAgentRegistry(cwd);
+        assert.equal(reg.get("scout")?.source, "user");
+        assert.equal(reg.get("scout")?.prompt, "User-level scout.");
+        rmSync(cwd, { recursive: true, force: true });
+      });
     } finally {
-      if (originalHome === undefined) delete process.env.HOME;
-      else process.env.HOME = originalHome;
       if (originalAgentDirEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
       else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
       rmSync(tmpHome, { recursive: true, force: true });

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -1,25 +1,42 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
 import type { AgentRunOptions, AgentUsage } from "../src/agent.js";
-import { listAvailableModelSpecs, resolveAgentModelSpec, WorkflowAgent } from "../src/agent.js";
+import {
+  createAgentUsageEventHandler,
+  listAvailableModelSpecs,
+  resolveAgentModelSpec,
+  WorkflowAgent,
+} from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { resolveModelSpecWithThinking } from "../src/model-spec.js";
 import type { ModelTierConfig } from "../src/model-tier-config.js";
 import { runWorkflow } from "../src/workflow.js";
+import { workflowProjectPaths } from "../src/workflow-paths.js";
 import { withFakeHome } from "./helpers/fake-home.js";
 
 // Private methods used for testing - cast to this type to access them without `any`
 type WorkflowAgentPrivates = {
   buildPrompt(prompt: string, options: AgentRunOptions<any>, structured: boolean): string;
   lastAssistantText(messages: unknown[]): string;
-  createSessionManager(): { isPersisted(): boolean; getCwd(): string };
+  createSessionManager(): {
+    isPersisted(): boolean;
+    getCwd(): string;
+    getSessionDir(): string;
+    usesDefaultSessionDir(): boolean;
+  };
+  resolveSessionManager(
+    resumeSessionFile: string | undefined,
+    runCwd: string,
+  ): { manager: { isPersisted(): boolean; getCwd(): string; getSessionFile(): string | undefined }; resumed: boolean };
+  buildResumePrompt(structured: boolean): string;
 };
 
 // ═══════════════════════════════════════════════════════════════════════
-// persistAgentSessions — in-memory by default, file-backed keyed by project cwd
+// persistAgentSessions — in-memory by default, file-backed outside /resume
 // ═══════════════════════════════════════════════════════════════════════
 
 test("WorkflowAgent uses an in-memory session manager by default", () => {
@@ -34,7 +51,7 @@ test("WorkflowAgent with persistAgentSessions=false explicitly stays in-memory",
   assert.equal(manager.isPersisted(), false);
 });
 
-test("WorkflowAgent with persistAgentSessions=true creates a file-backed manager keyed by the project cwd", () => {
+test("WorkflowAgent with persistAgentSessions=true creates a private file-backed manager outside /resume", () => {
   const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-persist-agent-"));
   const projectCwd = join(dir, "project");
   const fakeHome = join(dir, "home");
@@ -43,15 +60,83 @@ test("WorkflowAgent with persistAgentSessions=true creates a file-backed manager
       const agent = new WorkflowAgent({ cwd: projectCwd, persistAgentSessions: true });
       const manager = (agent as unknown as WorkflowAgentPrivates).createSessionManager();
       assert.equal(manager.isPersisted(), true, "flag must yield a file-backed session manager");
-      // Sessions must be keyed by the runner's project cwd — never a per-call
-      // worktree cwd — so transcripts group under the project's session dir.
-      // createSessionManager() takes no per-call cwd by design; assert the
-      // manager saw the project cwd.
       assert.equal(manager.getCwd(), projectCwd);
+      assert.equal(manager.getSessionDir(), workflowProjectPaths(projectCwd).agentSessionsDir);
+      assert.equal(manager.usesDefaultSessionDir(), false, "normal Pi /resume must not index workflow children");
     });
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("WorkflowAgent reopens a persisted child session at its durable boundary", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-resume-agent-"));
+  const projectCwd = join(dir, "project");
+  const fakeHome = join(dir, "home");
+  try {
+    withFakeHome(fakeHome, () => {
+      const original = SessionManager.create(projectCwd, workflowProjectPaths(projectCwd).agentSessionsDir);
+      original.appendMessage({
+        role: "user",
+        content: [{ type: "text", text: "resume probe" }],
+        timestamp: Date.now(),
+      });
+      original.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "checkpoint" }],
+        api: "test",
+        provider: "test",
+        model: "test",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      } as never);
+      const sessionFile = original.getSessionFile();
+      assert.ok(sessionFile && existsSync(sessionFile));
+
+      const agent = new WorkflowAgent({ cwd: projectCwd, persistAgentSessions: true });
+      const resolved = (agent as unknown as WorkflowAgentPrivates).resolveSessionManager(sessionFile, projectCwd);
+      assert.equal(resolved.resumed, true);
+      assert.equal(resolved.manager.getSessionFile(), sessionFile);
+      assert.equal(resolved.manager.getCwd(), projectCwd);
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("WorkflowAgent falls back to a fresh session when the persisted child session is missing", () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-resume-missing-"));
+  const projectCwd = join(dir, "project");
+  const fakeHome = join(dir, "home");
+  try {
+    withFakeHome(fakeHome, () => {
+      const agent = new WorkflowAgent({ cwd: projectCwd, persistAgentSessions: true });
+      const resolved = (agent as unknown as WorkflowAgentPrivates).resolveSessionManager(
+        join(dir, "missing.jsonl"),
+        projectCwd,
+      );
+      assert.equal(resolved.resumed, false);
+      assert.equal(resolved.manager.isPersisted(), true);
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("WorkflowAgent resume prompt explicitly avoids repeating completed side effects", () => {
+  const agent = new WorkflowAgent({ cwd: "/tmp" });
+  const prompt = (agent as unknown as WorkflowAgentPrivates).buildResumePrompt(true);
+  assert.match(prompt, /last durable message\/tool-result boundary/i);
+  assert.match(prompt, /Do not repeat completed side effects/i);
+  assert.match(prompt, /structured_output/);
 });
 
 test("WorkflowAgent degrades to in-memory when the session directory can't be created", () => {
@@ -60,10 +145,9 @@ test("WorkflowAgent degrades to in-memory when the session directory can't be cr
   const fakeHome = join(dir, "home");
   try {
     withFakeHome(fakeHome, () => {
-      // Pre-occupy the sessions directory with a plain file so the SDK's
-      // mkdirSync(recursive) inside SessionManager.create() throws ENOTDIR —
-      // simulating a permissions/disk-full failure at session-creation time.
-      const sessionsPath = join(fakeHome, ".pi", "agent", "sessions");
+      // Pre-occupy the workflow state root with a plain file so the SDK's
+      // mkdirSync(recursive) for the private session directory throws ENOTDIR.
+      const sessionsPath = join(fakeHome, ".pi", "workflows");
       mkdirSync(dirname(sessionsPath), { recursive: true });
       writeFileSync(sessionsPath, "not a directory");
 
@@ -388,6 +472,78 @@ test("lastAssistantText picks the last assistant message, not first", () => {
   assert.equal(text, "final");
 });
 
+test("usage events emit throttled estimates then exact cumulative message usage", () => {
+  const events: AgentUsage[] = [];
+  let timestamp = 0;
+  const handle = createAgentUsageEventHandler(
+    (usage) => events.push(usage),
+    () => timestamp,
+  );
+  const updatingMessage = {
+    role: "assistant",
+    content: [{ type: "text", text: "12345678" }],
+  };
+
+  handle({ type: "message_update", message: updatingMessage, assistantMessageEvent: {} } as never);
+  timestamp = 100;
+  updatingMessage.content[0].text = "123456789012";
+  handle({ type: "message_update", message: updatingMessage, assistantMessageEvent: {} } as never);
+  timestamp = 250;
+  handle({ type: "message_update", message: updatingMessage, assistantMessageEvent: {} } as never);
+
+  const endedMessage = {
+    role: "assistant",
+    content: [{ type: "text", text: "done" }],
+    usage: {
+      input: 7,
+      output: 3,
+      cacheRead: 2,
+      cacheWrite: 1,
+      totalTokens: 13,
+      cost: { input: 0.01, output: 0.02, cacheRead: 0, cacheWrite: 0, total: 0.03 },
+    },
+  };
+  handle({ type: "message_end", message: endedMessage } as never);
+  handle({ type: "message_end", message: endedMessage } as never);
+
+  assert.deepEqual(
+    events.map((usage) => ({ total: usage.total, output: usage.output, estimated: usage.estimated })),
+    [
+      { total: 2, output: 2, estimated: true },
+      { total: 3, output: 3, estimated: true },
+      { total: 13, output: 3, estimated: false },
+    ],
+  );
+  assert.equal(events[2].input, 7);
+  assert.equal(events[2].cacheRead, 2);
+  assert.equal(events[2].cost, 0.03);
+});
+
+test("usage message_end events accumulate across assistant turns", () => {
+  const events: AgentUsage[] = [];
+  const handle = createAgentUsageEventHandler((usage) => events.push(usage));
+  const message = (input: number, output: number) => ({
+    role: "assistant",
+    content: [{ type: "text", text: "done" }],
+    usage: {
+      input,
+      output,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: input + output,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 },
+    },
+  });
+
+  handle({ type: "message_end", message: message(10, 4) } as never);
+  handle({ type: "message_end", message: message(6, 2) } as never);
+
+  assert.equal(events.at(-1)?.input, 16);
+  assert.equal(events.at(-1)?.output, 6);
+  assert.equal(events.at(-1)?.total, 22);
+  assert.equal(events.at(-1)?.cost, 0.002);
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Full agent() pipeline inside runWorkflow — verifies the agent() function
 // in workflow.ts correctly invokes the runner with all options.
@@ -638,8 +794,8 @@ test("agent() in workflow fires onTokenUsage after run", async () => {
       onTokenUsage: (u) => usageEvents.push({ input: u.input, output: u.output, total: u.total }),
     },
   );
-  assert.equal(usageEvents.length, 1, "should fire onTokenUsage once");
-  assert.equal(usageEvents[0].total, 30, "should accumulate from agent usage");
+  assert.ok(usageEvents.length >= 1, "should fire onTokenUsage during the run");
+  assert.equal(usageEvents.at(-1)?.total, 30, "should finish with accumulated agent usage");
 });
 
 test("agent() passes onModelResolved callback for display model updates", async () => {
@@ -673,8 +829,8 @@ test("agent() accumulates usage across multiple agents", async () => {
       onTokenUsage: (u) => usageEvents.push({ total: u.total }),
     },
   );
-  assert.equal(usageEvents.length, 1, "one final usage event");
-  assert.equal(usageEvents[0].total, 60, "two agents × 30 tokens each");
+  assert.ok(usageEvents.length >= 2, "usage should update as each agent reports");
+  assert.equal(usageEvents.at(-1)?.total, 60, "two agents × 30 tokens each");
 });
 
 test("agent() with timeout should handle gracefully (timeout returns null)", async () => {

--- a/tests/checkpoint.test.ts
+++ b/tests/checkpoint.test.ts
@@ -23,6 +23,7 @@ return { ok, name }`;
   assert.equal(res.result.ok, true);
   assert.equal(res.result.name, "fallback");
   assert.equal(journal.length, 2, "both checkpoints journaled");
+  assert.ok(journal.every((entry) => entry.source === "checkpoint"));
 });
 
 test("checkpoint(): headless 'abort' throws when no UI is threaded in", async () => {

--- a/tests/run-persistence.test.ts
+++ b/tests/run-persistence.test.ts
@@ -4,7 +4,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { WORKFLOW_RUNS_DIR } from "../src/config.js";
-import { createRunPersistence, generateRunId, type PersistedRunState } from "../src/run-persistence.js";
+import {
+  createRunPersistence,
+  generateRunId,
+  type PersistedRunState,
+  RUN_STATE_VERSION,
+  type RunPersistence,
+} from "../src/run-persistence.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
 import { workflowProjectPaths } from "../src/workflow-paths.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
@@ -359,6 +365,214 @@ test(
   }),
 );
 
+test(
+  "save accepts legacy agent rows without identity and load returns normalized identity",
+  withTempCwd(async (cwd) => {
+    const persistence = createRunPersistence(cwd);
+    persistence.save({
+      runId: "legacy-save-shape",
+      workflowName: "legacy",
+      script: "return 1",
+      status: "paused",
+      phases: [],
+      agents: [{ id: 1, label: "old", prompt: "work", status: "done", tokens: 4 }],
+      logs: [],
+      startedAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    });
+
+    const loaded = persistence.load("legacy-save-shape");
+    assert.equal(loaded?.agents[0].executionId, "legacy-save-shape:0");
+    assert.equal(loaded?.agents[0].callIndex, 0);
+  }),
+);
+
+test(
+  "paused agent session and preserved worktree survive persistence",
+  withTempCwd(async (cwd) => {
+    const persistence = createRunPersistence(cwd);
+    persistence.save({
+      version: RUN_STATE_VERSION,
+      runId: "paused-session",
+      workflowName: "resume",
+      script: "return 1",
+      status: "paused",
+      phases: ["Work"],
+      agents: [
+        {
+          id: 1,
+          executionId: "paused-session:0",
+          callIndex: 0,
+          label: "interrupted",
+          phase: "Work",
+          prompt: "continue",
+          status: "paused",
+          sessionFile: "C:/sessions/child.jsonl",
+          worktree: {
+            isolated: true,
+            cwd: "C:/repo/.pi/worktrees/child",
+            branch: "pi/wf/child",
+            repoRoot: "C:/repo",
+          },
+        },
+        {
+          id: 2,
+          executionId: "paused-session:1",
+          callIndex: 1,
+          label: "not-started",
+          phase: "Work",
+          prompt: "later",
+          status: "queued",
+        },
+      ],
+      logs: [],
+      startedAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:01.000Z",
+    });
+
+    const loaded = persistence.load("paused-session");
+    assert.equal(loaded?.agents[0].status, "paused");
+    assert.equal(loaded?.agents[0].sessionFile, "C:/sessions/child.jsonl");
+    assert.equal(loaded?.agents[0].worktree?.branch, "pi/wf/child");
+    assert.equal(loaded?.agents[1].status, "queued");
+  }),
+);
+
+test("RunPersistence remains compatible with legacy PersistedRunState return types", () => {
+  const state = {
+    runId: "legacy-implementation",
+    workflowName: "legacy",
+    script: "return 1",
+    status: "completed",
+    phases: [],
+    agents: [],
+    logs: [],
+    startedAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  } satisfies PersistedRunState;
+  const legacyImplementation: RunPersistence = {
+    save() {},
+    load(): PersistedRunState | null {
+      return state;
+    },
+    list(): PersistedRunState[] {
+      return [state];
+    },
+    delete: () => false,
+    acquireRunLease: () => null,
+    releaseRunLease() {},
+    getRunsDir: () => ".",
+  };
+
+  assert.equal(legacyImplementation.load(state.runId)?.runId, state.runId);
+});
+
+test(
+  "legacy run migration fills stable identity and ignores malformed optional fields",
+  withTempCwd(async (cwd) => {
+    const runsDir = workflowProjectPaths(cwd).runsDir;
+    mkdirSync(runsDir, { recursive: true });
+    writeFileSync(
+      join(runsDir, "legacy-v1.json"),
+      JSON.stringify({
+        runId: "legacy-v1",
+        workflowName: "legacy",
+        script: "return 1",
+        status: "paused",
+        phases: ["Work", 7],
+        agents: [
+          {
+            id: 1,
+            label: "old agent",
+            prompt: "work",
+            status: "done",
+            tokens: 12,
+            usage: { input: 8, output: 4, total: 12, cost: 0.01 },
+          },
+        ],
+        logs: ["ok", null],
+        requestedConcurrency: "bad",
+        tokenBudget: "bad",
+        journal: [{ index: 0, hash: "hash", result: "done", usage: { input: 8, output: 4, total: 12 } }],
+        startedAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:01:00.000Z",
+      }),
+    );
+
+    const loaded = createRunPersistence(cwd).load("legacy-v1");
+    assert.equal(loaded?.version, RUN_STATE_VERSION);
+    assert.deepEqual(loaded?.phases, ["Work"]);
+    assert.deepEqual(loaded?.logs, ["ok"]);
+    assert.equal(loaded?.agents[0].executionId, "legacy-v1:0");
+    assert.equal(loaded?.agents[0].callIndex, 0);
+    assert.equal(loaded?.agents[0].usage?.total, 12);
+    assert.equal(loaded?.journal?.[0].executionId, "legacy-v1:0");
+    assert.equal(loaded?.journal?.[0].usage?.total, 12);
+    assert.equal(loaded?.requestedConcurrency, undefined);
+    assert.equal(loaded?.tokenBudget, undefined);
+  }),
+);
+
+test(
+  "current loader warns when malformed nested usage and journal fields are normalized or dropped",
+  withTempCwd(async (cwd) => {
+    const runsDir = workflowProjectPaths(cwd).runsDir;
+    mkdirSync(runsDir, { recursive: true });
+    writeFileSync(
+      join(runsDir, "malformed-nested.json"),
+      JSON.stringify({
+        version: RUN_STATE_VERSION,
+        runId: "malformed-nested",
+        workflowName: "malformed",
+        script: "return 1",
+        status: "paused",
+        phases: [],
+        agents: [
+          {
+            id: 1,
+            executionId: "malformed-nested:0",
+            callIndex: 0,
+            label: "agent",
+            prompt: "work",
+            status: "done",
+            usage: { input: "bad", output: 2, total: 2 },
+          },
+        ],
+        logs: [],
+        journal: [
+          null,
+          {
+            index: 0,
+            executionId: 42,
+            hash: "hash",
+            result: "done",
+            usage: { total: "bad" },
+            storeDelta: [],
+          },
+        ],
+        startedAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:01:00.000Z",
+      }),
+    );
+
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "));
+    try {
+      const loaded = createRunPersistence(cwd).load("malformed-nested");
+      assert.equal(loaded?.agents[0].usage?.input, 0);
+      assert.equal(loaded?.journal?.length, 1);
+      assert.equal(loaded?.journal?.[0].executionId, "malformed-nested:0");
+      assert.equal(loaded?.journal?.[0].usage?.total, 0);
+      assert.equal(loaded?.journal?.[0].storeDelta, undefined);
+      assert.equal(warnings.length, 1);
+      assert.match(warnings[0], /Ignored malformed fields.*malformed-nested/);
+    } finally {
+      console.warn = originalWarn;
+    }
+  }),
+);
+
 test("generateRunId returns a string with timestamp and random parts", () => {
   const id = generateRunId();
   assert.equal(typeof id, "string");
@@ -483,7 +697,10 @@ test(
     assert.equal(loaded.agents[1].status, "running");
     assert.deepEqual(loaded.logs, ["started", "phase: Scan", "phase: Analyze"]);
     assert.deepEqual(loaded.tokenUsage, { input: 500, output: 200, total: 700 });
-    assert.deepEqual(loaded.journal, [{ index: 0, hash: "abc", result: { ok: true } }]);
+    assert.equal(loaded.journal?.[0].index, 0);
+    assert.equal(loaded.journal?.[0].executionId, "concurrent-test:0");
+    assert.equal(loaded.journal?.[0].hash, "abc");
+    assert.deepEqual(loaded.journal?.[0].result, { ok: true });
   }),
 );
 
@@ -674,7 +891,7 @@ test(
 );
 
 test(
-  "delete removes the lock sidecar too",
+  "artifact deletion leaves the lease for its owner to release",
   withTempCwd(async (cwd) => {
     const rp = createRunPersistence(cwd);
     rp.save({
@@ -688,7 +905,10 @@ test(
     const lease = rp.acquireRunLease("delete-lock");
     assert.ok(lease, "lease exists before delete");
     rp.delete("delete-lock");
-    assert.equal(existsSync(join(workflowProjectPaths(cwd).runsDir, "delete-lock.lock")), false, "lock cleaned up");
+    const lockPath = join(workflowProjectPaths(cwd).runsDir, "delete-lock.lock");
+    assert.equal(existsSync(lockPath), true, "artifact deletion must not remove an ownership record");
+    rp.releaseRunLease(lease);
+    assert.equal(existsSync(lockPath), false, "the owner explicitly releases its lease");
   }),
 );
 
@@ -702,12 +922,23 @@ test(
       status: "running",
       script: "export const meta = { name: 'w', description: 'd' }\nawait agent('x',{label:'x'})\nreturn 1",
       phases: [],
-      agents: [],
+      agents: [
+        {
+          id: 1,
+          executionId: "stale:0",
+          callIndex: 0,
+          label: "orphan",
+          prompt: "x",
+          status: "running",
+        },
+      ],
       logs: [],
     } as PersistedRunState);
     // A fresh manager (the previous process died) should recover the orphan.
     new WorkflowManager({ cwd });
-    assert.equal(rp.load("stale")?.status, "paused", "stale running -> paused (journal preserved for resume)");
+    const recovered = rp.load("stale");
+    assert.equal(recovered?.status, "paused", "stale running -> paused (journal preserved for resume)");
+    assert.equal(recovered?.agents[0].status, "paused", "orphaned running invocation is visibly paused mid-run");
   }),
 );
 

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
+import { join } from "node:path";
 import { before, describe, it } from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
@@ -173,7 +174,7 @@ describe("installResultDelivery", () => {
 
     const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
     assert.ok(content.includes("Full result:"), "should include the pointer label");
-    assert.ok(content.includes("/runs/test-run-1.json"), "should point at <runsDir>/<runId>.json");
+    assert.ok(content.includes(join("/runs", "test-run-1.json")), "should point at <runsDir>/<runId>.json");
     // The verdict summary itself is unchanged apart from the appended pointer.
     assert.ok(content.includes("All tests passed"), "verdict text preserved");
   });
@@ -206,7 +207,7 @@ describe("installResultDelivery", () => {
     const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
     assert.ok(/…\(truncated [\d.]+ (B|KB|MB)\)/.test(content), "the 50-char setting truncates a sub-400 dump");
     assert.ok(!content.includes("z".repeat(200)), "the body is cut at the configured threshold");
-    assert.ok(content.includes("/runs/test-run-1.json"), "pointer still appended");
+    assert.ok(content.includes(join("/runs", "test-run-1.json")), "pointer still appended");
   });
 
   // ── installResultDelivery: guard / stale ctx ──
@@ -374,6 +375,34 @@ describe("installTaskPanel", () => {
     assert.equal(registeredPlacement, "belowEditor");
   });
 
+  it("rerenders on queued, usage, and history-only events", () => {
+    const manager = new EventEmitter() as ReturnType<typeof EventEmitter> & {
+      getRun: (...args: unknown[]) => unknown;
+      listRuns: () => unknown[];
+    };
+    manager.getRun = () => undefined;
+    manager.listRuns = () => [];
+    let factory: ((tui: { requestRender(): void }, theme: unknown) => { dispose?(): void }) | undefined;
+    const ui = {
+      setWidget: (_name: string, registeredFactory: typeof factory) => {
+        factory = registeredFactory;
+      },
+    };
+    mod.installTaskPanel(null, manager, ui);
+    let renders = 0;
+    const component = factory?.(
+      { requestRender: () => renders++ },
+      { fg: (_c: string, t: string) => t, bold: (t: string) => t },
+    );
+
+    manager.emit("agentQueued", { runId: "r1", executionId: "r1:0" });
+    manager.emit("agentUsage", { runId: "r1", executionId: "r1:0" });
+    manager.emit("agentHistory", { runId: "r1", executionId: "r1:0" });
+
+    assert.equal(renders, 3);
+    component?.dispose?.();
+  });
+
   it("passes the render width through to the task panel", () => {
     const manager = new EventEmitter() as ReturnType<typeof EventEmitter> & {
       getRun: (...args: unknown[]) => unknown;
@@ -445,6 +474,29 @@ describe("renderPanel", () => {
       getRun: () => undefined,
     };
     assert.deepEqual(renderPanel(manager as never, theme as never), []);
+  });
+
+  it("shows finished, paused-mid-run, and not-started agents separately", async () => {
+    const { renderPanel } = await import("../src/task-panel.js");
+    const manager = {
+      listRuns: () => [
+        {
+          runId: "paused-run",
+          workflowName: "paused_work",
+          status: "paused",
+          agents: [
+            { id: 1, label: "finished", status: "done" },
+            { id: 2, label: "interrupted", status: "paused", sessionFile: "C:/sessions/child.jsonl" },
+            { id: 3, label: "later", status: "queued" },
+          ],
+          logs: [],
+        },
+      ],
+      getRun: () => undefined,
+    };
+    const text = renderPanel(manager as never, theme as never).join("\n");
+    assert.match(text, /1\/3 agents · 0 running · 1 paused · 1 not started/);
+    assert.match(text, /Paused mid-run \(1\): interrupted \(session saved\)/);
   });
 
   it("truncates every rendered line to the requested visible width", async () => {
@@ -527,10 +579,9 @@ describe("token rate", () => {
 describe("renderPanelDetailed", () => {
   const theme = { fg: (_c: string, t: string) => t, bold: (t: string) => t };
 
-  // `blueTokens` drives the first agent's live token count; the run aggregate and
-  // token/s are summed from per-agent tokens (the run-level tokenUsage aggregate is
-  // not live — see renderPanelDetailed), so growing blueTokens grows the rate.
-  function detailedManager(blueTokens: number, status = "running") {
+  // `blueTokens` drives the completed agent subtotal; `runningTokens` drives the
+  // active invocation's stable-identity token-rate series.
+  function detailedManager(blueTokens: number, status = "running", runningTokens = 1800) {
     const snapshot = {
       name: "auth_audit",
       phases: ["Scan", "Review"],
@@ -545,7 +596,14 @@ describe("renderPanelDetailed", () => {
           tokens: blueTokens,
           model: "anthropic/claude-haiku-4-5",
         },
-        { id: 2, label: "audit_auth", status: "running", phase: "Scan", tokens: 1800 },
+        {
+          id: 2,
+          executionId: "r1:1",
+          label: "audit_auth",
+          status: "running",
+          phase: "Scan",
+          tokens: runningTokens,
+        },
         { id: 3, label: "scan_middleware", status: "queued", phase: "Scan" },
         { id: 4, label: "cross_check", status: "queued", phase: "Review" },
       ],
@@ -554,9 +612,16 @@ describe("renderPanelDetailed", () => {
     };
     return {
       listRuns: () => [
-        { runId: "r1", workflowName: "auth_audit", status, agents: snapshot.agents, tokenUsage: snapshot.tokenUsage },
+        {
+          runId: "r1",
+          workflowName: "auth_audit",
+          status,
+          agents: snapshot.agents,
+          tokenUsage: snapshot.tokenUsage,
+          effectiveConcurrency: 8,
+        },
       ],
-      getRun: (id: string) => (id === "r1" ? { snapshot, status } : undefined),
+      getRun: (id: string) => (id === "r1" ? { snapshot, status, execution: { effectiveConcurrency: 8 } } : undefined),
     };
   }
 
@@ -595,12 +660,29 @@ describe("renderPanelDetailed", () => {
     );
   });
 
+  it("marks streaming token estimates with a tilde", async () => {
+    const { renderPanelDetailed, clearTokenSamples } = await import("../src/task-panel.js");
+    clearTokenSamples("r1");
+    const manager = detailedManager(2100) as ReturnType<typeof detailedManager>;
+    const run = manager.getRun("r1");
+    if (run) run.snapshot.agents[1].tokensEstimated = true;
+    const text = renderPanelDetailed(manager as never, theme as never, undefined, 8, 1000).join("\n");
+    assert.match(text, /~1\.8K tok/);
+    assert.match(text, /Running now \(1\/8\): audit_auth/);
+  });
+
   it("shows a live token/s after two growing samples", async () => {
     const { renderPanelDetailed, clearTokenSamples } = await import("../src/task-panel.js");
     clearTokenSamples("r1");
-    // aggregate goes 3900 → 5900 over 1s = 2000 tok/s
-    renderPanelDetailed(detailedManager(2100) as never, theme as never, undefined, 8, 1000);
-    const lines = renderPanelDetailed(detailedManager(4100) as never, theme as never, undefined, 8, 2000);
+    // Running invocation goes 1800 → 3800 over 1s = 2000 tok/s.
+    renderPanelDetailed(detailedManager(2100, "running", 1800) as never, theme as never, undefined, 8, 1000);
+    const lines = renderPanelDetailed(
+      detailedManager(2100, "running", 3800) as never,
+      theme as never,
+      undefined,
+      8,
+      2000,
+    );
     assert.ok(
       lines.some((l) => /2000 tok\/s/.test(l)),
       `expected a tok/s readout, got:\n${lines.join("\n")}`,

--- a/tests/usage-limit-integration.test.ts
+++ b/tests/usage-limit-integration.test.ts
@@ -11,11 +11,11 @@
  */
 
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { WorkflowAgent } from "../src/agent.js";
 import { WorkflowErrorCode } from "../src/errors.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
@@ -38,7 +38,7 @@ async function loadFaux(): Promise<typeof import("@earendil-works/pi-ai/compat")
       import.meta.url,
     ),
   );
-  const entry = existsSync(nested) ? nested : "@earendil-works/pi-ai/compat";
+  const entry = existsSync(nested) ? pathToFileURL(nested).href : "@earendil-works/pi-ai/compat";
   return import(entry) as Promise<typeof import("@earendil-works/pi-ai/compat")>;
 }
 
@@ -106,6 +106,41 @@ test("a successful real turn whose text merely mentions 'rate limit' is NOT misc
     const agent = new WorkflowAgent({ cwd, session: { model: model as never } });
     const text = await agent.run("do the task", { label: "ok" });
     assert.ok(typeof text === "string" && text.includes("Done."), `expected normal text, got ${String(text)}`);
+  }));
+
+test("a paused real child session reopens the same Pi session file on resume", () =>
+  withFauxSession(async ({ cwd, model, setResponses, fauxAssistantMessage }) => {
+    const managerAgent = new WorkflowAgent({ cwd, session: { model: model as never }, persistAgentSessions: true });
+    const manager = new WorkflowManager({ cwd, agent: managerAgent, persistAgentSessions: true });
+    manager.on("error", () => {});
+    const script = `export const meta = { name: 'session_resume', description: 'resume one child' }
+return await agent('finish the task', { label: 'resumable' })`;
+
+    setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: USAGE_LIMIT_MSG })]);
+    const { runId, promise } = manager.startInBackground(script);
+    await promise.catch(() => {});
+
+    const paused = manager.listRuns().find((run) => run.runId === runId);
+    assert.equal(paused?.status, "paused");
+    assert.equal(paused?.agents[0].status, "paused");
+    const sessionFile = paused?.agents[0].sessionFile;
+    assert.ok(sessionFile && existsSync(sessionFile), "paused invocation stores a durable Pi child session");
+    const before = readFileSync(sessionFile, "utf8");
+    assert.match(before, /usage limit reached/i);
+
+    setResponses([fauxAssistantMessage("continued-result", { stopReason: "stop" })]);
+    assert.equal(await manager.resume(runId), true);
+    for (let i = 0; i < 100 && manager.getRun(runId)?.status === "running"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    const completed = manager.getRun(runId);
+    assert.equal(completed?.status, "completed");
+    assert.equal(completed?.snapshot.agents[0].sessionFile, sessionFile, "resume keeps the same child session file");
+    assert.equal(completed?.result?.result, "continued-result");
+    const after = readFileSync(sessionFile, "utf8");
+    assert.ok(after.length > before.length, "continuation appends to the existing child session");
+    assert.match(after, /continued-result/);
   }));
 
 test("through the manager: a usage limit pauses the run (not fails) and resume replays the journal", () =>

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -136,7 +136,7 @@ describe("config", () => {
   it("exports expected constants", async () => {
     const c = await loadConfig();
     assert.equal(c.MAX_AGENTS_PER_RUN, 1000);
-    assert.equal(c.MAX_CONCURRENCY, 16);
+    assert.equal(c.DEFAULT_CONCURRENCY, 16);
     assert.equal(c.DEFAULT_AGENT_TIMEOUT_MS, null);
     assert.equal(c.WORKFLOW_RUNS_DIR, ".pi/workflows/runs");
     assert.equal(c.WORKFLOW_SAVED_DIR, ".pi/workflows/saved");

--- a/tests/workflow-commands.test.ts
+++ b/tests/workflow-commands.test.ts
@@ -51,6 +51,10 @@ function harness(
     listRuns: () => [],
     getSnapshot: () => null,
     getRun: () => undefined,
+    setConcurrency: (id: string, concurrency: number) => {
+      calls.push(`concurrency:${id}:${concurrency}`);
+      return { previousConcurrency: 4, requestedConcurrency: concurrency, effectiveConcurrency: concurrency };
+    },
     stop: (id: string) => {
       calls.push(`stop:${id}`);
       return true;
@@ -231,6 +235,26 @@ test("/workflows status watches a running run: live status bar + prints on compl
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
+// concurrency — resizes a live/resumable run
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("/workflows concurrency <id> <n> calls manager.setConcurrency", async () => {
+  const h = harness();
+  await h.run("concurrency run-c1 12");
+  assert.deepEqual(h.calls, ["concurrency:run-c1:12"]);
+  assert.match(h.notified[0].message, /4 → 12/);
+});
+
+test("/workflows concurrency requires a positive integer", async () => {
+  for (const args of ["concurrency", "concurrency run-c1", "concurrency run-c1 0", "concurrency run-c1 1.5"]) {
+    const h = harness();
+    await h.run(args);
+    assert.deepEqual(h.calls, []);
+    assert.equal(h.notified[0].type, "warning");
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
 // pause — calls manager.pause, shows notify
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -311,6 +335,19 @@ test("/workflows rm <id> calls manager.deleteRun and notifies Removed", async ()
     h.notified.some((n) => n.message.includes("Removed")),
     "should notify Removed",
   );
+});
+
+test("/workflows rm requires running and paused runs to be stopped first", async () => {
+  const statuses = ["running", "paused"] as const;
+  for (const status of statuses) {
+    const h = harness({
+      listRuns: () => [{ runId: `run-${status}`, workflowName: "demo", status, phases: [], agents: [], logs: [] }],
+    });
+    await h.run(`rm run-${status}`);
+    assert.deepEqual(h.calls, []);
+    assert.match(h.notified[0].message, /stop it first/);
+    assert.equal(h.notified[0].type, "warning");
+  }
 });
 
 test("/workflows rm without id warns usage", async () => {

--- a/tests/workflow-control-tool.test.ts
+++ b/tests/workflow-control-tool.test.ts
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { Check } from "typebox/value";
+import type { PersistedRunState, RunStatus } from "../src/run-persistence.js";
+import { createWorkflowControlTool } from "../src/workflow-control-tool.js";
+import { type ExecOptions, WorkflowManager } from "../src/workflow-manager.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+function run(status: RunStatus = "running", runId = "audit-abc123"): PersistedRunState {
+  return {
+    version: 2,
+    runId,
+    workflowName: "audit",
+    script: "export const meta = { name: 'audit', description: 'audit' }; return await agent('x')",
+    status,
+    phases: ["Inspect"],
+    currentPhase: "Inspect",
+    agents: [
+      {
+        id: 1,
+        executionId: `${runId}:0`,
+        callIndex: 0,
+        label: "active scan",
+        prompt: "scan",
+        status: status === "running" ? "running" : "done",
+        tokens: 30,
+      },
+      {
+        id: 2,
+        executionId: `${runId}:1`,
+        callIndex: 1,
+        label: "queued check",
+        prompt: "check",
+        status: "queued",
+      },
+      {
+        id: 3,
+        executionId: `${runId}:2`,
+        callIndex: 2,
+        label: "failed check",
+        prompt: "fail",
+        status: "error",
+      },
+    ],
+    logs: [],
+    startedAt: "2026-07-14T00:00:00.000Z",
+    updatedAt: "2026-07-14T00:00:01.000Z",
+    requestedConcurrency: 4,
+    effectiveConcurrency: 4,
+    maxAgents: 20,
+    agentRetries: 2,
+    agentTimeoutMs: 5000,
+    tokenBudget: 1000,
+    tokenUsage: { input: 20, output: 10, total: 30 },
+  };
+}
+
+function fakeManager(initial: PersistedRunState[]) {
+  const runs = new Map(initial.map((item) => [item.runId, item]));
+  const calls: Array<{ action: string; runId: string; exec?: ExecOptions }> = [];
+  const manager = {
+    listRuns: () => [...runs.values()],
+    getSnapshot: () => null,
+    setConcurrency(runId: string, concurrency: number) {
+      calls.push({ action: "set_concurrency", runId });
+      const item = runs.get(runId);
+      if (!item || !["running", "paused", "failed", "pending"].includes(item.status)) return null;
+      const previousConcurrency = item.effectiveConcurrency;
+      item.requestedConcurrency = concurrency;
+      item.effectiveConcurrency = concurrency;
+      return { previousConcurrency, requestedConcurrency: concurrency, effectiveConcurrency: concurrency };
+    },
+    pause(runId: string) {
+      calls.push({ action: "pause", runId });
+      const item = runs.get(runId);
+      if (item?.status !== "running") return false;
+      item.status = "paused";
+      return true;
+    },
+    async resume(runId: string) {
+      calls.push({ action: "resume", runId });
+      const item = runs.get(runId);
+      if (!item || (item.status !== "paused" && item.status !== "failed")) return false;
+      item.status = "running";
+      return true;
+    },
+    stop(runId: string) {
+      calls.push({ action: "stop", runId });
+      const item = runs.get(runId);
+      if (!item || (item.status !== "running" && item.status !== "paused")) return false;
+      item.status = "aborted";
+      return true;
+    },
+    restart(sourceRunId: string) {
+      const source = runs.get(sourceRunId);
+      if (!source || source.status === "running") return null;
+      const runId = "audit-new456";
+      const exec: ExecOptions = {
+        concurrency: source.requestedConcurrency ?? source.effectiveConcurrency,
+        maxAgents: source.maxAgents,
+        agentRetries: source.agentRetries,
+        agentTimeoutMs: source.agentTimeoutMs,
+        tokenBudget: source.tokenBudget,
+      };
+      calls.push({ action: "restart", runId, exec });
+      runs.set(runId, run("running", runId));
+      return { runId, promise: Promise.resolve(undefined) };
+    },
+    deleteRun(runId: string) {
+      calls.push({ action: "remove", runId });
+      return runs.delete(runId);
+    },
+  } as unknown as WorkflowManager;
+  return { manager, calls, runs };
+}
+
+async function execute(manager: WorkflowManager, params: Record<string, unknown>) {
+  const tool = createWorkflowControlTool({ manager });
+  return (tool.execute as any)("control-call", params, undefined, undefined, {});
+}
+
+function text(result: Awaited<ReturnType<typeof execute>>): string {
+  return result.content[0].text;
+}
+
+test("workflow_control exposes a strict action schema and requires runId for run actions", () => {
+  const { manager } = fakeManager([]);
+  const tool = createWorkflowControlTool({ manager });
+
+  assert.equal(tool.name, "workflow_control");
+  assert.equal(Check(tool.parameters, { action: "list" }), true);
+  assert.equal(Check(tool.parameters, { action: "status", runId: "abc" }), true);
+  assert.equal(Check(tool.parameters, { action: "set_concurrency", runId: "abc", concurrency: 128 }), true);
+  assert.equal(Check(tool.parameters, { action: "set_concurrency", runId: "abc", concurrency: 0 }), false);
+  assert.equal(Check(tool.parameters, { action: "set_concurrency", runId: "abc" }), false);
+  assert.equal(Check(tool.parameters, { action: "status" }), false);
+  assert.equal(Check(tool.parameters, { action: "unknown", runId: "abc" }), false);
+  assert.equal(Check(tool.parameters, { action: "list", runId: "abc" }), false);
+
+  const prepare = tool.prepareArguments as (value: unknown) => unknown;
+  assert.throws(() => prepare({ action: "pause" }), /requires runId/);
+  assert.throws(
+    () => prepare({ action: "set_concurrency", runId: "abc", concurrency: 1.5 }),
+    /positive integer concurrency/,
+  );
+  assert.throws(() => prepare({ action: "unknown", runId: "abc" }), /requires action/);
+});
+
+test("list and status return compact run state with activity, concurrency, and usage", async () => {
+  const { manager } = fakeManager([run()]);
+
+  const listed = text(await execute(manager, { action: "list" }));
+  assert.match(listed, /runId=audit-abc123 status=running phase="Inspect"/);
+  assert.match(listed, /done=0 running=1 paused=0 queued=1 error=1/);
+  assert.match(listed, /active="active scan" pausedAgents="-" concurrency=4 tokens=30/);
+
+  const status = text(await execute(manager, { action: "status", runId: "audit-abc123" }));
+  assert.match(status, /^action=status result=ok /);
+  assert.doesNotMatch(status, /\/workflows/);
+});
+
+test("status identifies paused agents and whether their child session was saved", async () => {
+  const paused = run("paused");
+  paused.agents[0] = {
+    ...paused.agents[0],
+    status: "paused",
+    sessionFile: "C:/sessions/resumable.jsonl",
+  };
+  const { manager } = fakeManager([paused]);
+
+  const status = text(await execute(manager, { action: "status", runId: "audit-abc123" }));
+  assert.match(status, /done=0 running=0 paused=1 queued=1 error=1/);
+  assert.match(status, /pausedAgents="active scan \(session saved\)"/);
+});
+
+test("set_concurrency, pause, resume, and stop call the shared manager lifecycle methods", async () => {
+  const fixture = fakeManager([run()]);
+
+  const resized = text(
+    await execute(fixture.manager, { action: "set_concurrency", runId: "audit-abc123", concurrency: 12 }),
+  );
+  assert.match(resized, /action=set_concurrency result=updated previous=4/);
+  assert.match(resized, /concurrency=12/);
+  assert.match(text(await execute(fixture.manager, { action: "pause", runId: "audit-abc123" })), /result=paused/);
+  assert.match(text(await execute(fixture.manager, { action: "resume", runId: "audit-abc123" })), /result=resumed/);
+  assert.match(text(await execute(fixture.manager, { action: "stop", runId: "audit-abc123" })), /result=stopped/);
+  assert.deepEqual(
+    fixture.calls.map((call) => call.action),
+    ["set_concurrency", "pause", "resume", "stop"],
+  );
+});
+
+test("restart creates a new run through the shared manager and retains execution controls", async () => {
+  const fixture = fakeManager([run("completed")]);
+
+  const response = await execute(fixture.manager, { action: "restart", runId: "audit-abc123" });
+
+  assert.match(text(response), /action=restart result=restarted sourceRunId=audit-abc123 runId=audit-new456/);
+  assert.equal(response.details.runId, "audit-new456");
+  assert.deepEqual(fixture.calls[0].exec, {
+    concurrency: 4,
+    maxAgents: 20,
+    agentRetries: 2,
+    agentTimeoutMs: 5000,
+    tokenBudget: 1000,
+  });
+});
+
+test("remove deletes a non-running run through the shared manager", async () => {
+  const fixture = fakeManager([run("completed")]);
+
+  const response = await execute(fixture.manager, { action: "remove", runId: "audit-abc123" });
+
+  assert.match(text(response), /action=remove result=removed runId=audit-abc123/);
+  assert.equal(fixture.runs.has("audit-abc123"), false);
+});
+
+test("cold persisted paused run can be stopped under the manager then removed through workflow_control", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-control-cold-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-control-home-"));
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const bootstrap = new WorkflowManager({ cwd });
+      const runId = "cold-paused-control";
+      bootstrap.getPersistence().save({
+        runId,
+        workflowName: "cold_control",
+        script: "export const meta = { name: 'cold_control', description: 'cold' }; return true",
+        status: "paused",
+        phases: [],
+        agents: [],
+        logs: [],
+        startedAt: "2026-07-14T00:00:00.000Z",
+        updatedAt: "2026-07-14T00:00:01.000Z",
+      });
+
+      const manager = new WorkflowManager({ cwd });
+      assert.equal(manager.getRun(runId), undefined, "fixture must remain persisted-only");
+      assert.match(text(await execute(manager, { action: "stop", runId })), /result=stopped/);
+      assert.equal(manager.getPersistence().load(runId)?.status, "aborted");
+      assert.match(text(await execute(manager, { action: "remove", runId })), /result=removed/);
+      assert.equal(manager.getPersistence().load(runId), null);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("unknown IDs and illegal transitions return explicit errors with allowed next actions", async () => {
+  const fixture = fakeManager([run("completed"), run("running", "live-123"), run("paused", "paused-123")]);
+
+  const unknown = text(await execute(fixture.manager, { action: "status", runId: "missing" }));
+  assert.match(unknown, /result=error runId=missing error=run not found allowed=list/);
+
+  const pauseCompleted = text(await execute(fixture.manager, { action: "pause", runId: "audit-abc123" }));
+  assert.match(pauseCompleted, /cannot pause run with status completed/);
+  assert.match(pauseCompleted, /allowed=status,restart,remove/);
+
+  const restartRunning = text(await execute(fixture.manager, { action: "restart", runId: "live-123" }));
+  assert.match(restartRunning, /cannot restart a running run/);
+  assert.match(restartRunning, /allowed=status,set_concurrency,pause,stop/);
+
+  const removeRunning = text(await execute(fixture.manager, { action: "remove", runId: "live-123" }));
+  assert.match(removeRunning, /cannot remove a running run; stop it first/);
+  assert.equal(fixture.runs.has("live-123"), true);
+
+  const removePaused = text(await execute(fixture.manager, { action: "remove", runId: "paused-123" }));
+  assert.match(removePaused, /cannot remove a paused run; stop it first/);
+  assert.equal(fixture.runs.has("paused-123"), true);
+});

--- a/tests/workflow-display.test.ts
+++ b/tests/workflow-display.test.ts
@@ -153,6 +153,54 @@ describe("renderWorkflowText", () => {
     assert.ok(text.includes("1 skipped"), "should show skipped count");
   });
 
+  it("shows running inventory, queued count, explicit statuses, and estimated tokens", async () => {
+    const { createWorkflowSnapshot, renderWorkflowLines, recomputeWorkflowSnapshot } = await loadDisplay();
+    const snap = createWorkflowSnapshot(fakeMeta("fleet", "d", ["Fleet"]));
+    snap.effectiveConcurrency = 8;
+    snap.agents = Array.from({ length: 42 }, (_, index) => ({
+      id: index + 1,
+      executionId: `fleet:${index}`,
+      callIndex: index,
+      label: `agent-${index + 1}`,
+      phase: "Fleet",
+      prompt: "p",
+      status: index < 8 ? ("running" as const) : ("queued" as const),
+      tokens: index === 0 ? 120 : undefined,
+      tokensEstimated: index === 0,
+    }));
+
+    const text = renderWorkflowLines(recomputeWorkflowSnapshot(snap), { maxAgents: 42 }).join("\n");
+    assert.match(text, /8 running/);
+    assert.match(text, /34 not started/);
+    assert.match(text, /Running now \(8\/8\): agent-1, agent-2, agent-3, agent-4, agent-5, agent-6, agent-7, agent-8/);
+    assert.match(text, /● agent-1 \[~120 tok\] · running/);
+    assert.match(text, /○ agent-42 · queued/);
+  });
+
+  it("distinguishes finished, paused-mid-run, and never-started agents", async () => {
+    const { createWorkflowSnapshot, renderWorkflowLines, recomputeWorkflowSnapshot } = await loadDisplay();
+    const snap = createWorkflowSnapshot(fakeMeta("paused", "d", ["Work"]));
+    snap.agents = [
+      { id: 1, label: "finished", phase: "Work", prompt: "p", status: "done" },
+      {
+        id: 2,
+        label: "interrupted",
+        phase: "Work",
+        prompt: "p",
+        status: "paused",
+        sessionFile: "C:/sessions/child.jsonl",
+      },
+      { id: 3, label: "later", phase: "Work", prompt: "p", status: "queued" },
+    ];
+    const text = renderWorkflowLines(recomputeWorkflowSnapshot(snap), { maxAgents: 3 }).join("\n");
+    assert.match(text, /1 paused mid-run/);
+    assert.match(text, /1 not started/);
+    assert.match(text, /Paused mid-run \(1\): interrupted \(session saved\)/);
+    assert.match(text, /⏸ interrupted · paused mid-run \(session saved\)/);
+    assert.match(text, /○ later · queued/);
+    assert.match(text, /✓ finished · done/);
+  });
+
   it("shows unphased agents when agents have no phase", async () => {
     const { createWorkflowSnapshot, renderWorkflowLines } = await loadDisplay();
     const snap = createWorkflowSnapshot(fakeMeta("t", "d", []));

--- a/tests/workflow-editor.test.ts
+++ b/tests/workflow-editor.test.ts
@@ -129,6 +129,41 @@ describe("hasTrigger", () => {
     assert.equal(hasTrigger("/workflow"), false);
   });
 
+  it("requires token boundaries for the built-in trigger", async () => {
+    const { hasTrigger } = await load();
+    for (const text of [
+      "myworkflow",
+      "workflows2",
+      "workflow_name",
+      "workflow-based",
+      "src/workflow-editor.ts",
+      "src\\workflow-editor.ts",
+    ]) {
+      assert.equal(hasTrigger(text), false, `${text} should not trigger`);
+    }
+    for (const text of ["workflow, please", "(workflows)", "WORKFLOW!", "Discuss workflows."]) {
+      assert.equal(hasTrigger(text), true, `${text} should trigger`);
+    }
+  });
+
+  it("rejects Unicode identifier and dollar boundaries on either side", async () => {
+    const { hasTrigger } = await load();
+    for (const text of [
+      "$workflow",
+      "workflow$",
+      "caféworkflow",
+      "workflowcafé",
+      "变量workflow变量",
+      "变量workflow",
+      "workflow变量",
+    ]) {
+      assert.equal(hasTrigger(text), false, `${text} should not trigger`);
+    }
+    for (const text of ["¿workflow?", "café, workflow!", "变量：workflow。", "workflow—please"]) {
+      assert.equal(hasTrigger(text), true, `${text} should trigger`);
+    }
+  });
+
   it("returns false for unrelated text", async () => {
     const { hasTrigger } = await load();
     assert.equal(hasTrigger("hello world"), false);
@@ -611,6 +646,88 @@ describe("installWorkflowEditor", () => {
     assert.equal(setActiveToolsCalls, 1, "workflow trigger should still add the workflow tool");
   });
 
+  it("leaves ordinary workflow mentions untouched in fresh settings and compatibility mode", async () => {
+    const mod = await load();
+    const captured: Array<{ event: string; handler: (...args: unknown[]) => unknown }> = [];
+    let setEditorCalls = 0;
+    let setActiveToolsCalls = 0;
+    const pi = {
+      on: (event: string, handler: (...args: unknown[]) => unknown) => {
+        captured.push({ event, handler });
+      },
+      registerCommand: () => {},
+      getActiveTools: () => ["bash", "read"],
+      setActiveTools: () => {
+        setActiveToolsCalls++;
+      },
+    } as unknown as ExtensionAPI;
+    const ui = {
+      getEditorComponent: () => () => ({ kind: "existing-editor" }),
+      setEditorComponent: () => {
+        setEditorCalls++;
+      },
+    } as unknown as ExtensionUIContext;
+
+    const state = mod.installWorkflowEditor(pi, ui, undefined, {
+      settingsStore: { load: () => ({}), save: () => {} },
+    });
+    state.suppressedKeywordText = "leave this marker unchanged";
+
+    assert.equal(state.keywordTriggerEnabled, false);
+    assert.equal(setEditorCalls, 0, "existing custom editor should remain installed");
+    const inputHandler = captured.find((h) => h.event === "input")?.handler;
+    assert.ok(inputHandler, "input handler should still be registered");
+    for (const text of [
+      "Discuss workflow design.",
+      "Compare workflows, please.",
+      "WORKFLOW!",
+      "myworkflow identifier",
+      "src/workflow-editor.ts",
+      "/workflows status",
+    ]) {
+      assert.deepEqual(inputHandler({ source: "interactive", text }), { action: "continue" });
+    }
+    assert.equal(setActiveToolsCalls, 0);
+    assert.equal(state.suppressedKeywordText, "leave this marker unchanged");
+  });
+
+  it("explicit opt-in restores bounded keyword transformation", async () => {
+    const mod = await load();
+    const captured: Array<{ event: string; handler: (...args: unknown[]) => unknown }> = [];
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+    let setActiveToolsCalls = 0;
+    const pi = {
+      on: (event: string, handler: (...args: unknown[]) => unknown) => {
+        captured.push({ event, handler });
+      },
+      registerCommand: (name: string, command: { handler: (args: string, ctx: unknown) => Promise<void> }) => {
+        commands.set(name, command);
+      },
+      sendMessage: () => {},
+      getActiveTools: () => ["bash", "read"],
+      setActiveTools: () => {
+        setActiveToolsCalls++;
+      },
+    } as unknown as ExtensionAPI;
+    const ui = { setEditorComponent: () => {} } as unknown as ExtensionUIContext;
+    const store = memorySettingsOptions(false);
+
+    const state = mod.installWorkflowEditor(pi, ui, undefined, store.options);
+    assert.equal(state.keywordTriggerEnabled, false);
+    await commands.get("workflows-trigger")?.handler("on", {});
+    assert.equal(state.keywordTriggerEnabled, true);
+
+    const inputHandler = captured.find((h) => h.event === "input")?.handler;
+    assert.ok(inputHandler, "input handler should be registered");
+    assert.deepEqual(inputHandler({ source: "interactive", text: "myworkflow identifier" }), {
+      action: "continue",
+    });
+    const result = inputHandler({ source: "interactive", text: "Please run a workflow, now." });
+    assert.equal((result as { action?: string }).action, "transform");
+    assert.equal(setActiveToolsCalls, 1);
+    assert.deepEqual(store.settings, { keywordTriggerEnabled: true });
+  });
+
   it("registers /workflows-trigger and toggles the keyword trigger", async () => {
     const mod = await load();
     const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
@@ -633,7 +750,7 @@ describe("installWorkflowEditor", () => {
     } as unknown as ExtensionUIContext;
 
     const state = mod.installWorkflowEditor(pi, ui, undefined, store.options);
-    assert.equal(state.keywordTriggerEnabled, true, "keyword trigger should default on");
+    assert.equal(state.keywordTriggerEnabled, true, "persisted on preference should be restored");
     assert.equal(state.keywordTriggerWord, "workflow", "keyword trigger word should default to workflow");
 
     const command = commands.get("workflows-trigger");

--- a/tests/workflow-manager-abort.test.ts
+++ b/tests/workflow-manager-abort.test.ts
@@ -278,7 +278,10 @@ test(
   withTempCwd(async (cwd) => {
     const da = deferredAgent();
     const manager = new WorkflowManager({ cwd, agent: da.runner });
-    manager.on("error", () => {});
+    let errorEvents = 0;
+    manager.on("error", () => {
+      errorEvents++;
+    });
 
     let pausedEvent: { runId: string } | null = null;
     manager.on("paused", (ev: { runId: string }) => {
@@ -294,6 +297,7 @@ test(
 
     da.resolve("done");
     await promise.catch(() => {});
+    assert.equal(errorEvents, 0, "manual pause must not also emit a failure event");
   }),
 );
 
@@ -350,16 +354,14 @@ test(
     assert.equal(paused, true);
     assert.equal(manager.getRun(runId)?.status, "paused");
 
-    // Resume — replays journal (empty for single-agent that never completed) and
-    // re-runs the live agent with a fresh (non-aborted) controller.
-    const resumed = await manager.resume(runId);
+    // Resume waits for the aborted execution to settle before starting its replacement.
+    const resumePromise = manager.resume(runId);
+    da.resolve("resumed-done");
+    const resumed = await resumePromise;
     assert.equal(resumed, true, "resume should succeed");
 
     // The resumed run should be running
     assert.equal(manager.getRun(runId)?.status, "running", "resumed run should be running");
-
-    // Resolve the deferred agent so the resumed run's agent completes
-    da.resolve("resumed-done");
 
     // The original promise will reject (its controller was aborted). Suppress it.
     await origPromise.catch(() => {});
@@ -409,7 +411,7 @@ return { a, b }`;
       const persisted = manager.listRuns().find((r) => r.runId === runId);
       assert.ok(persisted?.journal && persisted.journal.length >= 1, "journal should have at least one entry");
 
-      // Resume
+      // Resume waits for the old execution; the shared deferred is already resolved.
       const resumed = await manager.resume(runId);
       assert.equal(resumed, true);
 
@@ -422,6 +424,92 @@ return { a, b }`;
     }
 
     await origPromise.catch(() => {});
+  }),
+);
+
+test(
+  "immediate pause then resume serializes behind the prior execution",
+  withTempCwd(async (cwd) => {
+    const pending: Array<(value: unknown) => void> = [];
+    let active = 0;
+    let maximum = 0;
+    let calls = 0;
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          const index = calls++;
+          active++;
+          maximum = Math.max(maximum, active);
+          try {
+            return await new Promise((resolve) => {
+              pending[index] = resolve;
+            });
+          } finally {
+            active--;
+          }
+        },
+      },
+    });
+
+    const { runId, promise } = manager.startInBackground(oneAgentScript, undefined, { concurrency: 99 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    let persisted = manager.listRuns().find((run) => run.runId === runId);
+    assert.equal(persisted?.requestedConcurrency, 99);
+    assert.equal(persisted?.effectiveConcurrency, 99);
+    manager.pause(runId);
+    const resumePromise = manager.resume(runId);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(calls, 1, "replacement execution must not start while the old agent is settling");
+
+    pending[0]?.("old-done");
+    await promise.catch(() => {});
+    assert.equal(await resumePromise, true);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(calls, 2);
+    assert.equal(maximum, 1, "one invocation must never have overlapping executions");
+    persisted = manager.listRuns().find((run) => run.runId === runId);
+    assert.equal(persisted?.requestedConcurrency, 99);
+    assert.equal(persisted?.effectiveConcurrency, 99);
+
+    pending[1]?.("resumed-done");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(manager.getRun(runId)?.status, "completed");
+  }),
+);
+
+test(
+  "restart rejects running work and preserves all persisted execution controls",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    const source = manager.startInBackground(
+      oneAgentScript,
+      { value: 7 },
+      {
+        concurrency: 99,
+        maxAgents: 23,
+        agentRetries: 2,
+        agentTimeoutMs: 1234,
+        tokenBudget: 5678,
+      },
+    );
+    assert.equal(manager.restart(source.runId), null, "running work cannot be restarted");
+    await source.promise;
+
+    const persisted = manager.listRuns().find((run) => run.runId === source.runId);
+    assert.equal(persisted?.requestedConcurrency, 99);
+    assert.equal(persisted?.effectiveConcurrency, 99);
+
+    const restarted = manager.restart(source.runId);
+    assert.ok(restarted);
+    await restarted.promise;
+    const copy = manager.listRuns().find((run) => run.runId === restarted.runId);
+    assert.equal(copy?.requestedConcurrency, 99);
+    assert.equal(copy?.effectiveConcurrency, 99);
+    assert.equal(copy?.maxAgents, 23);
+    assert.equal(copy?.agentRetries, 2);
+    assert.equal(copy?.agentTimeoutMs, 1234);
+    assert.equal(copy?.tokenBudget, 5678);
   }),
 );
 
@@ -497,7 +585,7 @@ test(
     const { runId, promise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
 
-    // Stop first, then delete
+    assert.equal(manager.deleteRun(runId), false, "running run must be stopped before removal");
     manager.stop(runId);
     const deleted = manager.deleteRun(runId);
     assert.equal(deleted, true);
@@ -507,13 +595,71 @@ test(
 
     da.resolve("done");
     await promise.catch(() => {});
+    assert.equal(
+      manager.listRuns().some((item) => item.runId === runId),
+      false,
+      "settlement must not resurrect it",
+    );
+  }),
+);
+
+test(
+  "cold stop terminalizes every queued and running persisted agent row",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd });
+    manager.getPersistence().save({
+      runId: "cold-paused",
+      workflowName: "cold",
+      script: oneAgentScript,
+      status: "paused",
+      phases: ["Work"],
+      agents: [
+        { id: 1, label: "queued", prompt: "q", status: "queued" },
+        { id: 2, label: "running", prompt: "r", status: "running" },
+        { id: 3, label: "done", prompt: "d", status: "done" },
+      ],
+      logs: [],
+      startedAt: "2026-07-14T00:00:00.000Z",
+      updatedAt: "2026-07-14T00:00:01.000Z",
+    });
+
+    assert.equal(manager.stop("cold-paused"), true);
+    const stopped = manager.getPersistence().load("cold-paused");
+    assert.equal(stopped?.status, "aborted");
+    assert.deepEqual(
+      stopped?.agents.map((agent) => agent.status),
+      ["skipped", "skipped", "done"],
+    );
+    assert.ok(stopped?.agents.slice(0, 2).every((agent) => agent.endedAt));
+  }),
+);
+
+test(
+  "persisted-only remove cannot steal a live owner's lease or resurrect after unwind",
+  withTempCwd(async (cwd) => {
+    const deferred = deferredAgent();
+    const owner = new WorkflowManager({ cwd, agent: deferred.runner });
+    const { runId, promise } = owner.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(owner.stop(runId), true);
+
+    const remover = new WorkflowManager({ cwd });
+    assert.equal(remover.getRun(runId), undefined, "the second manager sees persisted-only state");
+    assert.equal(remover.deleteRun(runId), false, "live owner lease blocks removal during unwind");
+    assert.ok(remover.getPersistence().load(runId), "failed removal preserves the artifact");
+
+    deferred.resolve("settled");
+    await promise.catch(() => {});
+    assert.equal(remover.deleteRun(runId), true, "removal succeeds after owner settlement releases the lease");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(remover.getPersistence().load(runId), null, "the removed run is not recreated");
   }),
 );
 
 // ─── deleteRun tests (2 tests) ─────────────────────────────────────────────────
 
 test(
-  "deleteRun can delete a running run (removes from memory and persistence)",
+  "deleteRun refuses running and paused runs until they are stopped",
   withTempCwd(async (cwd) => {
     const da = deferredAgent();
     const manager = new WorkflowManager({ cwd, agent: da.runner });
@@ -521,22 +667,20 @@ test(
     const { runId, promise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
 
-    // Delete while running — should succeed (removes from tracking)
-    const deleted = manager.deleteRun(runId);
-    assert.equal(deleted, true);
+    assert.equal(manager.deleteRun(runId), false);
+    assert.ok(manager.getRun(runId));
+    manager.pause(runId);
+    assert.equal(manager.deleteRun(runId), false);
+    assert.equal(manager.listRuns().find((run) => run.runId === runId)?.status, "paused");
 
-    // Should not be in memory
-    assert.equal(manager.getRun(runId), undefined);
-
-    // Should not be in persistence
-    const runs = manager.listRuns();
-    assert.equal(
-      runs.find((r) => r.runId === runId),
-      undefined,
-    );
-
+    manager.stop(runId);
+    assert.equal(manager.deleteRun(runId), true);
     da.resolve("done");
     await promise.catch(() => {});
+    assert.equal(
+      manager.listRuns().some((run) => run.runId === runId),
+      false,
+    );
   }),
 );
 
@@ -663,6 +807,7 @@ test(
     const _ac = new AbortController();
     const da = deferredAgent();
     const manager = new WorkflowManager({ cwd, agent: da.runner });
+    manager.on("error", () => {});
 
     // Track resumed event
     let resumedEvent: { runId: string } | null = null;
@@ -674,12 +819,13 @@ test(
     const { runId, promise: origPromise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
     manager.pause(runId);
-    await manager.resume(runId);
+    const resumePromise = manager.resume(runId);
+    da.resolve("done");
+    await resumePromise;
 
     assert.ok(resumedEvent, "resumed event should fire on resume");
     assert.equal(resumedEvent?.runId, runId);
 
-    da.resolve("done");
     await origPromise.catch(() => {});
 
     // Now test error event on abort

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
+import { recomputeWorkflowSnapshot, renderWorkflowText } from "../src/display.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
@@ -206,6 +207,40 @@ test(
 );
 
 test(
+  "accepted checkpoint is durable before later blocked work and survives manager reload",
+  withTempCwd(async (cwd) => {
+    const blocked = deferredAgent();
+    const manager = new WorkflowManager({ cwd, agent: blocked.runner });
+    const agentStarted = new Promise<void>((resolve) => manager.once("agentStart", () => resolve()));
+    const script = `export const meta = { name: 'checkpoint_crash', description: 'durable checkpoint' }
+const approved = await checkpoint('Approve?', { kind: 'confirm' })
+const later = await agent('later work', { label: 'later' })
+return { approved, later }`;
+
+    const { runId, promise } = manager.startInBackground(script, undefined, {
+      confirm: async () => "accepted",
+    });
+    await agentStarted;
+
+    const beforeReload = manager.getPersistence().load(runId);
+    assert.equal(beforeReload?.journal?.[0]?.result, "accepted", "checkpoint must be saved before agent end");
+
+    const live = manager.getRun(runId);
+    assert.ok(live?.lease, "running test fixture should own a lease");
+    manager.getPersistence().releaseRunLease(live.lease);
+    live.lease = undefined;
+
+    const reloaded = new WorkflowManager({ cwd });
+    const recovered = reloaded.listRuns().find((run) => run.runId === runId);
+    assert.equal(recovered?.status, "paused");
+    assert.equal(recovered?.journal?.[0]?.result, "accepted", "reloaded manager keeps the accepted reply");
+
+    blocked.resolve("done");
+    await promise;
+  }),
+);
+
+test(
   "each agent's model is recorded for /workflows: explicit opts.model, else the main model",
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({ cwd, agent: fakeAgent(), mainModel: "anthropic/claude-opus-4-8" });
@@ -365,6 +400,31 @@ test(
 );
 
 test(
+  "manager snapshots carry effective concurrency into live display rendering",
+  withTempCwd(async (cwd) => {
+    const deferred = deferredAgent();
+    const manager = new WorkflowManager({ cwd, agent: deferred.runner });
+    const twoAgents = `export const meta = { name: 'display_cap', description: 'display concurrency' }
+return await parallel(['a', 'b'].map((label) => () => agent(label, { label })))`;
+    const { runId, promise } = manager.startInBackground(twoAgents);
+    for (let attempt = 0; attempt < 50; attempt++) {
+      if (manager.getSnapshot(runId)?.agents.filter((agent) => agent.status === "running").length === 2) break;
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
+
+    const snapshot = manager.getSnapshot(runId);
+    assert.ok(snapshot);
+    assert.equal(snapshot.requestedConcurrency, 16);
+    assert.equal(snapshot.effectiveConcurrency, 16);
+    assert.match(renderWorkflowText(recomputeWorkflowSnapshot(snapshot)), /Running now \(2\/16\): a, b/);
+
+    manager.stop(runId);
+    deferred.resolve("done");
+    await promise.catch(() => {});
+  }),
+);
+
+test(
   "deleteRun removes the run from memory and persistence",
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({ cwd, agent: fakeAgent() });
@@ -431,6 +491,99 @@ test(
     assert.ok(p, "p should be truthy");
     assert.equal(typeof p.save, "function");
     assert.equal(typeof p.list, "function");
+  }),
+);
+
+test(
+  "setConcurrency resizes a live FIFO limiter without aborting running agents",
+  withTempCwd(async (cwd) => {
+    const started: string[] = [];
+    const resolvers: Array<() => void> = [];
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string) {
+          started.push(prompt);
+          return new Promise<string>((resolve) => {
+            resolvers.push(() => resolve(`done:${prompt}`));
+          });
+        },
+      },
+    });
+    const script = `export const meta = { name: 'live_resize', description: 'live resize' }
+return await parallel(['a', 'b', 'c', 'd', 'e'].map((label) => () => agent(label, { label })))`;
+    const waitForStarts = async (count: number) => {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (started.length >= count) return;
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+      assert.fail(`expected ${count} started agents, saw ${started.length}`);
+    };
+    const changes: Array<{ previousConcurrency?: number; effectiveConcurrency: number }> = [];
+    manager.on("concurrencyChanged", (event) => changes.push(event));
+
+    const { runId, promise } = manager.startInBackground(script, undefined, { concurrency: 1 });
+    await waitForStarts(1);
+
+    assert.deepEqual(manager.setConcurrency(runId, 3), {
+      previousConcurrency: 1,
+      requestedConcurrency: 3,
+      effectiveConcurrency: 3,
+    });
+    await waitForStarts(3);
+    assert.equal(manager.getSnapshot(runId)?.effectiveConcurrency, 3);
+    assert.equal(manager.listRuns().find((run) => run.runId === runId)?.effectiveConcurrency, 3);
+
+    assert.equal(manager.setConcurrency(runId, 1)?.effectiveConcurrency, 1);
+    resolvers[0]?.();
+    resolvers[1]?.();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(started.length, 3, "decreasing waits for excess running agents instead of aborting them");
+
+    resolvers[2]?.();
+    await waitForStarts(4);
+    assert.equal(manager.setConcurrency(runId, 2)?.effectiveConcurrency, 2);
+    await waitForStarts(5);
+    resolvers[3]?.();
+    resolvers[4]?.();
+    await promise;
+
+    assert.equal(manager.getRun(runId)?.status, "completed");
+    assert.deepEqual(
+      changes.map((event) => event.effectiveConcurrency),
+      [3, 1, 2],
+    );
+  }),
+);
+
+test(
+  "setConcurrency updates a cold paused run for its next resume",
+  withTempCwd(async (cwd) => {
+    const bootstrap = new WorkflowManager({ cwd, agent: fakeAgent() });
+    bootstrap.getPersistence().save({
+      runId: "cold-resize",
+      workflowName: "cold_resize",
+      script: oneAgentScript,
+      status: "paused",
+      phases: ["Work"],
+      agents: [],
+      logs: [],
+      requestedConcurrency: 2,
+      effectiveConcurrency: 2,
+      startedAt: "2026-07-14T00:00:00.000Z",
+      updatedAt: "2026-07-14T00:00:01.000Z",
+    });
+
+    const manager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    assert.equal(manager.getRun("cold-resize"), undefined);
+    assert.deepEqual(manager.setConcurrency("cold-resize", 9), {
+      previousConcurrency: 2,
+      requestedConcurrency: 9,
+      effectiveConcurrency: 9,
+    });
+    const persisted = manager.getPersistence().load("cold-resize");
+    assert.equal(persisted?.requestedConcurrency, 9);
+    assert.equal(persisted?.effectiveConcurrency, 9);
   }),
 );
 
@@ -790,16 +943,14 @@ test(
     assert.equal(paused, true);
     assert.equal(manager.getRun(runId)?.status, "paused");
 
-    // Resume — replays journal (empty for single-agent that never completed) and
-    // re-runs the live agent with a fresh (non-aborted) controller.
-    const resumed = await manager.resume(runId);
+    // Resume waits for the aborted execution to settle before starting its replacement.
+    const resumePromise = manager.resume(runId);
+    da.resolve("resumed-done");
+    const resumed = await resumePromise;
     assert.equal(resumed, true, "resume should succeed");
 
     // The resumed run should be running
     assert.equal(manager.getRun(runId)?.status, "running", "resumed run should be running");
-
-    // Resolve the deferred agent so the resumed run's agent completes
-    da.resolve("resumed-done");
 
     // The original promise will reject (its controller was aborted). Suppress it.
     await origPromise.catch(() => {});
@@ -1089,6 +1240,82 @@ test(
 );
 
 test(
+  "startup marks orphaned running agent rows paused in resumable artifacts",
+  withTempCwd(async (cwd) => {
+    const bootstrap = new WorkflowManager({ cwd });
+    const runId = "paused-orphan-agent";
+    bootstrap.getPersistence().save({
+      runId,
+      workflowName: "paused_orphan",
+      script: oneAgentScript,
+      status: "paused",
+      phases: [],
+      agents: [
+        {
+          id: 1,
+          executionId: `${runId}:0`,
+          callIndex: 0,
+          label: "orphan",
+          prompt: "work",
+          status: "running",
+          startedAt: "2026-07-14T00:00:00.000Z",
+          sessionFile: "C:/sessions/orphan.jsonl",
+        },
+      ],
+      logs: [],
+      startedAt: "2026-07-14T00:00:00.000Z",
+      updatedAt: "2026-07-14T00:00:01.000Z",
+    });
+
+    const recovered = new WorkflowManager({ cwd }).listRuns().find((run) => run.runId === runId);
+    assert.equal(recovered?.status, "paused");
+    assert.equal(recovered?.agents[0]?.status, "paused");
+    assert.equal(recovered?.agents[0]?.sessionFile, "C:/sessions/orphan.jsonl");
+    assert.equal(recovered?.agents[0]?.endedAt, undefined);
+  }),
+);
+
+test(
+  "startup terminalizes orphaned running rows in completed and aborted artifacts",
+  withTempCwd(async (cwd) => {
+    const bootstrap = new WorkflowManager({ cwd });
+    for (const status of ["completed", "aborted"] as const) {
+      const runId = `${status}-orphan-agent`;
+      bootstrap.getPersistence().save({
+        runId,
+        workflowName: `${status}_orphan`,
+        script: oneAgentScript,
+        status,
+        phases: [],
+        agents: [
+          {
+            id: 1,
+            executionId: `${runId}:0`,
+            callIndex: 0,
+            label: "orphan",
+            prompt: "work",
+            status: "running",
+            startedAt: "2026-07-14T00:00:00.000Z",
+          },
+        ],
+        logs: [],
+        startedAt: "2026-07-14T00:00:00.000Z",
+        updatedAt: "2026-07-14T00:00:01.000Z",
+        completedAt: status === "completed" ? "2026-07-14T00:00:02.000Z" : undefined,
+      });
+    }
+
+    const recovered = new WorkflowManager({ cwd }).listRuns();
+    for (const status of ["completed", "aborted"] as const) {
+      const run = recovered.find((candidate) => candidate.runId === `${status}-orphan-agent`);
+      assert.equal(run?.status, status);
+      assert.equal(run?.agents[0]?.status, "skipped");
+      assert.ok(run?.agents[0]?.endedAt, `${status} orphan should have a terminal timestamp`);
+    }
+  }),
+);
+
+test(
   "cold-start recovery leaves a live leased running run untouched",
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({ cwd });
@@ -1153,6 +1380,85 @@ test(
   }),
 );
 
+test(
+  "parallel journal hole reruns done rows as queued then running while cached rows keep completion metadata",
+  withTempCwd(async (cwd) => {
+    const script = `export const meta = { name: 'parallel_hole', description: 'parallel resume hole' }
+const values = await parallel(['a', 'b', 'c'].map((p) => () => agent(p, { label: p })))
+return values`;
+    const initial = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string) {
+          return `first:${prompt}`;
+        },
+      },
+    });
+    await initial.runSync(script, undefined, { concurrency: 3 });
+    const persisted = initial.listRuns().find((run) => run.workflowName === "parallel_hole");
+    assert.ok(persisted?.journal);
+    const cachedEndedAt = persisted.agents.find((agent) => agent.callIndex === 0)?.endedAt;
+    initial.getPersistence().save({
+      ...persisted,
+      status: "paused",
+      journal: persisted.journal.filter((entry) => entry.index !== 1),
+    });
+
+    const releases = new Map<string, (value: string) => void>();
+    let startedCount = 0;
+    let resolveStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const resumed = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string) {
+          startedCount++;
+          if (startedCount === 2) resolveStarted();
+          return new Promise<string>((resolve) => releases.set(prompt, resolve));
+        },
+      },
+    });
+
+    assert.equal(await resumed.resume(persisted.runId), true);
+    await started;
+    const liveByLabel = new Map(resumed.getSnapshot(persisted.runId)?.agents.map((agent) => [agent.label, agent]));
+    assert.equal(liveByLabel.get("a")?.status, "done", "actual cache replay remains done");
+    assert.equal(liveByLabel.get("b")?.status, "running", "journal hole must rerun live");
+    assert.equal(liveByLabel.get("c")?.status, "running", "suffix after the hole must rerun live");
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    const durableByLabel = new Map(
+      resumed
+        .listRuns()
+        .find((run) => run.runId === persisted.runId)
+        ?.agents.map((agent) => [agent.label, agent]),
+    );
+    assert.equal(durableByLabel.get("a")?.endedAt, cachedEndedAt, "cached replay preserves completion time");
+    assert.equal(durableByLabel.get("b")?.endedAt, undefined, "live rerun clears stale completion time");
+    assert.equal(durableByLabel.get("c")?.endedAt, undefined, "live suffix clears stale completion time");
+
+    const cEnded = new Promise<void>((resolve) => {
+      resumed.on("agentEnd", (event: { label: string }) => {
+        if (event.label === "c") resolve();
+      });
+    });
+    releases.get("c")?.("second:c");
+    await cEnded;
+    const outOfOrder = new Map(
+      resumed.getSnapshot(persisted.runId)?.agents.map((agent) => [agent.label, agent.status]),
+    );
+    assert.equal(outOfOrder.get("b"), "running");
+    assert.equal(outOfOrder.get("c"), "done");
+
+    const completed = new Promise<void>((resolve) => resumed.once("complete", () => resolve()));
+    releases.get("b")?.("second:b");
+    await completed;
+    assert.equal(resumed.getRun(persisted.runId)?.status, "completed");
+  }),
+);
+
 // ─── getRun tests ──────────────────────────────────────────────────────────────
 
 test(
@@ -1209,7 +1515,7 @@ test(
     const { runId, promise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
 
-    // Stop first, then delete
+    assert.equal(manager.deleteRun(runId), false, "running run must be stopped before removal");
     manager.stop(runId);
     const deleted = manager.deleteRun(runId);
     assert.equal(deleted, true);
@@ -1219,13 +1525,18 @@ test(
 
     da.resolve("done");
     await promise.catch(() => {});
+    assert.equal(
+      manager.listRuns().some((item) => item.runId === runId),
+      false,
+      "settlement must not resurrect it",
+    );
   }),
 );
 
 // ─── deleteRun tests ───────────────────────────────────────────────────────────
 
 test(
-  "deleteRun can delete a running run (removes from memory and persistence)",
+  "deleteRun refuses running and paused runs until they are stopped",
   withTempCwd(async (cwd) => {
     const da = deferredAgent();
     const manager = new WorkflowManager({ cwd, agent: da.runner });
@@ -1233,22 +1544,18 @@ test(
     const { runId, promise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
 
-    // Delete while running — should succeed (removes from tracking)
-    const deleted = manager.deleteRun(runId);
-    assert.equal(deleted, true);
-
-    // Should not be in memory
-    assert.equal(manager.getRun(runId), undefined);
-
-    // Should not be in persistence
-    const runs = manager.listRuns();
-    assert.equal(
-      runs.find((r) => r.runId === runId),
-      undefined,
-    );
+    assert.equal(manager.deleteRun(runId), false);
+    manager.pause(runId);
+    assert.equal(manager.deleteRun(runId), false);
+    manager.stop(runId);
+    assert.equal(manager.deleteRun(runId), true);
 
     da.resolve("done");
     await promise.catch(() => {});
+    assert.equal(
+      manager.listRuns().some((run) => run.runId === runId),
+      false,
+    );
   }),
 );
 
@@ -1382,7 +1689,9 @@ test(
     await new Promise((resolve) => setTimeout(resolve, 20));
     manager.pause(runId);
 
-    const resumed = await manager.resume(runId);
+    const resumePromise = manager.resume(runId);
+    da.resolve("done");
+    const resumed = await resumePromise;
     const persisted = manager.listRuns().find((run) => run.runId === runId);
 
     assert.equal(resumed, true);
@@ -1408,7 +1717,9 @@ test(
     const { runId, promise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
     manager.pause(runId);
-    await manager.resume(runId);
+    const resumePromise = manager.resume(runId);
+    da.resolve("done");
+    await resumePromise;
 
     assert.ok(resumedEvent, "resumed event should fire");
     assert.equal(resumedEvent?.runId, runId);
@@ -1466,12 +1777,13 @@ test(
     assert.equal(manager.pause(runId), true);
     assert.equal(manager.getRun(runId)?.status, "paused", "should be paused after pause");
 
-    const resumed = await manager.resume(runId);
+    const resumePromise = manager.resume(runId);
+    da.resolve("resumed-done");
+    const resumed = await resumePromise;
     assert.equal(resumed, true);
     assert.equal(manager.getRun(runId)?.status, "running", "should be running after resume");
 
     // Complete the resumed run
-    da.resolve("resumed-done");
     await origPromise.catch(() => {});
     await new Promise((r) => setTimeout(r, 30));
 
@@ -1597,8 +1909,10 @@ test(
     assert.equal(manager.pause(runId), true);
     assert.equal(manager.getRun(runId)?.status, "paused");
 
-    // First resume should succeed
-    const firstResume = await manager.resume(runId);
+    // First resume waits for the old execution to settle, then succeeds.
+    const firstResumePromise = manager.resume(runId);
+    da.resolve("done");
+    const firstResume = await firstResumePromise;
     assert.equal(firstResume, true, "first resume should succeed");
 
     // The resumed run is now running; second resume should return false
@@ -1660,8 +1974,10 @@ test(
     });
 
     try {
-      // Resume — executeRun calls runWorkflow which calls the mocked runner
-      const resumed = await manager.resume(runId);
+      // Resume waits for the old execution, then calls the mocked runner.
+      const resumePromise = manager.resume(runId);
+      da.resolve("done");
+      const resumed = await resumePromise;
       assert.equal(resumed, true, "resume should schedule the run");
 
       // Wait for the background executed run to process the agent error
@@ -1732,8 +2048,10 @@ test(
     });
 
     try {
-      // Resume — the run will fail because the mocked agent throws
-      const resumed = await manager.resume(runId);
+      // Resume waits for the old execution, then fails because the mocked agent throws.
+      const resumePromise = manager.resume(runId);
+      da.resolve("done");
+      const resumed = await resumePromise;
       assert.equal(resumed, true, "resume should schedule the run");
       await new Promise((r) => setTimeout(r, 100));
 
@@ -1774,8 +2092,10 @@ test(
     });
 
     try {
-      // Resume — the run will fail
-      const resumed = await manager.resume(runId);
+      // Resume waits for the old execution, then fails.
+      const resumePromise = manager.resume(runId);
+      da.resolve("done");
+      const resumed = await resumePromise;
       assert.equal(resumed, true, "resume should schedule the run");
       await new Promise((r) => setTimeout(r, 100));
 
@@ -1816,8 +2136,10 @@ test(
     });
 
     try {
-      // Resume — the run will fail
-      await manager.resume(runId);
+      // Resume waits for the old execution, then fails.
+      const resumePromise = manager.resume(runId);
+      da.resolve("done");
+      await resumePromise;
       await new Promise((r) => setTimeout(r, 100));
 
       // Verify the run is now in failed state
@@ -1899,11 +2221,11 @@ test(
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({ cwd, agent: fakeAgent(), persistAgentSessions: true });
     // The manager forwards the flag on every runWorkflow call; the flag is
-    // captured at construction and defaults to false when omitted.
+    // captured at construction and defaults to true for resumable workflow agents.
     assert.equal((manager as unknown as { persistAgentSessions: boolean }).persistAgentSessions, true);
 
     const defaulted = new WorkflowManager({ cwd, agent: fakeAgent() });
-    assert.equal((defaulted as unknown as { persistAgentSessions: boolean }).persistAgentSessions, false);
+    assert.equal((defaulted as unknown as { persistAgentSessions: boolean }).persistAgentSessions, true);
 
     // The run still completes normally with the flag set (injected agent
     // runner, so no real session is created here).
@@ -1930,6 +2252,79 @@ test(
     assert.equal(result.agentCount, 1);
     assert.equal(seen.length, 1);
     assert.equal(seen[0].label, "a");
-    assert.match(seen[0].sessionName ?? "", /^workflow:run-[a-z0-9]+ a$/);
+    assert.match(seen[0].sessionName ?? "", /^workflow:tracked-demo-[a-z0-9-]+ a$/);
+  }),
+);
+
+test(
+  "pause distinguishes interrupted agents from not-started work and resume reopens the child session",
+  withTempCwd(async (cwd) => {
+    const childSession = join(cwd, "first-child.jsonl");
+    let startedResolve!: () => void;
+    const started = new Promise<void>((resolve) => {
+      startedResolve = resolve;
+    });
+    const calls: Array<{ prompt: string; resumeSessionFile?: string }> = [];
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(
+          prompt: string,
+          options?: {
+            signal?: AbortSignal;
+            resumeSessionFile?: string;
+            onSession?: (checkpoint: { sessionFile?: string; resumed: boolean }) => void;
+          },
+        ) {
+          calls.push({ prompt, resumeSessionFile: options?.resumeSessionFile });
+          const resumed = options?.resumeSessionFile === childSession;
+          const sessionFile = prompt === "first" ? childSession : join(cwd, "second-child.jsonl");
+          options?.onSession?.({ sessionFile, resumed });
+          if (prompt === "first" && !resumed) {
+            startedResolve();
+            await new Promise<never>((_resolve, reject) => {
+              const abort = () => reject(new Error("Subagent was aborted"));
+              if (options?.signal?.aborted) abort();
+              else options?.signal?.addEventListener("abort", abort, { once: true });
+            });
+          }
+          return resumed ? "continued-first" : "fresh-second";
+        },
+      },
+    });
+    const script = `export const meta = { name: 'resume_children', description: 'resume child sessions' }
+return await parallel([
+  () => agent('first', { label: 'first' }),
+  () => agent('second', { label: 'second' })
+])`;
+
+    const { runId, promise } = manager.startInBackground(script, undefined, { concurrency: 1 });
+    await started;
+    assert.equal(manager.pause(runId), true);
+    await promise.catch(() => {});
+
+    const paused = manager.listRuns().find((run) => run.runId === runId);
+    assert.equal(paused?.status, "paused");
+    assert.deepEqual(
+      paused?.agents.map((agent) => agent.status),
+      ["paused", "queued"],
+      "only the invocation that entered the runner is paused mid-run",
+    );
+    assert.equal(paused?.agents[0].sessionFile, childSession);
+    assert.equal(paused?.agents[1].sessionFile, undefined);
+
+    assert.equal(await manager.resume(runId), true);
+    for (let i = 0; i < 100 && manager.getRun(runId)?.status === "running"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(manager.getRun(runId)?.status, "completed");
+    assert.ok(
+      calls.some((call) => call.prompt === "first" && call.resumeSessionFile === childSession),
+      "the interrupted invocation reopens its child session",
+    );
+    assert.ok(
+      calls.some((call) => call.prompt === "second" && call.resumeSessionFile === undefined),
+      "never-started work begins in a fresh child session",
+    );
   }),
 );

--- a/tests/workflow-paths.test.ts
+++ b/tests/workflow-paths.test.ts
@@ -47,6 +47,7 @@ describe("workflow paths", () => {
       assert.ok(paths.rootDir.startsWith(join(home, WORKFLOW_HOME_RELATIVE_DIR, WORKFLOW_PROJECTS_SUBDIR)));
       assert.equal(paths.runsDir, join(paths.rootDir, "runs"));
       assert.equal(paths.savedDir, join(paths.rootDir, "saved"));
+      assert.equal(paths.agentSessionsDir, join(paths.rootDir, "agent-sessions"));
       assert.equal(paths.settingsPath, join(paths.rootDir, "settings.json"));
       assert.equal(paths.legacyRunsDir, normalize(join(cwd, ".pi/workflows/runs")));
       assert.equal(paths.legacySavedDir, normalize(join(cwd, ".pi/workflows/saved")));

--- a/tests/workflow-resume-state.test.ts
+++ b/tests/workflow-resume-state.test.ts
@@ -1,0 +1,332 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { AgentUsage } from "../src/agent.js";
+import { WorkflowManager } from "../src/workflow-manager.js";
+import { workflowProjectPaths } from "../src/workflow-paths.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+const script = `export const meta = { name: 'resume_42', description: 'durable restart fixture' }
+phase('Work')
+const results = await parallel(Array.from({ length: 42 }, (_, i) => () => agent('task-' + i, { label: 'worker' })))
+return results`;
+
+function usage(total: number): AgentUsage {
+  return { input: total - 1, output: 1, cacheRead: 0, cacheWrite: 0, total, cost: total / 1000 };
+}
+
+function agentWithUsage(total: number, activity?: { active: number; maximum: number; calls: number }) {
+  return {
+    async run(prompt: string, options: { onUsage?: (value: AgentUsage) => void }) {
+      if (activity) {
+        activity.active++;
+        activity.maximum = Math.max(activity.maximum, activity.active);
+        activity.calls++;
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+      options.onUsage?.(usage(total));
+      if (activity) activity.active--;
+      return `result:${prompt}`;
+    },
+  };
+}
+
+async function waitForCompletion(manager: WorkflowManager, runId: string): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    if (manager.getRun(runId)?.status === "completed") return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail("resumed workflow did not complete");
+}
+
+test("cold resume preserves 27 completed rows and execution controls without double charging", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-resume-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const first = new WorkflowManager({ cwd, agent: agentWithUsage(10) });
+      await first.runSync(script, undefined, {
+        concurrency: 8,
+        maxAgents: 42,
+        agentRetries: 1,
+        agentTimeoutMs: null,
+        tokenBudget: 10_000,
+      });
+      const seeded = first.listRuns()[0];
+      assert.equal(seeded.agents.length, 42);
+      assert.equal(seeded.journal?.length, 42);
+
+      first.getPersistence().save({
+        ...seeded,
+        status: "paused",
+        agents: seeded.agents.map((agent, index) =>
+          index < 27
+            ? agent
+            : {
+                ...agent,
+                status: "queued",
+                result: undefined,
+                resultPreview: undefined,
+                usage: undefined,
+                tokens: undefined,
+                endedAt: undefined,
+              },
+        ),
+        journal: seeded.journal?.slice(0, 27),
+        tokenUsage: { input: 243, output: 27, total: 270, cost: 0.27, cacheRead: 0, cacheWrite: 0 },
+        result: undefined,
+        completedAt: undefined,
+        durationMs: undefined,
+      });
+
+      const activity = { active: 0, maximum: 0, calls: 0 };
+      const resumed = new WorkflowManager({ cwd, agent: agentWithUsage(20, activity) });
+      assert.equal(await resumed.resume(seeded.runId), true);
+      await waitForCompletion(resumed, seeded.runId);
+
+      const final = resumed.listRuns().find((run) => run.runId === seeded.runId);
+      assert.ok(final);
+      assert.equal(final.agents.length, 42);
+      assert.equal(new Set(final.agents.map((agent) => agent.executionId)).size, 42);
+      assert.deepEqual(
+        final.agents.slice(0, 27).map((agent) => agent.status),
+        Array(27).fill("done"),
+      );
+      assert.deepEqual(
+        final.agents.slice(0, 27).map((agent) => agent.tokens),
+        Array(27).fill(10),
+      );
+      assert.deepEqual(
+        final.agents.slice(27).map((agent) => agent.tokens),
+        Array(15).fill(20),
+      );
+      assert.equal(activity.calls, 15, "journaled prefix is replayed, not re-run");
+      assert.ok(activity.maximum <= 8);
+      assert.equal(final.tokenUsage?.total, 570);
+      assert.equal(final.requestedConcurrency, 8);
+      assert.equal(final.effectiveConcurrency, 8);
+      assert.equal(final.maxAgents, 42);
+      assert.equal(final.agentRetries, 1);
+      assert.equal(final.agentTimeoutMs, null);
+      assert.equal(final.tokenBudget, 10_000);
+      assert.equal(new Date(final.startedAt).getTime(), new Date(seeded.startedAt).getTime());
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("exact message usage is debounced to disk while streaming estimates remain live-only", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-exact-usage-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
+  let release: (() => void) | undefined;
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const manager = new WorkflowManager({
+        cwd,
+        agent: {
+          async run(_prompt: string, options: { onUsage?: (value: AgentUsage) => void }) {
+            options.onUsage?.(usage(11));
+            options.onUsage?.({ ...usage(20), estimated: true });
+            await new Promise<void>((resolve) => {
+              release = resolve;
+            });
+            return "done";
+          },
+        },
+      });
+      manager.on("error", () => {});
+      const one = `export const meta = { name: 'usage', description: 'message usage' }
+return await agent('one', { label: 'one' })`;
+      const { runId, promise } = manager.startInBackground(one);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const live = manager.getSnapshot(runId)?.agents[0];
+      const durable = manager.getPersistence().load(runId)?.agents[0];
+      assert.equal(live?.tokens, 20);
+      assert.equal(live?.tokensEstimated, true);
+      assert.equal(durable?.usage?.total, 11);
+      assert.equal(durable?.tokens, 11);
+
+      manager.pause(runId);
+      release?.();
+      await promise.catch(() => {});
+    });
+  } finally {
+    release?.();
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("agent completion persists journal, terminal row, result, and exact usage together", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-crash-window-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const one = `export const meta = { name: 'atomic', description: 'atomic completion' }
+return await agent('one', { label: 'one' })`;
+      const manager = new WorkflowManager({ cwd, agent: agentWithUsage(33) });
+      let durableAtEvent = false;
+      manager.on("agentEnd", ({ runId }: { runId: string }) => {
+        const saved = manager.getPersistence().load(runId);
+        durableAtEvent =
+          saved?.journal?.[0]?.usage?.total === 33 &&
+          saved.agents[0]?.status === "done" &&
+          saved.agents[0]?.usage?.total === 33 &&
+          saved.agents[0]?.result === "result:one";
+      });
+
+      await manager.runSync(one);
+      assert.equal(durableAtEvent, true);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("nested cold resume replays scoped journal rows and preserves completed timestamps at zero remaining budget", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-nested-resume-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const child = `export const meta = { name: 'child', description: 'child' }
+return await agent('child work', { label: 'child' })`;
+      const parent = `export const meta = { name: 'parent', description: 'parent' }
+const parentResult = await agent('parent work', { label: 'parent' })
+const childResult = await workflow('child')
+return { parentResult, childResult }`;
+      const loadSavedWorkflow = (name: string) => (name === "child" ? child : undefined);
+      const first = new WorkflowManager({ cwd, agent: agentWithUsage(10), loadSavedWorkflow });
+      await first.runSync(parent, undefined, { tokenBudget: 20 });
+      const seeded = first.listRuns()[0];
+      assert.equal(seeded.journal?.length, 2);
+      assert.equal(new Set(seeded.journal?.map((entry) => entry.executionId)).size, 2);
+      const timestamps = new Map(seeded.agents.map((agent) => [agent.executionId, [agent.startedAt, agent.endedAt]]));
+      first.getPersistence().save({
+        ...seeded,
+        status: "paused",
+        result: undefined,
+        completedAt: undefined,
+        durationMs: undefined,
+      });
+
+      const activity = { active: 0, maximum: 0, calls: 0 };
+      const resumed = new WorkflowManager({ cwd, agent: agentWithUsage(99, activity), loadSavedWorkflow });
+      assert.equal(await resumed.resume(seeded.runId), true);
+      await waitForCompletion(resumed, seeded.runId);
+
+      const final = resumed.listRuns().find((run) => run.runId === seeded.runId);
+      assert.ok(final);
+      assert.equal(activity.calls, 0, "both scoped rows replay without live work");
+      assert.equal(final.tokenUsage?.total, 20);
+      assert.equal(new Set(final.agents.map((agent) => agent.executionId)).size, 2);
+      for (const agent of final.agents) {
+        assert.deepEqual([agent.startedAt, agent.endedAt], timestamps.get(agent.executionId));
+      }
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("tokens-only v1 completed rows survive cold replay and enter aggregate accounting once", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-v1-resume-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const one = `export const meta = { name: 'legacy_tokens', description: 'legacy tokens' }
+return await agent('work', { label: 'legacy' })`;
+      const first = new WorkflowManager({ cwd, agent: agentWithUsage(10) });
+      await first.runSync(one);
+      const seeded = first.listRuns()[0];
+      const runsDir = workflowProjectPaths(cwd).runsDir;
+      mkdirSync(runsDir, { recursive: true });
+      writeFileSync(
+        join(runsDir, `${seeded.runId}.json`),
+        JSON.stringify({
+          version: 1,
+          runId: seeded.runId,
+          workflowName: seeded.workflowName,
+          script: seeded.script,
+          status: "paused",
+          phases: seeded.phases,
+          agents: seeded.agents.map(
+            ({ executionId: _executionId, callIndex: _callIndex, usage: _usage, ...agent }) => ({
+              ...agent,
+              tokens: 10,
+            }),
+          ),
+          logs: seeded.logs,
+          journal: seeded.journal?.map(({ executionId: _executionId, usage: _usage, ...entry }) => entry),
+          startedAt: seeded.startedAt,
+          updatedAt: seeded.updatedAt,
+        }),
+      );
+
+      const activity = { active: 0, maximum: 0, calls: 0 };
+      const resumed = new WorkflowManager({ cwd, agent: agentWithUsage(50, activity) });
+      assert.equal(await resumed.resume(seeded.runId), true);
+      await waitForCompletion(resumed, seeded.runId);
+
+      const final = resumed.listRuns().find((run) => run.runId === seeded.runId);
+      assert.ok(final);
+      assert.equal(activity.calls, 0);
+      assert.equal(final.agents[0].tokens, 10);
+      assert.equal(final.agents[0].usage, undefined);
+      assert.equal(final.tokenUsage?.total, 10);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("unfinished exact usage is a per-invocation resume baseline included exactly once", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-usage-baseline-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-home-"));
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const one = `export const meta = { name: 'usage_baseline', description: 'usage baseline' }
+return await agent('work', { label: 'worker' })`;
+      const first = new WorkflowManager({ cwd, agent: agentWithUsage(7) });
+      await first.runSync(one);
+      const seeded = first.listRuns()[0];
+      first.getPersistence().save({
+        ...seeded,
+        status: "paused",
+        agents: seeded.agents.map((agent) => ({
+          ...agent,
+          status: "queued",
+          result: undefined,
+          resultPreview: undefined,
+          endedAt: undefined,
+        })),
+        journal: [],
+        tokenUsage: { input: 6, output: 1, total: 7, cost: 0.007, cacheRead: 0, cacheWrite: 0 },
+        result: undefined,
+        completedAt: undefined,
+        durationMs: undefined,
+      });
+
+      const resumed = new WorkflowManager({ cwd, agent: agentWithUsage(5) });
+      assert.equal(await resumed.resume(seeded.runId), true);
+      await waitForCompletion(resumed, seeded.runId);
+
+      const final = resumed.listRuns().find((run) => run.runId === seeded.runId);
+      assert.ok(final);
+      assert.equal(final.agents[0].usage?.total, 12);
+      assert.equal(final.agents[0].tokens, 12);
+      assert.equal(final.journal?.[0].usage?.total, 12);
+      assert.equal(final.tokenUsage?.total, 12);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
@@ -77,6 +80,230 @@ return xs`;
   assert.equal(maxActive, 2);
   assert.deepEqual(result.result, ["ok:a", "ok:b", "ok:c", "ok:d"]);
   assert.equal(result.agentCount, 4);
+});
+
+test("queued and running callbacks keep duplicate labels separated by executionId", async () => {
+  const release = createDeferred<void>();
+  let runnerStarts = 0;
+  const queued: Array<{ executionId: string; callIndex: number; label: string }> = [];
+  const started: Array<{ executionId: string; callIndex: number; label: string }> = [];
+  const histories: Array<{ executionId: string; history: unknown[] }> = [];
+  const usages: Array<{ executionId: string; usage: AgentUsage }> = [];
+  const ended: Array<{ executionId: string; result: unknown }> = [];
+  const runner = {
+    async run(
+      prompt: string,
+      options: { onHistory?: (history: unknown[]) => void; onUsage?: (usage: AgentUsage) => void },
+    ) {
+      runnerStarts++;
+      options.onHistory?.([{ role: "assistant", kind: "text", text: prompt }]);
+      await release.promise;
+      const total = prompt.charCodeAt(0) - 96;
+      options.onUsage?.({ input: total, output: 0, cacheRead: 0, cacheWrite: 0, total, cost: 0 });
+      return `done:${prompt}`;
+    },
+  };
+  const script = `export const meta = { name: 'identities', description: 'duplicate labels' }
+const xs = await parallel(['a','b','c','d'].map((p) => () => agent(p, { label: 'worker' })))
+return xs`;
+
+  const run = runWorkflow(script, {
+    runId: "identity-run",
+    agent: runner,
+    concurrency: 2,
+    persistLogs: false,
+    onAgentQueued: (event) => queued.push(event),
+    onAgentStart: (event) => started.push(event),
+    onAgentHistory: (event) => histories.push(event),
+    onAgentUsage: (event) => usages.push(event),
+    onAgentEnd: (event) => ended.push(event),
+  });
+  while (runnerStarts < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(queued.length, 4, "all logical invocations should be visible before limiter admission");
+  assert.equal(started.length, 2, "only admitted invocations should be running");
+  assert.equal(new Set(queued.map((event) => event.executionId)).size, 4);
+  assert.deepEqual(
+    queued.map((event) => event.executionId),
+    ["identity-run:0", "identity-run:1", "identity-run:2", "identity-run:3"],
+  );
+  assert.deepEqual(
+    started.map((event) => event.executionId),
+    ["identity-run:0", "identity-run:1"],
+  );
+  assert.equal(histories.length, 2);
+
+  release.resolve();
+  await run;
+  assert.equal(started.length, 4);
+  assert.equal(histories.length, 4);
+  assert.equal(new Set(histories.map((event) => event.executionId)).size, 4);
+  assert.equal(new Set(usages.map((event) => event.executionId)).size, 4);
+  assert.equal(ended.length, 4);
+  assert.equal(new Set(ended.map((event) => event.executionId)).size, 4);
+  assert.deepEqual(ended.map((event) => event.result).sort(), ["done:a", "done:b", "done:c", "done:d"]);
+});
+
+test("aborted queued agents without exact usage finish skipped at zero tokens", async () => {
+  const release = createDeferred<void>();
+  const controller = new AbortController();
+  let starts = 0;
+  const queued: string[] = [];
+  const ended: Array<{ status: string; tokens?: number; usage?: AgentUsage }> = [];
+  const run = runWorkflow(
+    `export const meta = { name: 'abort_queue', description: 'abort queue' }
+return await parallel(['a','b','c'].map((p) => () => agent(p, { label: p })))`,
+    {
+      agent: {
+        async run() {
+          starts++;
+          await release.promise;
+          return "done";
+        },
+      },
+      concurrency: 1,
+      signal: controller.signal,
+      persistLogs: false,
+      onAgentQueued: (event) => queued.push(event.executionId),
+      onAgentEnd: (event) => ended.push(event),
+    },
+  );
+  while (starts < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  controller.abort();
+  release.resolve();
+  await assert.rejects(run, /aborted/i);
+
+  assert.equal(starts, 1, "queued work never reaches the runner");
+  assert.equal(queued.length, 3, "all logical invocations remain visible");
+  assert.equal(ended.length, 1, "only the invocation that actually started can be aborted");
+  assert.ok(ended.every((event) => event.status === "skipped" && event.tokens === 0 && event.usage === undefined));
+});
+
+test("resumed invocation reuses its saved child session and preserved worktree cwd", async () => {
+  const worktreeCwd = mkdtempSync(join(tmpdir(), "pi-dw-resume-worktree-"));
+  const sessionFile = join(worktreeCwd, "child.jsonl");
+  const seen: Array<{ cwd?: string; resumeSessionFile?: string }> = [];
+  try {
+    const result = await runWorkflow(
+      `export const meta = { name: 'resume_worktree', description: 'resume worktree' }
+return await agent('continue', { label: 'worker', isolation: 'worktree' })`,
+      {
+        runId: "resume-worktree",
+        persistLogs: false,
+        resumeAgents: new Map([
+          [
+            "resume-worktree:0",
+            {
+              sessionFile,
+              worktree: {
+                isolated: true,
+                cwd: worktreeCwd,
+                repoRoot: worktreeCwd,
+                branch: "pi/wf/resume-worktree",
+              },
+            },
+          ],
+        ]),
+        agent: {
+          async run(
+            _prompt: string,
+            options: {
+              cwd?: string;
+              resumeSessionFile?: string;
+              onSession?: (checkpoint: { sessionFile?: string; resumed: boolean }) => void;
+            },
+          ) {
+            seen.push({ cwd: options.cwd, resumeSessionFile: options.resumeSessionFile });
+            options.onSession?.({ sessionFile: options.resumeSessionFile, resumed: true });
+            return "continued";
+          },
+        },
+      },
+    );
+    assert.equal(result.result, "continued");
+    assert.deepEqual(seen, [{ cwd: worktreeCwd, resumeSessionFile: sessionFile }]);
+  } finally {
+    rmSync(worktreeCwd, { recursive: true, force: true });
+  }
+});
+
+test("incremental estimates are display-only and exact usage replaces them before completion", async () => {
+  const reported = createDeferred<void>();
+  const release = createDeferred<void>();
+  const agentUsage: AgentUsage[] = [];
+  const runUsage: number[] = [];
+  let completed = false;
+  const runner = {
+    async run(_prompt: string, options: { onUsage?: (usage: AgentUsage) => void }) {
+      options.onUsage?.({
+        input: 0,
+        output: 20,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 20,
+        cost: 0,
+        estimated: true,
+      });
+      options.onUsage?.({ input: 8, output: 4, cacheRead: 0, cacheWrite: 0, total: 12, cost: 0.01 });
+      reported.resolve();
+      await release.promise;
+      return "done";
+    },
+  };
+
+  const run = runWorkflow(
+    `export const meta = { name: 'live_usage', description: 'usage before completion' }
+return await agent('work', { label: 'worker' })`,
+    {
+      runId: "usage-run",
+      agent: runner,
+      persistLogs: false,
+      onAgentUsage: (event) => agentUsage.push(event.usage),
+      onTokenUsage: (usage) => runUsage.push(usage.total),
+    },
+  ).then((result) => {
+    completed = true;
+    return result;
+  });
+  await reported.promise;
+
+  assert.equal(completed, false, "usage should move while the child is still blocked");
+  assert.deepEqual(
+    agentUsage.slice(0, 2).map((usage) => ({ total: usage.total, estimated: usage.estimated })),
+    [
+      { total: 20, estimated: true },
+      { total: 12, estimated: false },
+    ],
+  );
+  assert.deepEqual(runUsage, [12], "the streaming estimate must not enter budget/run accounting");
+
+  release.resolve();
+  const result = await run;
+  assert.equal(result.tokenUsage?.total, 12);
+  assert.equal(agentUsage.at(-1)?.total, 12, "terminal reconciliation replaces rather than adds usage");
+  assert.equal(agentUsage.at(-1)?.estimated, false);
+});
+
+test("repeated absolute usage updates are idempotent", async () => {
+  const result = await runWorkflow(
+    `export const meta = { name: 'idempotent_usage', description: 'usage' }
+return await agent('work', { label: 'worker' })`,
+    {
+      agent: {
+        async run(_prompt: string, options: { onUsage?: (usage: AgentUsage) => void }) {
+          const usage = { input: 6, output: 4, cacheRead: 0, cacheWrite: 0, total: 10, cost: 0.01 };
+          options.onUsage?.(usage);
+          options.onUsage?.(usage);
+          return "done";
+        },
+      },
+      persistLogs: false,
+    },
+  );
+
+  assert.equal(result.tokenUsage?.total, 10);
+  assert.equal(result.tokenUsage?.input, 6);
+  assert.equal(result.tokenUsage?.cost, 0.01);
 });
 
 test("runWorkflow retries recoverable empty output then succeeds", async () => {
@@ -216,16 +443,38 @@ return 1`;
   assert.equal(seenModel, "meta/default-model", "an agent with no model/tier/phase route uses meta.model");
 });
 
-test("runWorkflow falls back to an estimate when provider reports total === 0", async () => {
+test("an exact provider total of zero is not replaced by an estimate", async () => {
+  const journal: JournalEntry[] = [];
+  const usages: AgentUsage[] = [];
   const result = await runWorkflow(twoAgentScript, {
     agent: fakeAgent({ total: 0 }, "a result string"),
     persistLogs: false,
+    onAgentUsage: (event) => usages.push(event.usage),
+    onAgentJournal: (entry) => journal.push(entry),
   });
 
-  assert.equal(result.tokenUsage?.input, 0);
-  assert.equal(result.tokenUsage?.output, 0);
-  assert.ok((result.tokenUsage?.total ?? 0) > 0, "estimate should be positive");
-  assert.equal(result.tokenUsage?.cost, 0);
+  assert.equal(result.tokenUsage?.total, 0);
+  assert.ok(usages.every((usage) => usage.total === 0 && usage.estimated === false));
+  assert.ok(journal.every((entry) => entry.usage?.total === 0 && entry.usage.estimated === false));
+});
+
+test("missing provider usage emits an estimate without charging or journaling it", async () => {
+  const journal: JournalEntry[] = [];
+  const usages: AgentUsage[] = [];
+  const result = await runWorkflow(twoAgentScript, {
+    agent: {
+      async run() {
+        return "a result string";
+      },
+    },
+    persistLogs: false,
+    onAgentUsage: (event) => usages.push(event.usage),
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+
+  assert.equal(result.tokenUsage?.total, 0);
+  assert.ok(usages.every((usage) => usage.total > 0 && usage.estimated === true));
+  assert.ok(journal.every((entry) => entry.usage === undefined));
 });
 
 test("agents default to the first declared phase when the script omits phase()", async () => {
@@ -454,6 +703,11 @@ test("callSeq is deterministic under parallel()", async () => {
     journal.map((e) => e.index).sort((a, b) => a - b),
     [0, 1, 2],
   );
+  assert.equal(new Set(journal.map((entry) => entry.executionId)).size, 3);
+  assert.ok(
+    journal.every((entry) => entry.usage === undefined),
+    "estimates are not journaled as exact usage",
+  );
 });
 
 test("workflow() runs a nested saved workflow and shares the global agent counter", async () => {
@@ -473,6 +727,49 @@ return { a, nested }`;
 
   assert.equal(result.agentCount, 2);
   assert.equal(result.result.nested.child, "ran:child task");
+});
+
+test("a changed child invalidates later parent resume results", async () => {
+  const childV1 = `export const meta = { name: 'child', description: 'c' }
+return await agent('child original', { label: 'child' })`;
+  const childV2 = `export const meta = { name: 'child', description: 'c' }
+return await agent('child changed', { label: 'child' })`;
+  const parent = `export const meta = { name: 'parent', description: 'p' }
+const before = await agent('parent before', { label: 'before' })
+const child = await workflow('child')
+const after = await agent('parent after', { label: 'after' })
+return { before, child, after }`;
+  const journal: JournalEntry[] = [];
+  await runWorkflow(parent, {
+    runId: "nested-miss",
+    agent: {
+      async run(prompt: string) {
+        return `first:${prompt}`;
+      },
+    },
+    loadSavedWorkflow: () => childV1,
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+
+  const livePrompts: string[] = [];
+  const resumed = await runWorkflow<{ before: string; child: string; after: string }>(parent, {
+    runId: "nested-miss",
+    agent: {
+      async run(prompt: string) {
+        livePrompts.push(prompt);
+        return `second:${prompt}`;
+      },
+    },
+    loadSavedWorkflow: () => childV2,
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((entry) => [entry.executionId ?? entry.index, entry] as const)),
+  });
+
+  assert.deepEqual(livePrompts, ["child changed", "parent after"]);
+  assert.equal(resumed.result.before, "first:parent before", "unchanged prefix still replays");
+  assert.equal(resumed.result.child, "second:child changed");
+  assert.equal(resumed.result.after, "second:parent after", "downstream parent work must not replay stale cache");
 });
 
 test("workflow() nesting is one level deep (second level throws)", async () => {
@@ -495,6 +792,37 @@ return { err }`;
     loadSavedWorkflow: (name) => map[name],
   });
   assert.match(result.result.err, /one level deep/);
+});
+
+test("cached replay succeeds when the live-work token budget is already exhausted", async () => {
+  const journal: JournalEntry[] = [];
+  const script = `export const meta = { name: 'cached_budget', description: 'cached budget' }
+return await agent('cached', { label: 'cached' })`;
+  await runWorkflow(script, {
+    runId: "cached-budget",
+    agent: fakeAgent({ total: 10 }),
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+
+  let liveCalls = 0;
+  const resumed = await runWorkflow(script, {
+    runId: "cached-budget",
+    agent: {
+      async run() {
+        liveCalls++;
+        return "live";
+      },
+    },
+    tokenBudget: 0,
+    persistLogs: false,
+    resumeJournal: new Map(
+      journal.flatMap((entry) => (entry.executionId ? [[entry.executionId, entry] as const] : [])),
+    ),
+  });
+
+  assert.equal(liveCalls, 0);
+  assert.equal(resumed.result, "ok");
 });
 
 test("runWorkflow budget gates on accumulated tokens", async () => {

--- a/tests/workflow-settings.test.ts
+++ b/tests/workflow-settings.test.ts
@@ -33,13 +33,19 @@ describe("workflow settings", () => {
     });
   });
 
-  it("saves and loads keyword trigger preferences", () => {
+  it("saves and loads explicit keyword trigger preferences", () => {
     withSettingsPath((settingsPath) => {
       saveWorkflowSettings({ keywordTriggerEnabled: false, keywordTriggerWord: "pi-workflow" }, settingsPath);
 
       assert.ok(existsSync(settingsPath), "settings file should be created");
       assert.deepEqual(loadWorkflowSettings(settingsPath), {
         keywordTriggerEnabled: false,
+        keywordTriggerWord: "pi-workflow",
+      });
+
+      saveWorkflowSettings({ keywordTriggerEnabled: true }, settingsPath);
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {
+        keywordTriggerEnabled: true,
         keywordTriggerWord: "pi-workflow",
       });
     });
@@ -77,7 +83,7 @@ describe("workflow settings", () => {
       assert.deepEqual(loadWorkflowSettings(settingsPath), { defaultConcurrency: 4, defaultAgentRetries: 2 });
 
       writeFileSync(settingsPath, JSON.stringify({ defaultConcurrency: 99, defaultAgentRetries: 99 }), "utf-8");
-      assert.deepEqual(loadWorkflowSettings(settingsPath), { defaultConcurrency: 16, defaultAgentRetries: 3 });
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { defaultConcurrency: 99, defaultAgentRetries: 3 });
 
       writeFileSync(settingsPath, JSON.stringify({ defaultConcurrency: 0, defaultAgentRetries: -1 }), "utf-8");
       assert.deepEqual(loadWorkflowSettings(settingsPath), {});

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Check } from "typebox/value";
 import { WorkflowManager } from "../src/workflow-manager.js";
 import { backgroundStartedText, createWorkflowTool, modelRoutingGuideline } from "../src/workflow-tool.js";
 
@@ -89,12 +90,72 @@ test("createWorkflowTool schema describes unbounded default timeout", () => {
   assert.match(description, /only when the user asks/i);
 });
 
-test("createWorkflowTool schema exposes concurrency and agentRetries", () => {
+test("createWorkflowTool schema exposes bounded integer concurrency and agentRetries", () => {
   const tool = createWorkflowTool();
-  const parameters = tool.parameters as { properties?: Record<string, { description?: string }> };
+  const parameters = tool.parameters as {
+    properties?: Record<string, { type?: string; minimum?: number; maximum?: number; description?: string }>;
+  };
+  const concurrency = parameters.properties?.concurrency;
 
-  assert.match(parameters.properties?.concurrency?.description ?? "", /Maximum concurrent agents/i);
+  assert.equal(concurrency?.type, "integer");
+  assert.equal(concurrency?.minimum, 1);
+  assert.equal(concurrency?.maximum, undefined);
+  assert.match(concurrency?.description ?? "", /Maximum concurrent agents/i);
+  assert.match(concurrency?.description ?? "", /configured default/i);
+  assert.match(parameters.properties?.maxAgents?.description ?? "", /whole run/i);
   assert.match(parameters.properties?.agentRetries?.description ?? "", /Retry attempts/i);
+});
+
+test("createWorkflowTool concurrency schema accepts any positive integer", () => {
+  const schema = createWorkflowTool().parameters;
+  const script = "export const meta = { name: 't', description: 't' }; agent('x')";
+
+  assert.equal(Check(schema, { script, concurrency: 1 }), true);
+  assert.equal(Check(schema, { script, concurrency: 16 }), true);
+  assert.equal(Check(schema, { script, concurrency: 128 }), true);
+  assert.equal(Check(schema, { script, concurrency: 10_000 }), true);
+  assert.equal(Check(schema, { script, concurrency: 0 }), false);
+  assert.equal(Check(schema, { script, concurrency: 1.5 }), false);
+});
+
+test("createWorkflowTool forwards model-selected concurrency", async () => {
+  let forwarded: number | undefined;
+  const manager = {
+    getModelRegistry: () => undefined,
+    startInBackground: (_script: string, _args: unknown, options: { concurrency?: number }) => {
+      forwarded = options.concurrency;
+      return { runId: "run-1", promise: Promise.resolve() };
+    },
+  } as unknown as WorkflowManager;
+  const tool = createWorkflowTool({ manager });
+  const script = "export const meta = { name: 't', description: 't' }; agent('x')";
+
+  const result = await (tool.execute as any)("call-1", { script, concurrency: 6 }, undefined, undefined, {});
+
+  assert.equal(forwarded, 6);
+  assert.equal(result.details.requestedConcurrency, 6);
+  assert.equal(result.details.effectiveConcurrency, 6);
+  assert.match(result.content[0].text, /requested 6; effective 6/i);
+});
+
+test("createWorkflowTool delegates unvalidated legacy concurrency to the manager without losing the request", async () => {
+  let forwarded: number | undefined;
+  const manager = {
+    getModelRegistry: () => undefined,
+    startInBackground: (_script: string, _args: unknown, options: { concurrency?: number }) => {
+      forwarded = options.concurrency;
+      return { runId: "run-legacy", promise: Promise.resolve() };
+    },
+  } as unknown as WorkflowManager;
+  const tool = createWorkflowTool({ manager });
+  const script = "export const meta = { name: 't', description: 't' }; agent('x')";
+
+  const result = await (tool.execute as any)("call-1", { script, concurrency: 99 }, undefined, undefined, {});
+
+  assert.equal(forwarded, 99);
+  assert.equal(result.details.requestedConcurrency, 99);
+  assert.equal(result.details.effectiveConcurrency, 99);
+  assert.match(result.content[0].text, /requested 99; effective 99/i);
 });
 
 test("createWorkflowTool promptGuidelines mention retry and concurrency controls", () => {
@@ -102,6 +163,10 @@ test("createWorkflowTool promptGuidelines mention retry and concurrency controls
   const all = tool.promptGuidelines.join(" ");
 
   assert.match(all, /low concurrency/i);
+  assert.match(all, /independent tasks/i);
+  assert.match(all, /configured default \(16 unless overridden\)/i);
+  assert.match(all, /concurrency: 24/i);
+  assert.match(all, /maxAgents: 24/i);
   assert.match(all, /agentRetries/i);
   assert.match(all, /null handling/i);
 });

--- a/tests/workflow-tools-available.test.ts
+++ b/tests/workflow-tools-available.test.ts
@@ -33,6 +33,7 @@ const DEFAULT_PI_TOOLS = [
   "advisor",
   "subagent",
   "workflow",
+  "workflow_control",
 ];
 
 // Additional tools from context-mode plugin (common but not guaranteed)
@@ -141,7 +142,7 @@ describe("installWorkflowEditor - tool availability", () => {
     const { installWorkflowEditor } = await import("../src/workflow-editor.js");
 
     // Add a bonus tool to simulate a plugin adding a tool
-    const originalTools = ["bash", "read", "edit", "write", "custom-plugin-tool", "workflow"];
+    const originalTools = ["bash", "read", "edit", "write", "custom-plugin-tool", "workflow", "workflow_control"];
     const mockPi = createMockPi(originalTools);
 
     const ui = {
@@ -448,5 +449,49 @@ describe("installWorkflowEditor - tool availability", () => {
 
     assert.equal(typeof state.active, "boolean");
     assert.equal(state.active, false);
+  });
+});
+
+describe("workflow extension - control tool registration", () => {
+  it("registers and activates workflow and workflow_control together", async () => {
+    const registeredTools: string[] = [];
+    const activeTools = ["bash", "read"];
+    const handlers: Record<string, Array<(...args: any[]) => any>> = {};
+    const pi = {
+      registerTool: (tool: { name: string }) => registeredTools.push(tool.name),
+      registerCommand: () => {},
+      getCommands: () => [],
+      on: (event: string, handler: (...args: any[]) => any) => {
+        if (!handlers[event]) handlers[event] = [];
+        handlers[event].push(handler);
+      },
+      getActiveTools: () => [...activeTools],
+      setActiveTools: (tools: string[]) => {
+        activeTools.splice(0, activeTools.length, ...tools);
+      },
+      sendMessage: () => {},
+    } as unknown as ExtensionAPI;
+    const { default: installExtension } = await import("../extensions/workflow.js");
+
+    installExtension(pi);
+
+    assert.deepEqual(registeredTools.slice(0, 2), ["workflow", "workflow_control"]);
+    assert.equal(handlers.session_start.length, 1);
+    handlers.session_start[0](
+      {},
+      {
+        model: undefined,
+        modelRegistry: {},
+        sessionManager: { getSessionId: () => "session-1" },
+        ui: {
+          setWidget: () => {},
+          getEditorComponent: () => undefined,
+          setEditorComponent: () => {},
+        },
+      },
+    );
+
+    assert.ok(activeTools.includes("workflow"));
+    assert.ok(activeTools.includes("workflow_control"));
   });
 });

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -1,11 +1,18 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import test from "node:test";
 import type { WorkflowSnapshot } from "../src/display.js";
 import { WorkflowErrorCode } from "../src/errors.js";
 import type { PersistedRunState } from "../src/run-persistence.js";
 import type { ManagedRun, WorkflowManager } from "../src/workflow-manager.js";
 import type { SavedWorkflow } from "../src/workflow-saved.js";
-import { keyToAction, NavigatorModel, NavigatorState, renderNavigator } from "../src/workflow-ui.js";
+import {
+  keyToAction,
+  NavigatorModel,
+  NavigatorState,
+  openWorkflowNavigator,
+  renderNavigator,
+} from "../src/workflow-ui.js";
 
 /** Fake manager exposing one running run with two phases. */
 function fakeManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
@@ -138,6 +145,55 @@ function persistedRunManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
   };
 }
 
+function fleetManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
+  const agents: WorkflowSnapshot["agents"] = Array.from({ length: 42 }, (_, index) => ({
+    id: index + 1,
+    executionId: `fleet:${index}`,
+    callIndex: index,
+    label: `agent-${index + 1}`,
+    phase: "Fleet",
+    prompt: `task ${index + 1}`,
+    status: index < 8 ? "running" : "queued",
+    tokens: index === 0 ? 120 : index === 1 ? 200 : undefined,
+    tokensEstimated: index === 0,
+  }));
+  const snapshot: WorkflowSnapshot = {
+    name: "fleet",
+    phases: ["Fleet"],
+    currentPhase: "Fleet",
+    logs: [],
+    agents,
+    agentCount: 42,
+    runningCount: 8,
+    doneCount: 0,
+    errorCount: 0,
+    effectiveConcurrency: 8,
+  };
+  return {
+    listRuns: () =>
+      [
+        {
+          runId: "fleet",
+          workflowName: "fleet",
+          status: "running",
+          phases: ["Fleet"],
+          agents,
+          logs: [],
+          effectiveConcurrency: 8,
+        },
+      ] as unknown as PersistedRunState[],
+    getRun: (id: string) =>
+      id === "fleet"
+        ? ({
+            runId: "fleet",
+            status: "running",
+            snapshot,
+            execution: { requestedConcurrency: 8, effectiveConcurrency: 8 },
+          } as unknown as ManagedRun)
+        : undefined,
+  };
+}
+
 function savedStorage(): { list(): SavedWorkflow[]; delete(name: string, location?: string): boolean } {
   return {
     list: () => [
@@ -230,6 +286,62 @@ test("NavigatorModel reads from persisted runs when no live snapshot", () => {
   const agents = model.agents("r-old", "Build");
   assert.equal(agents.length, 1);
   assert.equal(agents[0].label, "builder");
+});
+
+test("NavigatorModel preserves persisted identity, exact usage, and concurrency", () => {
+  const manager = {
+    listRuns: () =>
+      [
+        {
+          runId: "restored",
+          workflowName: "restored",
+          status: "completed",
+          phases: ["P"],
+          logs: [],
+          effectiveConcurrency: 8,
+          agents: [
+            {
+              id: 1,
+              executionId: "restored:0",
+              callIndex: 0,
+              label: "same-label",
+              phase: "P",
+              prompt: "p",
+              status: "done",
+              usage: { input: 200, output: 121, cacheRead: 0, cacheWrite: 0, total: 321, cost: 0.01 },
+              tokens: 0,
+              startedAt: "2026-07-14T00:00:00.000Z",
+              endedAt: "2026-07-14T00:00:01.000Z",
+            },
+          ],
+        },
+      ] as unknown as PersistedRunState[],
+    getRun: () => undefined,
+  };
+  const model = new NavigatorModel(manager);
+
+  assert.equal(model.agents("restored", "P")[0].executionId, "restored:0");
+  assert.equal(model.agents("restored", "P")[0].tokens, 321);
+  assert.equal(model.agentDetail("restored", 1)?.usage?.total, 321);
+  assert.equal(model.agentDetail("restored", 1)?.startedAt, "2026-07-14T00:00:00.000Z");
+  assert.equal(model.activity("restored").effectiveConcurrency, 8);
+});
+
+test("NavigatorModel and navigator show eight running and 34 not-started agents with all active labels", () => {
+  const model = new NavigatorModel(fleetManager());
+  const run = model.runs()[0];
+  assert.equal(run.total, 42);
+  assert.equal(run.running, 8);
+  assert.equal(run.queued, 34);
+
+  const state = new NavigatorState();
+  state.drill(model);
+  const text = renderNavigator(state, model, 300, undefined, 30).join("\n");
+  assert.match(text, /8 running/);
+  assert.match(text, /34 not started/);
+  assert.match(text, /Running now \(8\/8\): agent-1, agent-2, agent-3, agent-4, agent-5, agent-6, agent-7, agent-8/);
+  assert.match(text, /~120 tok · running/);
+  assert.match(text, /200 tok · running/);
 });
 
 test("NavigatorState drills runs -> phases -> agents -> detail and back", () => {
@@ -497,6 +609,77 @@ test("renderNavigator shows correct footer hint per view", () => {
   state.drill(model);
   const detailLines = renderNavigator(state, model, 80);
   assert.match(detailLines.join("\n"), /j\/k scroll/);
+});
+
+test("open navigator delegates restart to the guarded manager method", () => {
+  const manager = new EventEmitter() as EventEmitter & Partial<WorkflowManager>;
+  manager.listRuns = () =>
+    [
+      {
+        runId: "done-1",
+        workflowName: "done",
+        script: "export const meta = { name: 'done', description: 'done' }; return agent('x')",
+        status: "completed",
+        phases: [],
+        agents: [],
+        logs: [],
+      },
+    ] as unknown as PersistedRunState[];
+  manager.getRun = () => undefined;
+  const restarted: string[] = [];
+  manager.restart = (runId: string) => {
+    restarted.push(runId);
+    return { runId: "done-2", promise: Promise.resolve({} as never) };
+  };
+  let component: { handleInput(data: string): void; dispose?(): void } | undefined;
+  const notifications: string[] = [];
+  const theme = {
+    fg: (_color: string, text: string) => text,
+    bg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  };
+  const ui = {
+    notify: (message: string) => notifications.push(message),
+    custom: (factory: (...args: unknown[]) => typeof component) => {
+      component = factory({ requestRender: () => {}, terminal: { rows: 24 } }, theme, undefined, () => {});
+      return Promise.resolve();
+    },
+  };
+
+  void openWorkflowNavigator({} as never, manager as WorkflowManager, ui as never);
+  component?.handleInput("r");
+
+  assert.deepEqual(restarted, ["done-1"]);
+  assert.match(notifications[0], /Restarted done as done-2/);
+  component?.dispose?.();
+});
+
+test("open navigator rerenders on usage and history-only events", () => {
+  const base = fakeManager();
+  const manager = new EventEmitter() as EventEmitter & Pick<WorkflowManager, "listRuns" | "getRun">;
+  manager.listRuns = base.listRuns;
+  manager.getRun = base.getRun;
+  let component: { dispose?(): void } | undefined;
+  let renders = 0;
+  const theme = {
+    fg: (_color: string, text: string) => text,
+    bg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+  };
+  const ui = {
+    custom: (factory: (...args: unknown[]) => { dispose?(): void }) => {
+      component = factory({ requestRender: () => renders++, terminal: { rows: 24 } }, theme, undefined, () => {});
+      return Promise.resolve();
+    },
+  };
+
+  void openWorkflowNavigator({} as never, manager as never, ui as never);
+  manager.emit("agentUsage", { runId: "run-1", executionId: "run-1:2" });
+  manager.emit("agentHistory", { runId: "run-1", executionId: "run-1:2" });
+  manager.emit("tokenUsage", { runId: "run-1" });
+
+  assert.equal(renders, 3);
+  component?.dispose?.();
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

This PR hardens workflow triggering, lifecycle control, observability, persistence, and resume behavior as one runtime-reliability change:

- disable forced keyword triggering by default; retain explicit opt-in with identifier-bounded matching and preserve slash commands
- add the LLM-facing `workflow_control` tool for list/status/set_concurrency/pause/resume/stop/restart/remove
- persist requested/effective concurrency and all execution controls; concurrency defaults to `16`, accepts any positive integer without a plugin hard cap, and can be resized while a run is live or paused
- track stable agent execution identities, queued/running/paused/terminal states, active labels, live usage estimates, and exact message-boundary usage
- add versioned run-state migration, lease/race protection, replay-safe aggregate accounting, and restart/resume semantics
- persist child Pi sessions by default in a private per-project workflow directory outside Pi's normal `/resume` picker, and reopen paused agents at the last durable message/tool-result boundary; `persistAgentSessions: false` remains an explicit opt-out
- preserve isolated worktrees while paused, reuse them on resume, and clean them on completion/stop
- distinguish finished, paused-mid-run, and never-started agents throughout the panel, navigator, and control output

## Why forced keyword triggering is disabled by default

Previously, merely typing `workflow` or `workflows` in an ordinary message could rewrite the prompt and force workflow mode. That made it difficult to discuss the feature itself, mention documentation or paths containing the word, or use the word naturally without unexpectedly launching orchestration. Hidden prompt mutation based on one keyword is poor UX and produces false positives.

The lexical forcing hack is also unnecessary: current models can select the advertised `workflow` tool from its schema and system guidance when orchestration is appropriate. Explicit `/workflows run ...`, direct tool selection, saved workflow commands, and slash-command controls remain available. Users who still want keyword activation can opt in with `/workflows-trigger on`; when enabled, matching is Unicode/identifier-bounded rather than a raw substring check.

## Resume semantics

- Completed journal entries replay without rerunning or double charging.
- Started-but-incomplete agents resume from their saved Pi session and preserved worktree.
- Never-started agents remain queued and start fresh.
- Missing/corrupt session files fall back per-agent to a fresh restart.
- Exact mid-token/mid-tool continuation is not possible; the continuation prompt tells agents to inspect existing state and avoid repeating completed side effects.
- Crash recovery pauses stale runs instead of auto-resuming them.
- Resume continues the same run; restart creates a new run from the beginning.

## Default behavior changes

Child session persistence is now on by default because reliable turn-boundary resume requires a durable transcript. Users can opt out with:

```json
{ "persistAgentSessions": false }
```

Child transcripts live under `~/.pi/workflows/projects/<project>/agent-sessions/`, not `~/.pi/agent/sessions/`, so they remain available through each run artifact's `sessionFile` links without cluttering Pi's normal `/resume` picker. The README calls out that full child transcripts may contain sensitive context.

Concurrency now defaults to `16` when neither the run nor settings specify it. The workflow schema accepts any positive integer and the plugin no longer clamps concurrency to 16; provider capacity and `maxAgents` remain the practical ceilings. `workflow_control set_concurrency` and `/workflows concurrency <runId> <n>` resize running or paused workflows. Raising the limit releases queued agents immediately; lowering it never aborts active agents and waits for activity to drain below the new limit before starting replacements. The mutable FIFO gate is shared with nested workflows and the updated value is persisted for resume/restart.

## Automated validation

- `npm test`: **892/892 passed** (Biome, TypeScript, 59 suites)
- `git diff --check`: passed
- real Pi `createAgentSession` faux-provider integration verifies reopening and appending to the same session JSONL
- schema/runtime tests verify positive concurrency values including `128` and `10_000` are accepted without clamping, invalid/non-integer values are rejected, and the omitted default is `16`
- live-resize tests verify `1 → 3` immediately starts queued work, `3 → 1` lets existing agents drain without aborting them, a later increase releases additional work, FIFO order is retained, UI/persistence update immediately, and cold paused runs retain the new value for resume

## Real-provider validation

Provider/model: `openai-codex/gpt-5.6-sol` through the installed local extension.

### Pause/resume smoke

- started a background child, confirmed `running`, paused it during a tool turn, resumed the same run, and completed with `RESUME_CHILD_OK`
- persisted result: completed, one agent, 71,058 tokens, 29.9s
- saved session contains the original tool turn, aborted boundary, resumed tool turn/result, and final stop turn
- the test exposed a duplicate false `Subagent was aborted` notification; this draft includes the regression fix so lifecycle-controlled pause/stop no longer also emit `error` (unexpected external aborts still do)

### 42-agent concurrency/UI stress

- requested/effective concurrency: `8`; max agents: `42`
- observed successive states with exactly eight active labels while queued work drained (for example 3 done / 8 running / 31 queued, then 34 done / 8 running / 0 queued)
- all 42 agents completed in 64.3s; no snapshot exceeded eight running agents
- persisted usage: 986,874 tokens; $3.6456
- all 42 results matched their assigned `PROBE_n` identifier after ignoring terminal punctuation. The workflow's own `ok:false` field came from an overly strict test assertion that expected a final period while the agents returned the requested identifiers without one; it was not a runtime/concurrency failure.

### Process restart after 27 completed calls

Before forced process termination:

- 27 done, one running, one queued; concurrency `1`
- aggregate usage: 658,068 tokens

After restarting Pi:

- stale run recovered as `paused` rather than auto-running
- exactly 27 agents remained done, the interrupted agent showed `paused mid-run (session saved)`, and the never-started agent remained queued
- requested/effective concurrency remained `1`

After `workflow_control resume`:

- completed with 29 unique execution IDs and no duplicate rows
- original 27 results remained exact and were not rerun
- interrupted agent reused the same child session and returned `INTERRUPTED_OK`
- queued agent started fresh and returned `QUEUED_OK`
- aggregate usage advanced monotonically from 658,068 to 705,447 tokens

### Live concurrency resize

- started six real agents at concurrency `1`: one running, five queued
- `workflow_control set_concurrency` changed `1 → 3`; queued agents were released immediately and status showed three running
- changed `3 → 1` while three agents were active; none were aborted, status truthfully showed three running against limit one, and no replacement started until activity drained
- observed drain states `3 done / 1 running / 2 queued`, then `4 done / 1 running / 1 queued`
- completed all six with six exact results and six unique execution IDs
- final requested/effective concurrency persisted as `1`
- all six child sessions were stored in the private workflow `agent-sessions` directory outside `/resume`
- persisted usage: 283,570 tokens; $0.7570; 113.0s

## Remaining manual checklist

The high-scale concurrency and real process-restart scenarios are now complete. This remains a draft pending any maintainer-requested manual checks for legacy artifact migration, safe-typing permutations, and the full navigator/keybinding compatibility matrix from `CONTRIBUTING.md`; those paths have automated coverage.
