### PR TITLE
feat: auto-resume workflows after a provider usage limit resets (closes #27)

### DIFF
--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -13,6 +13,7 @@ import {
   registerWorkflowCommands,
   registerWorkflowModelsCommand,
   saveWorkflowSettingsForCwd,
+  UsageLimitScheduler,
   WorkflowManager,
 } from "../src/index.js";
 
@@ -33,6 +34,15 @@ export default function extension(pi: ExtensionAPI) {
 
   const workflowTool = createWorkflowTool({ cwd, manager, storage });
   pi.registerTool(workflowTool);
+  // Auto-resume runs that paused on a provider usage limit once the quota is
+  // likely refilled. Standalone: only consumes the manager's public surface, so
+  // it stays decoupled from manager/persistence internals. Its constructor also
+  // re-arms any run that was already paused-on-usage_limit before this process
+  // started (cold start), so restarting pi doesn't strand a paused run.
+  const usageLimitScheduler = new UsageLimitScheduler(manager);
+  pi.on("session_shutdown", () => {
+    usageLimitScheduler.dispose();
+  });
   // Standing /effort opt-in (off|high|ultra): auto-arms a workflow for substantive
   // messages, like CC's ultracode. Shared with the editor's input hook below and
   // with the explicit /workflows run <prompt> manual trigger.

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,13 @@ export { createSharedStoreTools, SharedStore } from "./shared-store.js";
 export type { StructuredOutputCapture, StructuredOutputToolOptions } from "./structured-output.js";
 export { createStructuredOutputTool } from "./structured-output.js";
 export { deliverText, installResultDelivery, installTaskPanel, type TaskPanelOptions } from "./task-panel.js";
+export type {
+  AutoResumeDelayParams,
+  SchedulableWorkflowManager,
+  TimerHandle,
+  UsageLimitSchedulerOptions,
+} from "./usage-limit-scheduler.js";
+export { computeAutoResumeDelayMs, parseResetHintMs, UsageLimitScheduler } from "./usage-limit-scheduler.js";
 export { createWebFetchTool, createWebSearchTool, createWebTools } from "./web-tools.js";
 export type {
   AgentOptions,

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -64,6 +64,18 @@ export interface PersistedRunState {
   };
   /** Cached agent results for resume, keyed by deterministic call index. */
   journal?: Array<{ index: number; hash: string; result: unknown }>;
+  /**
+   * Opt-out of auto-resume for this run (default true, i.e. eligible unless
+   * explicitly set to false via ExecOptions.autoResume). Set once at run start
+   * and carried through resumes; see UsageLimitScheduler.
+   */
+  autoResume?: boolean;
+  /**
+   * Auto-resume attempt counter for the current usage_limit pause-cycle, owned
+   * and persisted by UsageLimitScheduler (best-effort). Absent/0 means no
+   * auto-resume attempt has been recorded yet.
+   */
+  autoResumeAttempts?: number;
 }
 
 export interface RunPersistence {

--- a/src/usage-limit-scheduler.ts
+++ b/src/usage-limit-scheduler.ts
@@ -1,0 +1,389 @@
+/**
+ * Auto-resume for runs paused on a provider usage limit.
+ *
+ * A workflow run pauses (does not fail) when a provider quota/usage limit is hit
+ * (see errors.ts PROVIDER_USAGE_LIMIT, workflow-manager.ts executeRun()'s catch
+ * block). Left alone, the run just sits there until a human runs /workflows and
+ * hits resume. This module watches the manager's public event stream and, for
+ * runs that are auto-resume-eligible, arms a timer to call manager.resume() once
+ * the provider's quota is likely to have refilled — with exponential backoff if
+ * it keeps hitting the wall, and a hard attempt cap so it never retries forever.
+ *
+ * Deliberately standalone: it consumes ONLY WorkflowManager's public surface
+ * (on/off, listAllRuns, resume, getPersistence) so it stays decoupled from
+ * manager/persistence internals. It owns its own timers and its own bookkeeping
+ * (in-memory, best-effort persisted) — it does not rely on manager.stop(), which
+ * only operates on in-memory runs.
+ */
+
+import type { PersistedRunState, RunPersistence, RunStatus } from "./run-persistence.js";
+
+/** Narrow surface this scheduler depends on — satisfied by WorkflowManager. */
+export interface SchedulableWorkflowManager {
+  on(event: string, listener: (...args: any[]) => void): unknown;
+  off(event: string, listener: (...args: any[]) => void): unknown;
+  listAllRuns(): PersistedRunState[];
+  resume(runId: string): Promise<boolean>;
+  getPersistence(): RunPersistence;
+}
+
+/** Opaque timer handle so tests can inject a fake clock/timer. */
+export type TimerHandle = unknown;
+
+export interface UsageLimitSchedulerOptions {
+  /** Injectable clock (default Date.now). */
+  now?: () => number;
+  /** Injectable timer scheduler (default setTimeout). */
+  setTimer?: (fn: () => void, ms: number) => TimerHandle;
+  /** Injectable timer canceller (default clearTimeout). */
+  clearTimer?: (handle: TimerHandle) => void;
+  /** Max auto-resume attempts per pause-cycle before giving up. Default 5. */
+  maxAttempts?: number;
+  /** Delay floor — never arm sooner than this. Default 60_000 (1m). */
+  minDelayMs?: number;
+  /** Delay used when the provider's resetHint can't be parsed. Default 300_000 (5m). */
+  fallbackDelayMs?: number;
+  /** Delay ceiling — backoff is clamped here. Default 6h. */
+  maxDelayMs?: number;
+  /** Diagnostics sink; defaults to console.warn. Never throws back into the caller. */
+  onDiagnostic?: (message: string, detail?: unknown) => void;
+}
+
+interface RunState {
+  /** How many auto-resume attempts have been made (or armed) for this pause-cycle. */
+  attempts: number;
+  /** The currently armed timer, if any. */
+  timer?: TimerHandle;
+  /** Set once the attempt cap is hit, so the give-up diagnostic logs once. */
+  gaveUp?: boolean;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_MIN_DELAY_MS = 60_000;
+const DEFAULT_FALLBACK_DELAY_MS = 300_000;
+const DEFAULT_MAX_DELAY_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Best-effort parse of a provider's human reset hint ("Resets in ~3h",
+ * "resets in 5m", "in 90s", "1h30m") into milliseconds. Sums every
+ * (number, unit) pair found, so combined forms like "1h30m" work for free.
+ * Returns undefined when nothing recognizable is found — callers should fall
+ * back to a fixed delay rather than guess.
+ */
+export function parseResetHintMs(hint?: string): number | undefined {
+  if (!hint) return undefined;
+  // No trailing \b: combined forms like "1h30m" have a digit right after the
+  // unit letter, which is itself a word character, so \b would never match
+  // there. A negative lookahead for another letter is the correct boundary —
+  // it still stops "hours" from partially matching as bare "h" mid-word while
+  // allowing a unit to be followed immediately by the next (digit, unit) pair.
+  const re = /(\d+(?:\.\d+)?)\s*(hours?|hrs?|h|minutes?|mins?|m|seconds?|secs?|s)(?![a-z])/gi;
+  let match: RegExpExecArray | null;
+  let totalMs = 0;
+  let found = false;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex-exec loop
+  while ((match = re.exec(hint)) !== null) {
+    const value = Number.parseFloat(match[1]);
+    if (!Number.isFinite(value)) continue;
+    const unit = match[2].toLowerCase();
+    found = true;
+    if (unit.startsWith("h")) totalMs += value * 3_600_000;
+    else if (unit.startsWith("m")) totalMs += value * 60_000;
+    else if (unit.startsWith("s")) totalMs += value * 1_000;
+  }
+  return found ? totalMs : undefined;
+}
+
+export interface AutoResumeDelayParams {
+  /** The provider's verbatim reset hint for this pause, if any. */
+  resetHint?: string;
+  /** 1-indexed attempt number for the pause currently being armed. */
+  attempts: number;
+  /** Milliseconds already elapsed since the pause began (0 for a live pause). */
+  elapsedMs: number;
+  minDelayMs: number;
+  fallbackDelayMs: number;
+  maxDelayMs: number;
+}
+
+/**
+ * delay = clamp(minDelayMs, remaining * 2^(attempts-1), maxDelayMs), where
+ * remaining = parsed(resetHint) ?? fallbackDelayMs, minus time already elapsed.
+ * The exponent is capped defensively so a pathological attempt count can't
+ * overflow the multiplication to Infinity/NaN before the maxDelayMs clamp runs.
+ */
+export function computeAutoResumeDelayMs(params: AutoResumeDelayParams): number {
+  const base = parseResetHintMs(params.resetHint) ?? params.fallbackDelayMs;
+  const remaining = base - params.elapsedMs;
+  const exponent = Math.min(Math.max(params.attempts - 1, 0), 30);
+  const backoff = remaining * 2 ** exponent;
+  return Math.min(params.maxDelayMs, Math.max(params.minDelayMs, backoff));
+}
+
+/**
+ * Watches a WorkflowManager for usage-limit pauses and auto-resumes eligible
+ * runs once the provider's quota is likely to have refilled.
+ *
+ * Event-driven "fire and watch": an attempt is consumed when a run ENTERS a
+ * usage_limit pause (live via the "paused" event, or once at cold start for a
+ * run that was already paused), never when a resume is merely fired. When an
+ * armed timer fires, resume() is called; if it returns false (lease busy, run
+ * already gone, etc.) no attempt is consumed and a short un-backed-off retry is
+ * armed instead, unless the run has reached a terminal state on disk. If resume()
+ * returns true, this scheduler steps back — the existing "paused" subscription
+ * re-arms with backoff if the run hits the wall again, and "complete"/"error"/
+ * "stopped" clean up its timer.
+ */
+export class UsageLimitScheduler {
+  private readonly manager: SchedulableWorkflowManager;
+  private readonly now: () => number;
+  private readonly setTimer: (fn: () => void, ms: number) => TimerHandle;
+  private readonly clearTimer: (handle: TimerHandle) => void;
+  private readonly maxAttempts: number;
+  private readonly minDelayMs: number;
+  private readonly fallbackDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly diagnostic: (message: string, detail?: unknown) => void;
+
+  private readonly state = new Map<string, RunState>();
+  private disposed = false;
+
+  private readonly onPaused = (event: { runId?: string; reason?: string; resetHint?: string }): void => {
+    this.safe(() => this.handlePaused(event));
+  };
+  private readonly onTerminal = (event: { runId?: string }): void => {
+    this.safe(() => this.cleanup(event?.runId));
+  };
+
+  constructor(manager: SchedulableWorkflowManager, options: UsageLimitSchedulerOptions = {}) {
+    this.manager = manager;
+    this.now = options.now ?? Date.now;
+    this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle as NodeJS.Timeout));
+    this.maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    this.minDelayMs = options.minDelayMs ?? DEFAULT_MIN_DELAY_MS;
+    this.fallbackDelayMs = options.fallbackDelayMs ?? DEFAULT_FALLBACK_DELAY_MS;
+    this.maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+    this.diagnostic =
+      options.onDiagnostic ??
+      ((message, detail) => {
+        console.warn(message, detail ?? "");
+      });
+
+    this.manager.on("paused", this.onPaused);
+    this.manager.on("complete", this.onTerminal);
+    this.manager.on("error", this.onTerminal);
+    this.manager.on("stopped", this.onTerminal);
+
+    // Cold-start re-arm: pick up any run that was already paused-on-usage_limit
+    // before this process (and thus this scheduler instance) existed.
+    this.safe(() => this.coldStartRearm());
+  }
+
+  /** Clear every armed timer and unsubscribe from the manager. Idempotent. */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.manager.off("paused", this.onPaused);
+    this.manager.off("complete", this.onTerminal);
+    this.manager.off("error", this.onTerminal);
+    this.manager.off("stopped", this.onTerminal);
+    for (const entry of this.state.values()) {
+      if (entry.timer !== undefined) this.clearTimer(entry.timer);
+    }
+    this.state.clear();
+  }
+
+  /** Test/diagnostic helper: in-memory attempt count tracked for a run, if any. */
+  getAttemptCount(runId: string): number | undefined {
+    return this.state.get(runId)?.attempts;
+  }
+
+  /** Test/diagnostic helper: whether a resume timer is currently armed for a run. */
+  hasArmedTimer(runId: string): boolean {
+    return this.state.get(runId)?.timer !== undefined;
+  }
+
+  // ---- event handlers -----------------------------------------------------
+
+  private handlePaused(event: { runId?: string; reason?: string; resetHint?: string }): void {
+    if (this.disposed || !event?.runId || event.reason !== "usage_limit") return;
+    const runId = event.runId;
+
+    // The "paused" event fires BEFORE the manager's own persistRun() write for
+    // this pause (see executeRun()'s catch block: emit then persist). A disk
+    // read here can therefore be stale for fields this exact pause is about to
+    // set (status/pauseReason/resetHint) — but NOT for `autoResume`, which is
+    // fixed at run-start and persisted on every persistRun() call since, so a
+    // stale read of it is still correct. resetHint comes off the event itself,
+    // not disk, to avoid that race.
+    const persisted = this.safeLoad(runId);
+    if (persisted?.autoResume === false) {
+      this.diagnostic(`[usage-limit-scheduler] ${runId}: autoResume is disabled for this run, not arming`);
+      return;
+    }
+
+    const priorAttempts = this.state.get(runId)?.attempts ?? persisted?.autoResumeAttempts ?? 0;
+    this.arm(runId, {
+      attempts: priorAttempts + 1,
+      resetHint: event.resetHint ?? persisted?.resetHint,
+      elapsedMs: 0,
+    });
+  }
+
+  private cleanup(runId?: string): void {
+    if (!runId) return;
+    const entry = this.state.get(runId);
+    if (entry?.timer !== undefined) this.clearTimer(entry.timer);
+    this.state.delete(runId);
+  }
+
+  private coldStartRearm(): void {
+    const runs = this.manager.listAllRuns();
+    for (const run of runs) {
+      if (run.status !== "paused" || run.pauseReason !== "usage_limit") continue;
+      if (run.autoResume === false) continue;
+      if (this.state.has(run.runId)) continue;
+
+      const priorAttempts = run.autoResumeAttempts ?? 0;
+      const updatedAtMs = Date.parse(run.updatedAt);
+      const elapsedMs = Number.isFinite(updatedAtMs) ? Math.max(0, this.now() - updatedAtMs) : 0;
+      this.arm(run.runId, {
+        attempts: priorAttempts + 1,
+        resetHint: run.resetHint,
+        elapsedMs,
+      });
+    }
+  }
+
+  // ---- arming / firing ------------------------------------------------------
+
+  private arm(runId: string, params: { attempts: number; resetHint?: string; elapsedMs: number }): void {
+    const existing = this.state.get(runId);
+    if (existing?.timer !== undefined) this.clearTimer(existing.timer);
+
+    if (params.attempts > this.maxAttempts) {
+      const alreadyLogged = existing?.gaveUp === true;
+      this.state.set(runId, { attempts: params.attempts, gaveUp: true });
+      this.persistAttempts(runId, params.attempts);
+      if (!alreadyLogged) {
+        this.diagnostic(
+          `[usage-limit-scheduler] ${runId}: giving up after ${params.attempts - 1} auto-resume attempt(s) ` +
+            `(max ${this.maxAttempts}); leaving paused for manual resume`,
+        );
+      }
+      return;
+    }
+
+    const delay = computeAutoResumeDelayMs({
+      resetHint: params.resetHint,
+      attempts: params.attempts,
+      elapsedMs: params.elapsedMs,
+      minDelayMs: this.minDelayMs,
+      fallbackDelayMs: this.fallbackDelayMs,
+      maxDelayMs: this.maxDelayMs,
+    });
+
+    const timer = this.setTimer(() => this.safe(() => this.onTimerFire(runId)), delay);
+    this.state.set(runId, { attempts: params.attempts, timer });
+    this.persistAttempts(runId, params.attempts);
+  }
+
+  private async onTimerFire(runId: string): Promise<void> {
+    if (this.disposed) return;
+    const entry = this.state.get(runId);
+    if (!entry || entry.gaveUp) return;
+    // The timer that just fired is spent; clear its handle while we await.
+    this.state.set(runId, { ...entry, timer: undefined });
+
+    let resumed = false;
+    try {
+      resumed = await this.manager.resume(runId);
+    } catch (err) {
+      this.diagnostic(`[usage-limit-scheduler] ${runId}: resume() threw`, err);
+      resumed = false;
+    }
+    if (this.disposed) return;
+
+    if (resumed) {
+      // Don't consume/advance anything further here — the existing "paused"
+      // subscription re-arms (with backoff) if this run hits the wall again,
+      // and "complete"/"error"/"stopped" clean up on any terminal outcome.
+      return;
+    }
+
+    // resume() returned false without throwing: it refused for a structural
+    // reason (already running/aborted, no persisted script, or the lease is
+    // held elsewhere) rather than a real failed attempt. Per the fix for bug
+    // (a), that must NOT consume an attempt. Distinguish "gone for good" from
+    // "try again shortly":
+    const status = this.safeStatus(runId);
+    if (status === undefined || status === "completed" || status === "aborted") {
+      this.cleanup(runId);
+      return;
+    }
+
+    const current = this.state.get(runId) ?? entry;
+    const timer = this.setTimer(() => this.safe(() => this.onTimerFire(runId)), this.minDelayMs);
+    this.state.set(runId, { attempts: current.attempts, timer });
+  }
+
+  // ---- helpers --------------------------------------------------------------
+
+  private safeLoad(runId: string): PersistedRunState | undefined {
+    try {
+      return this.manager.getPersistence().load(runId) ?? undefined;
+    } catch (err) {
+      this.diagnostic(`[usage-limit-scheduler] ${runId}: persistence load failed`, err);
+      return undefined;
+    }
+  }
+
+  private safeStatus(runId: string): RunStatus | undefined {
+    try {
+      return this.manager.listAllRuns().find((r) => r.runId === runId)?.status;
+    } catch (err) {
+      this.diagnostic(`[usage-limit-scheduler] ${runId}: listAllRuns() failed`, err);
+      return undefined;
+    }
+  }
+
+  /**
+   * Best-effort persist of the in-memory attempt counter, so a cold start after
+   * a crash can approximately resume the backoff sequence instead of restarting
+   * it. Deferred to a microtask so it lands AFTER the manager's own persistRun()
+   * write for this same pause (which happens synchronously, right after the
+   * "paused" event we're reacting to returns control to executeRun()) — writing
+   * synchronously here would just get clobbered, since persistRun() writes a
+   * fresh PersistedRunState object literal that doesn't know about this field.
+   * This is still inherently racy across process crashes (see class docs); it
+   * is a best-effort durability aid, not a correctness requirement for the live
+   * (in-memory) path.
+   */
+  private persistAttempts(runId: string, attempts: number): void {
+    queueMicrotask(() => {
+      if (this.disposed) return;
+      try {
+        const persistence = this.manager.getPersistence();
+        const current = persistence.load(runId);
+        if (!current) return;
+        persistence.save({ ...current, autoResumeAttempts: attempts });
+      } catch (err) {
+        this.diagnostic(`[usage-limit-scheduler] ${runId}: failed to persist autoResumeAttempts`, err);
+      }
+    });
+  }
+
+  private safe(fn: () => void | Promise<void>): void {
+    try {
+      const result = fn();
+      if (result && typeof (result as Promise<void>).catch === "function") {
+        (result as Promise<void>).catch((err: unknown) => {
+          this.diagnostic("[usage-limit-scheduler] async handler error", err);
+        });
+      }
+    } catch (err) {
+      this.diagnostic("[usage-limit-scheduler] handler error", err);
+    }
+  }
+}

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -39,6 +39,12 @@ export interface ManagedRun {
    * result, so re-delivering would duplicate it.
    */
   background: boolean;
+  /**
+   * Auto-resume eligibility for this run (see ExecOptions.autoResume). Set once
+   * at creation and carried through resume() so it survives pause/resume cycles.
+   * Undefined means eligible (default-on); false opts out.
+   */
+  autoResume?: boolean;
 }
 
 /** Per-execution options shared by sync, background, and resume runs. */
