### PR TITLE
chore: two small hardening tweaks — VM-realm doc caveat + persistAgentSessions secrets warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ return await agent(
 
 ## Why use it
 
-- **Real parallel orchestration** — fan out up to 16 concurrent and 1000 total subagents from a sandboxed script.
+- **Real parallel orchestration** — fan out up to 16 concurrent and 1000 total subagents from one orchestration script.
 - **Per-agent model routing** — use `small`, `medium`, or `big` tiers, or choose an exact provider/model and thinking level.
 - **Journaled resume** — replay completed agents after interruption without rerunning them or spending their tokens again.
 - **Git worktree isolation** — let parallel agents edit safely on throwaway branches with `isolation: "worktree"`.
@@ -208,7 +208,7 @@ The default `workflow` also matches `workflows`; a custom word matches exactly. 
 
 | Claude Code dynamic workflows | pi-dynamic-workflows on Pi |
 | --- | --- |
-| Code-mode orchestration | JavaScript `agent()` / `parallel()` / `pipeline()` / `phase()` in a VM sandbox |
+| Code-mode orchestration | JavaScript `agent()` / `parallel()` / `pipeline()` / `phase()` in a VM realm (for determinism, not a security boundary) |
 | Isolated subagent contexts | Fresh in-memory Pi sessions; results remain in variables |
 | Structured outputs | JSON Schema validation with bounded repair |
 | Background runs | Non-blocking run, live panel, and automatic result delivery |

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -285,6 +285,21 @@ function warnTierUnconfiguredOnce(mainModel: string | undefined, registry: Model
   }
 }
 
+/**
+ * Emitted at most once per process when persistAgentSessions is enabled and a
+ * session is actually persisted: full subagent transcripts (which may include
+ * secrets or other sensitive context) are being written to disk. Surface the
+ * privacy trade-off at run time, not only in the docs.
+ */
+let warnedPersistSecrets = false;
+function warnPersistSecretsOnce(sessionDir: string): void {
+  if (warnedPersistSecrets) return;
+  warnedPersistSecrets = true;
+  console.warn(
+    `[workflow] persistAgentSessions is ON: full subagent transcripts (which may include secrets or other sensitive context) are being written to disk under ${sessionDir}. Disable persistAgentSessions if that isn't intended.`,
+  );
+}
+
 /** Real token/cost usage for a single subagent run, read from the SDK session. */
 export interface AgentUsage {
   input: number;
@@ -458,6 +473,7 @@ export class WorkflowAgent {
     try {
       const manager = SessionManager.create(this.cwd);
       this.assertSessionDirWritable(manager.getSessionDir());
+      warnPersistSecretsOnce(manager.getSessionDir());
       return manager;
     } catch (error) {
       console.warn(


### PR DESCRIPTION
Two small, independent hardening tweaks — each its own commit.

## VM realm is not a security boundary (docs)
The homepage described execution as a "sandboxed script" / "VM sandbox", which can read as a security guarantee. It isn't — an injected bridge function's `.constructor` is still the host `Function` (already noted in `workflow.ts`), and scripts are model-generated, so content read from files/web could influence them. Reworded to "one orchestration script" and "a VM realm (for determinism, not a security boundary)" so the docs don't over-promise isolation.

## Warn once when persistAgentSessions writes transcripts to disk
`persistAgentSessions` persists full subagent transcripts, which can contain secrets or other sensitive context. That trade-off lived only in the docs. Now a one-time `console.warn` fires at run time when a session is actually persisted (after the write-probe succeeds), naming the directory and the setting — using the same one-time-warn idiom already in the file. It only fires on the real persist path; the failure→in-memory degrade path is unchanged.

No behavior change beyond the added diagnostic. `tsc` + biome clean, 861 unit tests pass.
