### PR TITLE
feat(model-tier): rank default tiers by cost signal + surface unconfigured-tier fallback

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -19,7 +19,13 @@ import { type AgentHistoryEntry, compactAgentHistory } from "./agent-history.js"
 import { applyToolPolicy } from "./agent-registry.js";
 import { classifyProviderLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import { canonicalModelSpec, resolveModelSpecWithThinking } from "./model-spec.js";
-import { loadModelTierConfig, type ModelTierConfig, resolveTierModel } from "./model-tier-config.js";
+import {
+  formatTierFallbackNotice,
+  loadModelTierConfig,
+  type ModelTierConfig,
+  type RankableModel,
+  resolveTierModel,
+} from "./model-tier-config.js";
 import { createStructuredOutputTool, type StructuredOutputCapture } from "./structured-output.js";
 
 /**
@@ -177,10 +183,14 @@ export function resolveAgentModelSpec(
   options: { model?: string; tier?: string },
   mainModel: string | undefined,
   loadConfig: () => ModelTierConfig | null = loadModelTierConfig,
+  onTierWithoutConfig?: (tier: string) => void,
 ): string | undefined {
   if (options.model) return options.model;
   const config = loadConfig();
   if (options.tier) {
+    // Tier requested but unconfigured → it silently falls back to mainModel.
+    // Let the caller surface that (once) so the no-op is discoverable.
+    if (!config) onTierWithoutConfig?.(options.tier);
     return (config ? resolveTierModel(options.tier, config) : undefined) ?? mainModel;
   }
   // Untagged agent: default to the configured medium tier when one exists.
@@ -224,11 +234,13 @@ export interface WorkflowAgentOptions {
 }
 
 /**
- * List the user's currently available models (those with auth configured) as
- * `provider/modelId` specs. Used to tell the workflow author which models it may
- * route agents to. Best-effort: returns [] if the registry can't be built.
+ * List the user's currently available models (those with auth configured) with
+ * the minimal fields tier ranking needs: canonical spec, output price, and
+ * context window. This is the single place the SDK `Model` is projected into
+ * the SDK-agnostic `RankableModel`. Best-effort: returns [] if the registry
+ * can't be built.
  */
-export function listAvailableModelSpecs(registry?: ModelRegistry): string[] {
+export function listAvailableModels(registry?: ModelRegistry): RankableModel[] {
   try {
     const modelRegistry =
       registry ??
@@ -237,9 +249,39 @@ export function listAvailableModelSpecs(registry?: ModelRegistry): string[] {
         const auth = AuthStorage.create(join(dir, "auth.json"));
         return ModelRegistry.create(auth, join(dir, "models.json"));
       })();
-    return modelRegistry.getAvailable().map(canonicalModelSpec);
+    return modelRegistry.getAvailable().map((model) => ({
+      spec: canonicalModelSpec(model),
+      costOutput: model.cost?.output,
+      contextWindow: model.contextWindow,
+    }));
   } catch {
     return [];
+  }
+}
+
+/**
+ * List the user's currently available models as `provider/modelId` specs. Used
+ * to tell the workflow author which models it may route agents to. Best-effort:
+ * returns [] if the registry can't be built.
+ */
+export function listAvailableModelSpecs(registry?: ModelRegistry): string[] {
+  return listAvailableModels(registry).map((model) => model.spec);
+}
+
+/**
+ * Emitted at most once per process: when an agent asks for a tier but no
+ * model-tiers.json exists, the tier silently falls back to the session model.
+ * Surface that once (with the mapping the user would get by configuring) so the
+ * no-op is discoverable. Diagnostics only — never lets a failure break a run.
+ */
+let warnedTierUnconfigured = false;
+function warnTierUnconfiguredOnce(mainModel: string | undefined, registry: ModelRegistry): void {
+  if (warnedTierUnconfigured) return;
+  warnedTierUnconfigured = true;
+  try {
+    console.warn(formatTierFallbackNotice(mainModel, listAvailableModels(registry)));
+  } catch {
+    // best-effort diagnostic
   }
 }
 
@@ -463,7 +505,9 @@ export class WorkflowAgent {
     // Resolve the model spec (explicit model > tier > session default). This
     // composes with phase-based routing in workflow.ts, which only supplies
     // options.model when a phase pattern matches — so an explicit model wins.
-    const modelSpec = resolveAgentModelSpec(options, this.mainModel);
+    const modelSpec = resolveAgentModelSpec(options, this.mainModel, loadModelTierConfig, () =>
+      warnTierUnconfiguredOnce(this.mainModel, this.getRegistry(options.modelRegistry)),
+    );
 
     // Resolve a requested model spec to a Model object. Specs use Pi CLI-style
     // parsing, including an optional :thinking suffix such as gpt-5.5:xhigh.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export type { AdversarialReviewConfig } from "./adversarial-review.js";
 export { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
 export type { AgentRunOptions, AgentRunResult, WorkflowAgentOptions } from "./agent.js";
-export { listAvailableModelSpecs, WorkflowAgent } from "./agent.js";
+export { listAvailableModelSpecs, listAvailableModels, WorkflowAgent } from "./agent.js";
 export type { AgentHistoryEntry, AgentHistoryKind, AgentHistoryRole } from "./agent-history.js";
 export { compactAgentHistory } from "./agent-history.js";
 export type { AgentDefinition, AgentRegistry } from "./agent-registry.js";
@@ -56,9 +56,10 @@ export {
   splitModelSpecThinking,
   THINKING_LEVELS,
 } from "./model-spec.js";
-export type { ModelTierConfig } from "./model-tier-config.js";
+export type { ModelTierConfig, RankableModel } from "./model-tier-config.js";
 export {
   buildDefaultTierConfig,
+  formatTierFallbackNotice,
   getModelTierConfigPath,
   loadModelTierConfig,
   resolveTierModel,

--- a/src/model-tier-config.ts
+++ b/src/model-tier-config.ts
@@ -16,7 +16,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { listAvailableModelSpecs } from "./agent.js";
+import { listAvailableModels } from "./agent.js";
 import { MODEL_TIERS_FILE } from "./config.js";
 
 // ---------------------------------------------------------------------------
@@ -32,6 +32,22 @@ export interface ModelTierConfig {
   tiers: Record<string, string>;
 }
 
+/**
+ * The minimal projection of a model that tier ranking needs. Deliberately NOT
+ * the SDK's full `Model` type: tier logic depends only on these three fields,
+ * so it stays decoupled from the SDK (no `@earendil-works/pi-ai` import here)
+ * and is trivially unit-testable with plain objects. `agent.ts`'s
+ * `listAvailableModels()` produces these from the live registry.
+ */
+export interface RankableModel {
+  /** Canonical "provider/id" spec string. */
+  spec: string;
+  /** Per-token output price, if the registry reports one. Missing or 0 = unknown. */
+  costOutput?: number;
+  /** Context window size, if the registry reports one. */
+  contextWindow?: number;
+}
+
 // ---------------------------------------------------------------------------
 // Configuration path
 // ---------------------------------------------------------------------------
@@ -42,47 +58,82 @@ export function getModelTierConfigPath(): string {
 }
 
 // ---------------------------------------------------------------------------
-// Capability hints
+// Capability signal
 // ---------------------------------------------------------------------------
 
 /**
- * Substrings that identify small/cheap models (case-insensitive).
- * Used by `rankByCapability` to rank models lowest so a mini/flash/haiku model
- * never lands in a higher tier than a model without this hint.
+ * Substrings that identify small/cheap models (case-insensitive), used only as
+ * a fallback capability hint when price signals are absent or tied.
  */
 export const SMALL_MODEL_HINTS = ["mini", "flash", "haiku", "nano", "small"] as const;
 
 /**
- * Substrings that identify large/capable models (case-insensitive).
- * Used by `rankByCapability` to rank models highest so they are preferred for
- * the big tier over models without this hint.
+ * Substrings that identify large/capable models (case-insensitive), used only
+ * as a fallback capability hint when price signals are absent or tied.
  */
 export const BIG_MODEL_HINTS = ["opus", "pro", "ultra", "large", "plus"] as const;
 
 /**
- * Capability score for a single model spec: +1 if it matches a big-model hint,
- * -1 if it matches a small-model hint, 0 otherwise. If a model happens to
- * match both hint sets (e.g. a name containing both "mini" and "pro"), the
- * small hint wins — we never want a "mini"-labelled model to outrank a
- * neutral or clearly-large one.
+ * Fallback capability hint from a model's name: -1 for a small/cheap name, +1
+ * for a large/capable name, 0 otherwise. If a name matches both sets, the small
+ * hint wins (we never want a "mini"-labelled model to outrank a neutral or
+ * clearly-large one). This is only a FALLBACK: `rankByCapability` prefers the
+ * registry's price signal, which is robust to new vendor names (e.g. "fable",
+ * "mimo") that match no hint and would otherwise all score 0.
  */
-function capabilityScore(model: string): number {
-  const lower = model.toLowerCase();
+export function hintScore(spec: string): number {
+  const lower = spec.toLowerCase();
   if (SMALL_MODEL_HINTS.some((hint) => lower.includes(hint))) return -1;
   if (BIG_MODEL_HINTS.some((hint) => lower.includes(hint))) return 1;
   return 0;
 }
 
 /**
- * Rank `available` models from least to most capable using `capabilityScore`.
- * The sort is stable (ties preserve registry order), so within a score bucket
- * models keep their original relative order.
+ * Rank models from least → most capable.
+ *
+ * PRIMARY signal is output price (higher price ≈ more capable): within a single
+ * registry, price tracks the vendor's capability tier far more robustly than
+ * model-name substrings, and it works for models whose names match no hint.
+ *
+ * Models with an UNKNOWN price (missing or 0 — common for self-hosted
+ * `models.json` entries) are NOT treated as "cheapest = weakest". Instead they
+ * are projected onto the known price range via their substring hint: a
+ * big-hint name lands at the top of the range, a small-hint name at the bottom,
+ * a neutral name at the middle. When NO model has a known price at all, this
+ * degrades to pure hint ordering (the previous behavior).
+ *
+ * The comparison is a single total order (projected cost → hint → contextWindow
+ * → stable registry index), so the sort is transitive and stable.
  */
-function rankByCapability(available: string[]): string[] {
-  return available
-    .map((model, index) => ({ model, index, score: capabilityScore(model) }))
-    .sort((a, b) => a.score - b.score || a.index - b.index)
-    .map((entry) => entry.model);
+export function rankByCapability(models: readonly RankableModel[]): RankableModel[] {
+  const knownCosts = models
+    .map((m) => m.costOutput)
+    .filter((c): c is number => typeof c === "number" && c > 0)
+    .sort((a, b) => a - b);
+  const hasPriceSignal = knownCosts.length > 0;
+  const min = knownCosts[0];
+  const max = knownCosts[knownCosts.length - 1];
+  const median = knownCosts[Math.floor(knownCosts.length / 2)];
+
+  // Project every model onto the price axis. Undefined only when there is no
+  // price signal anywhere (all models unpriced) — then the sort falls through
+  // to the hint comparison below.
+  const costKey = (m: RankableModel): number | undefined => {
+    if (typeof m.costOutput === "number" && m.costOutput > 0) return m.costOutput;
+    if (!hasPriceSignal) return undefined;
+    const hint = hintScore(m.spec);
+    return hint > 0 ? max : hint < 0 ? min : median;
+  };
+
+  return models
+    .map((m, index) => ({ m, index, cost: costKey(m), hint: hintScore(m.spec), ctx: m.contextWindow ?? 0 }))
+    .sort((a, b) => {
+      if (a.cost !== undefined && b.cost !== undefined && a.cost !== b.cost) return a.cost - b.cost;
+      if (a.hint !== b.hint) return a.hint - b.hint;
+      if (a.ctx !== b.ctx) return a.ctx - b.ctx;
+      return a.index - b.index;
+    })
+    .map((entry) => entry.m);
 }
 
 // ---------------------------------------------------------------------------
@@ -95,34 +146,32 @@ function rankByCapability(available: string[]): string[] {
  * box. When the registry is empty or unavailable, fall back to the current Pi
  * model so fresh installs still get usable tier values.
  *
- * Models are first ranked least → most capable via `rankByCapability` (which
- * consults `SMALL_MODEL_HINTS` / `BIG_MODEL_HINTS`, falling back to registry
- * order for models that match neither). Tiers are then assigned from this
- * single ranked pool with exclusion — each model is used for at most one
- * tier — so distinct tiers never collapse onto the same model and a
- * mini/flash/haiku model can never outrank a bigger one (no inversion):
+ * Models are first ranked least → most capable via `rankByCapability` (price
+ * first, name-substring hint as fallback). Tiers are then assigned from this
+ * single ranked pool with exclusion — each model is used for at most one tier —
+ * so distinct tiers never collapse onto the same model and a weaker model can
+ * never outrank a stronger one (no inversion):
  *
  *   - big    = the most capable model (last in the ranking)
  *   - small  = the least capable model (first in the ranking)
  *   - medium = the middle-ranked model
  *
- * When fewer than 3 distinct models are available, this degrades gracefully
- * by reusing the *strongest* available model for the higher tier(s) — it
- * never reuses a weaker model for a higher tier than a stronger one:
+ * When fewer than 3 distinct models are available, this degrades gracefully by
+ * reusing the *strongest* available model for the higher tier(s):
  *
  *   - 2 models: small = weaker, medium = big = stronger
- *   - 1 model / 0 models: small = medium = big = that model (or the current
- *     model / "" fallback)
+ *   - 1 / 0 models: small = medium = big = that model (or the current model /
+ *     "" fallback)
  *
- * `_availableModels` is injectable for testing and for callers that already
- * fetched the registry. When omitted, this reads from the live registry
- * regardless of whether `currentModelSpec` was also provided, so the
- * default-argument path always goes through the same corrected logic instead
- * of silently reproducing the original single-tier collapse.
+ * `availableModels` is injectable for testing and for callers that already
+ * fetched the registry. When omitted, this reads from the live registry.
  */
-export function buildDefaultTierConfig(currentModelSpec?: string, _availableModels?: string[]): ModelTierConfig {
-  const available = _availableModels ?? listAvailableModelSpecs();
-  const ranked = rankByCapability(available);
+export function buildDefaultTierConfig(
+  currentModelSpec?: string,
+  availableModels?: readonly RankableModel[],
+): ModelTierConfig {
+  const models = availableModels ?? listAvailableModels();
+  const ranked = rankByCapability(models).map((m) => m.spec);
 
   if (ranked.length >= 3) {
     const small = ranked[0];
@@ -142,6 +191,30 @@ export function buildDefaultTierConfig(currentModelSpec?: string, _availableMode
       big: fallback,
     },
   };
+}
+
+/**
+ * One-time notice shown when an agent requests `opts.tier` but no
+ * model-tiers.json is configured — in that state tiers silently fall back to
+ * the session model (see `resolveAgentModelSpec` in agent.ts), which is easy to
+ * miss. This surfaces the fallback and the mapping the user *would* get by
+ * configuring, using the same `buildDefaultTierConfig` ranking so the hint is
+ * actionable. Pure/string-only so the caller owns how it's emitted.
+ */
+export function formatTierFallbackNotice(
+  mainModel: string | undefined,
+  availableModels: readonly RankableModel[],
+): string {
+  const fallback = mainModel ?? "the session default model";
+  const suggested = buildDefaultTierConfig(mainModel, availableModels);
+  const mapping = sortedTierNames(suggested)
+    .map((tier) => `${tier}=${suggested.tiers[tier] || "?"}`)
+    .join("  ");
+  return (
+    `[workflow] An agent requested opts.tier but no model-tiers.json is configured, so tiers currently ` +
+    `fall back to ${fallback}. Run /workflows-models to configure them` +
+    (mapping ? `. Suggested mapping from your available models: ${mapping}` : ".")
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/workflows-models-command.ts
+++ b/src/workflows-models-command.ts
@@ -23,7 +23,7 @@ import {
   Text,
   type TUI,
 } from "@earendil-works/pi-tui";
-import { listAvailableModelSpecs } from "./agent.js";
+import { listAvailableModelSpecs, listAvailableModels } from "./agent.js";
 import {
   formatModelSpecWithThinking,
   type ModelThinkingLevel,
@@ -50,7 +50,7 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
       // available models. If the model registry is empty, fall back to the
       // current Pi model so the tiers are still usable.
       const currentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
-      let config = loadModelTierConfig() ?? buildDefaultTierConfig(currentModel, listAvailableModelSpecs());
+      let config = loadModelTierConfig() ?? buildDefaultTierConfig(currentModel, listAvailableModels());
       let dirty = false;
 
       const ensureFresh = (cfg: typeof config) => {
@@ -94,7 +94,7 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
             "This will reset tiers from your available model list. Continue?",
           );
           if (confirmed) {
-            ensureFresh(buildDefaultTierConfig(currentModel, listAvailableModelSpecs()));
+            ensureFresh(buildDefaultTierConfig(currentModel, listAvailableModels()));
             ctx.ui.notify("Tiers reset to defaults. Use 'Save and exit' to persist.", "info");
           }
         }

--- a/tests/model-tier-config.test.ts
+++ b/tests/model-tier-config.test.ts
@@ -2,11 +2,13 @@
  * Tests for model-tier-config.ts
  *
  * Covers:
- * 1. buildDefaultTierConfig — all tiers default to the given model
- * 2. buildDefaultTierConfig — capability-hint ordering (SMALL_MODEL_HINTS / BIG_MODEL_HINTS)
- * 3. resolveTierModel logic
- * 4. save/load round-trip + all validation/error paths (scoped to a temp dir)
- * 5. sortedTierNames helper
+ * 1. rankByCapability — cost-first ranking, hint fallback, cost=0/missing handling, tie-breaks
+ * 2. hintScore — substring capability hints
+ * 3. buildDefaultTierConfig — tier spread + capability ordering (via hint fallback and via cost)
+ * 4. formatTierFallbackNotice — unconfigured-tier notice text
+ * 5. resolveTierModel logic
+ * 6. save/load round-trip + all validation/error paths (scoped to a temp dir)
+ * 7. sortedTierNames helper
  *
  * All tier configs are single-model-per-tier (Record<string, string>).
  */
@@ -21,13 +23,121 @@ async function loadModule() {
   return await import("../src/model-tier-config.js");
 }
 
+/**
+ * Wrap bare spec strings as RankableModel[] with NO cost/context, so ranking
+ * goes through the substring-hint fallback path (the pre-cost behavior). Used
+ * by the hint-ordering tests, which are about names, not prices.
+ */
+function specs(...names: string[]): { spec: string }[] {
+  return names.map((spec) => ({ spec }));
+}
+
 describe("model-tier-config", () => {
+  describe("hintScore", () => {
+    it("scores small-hint names -1, big-hint names +1, neutral 0", async () => {
+      const { hintScore } = await loadModule();
+      assert.equal(hintScore("openai/gpt-4o-mini"), -1);
+      assert.equal(hintScore("x/flash-2"), -1);
+      assert.equal(hintScore("anthropic/claude-3-opus"), 1);
+      assert.equal(hintScore("x/pro-model"), 1);
+      assert.equal(hintScore("vendor/fable-5"), 0);
+      assert.equal(hintScore("vendor/mimo"), 0);
+    });
+
+    it("lets the small hint win when a name matches both sets", async () => {
+      const { hintScore } = await loadModule();
+      assert.equal(hintScore("x/mini-pro"), -1);
+    });
+  });
+
+  describe("rankByCapability (cost-first, hint fallback)", () => {
+    it("ranks by output price when prices are known, ignoring name hints", async () => {
+      const { rankByCapability } = await loadModule();
+      const ranked = rankByCapability([
+        { spec: "v/expensive", costOutput: 10 },
+        { spec: "v/cheap", costOutput: 1 },
+        { spec: "v/mid", costOutput: 5 },
+      ]).map((m) => m.spec);
+      assert.deepEqual(ranked, ["v/cheap", "v/mid", "v/expensive"]);
+    });
+
+    it("lets price beat a misleading name hint", async () => {
+      // A model NAMED like a small one but actually priced high must rank above
+      // a model named like a big one but priced low.
+      const { rankByCapability } = await loadModule();
+      const ranked = rankByCapability([
+        { spec: "x/pro-but-cheap", costOutput: 1 },
+        { spec: "y/mini-but-pricey", costOutput: 9 },
+        { spec: "z/mid", costOutput: 5 },
+      ]).map((m) => m.spec);
+      assert.deepEqual(ranked, ["x/pro-but-cheap", "z/mid", "y/mini-but-pricey"]);
+    });
+
+    it("ranks new vendor names by cost instead of collapsing them to neutral", async () => {
+      // "fable"/"mimo" match no hint; with cost they must still sort correctly.
+      const { rankByCapability } = await loadModule();
+      const ranked = rankByCapability([
+        { spec: "x/fable-5", costOutput: 8 },
+        { spec: "x/mimo", costOutput: 2 },
+        { spec: "x/mid", costOutput: 5 },
+      ]).map((m) => m.spec);
+      assert.deepEqual(ranked, ["x/mimo", "x/mid", "x/fable-5"]);
+    });
+
+    it("projects an unknown-cost model onto the price range via its hint (never treated as cheapest)", async () => {
+      // A self-hosted big model with NO price (cost missing) must not be ranked
+      // as the weakest; its big-hint projects it to the top of the known range.
+      const { rankByCapability } = await loadModule();
+      const ranked = rankByCapability([
+        { spec: "self/opus-local" }, // no cost, big hint → projects to max
+        { spec: "v/a", costOutput: 1 },
+        { spec: "v/b", costOutput: 5 },
+      ]).map((m) => m.spec);
+      // a(1) < b(5) == opus-local(projected 5); tie broken by hint (b:0 before opus:+1).
+      assert.deepEqual(ranked, ["v/a", "v/b", "self/opus-local"]);
+    });
+
+    it("projects an unknown-cost small model to the bottom of the range", async () => {
+      const { rankByCapability } = await loadModule();
+      const ranked = rankByCapability([
+        { spec: "self/mini-local" }, // no cost, small hint → projects to min
+        { spec: "v/a", costOutput: 2 },
+        { spec: "v/b", costOutput: 5 },
+      ]).map((m) => m.spec);
+      // mini-local projected to min(2) == a(2); tie broken by hint (mini:-1 before a:0).
+      assert.deepEqual(ranked, ["self/mini-local", "v/a", "v/b"]);
+    });
+
+    it("falls back to pure hint ordering when no model has a known price (back-compat)", async () => {
+      const { rankByCapability } = await loadModule();
+      const ranked = rankByCapability(specs("a-mini", "b-neutral", "c-opus")).map((m) => m.spec);
+      assert.deepEqual(ranked, ["a-mini", "b-neutral", "c-opus"]);
+    });
+
+    it("breaks cost ties by contextWindow (smaller = less capable)", async () => {
+      const { rankByCapability } = await loadModule();
+      const ranked = rankByCapability([
+        { spec: "x/a", costOutput: 5, contextWindow: 8000 },
+        { spec: "x/b", costOutput: 5, contextWindow: 200000 },
+        { spec: "x/c", costOutput: 1 },
+      ]).map((m) => m.spec);
+      assert.deepEqual(ranked, ["x/c", "x/a", "x/b"]);
+    });
+
+    it("is stable for fully-tied models (registry order preserved)", async () => {
+      const { rankByCapability } = await loadModule();
+      const ranked = rankByCapability([
+        { spec: "x/a", costOutput: 5 },
+        { spec: "x/b", costOutput: 5 },
+        { spec: "x/c", costOutput: 5 },
+      ]).map((m) => m.spec);
+      assert.deepEqual(ranked, ["x/a", "x/b", "x/c"]);
+    });
+  });
+
   describe("buildDefaultTierConfig", () => {
     it("sets every tier to the provided current model when no models are available", async () => {
       const { buildDefaultTierConfig } = await loadModule();
-      // Explicitly inject an empty registry so this exercises the "no models
-      // known" fallback rather than depending on whatever registry happens to
-      // be configured in the environment running the tests.
       const cfg = buildDefaultTierConfig("openai/gpt-4.1", []);
       assert.deepEqual(cfg.tiers, {
         small: "openai/gpt-4.1",
@@ -50,10 +160,7 @@ describe("model-tier-config", () => {
       assert.deepEqual(Object.keys(cfg.tiers).sort(), ["big", "medium", "small"]);
     });
 
-    it("spreads three or more available models across tiers", async () => {
-      // This uses the real listAvailableModelSpecs() which may return [] in test env.
-      // We can only test the code path where currentModelSpec is undefined and
-      // verify the structure is still valid.
+    it("spreads three or more available models across tiers (structure holds with the live registry)", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig();
       assert.deepEqual(Object.keys(cfg.tiers).sort(), ["big", "medium", "small"]);
@@ -62,20 +169,10 @@ describe("model-tier-config", () => {
       }
     });
 
-    it("the exported default-argument path (no availableModels passed) still spreads distinct tiers when a real registry is available", async () => {
-      // Regression test for the original #38 bug resurfacing through the public
-      // API: buildDefaultTierConfig(currentModelSpec) called WITHOUT its 2nd
-      // argument must still consult the live registry and spread tiers, not
-      // silently collapse to a single model just because currentModelSpec was
-      // also passed. We can't control the real listAvailableModelSpecs() output
-      // here, so we only assert the structural invariant that matters: whatever
-      // it returns, the function must not special-case away the registry lookup
-      // when currentModelSpec is provided (verified functionally in the
-      // 3+/2/1-model tests below via explicit injection, which exercise the
-      // exact same code path).
+    it("the default-argument path (no availableModels passed) still spreads distinct tiers", async () => {
       const { buildDefaultTierConfig } = await loadModule();
-      const withCurrentModel = buildDefaultTierConfig("openai/gpt-4.1", ["a", "b", "c"]);
-      const withoutCurrentModel = buildDefaultTierConfig(undefined, ["a", "b", "c"]);
+      const withCurrentModel = buildDefaultTierConfig("openai/gpt-4.1", specs("a", "b", "c"));
+      const withoutCurrentModel = buildDefaultTierConfig(undefined, specs("a", "b", "c"));
       assert.deepEqual(
         withCurrentModel.tiers,
         withoutCurrentModel.tiers,
@@ -85,25 +182,25 @@ describe("model-tier-config", () => {
 
     it("spreads exactly three available models across small/medium/big (no overlap)", async () => {
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["model-a", "model-b", "model-c"]);
+      const cfg = buildDefaultTierConfig(undefined, specs("model-a", "model-b", "model-c"));
       assert.equal(cfg.tiers.small, "model-a");
       assert.equal(cfg.tiers.medium, "model-b");
       assert.equal(cfg.tiers.big, "model-c");
     });
 
-    it("spreads available models even when a current model fallback is provided", async () => {
+    it("ranks three priced models across tiers by cost", async () => {
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig("current-model", ["model-a", "model-b", "model-c"]);
-      assert.deepEqual(cfg.tiers, {
-        small: "model-a",
-        medium: "model-b",
-        big: "model-c",
-      });
+      const cfg = buildDefaultTierConfig(undefined, [
+        { spec: "v/big", costOutput: 30 },
+        { spec: "v/small", costOutput: 1 },
+        { spec: "v/mid", costOutput: 8 },
+      ]);
+      assert.deepEqual(cfg.tiers, { small: "v/small", medium: "v/mid", big: "v/big" });
     });
 
     it("spreads two available models: small gets first, medium and big get second", async () => {
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["model-a", "model-b"]);
+      const cfg = buildDefaultTierConfig(undefined, specs("model-a", "model-b"));
       assert.equal(cfg.tiers.small, "model-a");
       assert.equal(cfg.tiers.medium, "model-b");
       assert.equal(cfg.tiers.big, "model-b");
@@ -111,30 +208,19 @@ describe("model-tier-config", () => {
 
     it("with exactly one available model, all three tiers resolve to it (no crash)", async () => {
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["only-model"]);
-      assert.deepEqual(cfg.tiers, {
-        small: "only-model",
-        medium: "only-model",
-        big: "only-model",
-      });
+      const cfg = buildDefaultTierConfig(undefined, specs("only-model"));
+      assert.deepEqual(cfg.tiers, { small: "only-model", medium: "only-model", big: "only-model" });
     });
 
     it("with exactly one available model, the current model fallback is ignored in favor of it", async () => {
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig("current-model", ["only-model"]);
-      assert.deepEqual(cfg.tiers, {
-        small: "only-model",
-        medium: "only-model",
-        big: "only-model",
-      });
+      const cfg = buildDefaultTierConfig("current-model", specs("only-model"));
+      assert.deepEqual(cfg.tiers, { small: "only-model", medium: "only-model", big: "only-model" });
     });
 
     it("respects capability hints for the 2-model case: big-hint model always lands in medium/big, never small", async () => {
-      // Registry order is [big-hint model, small-hint model] — a naive positional
-      // split would put the opus model in "small" and the mini model in
-      // "medium"/"big", inverting capability. The fix must rank first.
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["claude-3-opus", "gpt-4o-mini"]);
+      const cfg = buildDefaultTierConfig(undefined, specs("claude-3-opus", "gpt-4o-mini"));
       assert.equal(cfg.tiers.small, "gpt-4o-mini");
       assert.equal(cfg.tiers.medium, "claude-3-opus");
       assert.equal(cfg.tiers.big, "claude-3-opus");
@@ -142,7 +228,7 @@ describe("model-tier-config", () => {
 
     it("respects capability hints for the 2-model case regardless of registry order", async () => {
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["gpt-4o-mini", "claude-3-opus"]);
+      const cfg = buildDefaultTierConfig(undefined, specs("gpt-4o-mini", "claude-3-opus"));
       assert.equal(cfg.tiers.small, "gpt-4o-mini");
       assert.equal(cfg.tiers.medium, "claude-3-opus");
       assert.equal(cfg.tiers.big, "claude-3-opus");
@@ -150,8 +236,7 @@ describe("model-tier-config", () => {
 
     it("with four available models, assigns middle index to medium", async () => {
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["m-a", "m-b", "m-c", "m-d"]);
-      // Math.floor(4 / 2) = 2 → medium = m-c
+      const cfg = buildDefaultTierConfig(undefined, specs("m-a", "m-b", "m-c", "m-d"));
       assert.equal(cfg.tiers.small, "m-a");
       assert.equal(cfg.tiers.medium, "m-c");
       assert.equal(cfg.tiers.big, "m-d");
@@ -169,65 +254,47 @@ describe("model-tier-config", () => {
     it("falls back to the current model when no available models are known", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const cfg = buildDefaultTierConfig("current-model", []);
-      assert.deepEqual(cfg.tiers, {
-        small: "current-model",
-        medium: "current-model",
-        big: "current-model",
-      });
+      assert.deepEqual(cfg.tiers, { small: "current-model", medium: "current-model", big: "current-model" });
     });
 
-    // -----------------------------------------------------------------------
-    // Capability-hint ordering (SMALL_MODEL_HINTS / BIG_MODEL_HINTS)
-    // -----------------------------------------------------------------------
+    // Capability-hint ordering (SMALL_MODEL_HINTS / BIG_MODEL_HINTS), pure-hint path.
 
     it("assigns small via SMALL_MODEL_HINTS even when mini model is not first in list", async () => {
-      // Simulates a provider-grouped registry: ["gpt-4o", "gpt-4o-mini", "claude-3-5-sonnet"]
-      // Without hint matching, positional would set small="gpt-4o" and big="claude-3-5-sonnet".
-      // With hint matching, "mini" wins for small regardless of position.
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["gpt-4o-mini", "claude-3-5-sonnet", "gpt-4o"]);
+      const cfg = buildDefaultTierConfig(undefined, specs("gpt-4o-mini", "claude-3-5-sonnet", "gpt-4o"));
       assert.equal(cfg.tiers.small, "gpt-4o-mini");
       assert.equal(cfg.tiers.medium, "claude-3-5-sonnet");
       assert.equal(cfg.tiers.big, "gpt-4o");
     });
 
     it("assigns small and big via hints when both hint sets match, ignoring list position", async () => {
-      // "claude-3-opus" is at index 0 but should be big; "gpt-4o-mini" is at index 2 but should be small.
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["claude-3-opus", "claude-3-5-sonnet", "gpt-4o-mini"]);
+      const cfg = buildDefaultTierConfig(undefined, specs("claude-3-opus", "claude-3-5-sonnet", "gpt-4o-mini"));
       assert.equal(cfg.tiers.small, "gpt-4o-mini");
       assert.equal(cfg.tiers.medium, "claude-3-5-sonnet");
       assert.equal(cfg.tiers.big, "claude-3-opus");
     });
 
     it("falls back to positional for small/big when no hint matches", async () => {
-      // Generic names have no hint substrings — positional behaviour must be preserved.
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["model-a", "model-b", "model-c"]);
+      const cfg = buildDefaultTierConfig(undefined, specs("model-a", "model-b", "model-c"));
       assert.equal(cfg.tiers.small, "model-a");
       assert.equal(cfg.tiers.medium, "model-b");
       assert.equal(cfg.tiers.big, "model-c");
     });
 
-    // -----------------------------------------------------------------------
-    // Collapse / inversion regressions (#38, PR #44 review defects)
-    // -----------------------------------------------------------------------
+    // Collapse / inversion regressions (#38, PR #44 review defects).
 
     it("does not collapse tiers when a model matches both small and big hints (small hint wins)", async () => {
-      // "gpt-4o-mini-pro" contains both "mini" (small hint) and "pro" (big hint).
-      // Picking small and big independently via `find()` would assign this same
-      // model to both small AND big, collapsing two tiers together. The fix
-      // must rank each model with a single score (small hint wins ties) and
-      // assign from one pool with exclusion so no model is used twice.
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["gpt-4o-mini-pro", "gpt-4o", "claude-3-sonnet"]);
+      const cfg = buildDefaultTierConfig(undefined, specs("gpt-4o-mini-pro", "gpt-4o", "claude-3-sonnet"));
       const values = Object.values(cfg.tiers);
       assert.equal(new Set(values).size, values.length, "all three tiers must be distinct models");
       assert.equal(cfg.tiers.small, "gpt-4o-mini-pro");
       assert.notEqual(cfg.tiers.big, cfg.tiers.small);
     });
 
-    it("never inverts capability ranking: big is always at least as capable as medium and small across many model sets", async () => {
+    it("never inverts capability ranking across many model sets (hint path)", async () => {
       const { buildDefaultTierConfig } = await loadModule();
       const scenarios: string[][] = [
         ["claude-3-opus", "gpt-4o-mini", "claude-3-5-sonnet"],
@@ -242,26 +309,17 @@ describe("model-tier-config", () => {
         return 0;
       };
       for (const models of scenarios) {
-        const cfg = buildDefaultTierConfig(undefined, models);
+        const cfg = buildDefaultTierConfig(undefined, specs(...models));
         const values = Object.values(cfg.tiers);
         assert.equal(new Set(values).size, values.length, `tiers must be distinct for ${JSON.stringify(models)}`);
-        assert.ok(
-          rank(cfg.tiers.big) >= rank(cfg.tiers.medium),
-          `big (${cfg.tiers.big}) must not be weaker than medium (${cfg.tiers.medium})`,
-        );
-        assert.ok(
-          rank(cfg.tiers.medium) >= rank(cfg.tiers.small),
-          `medium (${cfg.tiers.medium}) must not be weaker than small (${cfg.tiers.small})`,
-        );
+        assert.ok(rank(cfg.tiers.big) >= rank(cfg.tiers.medium), `big must not be weaker than medium`);
+        assert.ok(rank(cfg.tiers.medium) >= rank(cfg.tiers.small), `medium must not be weaker than small`);
       }
     });
 
-    it("with an odd/limited model set (2 distinct capability tiers), degrades gracefully without inversion", async () => {
-      // Only a "small" model and a "neutral" model are available — big and
-      // medium must both resolve to the stronger (neutral) one, never the
-      // small one, and small must never end up in a higher tier.
+    it("degrades gracefully without inversion for a 2-capability-tier set", async () => {
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["vendor/neutral-model", "vendor/tiny-mini-model"]);
+      const cfg = buildDefaultTierConfig(undefined, specs("vendor/neutral-model", "vendor/tiny-mini-model"));
       assert.equal(cfg.tiers.small, "vendor/tiny-mini-model");
       assert.equal(cfg.tiers.medium, "vendor/neutral-model");
       assert.equal(cfg.tiers.big, "vendor/neutral-model");
@@ -269,18 +327,39 @@ describe("model-tier-config", () => {
 
     it("with 3+ distinct models, small/medium/big are always pairwise distinct", async () => {
       const { buildDefaultTierConfig } = await loadModule();
-      const cfg = buildDefaultTierConfig(undefined, ["model-a", "model-b", "model-c", "model-d", "model-e"]);
+      const cfg = buildDefaultTierConfig(undefined, specs("model-a", "model-b", "model-c", "model-d", "model-e"));
       const values = Object.values(cfg.tiers);
       assert.equal(new Set(values).size, 3, "small/medium/big must all be distinct with 5 available models");
+    });
+  });
+
+  describe("formatTierFallbackNotice", () => {
+    it("names the fallback model and includes the suggested mapping", async () => {
+      const { formatTierFallbackNotice } = await loadModule();
+      const notice = formatTierFallbackNotice("openai/gpt-4.1", [
+        { spec: "v/small", costOutput: 1 },
+        { spec: "v/mid", costOutput: 5 },
+        { spec: "v/big", costOutput: 20 },
+      ]);
+      assert.match(notice, /no model-tiers\.json/);
+      assert.match(notice, /fall back to openai\/gpt-4\.1/);
+      assert.match(notice, /\/workflows-models/);
+      assert.match(notice, /small=v\/small/);
+      assert.match(notice, /medium=v\/mid/);
+      assert.match(notice, /big=v\/big/);
+    });
+
+    it("uses a generic phrase when no session model is known", async () => {
+      const { formatTierFallbackNotice } = await loadModule();
+      const notice = formatTierFallbackNotice(undefined, specs("only-model"));
+      assert.match(notice, /the session default model/);
     });
   });
 
   describe("resolveTierModel", () => {
     it("returns the model for a valid tier", async () => {
       const { resolveTierModel } = await loadModule();
-      const config = {
-        tiers: { small: "openai/gpt-4.1-mini", medium: "openai/gpt-4.1", big: "openai/gpt-5" },
-      };
+      const config = { tiers: { small: "openai/gpt-4.1-mini", medium: "openai/gpt-4.1", big: "openai/gpt-5" } };
       assert.equal(resolveTierModel("small", config), "openai/gpt-4.1-mini");
       assert.equal(resolveTierModel("medium", config), "openai/gpt-4.1");
       assert.equal(resolveTierModel("big", config), "openai/gpt-5");
@@ -302,9 +381,7 @@ describe("model-tier-config", () => {
       const { loadModelTierConfig, saveModelTierConfig } = await loadModule();
       const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
       const cfgPath = join(tmpDir, "model-tiers.json");
-      const config = {
-        tiers: { small: "gpt-4.1-mini", medium: "gpt-4.1", big: "gpt-5" },
-      };
+      const config = { tiers: { small: "gpt-4.1-mini", medium: "gpt-4.1", big: "gpt-5" } };
       saveModelTierConfig(config, cfgPath);
       const loaded = loadModelTierConfig(cfgPath);
       assert.deepEqual(loaded, config);


### PR DESCRIPTION
## What & why

Default workflow model tiers were assigned by ranking available models on **model-name substrings** (`mini`/`flash` → small, `opus`/`pro` → big). That's fragile: a new vendor whose name matches no hint (e.g. `fable`, `mimo`) scores neutral and lands in a tier by registry insertion order. The SDK `Model` already carries `cost` and `contextWindow`, but `listAvailableModelSpecs()` dropped them at `.map(canonicalModelSpec)` before ranking ever saw them.

While implementing this I found a related gap worth surfacing: at **runtime**, `resolveAgentModelSpec` only reads `model-tiers.json` from disk. With **no** config file, an agent's `opts.tier` silently falls back to the session model — the tier has no effect and nothing tells the user. `buildDefaultTierConfig` (the ranked default) is only ever used by the `/workflows-models` command's suggestion, not at runtime.

This PR does two cohesive things:

### (a) Rank default tiers by a real cost signal
- Primary signal: **output price** (higher ≈ more capable) — robust within a registry and works for unknown vendor names.
- Fallback: the name-substring hint, now demoted to a tie-break / used only when price is absent.
- Tie-break: `contextWindow`, then stable registry order.
- **Unknown/zero cost** (self-hosted `models.json` entries) is *not* treated as "cheapest = weakest": it's projected onto the known price range via the hint (big-hint → top, small-hint → bottom, neutral → middle). If **no** model has a price, ranking degrades to pure hint ordering (previous behavior — fully back-compat).

### (b) Surface the unconfigured-tier fallback
When an agent requests `opts.tier` but no `model-tiers.json` exists, emit a **one-time** `console.warn` at run time naming the fallback model and the suggested mapping, pointing at `/workflows-models`. Makes the silent no-op discoverable.

## Design (high-cohesion / low-coupling)
- **`RankableModel { spec, costOutput?, contextWindow? }`** — a minimal projection defined in `model-tier-config.ts` that deliberately does **not** import the SDK `Model`. All ranking is pure functions with zero IO / zero SDK dependency, so they're trivially unit-testable with plain objects.
- **`listAvailableModels()`** in `agent.ts` is the single place the SDK `Model` is projected into `RankableModel` (`cost?.output` / `contextWindow`). `listAvailableModelSpecs()` now just maps it to spec strings — no duplication.
- **(b) keeps `resolveAgentModelSpec` pure**: it gains an optional `onTierWithoutConfig` callback; the notice text is a pure function (`formatTierFallbackNotice`); the actual `console.warn` (guarded by a one-time flag) lives in `WorkflowAgent.run()`, matching the existing `[workflow] …` diagnostic convention there.

## Behavior
| case | result |
|---|---|
| prices known | rank by output price (name ignored — `pro-but-cheap` ranks below `mini-but-pricey`) |
| cost missing/0 | project onto price range via hint — never auto-weakest |
| no prices at all | pure hint ordering (unchanged) |
| new vendor `fable`/`mimo` with price | ranks by price, no longer neutral-collapsed |

## Tests
Rewrote `tests/model-tier-config.test.ts`: cost ranking, misleading-name-vs-price, unknown-cost projection (big & small), new-vendor, contextWindow tie-break, stable order, pure-hint fallback, and `formatTierFallbackNotice`. All existing hint-ordering / no-collapse / no-inversion regressions preserved (now via `{spec}` objects). **861 unit tests pass; `tsc` + biome clean.**

## Not included
No README change — the homepage was just redesigned in #75, so I kept this PR to code + tests and left docs for a follow-up if we want to document tier behavior on the new page.