@@ -61,6 +67,13 @@ export interface ExecOptions {
   agentRetries?: number;
   /** Resolve a checkpoint() question with a human reply (only for UI-bearing runs). */
   confirm?: (promptText: string, options: unknown) => Promise<unknown>;
+  /**
+   * Whether this run is eligible for auto-resume when it pauses on a provider
+   * usage limit. Default-on: omit or pass true to stay eligible, pass false to
+   * opt out. Persisted on the run so a cold-start UsageLimitScheduler respects
+   * it too. See usage-limit-scheduler.ts.
+   */
+  autoResume?: boolean;
 }
 
 export interface WorkflowManagerOptions {
@@ -215,6 +228,7 @@ export class WorkflowManager extends EventEmitter {
       journal: [],
       background: true,
       lease,
+      autoResume: exec.autoResume,
     };
 
     this.runs.set(runId, managed);
@@ -233,6 +247,7 @@ export class WorkflowManager extends EventEmitter {
         logs: [],
         startedAt: managed.startedAt.toISOString(),
         updatedAt: managed.startedAt.toISOString(),
+        autoResume: managed.autoResume,
       });
     } catch (err) {
       this.releaseRunLease(managed);
@@ -262,6 +277,7 @@ export class WorkflowManager extends EventEmitter {
     const lease = this.persistence.acquireRunLease(managed.runId);
     if (!lease) throw new Error(`Could not acquire workflow run lease for ${managed.runId}`);
     managed.lease = lease;
+    managed.autoResume = exec.autoResume;
     this.runs.set(managed.runId, managed);
     // Persist the initial state immediately so listRuns()/the task panel can see
     // the run the moment it starts, not only after the first agent journals.
@@ -484,6 +500,10 @@ export class WorkflowManager extends EventEmitter {
         sessionId: this.sessionId,
         journal: managed.journal,
         status: managed.status,
+        // Persisted every write (not just at pause) so a stale read during the
+        // "paused" event race (see UsageLimitScheduler) is still correct — this
+        // is fixed at run-start and doesn't change over the run's lifetime.
+        autoResume: managed.autoResume,
         // Why a usage-limit pause happened, so the navigator / a future cold start
         // can show it and (eventually) re-arm resume after the budget refills.
         pauseReason:
@@ -578,6 +598,9 @@ export class WorkflowManager extends EventEmitter {
       journal: persisted.journal ?? [],
       background: true,
       lease,
+      // Carry the original opt-out forward across resumes; it's fixed at
+      // run-start and persistRun() re-persists it on every subsequent write.
+      autoResume: persisted.autoResume,
     };
     this.runs.set(runId, managed);
     // Persist before notifying renderers: listRuns() is their source of truth for

--- a/tests/usage-limit-scheduler.test.ts
+++ b/tests/usage-limit-scheduler.test.ts
@@ -1,0 +1,509 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import type { PersistedRunState, RunPersistence } from "../src/run-persistence.js";
+import {
+  computeAutoResumeDelayMs,
+  parseResetHintMs,
+  type SchedulableWorkflowManager,
+  UsageLimitScheduler,
+} from "../src/usage-limit-scheduler.js";
+
+// ---- test doubles -----------------------------------------------------------
+
+/** Deterministic, manually-advanced fake clock + synchronous fake timers. */
+function createFakeClock(startMs = 0) {
+  let current = startMs;
+  const pending = new Map<number, { fn: () => void; ms: number; armedAt: number }>();
+  let nextId = 1;
+  return {
+    now: () => current,
+    advance(ms: number) {
+      current += ms;
+    },
+    setTimer: (fn: () => void, ms: number): number => {
+      const id = nextId++;
+      pending.set(id, { fn, ms, armedAt: current });
+      return id;
+    },
+    clearTimer: (id: number): void => {
+      pending.delete(id);
+    },
+    /** Fire every currently-armed timer, synchronously, in arm order. */
+    fireAll(): void {
+      const toFire = [...pending.entries()].sort((a, b) => a[0] - b[0]);
+      pending.clear();
+      for (const [, { fn }] of toFire) fn();
+    },
+    pendingCount: () => pending.size,
+    pendingDelays: (): number[] => [...pending.values()].map((p) => p.ms),
+  };
+}
+
+/** Flush the microtask queue a few times (covers queueMicrotask + resolved promises). */
+async function flush(times = 6): Promise<void> {
+  for (let i = 0; i < times; i++) await Promise.resolve();
+}
+
+class FakePersistence {
+  private runs = new Map<string, PersistedRunState>();
+
+  seed(run: PersistedRunState): void {
+    this.runs.set(run.runId, run);
+  }
+
+  get(runId: string): PersistedRunState | undefined {
+    return this.runs.get(runId);
+  }
+
+  list(): PersistedRunState[] {
+    return [...this.runs.values()];
+  }
+
+  asRunPersistence(): RunPersistence {
+    return {
+      save: (state: PersistedRunState) => {
+        this.runs.set(state.runId, { ...state, updatedAt: new Date().toISOString() });
+      },
+      load: (runId: string) => this.runs.get(runId) ?? null,
+      list: () => [...this.runs.values()],
+      delete: (runId: string) => this.runs.delete(runId),
+      acquireRunLease: () => null,
+      releaseRunLease: () => {},
+      getRunsDir: () => "/fake-runs",
+    };
+  }
+}
+
+class FakeManager extends EventEmitter implements SchedulableWorkflowManager {
+  readonly persistence = new FakePersistence();
+  resumeImpl: (runId: string) => Promise<boolean> = async () => false;
+
+  listAllRuns(): PersistedRunState[] {
+    return this.persistence.list();
+  }
+
+  resume(runId: string): Promise<boolean> {
+    return this.resumeImpl(runId);
+  }
+
+  getPersistence(): RunPersistence {
+    return this.persistence.asRunPersistence();
+  }
+}
+
+function makeRun(overrides: Partial<PersistedRunState> = {}): PersistedRunState {
+  // Default status is "running", NOT "paused" — most tests seed a persisted
+  // record only so handlePaused()'s autoResume-opt-out lookup has something to
+  // read. A "paused" + pauseReason "usage_limit" run is picked up by cold-start
+  // re-arm in the UsageLimitScheduler constructor, so tests that exercise a
+  // *live* "paused" event opt in to that separately (see the cold-start tests).
+  return {
+    runId: "run-1",
+    workflowName: "test_workflow",
+    script: "export const meta = { name: 'test_workflow', description: 'd' }",
+    status: "running",
+    phases: [],
+    agents: [],
+    logs: [],
+    startedAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+const TUNABLES = { maxAttempts: 3, minDelayMs: 60_000, fallbackDelayMs: 300_000, maxDelayMs: 6 * 3_600_000 };
+
+// ---- parseResetHintMs ---------------------------------------------------------
+
+test("parseResetHintMs: hours", () => {
+  assert.equal(parseResetHintMs("Resets in 3h"), 3 * 3_600_000);
+});
+
+test("parseResetHintMs: approx hours (~3h)", () => {
+  assert.equal(parseResetHintMs("Resets in ~3h"), 3 * 3_600_000);
+});
+
+test("parseResetHintMs: minutes", () => {
+  assert.equal(parseResetHintMs("resets in 5m"), 5 * 60_000);
+});
+
+test("parseResetHintMs: seconds", () => {
+  assert.equal(parseResetHintMs("resets in 90s"), 90 * 1_000);
+});
+
+test("parseResetHintMs: combined hours+minutes", () => {
+  assert.equal(parseResetHintMs("Resets in 1h30m"), 3_600_000 + 30 * 60_000);
+});
+
+test("parseResetHintMs: word units (5 minutes)", () => {
+  assert.equal(parseResetHintMs("resets in 5 minutes"), 5 * 60_000);
+});
+
+test("parseResetHintMs: missing hint returns undefined", () => {
+  assert.equal(parseResetHintMs(undefined), undefined);
+});
+
+test("parseResetHintMs: unparseable text returns undefined", () => {
+  assert.equal(parseResetHintMs("try again later"), undefined);
+});
+
+// ---- computeAutoResumeDelayMs --------------------------------------------------
+
+test("computeAutoResumeDelayMs: delay floor is enforced", () => {
+  const delay = computeAutoResumeDelayMs({
+    resetHint: "resets in 1s",
+    attempts: 1,
+    elapsedMs: 0,
+    minDelayMs: 60_000,
+    fallbackDelayMs: 300_000,
+    maxDelayMs: 3_600_000,
+  });
+  assert.equal(delay, 60_000, "1s base is below the floor, floor wins");
+});
+
+test("computeAutoResumeDelayMs: backoff grows with attempts and is capped by maxDelayMs", () => {
+  const base = { resetHint: "resets in 10m", elapsedMs: 0, minDelayMs: 1_000, fallbackDelayMs: 300_000 };
+  const attempt1 = computeAutoResumeDelayMs({ ...base, attempts: 1, maxDelayMs: 3_600_000 });
+  const attempt2 = computeAutoResumeDelayMs({ ...base, attempts: 2, maxDelayMs: 3_600_000 });
+  const attempt10 = computeAutoResumeDelayMs({ ...base, attempts: 10, maxDelayMs: 3_600_000 });
+  assert.equal(attempt1, 10 * 60_000);
+  assert.equal(attempt2, 20 * 60_000, "attempt 2 doubles attempt 1");
+  assert.equal(attempt10, 3_600_000, "clamped at maxDelayMs instead of overflowing");
+});
+
+// ---- scheduler behavior --------------------------------------------------------
+
+test("live pause: arms a timer that calls manager.resume() on fire", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(makeRun({ resetHint: "resets in 10m" }));
+  const clock = createFakeClock();
+  const resumedRunIds: string[] = [];
+  manager.resumeImpl = async (runId) => {
+    resumedRunIds.push(runId);
+    return true;
+  };
+
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  assert.equal(clock.pendingCount(), 1, "a timer was armed");
+  assert.deepEqual(clock.pendingDelays(), [10 * 60_000]);
+
+  clock.fireAll();
+  await flush();
+
+  assert.deepEqual(resumedRunIds, ["run-1"], "resume() was called when the timer fired");
+  scheduler.dispose();
+});
+
+test("re-pause after a failed resume reschedules with a larger (backoff) delay", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(makeRun({ resetHint: "resets in 10m" }));
+  const clock = createFakeClock();
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  assert.deepEqual(clock.pendingDelays(), [10 * 60_000], "attempt 1 delay");
+
+  // Simulate: resume() launched, run hit the wall again and re-paused.
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  assert.deepEqual(clock.pendingDelays(), [20 * 60_000], "attempt 2 backs off (2x attempt 1)");
+  assert.equal(scheduler.getAttemptCount("run-1"), 2);
+
+  scheduler.dispose();
+});
+
+test("attempt cap reached: gives up, arms no further timers", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(makeRun({ resetHint: "resets in 1m" }));
+  const clock = createFakeClock();
+  const diagnostics: string[] = [];
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    onDiagnostic: (msg) => diagnostics.push(msg),
+    ...TUNABLES, // maxAttempts: 3
+  });
+
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 1m" }); // attempt 1
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 1m" }); // attempt 2
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 1m" }); // attempt 3
+  assert.equal(clock.pendingCount(), 1, "attempt 3 is still armed (3 <= maxAttempts 3)");
+
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 1m" }); // attempt 4 > cap
+  assert.equal(clock.pendingCount(), 0, "no timer armed once the cap is exceeded");
+  assert.ok(
+    diagnostics.some((m) => m.includes("giving up")),
+    "a give-up diagnostic was logged",
+  );
+
+  // Further pauses beyond the cap must not spam the log.
+  const logCountBefore = diagnostics.filter((m) => m.includes("giving up")).length;
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 1m" });
+  const logCountAfter = diagnostics.filter((m) => m.includes("giving up")).length;
+  assert.equal(logCountAfter, logCountBefore, "give-up diagnostic doesn't repeat every time");
+
+  scheduler.dispose();
+});
+
+test("cold-start re-arm uses REMAINING time, not the full base delay", async () => {
+  const manager = new FakeManager();
+  const pausedAt = new Date(0);
+  manager.persistence.seed(
+    makeRun({
+      status: "paused",
+      pauseReason: "usage_limit",
+      resetHint: "resets in 1h",
+      updatedAt: pausedAt.toISOString(),
+    }),
+  );
+  // "now" is 55 minutes after the pause was persisted.
+  const clock = createFakeClock(55 * 60_000);
+
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  assert.equal(clock.pendingCount(), 1, "cold start re-armed the already-paused run");
+  assert.deepEqual(clock.pendingDelays(), [5 * 60_000], "remaining ~5m, not the full 60m base");
+  scheduler.dispose();
+});
+
+test("cold-start re-arm skips runs with autoResume: false", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(
+    makeRun({
+      runId: "opted-out",
+      status: "paused",
+      pauseReason: "usage_limit",
+      resetHint: "resets in 10m",
+      autoResume: false,
+    }),
+  );
+  const clock = createFakeClock();
+
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  assert.equal(clock.pendingCount(), 0, "no timer armed for an opted-out run");
+  assert.equal(scheduler.getAttemptCount("opted-out"), undefined);
+  scheduler.dispose();
+});
+
+test("live pause skips arming when autoResume: false is already persisted", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(makeRun({ autoResume: false }));
+  const clock = createFakeClock();
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  assert.equal(clock.pendingCount(), 0);
+  scheduler.dispose();
+});
+
+test("manual pause (no usage_limit reason) is ignored", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(makeRun());
+  const clock = createFakeClock();
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  manager.emit("paused", { runId: "run-1" }); // manager.pause() emits no `reason`
+  assert.equal(clock.pendingCount(), 0);
+  scheduler.dispose();
+});
+
+test("resume() returning false does NOT consume an attempt and re-arms at minDelayMs", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(makeRun({ resetHint: "resets in 10m", status: "paused" }));
+  const clock = createFakeClock();
+  let resumeCalls = 0;
+  manager.resumeImpl = async () => {
+    resumeCalls++;
+    return false; // e.g. lease busy / transient
+  };
+
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  assert.equal(scheduler.getAttemptCount("run-1"), 1);
+
+  clock.fireAll();
+  await flush();
+
+  assert.equal(resumeCalls, 1);
+  assert.equal(scheduler.getAttemptCount("run-1"), 1, "attempt count unchanged by a false resume()");
+  assert.deepEqual(clock.pendingDelays(), [TUNABLES.minDelayMs], "re-armed at the short floor delay");
+
+  clock.fireAll();
+  await flush();
+  assert.equal(resumeCalls, 2, "retried again on the next fire");
+  assert.equal(scheduler.getAttemptCount("run-1"), 1, "still hasn't consumed an attempt");
+
+  scheduler.dispose();
+});
+
+test("resume() returning false and run now completed/aborted stops retrying", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(makeRun({ resetHint: "resets in 10m" }));
+  const clock = createFakeClock();
+  manager.resumeImpl = async (runId) => {
+    // Simulate: something else completed the run out from under us.
+    const run = manager.persistence.get(runId);
+    if (run) manager.persistence.seed({ ...run, status: "completed" });
+    return false;
+  };
+
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  clock.fireAll();
+  await flush();
+
+  assert.equal(clock.pendingCount(), 0, "no retry armed once the run is terminal");
+  assert.equal(scheduler.getAttemptCount("run-1"), undefined, "state cleaned up");
+  scheduler.dispose();
+});
+
+test("resume() returning true stops this cycle; the existing 'paused' subscription re-arms on re-pause", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(makeRun({ resetHint: "resets in 10m" }));
+  const clock = createFakeClock();
+  manager.resumeImpl = async () => true;
+
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  clock.fireAll();
+  await flush();
+
+  assert.equal(clock.pendingCount(), 0, "no further timer armed after a successful resume()");
+  assert.equal(scheduler.hasArmedTimer("run-1"), false);
+  scheduler.dispose();
+});
+
+for (const terminalEvent of ["complete", "error", "stopped"] as const) {
+  test(`"${terminalEvent}" event clears the armed timer and forgets the run`, async () => {
+    const manager = new FakeManager();
+    manager.persistence.seed(makeRun({ resetHint: "resets in 10m" }));
+    const clock = createFakeClock();
+    const scheduler = new UsageLimitScheduler(manager, {
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      ...TUNABLES,
+    });
+
+    manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+    assert.equal(clock.pendingCount(), 1);
+
+    manager.emit(terminalEvent, { runId: "run-1" });
+    assert.equal(clock.pendingCount(), 0, "timer cleared on terminal event");
+    assert.equal(scheduler.getAttemptCount("run-1"), undefined);
+    scheduler.dispose();
+  });
+}
+
+test("dispose() clears all armed timers and unsubscribes from further events", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(makeRun({ resetHint: "resets in 10m" }));
+  const clock = createFakeClock();
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  assert.equal(clock.pendingCount(), 1);
+
+  scheduler.dispose();
+  assert.equal(clock.pendingCount(), 0, "dispose cleared the armed timer");
+
+  // Further events must not resurrect a timer post-dispose.
+  manager.emit("paused", { runId: "run-2", reason: "usage_limit", resetHint: "resets in 10m" });
+  assert.equal(clock.pendingCount(), 0);
+});
+
+test("scheduler never throws out of a manager event even when a listener's work fails", async () => {
+  const manager = new FakeManager();
+  // No seeded run: persistence.load() returns null/undefined inside the handler.
+  const clock = createFakeClock();
+  const diagnostics: string[] = [];
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    onDiagnostic: (msg) => diagnostics.push(msg),
+    ...TUNABLES,
+  });
+
+  assert.doesNotThrow(() => {
+    manager.emit("paused", { runId: "ghost-run", reason: "usage_limit", resetHint: "resets in 10m" });
+  });
+  assert.equal(clock.pendingCount(), 1, "still arms even though persistence had nothing for this run");
+  scheduler.dispose();
+});
+
+test("attempts and opt-out are persisted (best-effort) for a future cold start", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(makeRun({ resetHint: "resets in 10m", autoResume: true }));
+  const clock = createFakeClock();
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  await flush();
+
+  const persisted = manager.persistence.get("run-1");
+  assert.equal(persisted?.autoResumeAttempts, 1, "attempt count persisted after the microtask flush");
+  scheduler.dispose();
+});


### PR DESCRIPTION
Closes #27.

## What
A run that pauses on a provider usage/quota limit (the #26 behavior) now **auto-resumes** once the quota is likely to have refilled — instead of sitting paused until someone manually runs `/workflows resume`. Exponential backoff + a hard attempt cap keep it from bouncing off a still-exhausted budget forever.

## Design: standalone scheduler
`src/usage-limit-scheduler.ts` — a `UsageLimitScheduler` that consumes **only** the manager's public surface (`on`/`off`, `listAllRuns`, `resume`, `getPersistence`). No logic added inside `WorkflowManager`/`executeRun`/`recoverStaleRuns`. This keeps the footprint against the pending #74 manager/persistence rewrite minimal — the only edits to existing files are two additive `PersistedRunState` fields, `ExecOptions.autoResume`, and wiring.

Event-driven **"fire and watch"**: arm a timer on a `usage_limit` pause; when it fires, call `resume()`; then step back and let the existing `paused`/`complete`/`error`/`stopped` subscriptions drive backoff and cleanup. An attempt is consumed only when a run *enters* a usage_limit pause — never when a resume merely fires — so a `resume()` returning `false` (lease busy, already gone) doesn't burn an attempt.

## Default-on with per-run opt-out
Eligible unless `ExecOptions.autoResume === false` (persisted, so a cold start respects it). Tunables: attempt cap 5, delay floor 1m, ceiling 6h, resetHint-unparseable fallback 5m.

## resetHint & cold start
`resetHint` is a verbatim human string ("Resets in ~3h") and not guaranteed present — parsed best-effort (`~3h`, `1h30m`, `in 5m`, missing → fallback). Cold-start re-arm reschedules a still-paused run using time **remaining** (`now − updatedAt`), not a fresh full delay.

## Tests
`tests/usage-limit-scheduler.test.ts` — 26 tests using an injectable fake clock/timer that fires callbacks **synchronously**, so the timer-fire path is genuinely exercised (normal fire, backoff-on-repause, attempt-cap give-up, cold-start remaining-time, opt-out skip, resetHint parsing, delay floor, `resume()`→false not consuming an attempt). **887 unit tests pass; tsc + biome clean.**

## Honest notes
- **Test boundary**: true end-to-end validation needs a real provider usage limit to fire, which isn't reproducible on demand. Reliability here rests on the fake-clock unit tests covering every branch (which the prior attempt lacked) plus the existing real-session pause/resume integration test.
- **`autoResumeAttempts` persistence is best-effort**: the scheduler writes it, and the manager's `persistRun()` would overwrite it *while a run is executing* — but that only matters for a process crash in the brief window between a resume and the next persist. While paused (when a cold start actually reads it) the value is stable, and the live in-memory counter is always authoritative. Fails safe toward more retries, not fewer.
- **#74 overlap**: if #74 lands, its `migrateRunState()` will need to pass through the two new `PersistedRunState` fields.
