### PR TITLE
fix: bound workflow keyword matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Run a workflow to audit every route under src/routes/ for missing auth checks.
 
 Pi writes and starts the workflow in the background. A live panel tracks progress while you keep working, and the final result is delivered back into the conversation automatically.
 
-Use the word **workflow** or **workflows** in a message to force workflow mode, or run `/workflows run <prompt>` explicitly. If the default keyword is too broad, change it with `/workflows-trigger set pi-workflow` or disable it with `/workflows-trigger off`.
+Keyword triggering is on by default: use the bounded word **workflow** or **workflows** in a message to force workflow mode, or run `/workflows run <prompt>` explicitly. Identifier-like text and paths such as `myworkflow`, `workflow_name`, and `src/workflow-editor.ts` do not trigger. You can change the keyword with `/workflows-trigger set pi-workflow` or disable it with `/workflows-trigger off`.
 
 ## How it works
 
@@ -199,7 +199,7 @@ Set a literal, case-insensitive custom trigger in `~/.pi/workflows/settings.json
 }
 ```
 
-The default `workflow` also matches `workflows`; a custom word matches exactly. If another extension owns Pi's custom editor, the submit-time trigger still works, but animated keyword highlighting and Backspace one-shot disarm are unavailable. Editor visuals are load-order dependent.
+The default `workflow` also matches `workflows`; a custom word matches exactly. Trigger words are case-insensitive and Unicode identifier-bounded, and do not activate inside paths, slash commands, or identifier-like text. If another extension owns Pi's custom editor, the submit-time trigger still works, but animated keyword highlighting and Backspace one-shot disarm are unavailable. Editor visuals are load-order dependent.
 
 </details>
 

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -1,8 +1,8 @@
 /**
  * "Workflows mode" input affordance, à la a smart input box:
  *
- *  - While the editor text contains the word `workflow`/`workflows`, those letters
- *    render as a flowing rainbow, signalling that submitting will engage a workflow.
+ *  - While the editor text contains the bounded word `workflow`/`workflows`, those
+ *    letters render as a flowing rainbow, signalling that submitting will engage a workflow.
  *  - Pressing Backspace immediately after such a word toggles the highlight OFF
  *    (the word stays, but turns plain white) — a non-destructive "don't run a
  *    workflow after all". Re-typing a fresh trigger word turns it back on.
@@ -32,21 +32,20 @@ import {
   type WorkflowSettingsStore,
 } from "./workflow-settings.js";
 
-// A keyword trigger is a configured literal term. The default `workflow`
-// trigger keeps legacy substring behavior and plural support (`workflows`) while
-// custom trigger words match only that exact term. Slash commands like
-// `/workflows` or `/pi-workflow` are left alone (not colored, not armed).
+// A keyword trigger is a configured literal term. All trigger words use token
+// boundaries so slash commands, paths, and identifier-like text stay untouched.
+// The default `workflow` trigger additionally supports the plural `workflows`.
 function escapeRegExp(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function triggerSource(triggerWord: string): string {
   const escaped = escapeRegExp(triggerWord);
-  if (triggerWord.toLowerCase() === DEFAULT_KEYWORD_TRIGGER_WORD) return `(?<!\\/)${escaped}s?`;
-  return `(?<![/A-Za-z0-9_-])${escaped}(?![A-Za-z0-9_-])`;
+  const plural = triggerWord.toLowerCase() === DEFAULT_KEYWORD_TRIGGER_WORD ? "s?" : "";
+  return `(?<![/\\p{ID_Continue}$-])(?<!\\\\)${escaped}${plural}(?![/\\p{ID_Continue}$-])(?!\\\\)`;
 }
 
-function triggerRegex(triggerWord = DEFAULT_KEYWORD_TRIGGER_WORD, flags = "i", atEnd = false): RegExp {
+function triggerRegex(triggerWord = DEFAULT_KEYWORD_TRIGGER_WORD, flags = "iu", atEnd = false): RegExp {
   const word = normalizeKeywordTriggerWord(triggerWord) ?? DEFAULT_KEYWORD_TRIGGER_WORD;
   return new RegExp(`${triggerSource(word)}${atEnd ? "$" : ""}`, flags);
 }
@@ -62,7 +61,7 @@ export function hasTrigger(text: string, triggerWord = DEFAULT_KEYWORD_TRIGGER_W
 }
 
 export function endsWithTrigger(textBeforeCursor: string, triggerWord = DEFAULT_KEYWORD_TRIGGER_WORD): boolean {
-  return triggerRegex(triggerWord, "i", true).test(textBeforeCursor);
+  return triggerRegex(triggerWord, "iu", true).test(textBeforeCursor);
 }
 
 /** Shared, mutable view of whether "workflows mode" is currently armed. */
@@ -138,7 +137,7 @@ export function colorizeWorkflow(
   if (!hasTrigger(visible, triggerWord)) return line;
 
   const ranges: Array<[number, number]> = [];
-  const globalTrigger = triggerRegex(triggerWord, "gi");
+  const globalTrigger = triggerRegex(triggerWord, "giu");
   for (let m = globalTrigger.exec(visible); m; m = globalTrigger.exec(visible)) {
     ranges.push([m.index, m.index + m[0].length]);
   }

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -147,9 +147,11 @@ describe("loadAgentRegistry", () => {
   it("default userDir resolution uses getAgentDir() (~/.pi/agent/agents) with no injected opts", () => {
     const tmpHome = mkdtempSync(join(tmpdir(), "pi-home-"));
     const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
     const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
     delete process.env.PI_CODING_AGENT_DIR;
     process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
     try {
       const expectedUserDir = join(getAgentDir(), "agents");
       assert.equal(expectedUserDir, join(tmpHome, ".pi", "agent", "agents"), "sanity: HOME override took effect");
@@ -163,6 +165,8 @@ describe("loadAgentRegistry", () => {
     } finally {
       if (originalHome === undefined) delete process.env.HOME;
       else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
       if (originalAgentDirEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
       else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
       rmSync(tmpHome, { recursive: true, force: true });

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
+import { join } from "node:path";
 import { before, describe, it } from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
@@ -242,7 +243,7 @@ describe("installResultDelivery", () => {
 
     const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
     assert.ok(content.includes("Full result:"), "should include the pointer label");
-    assert.ok(content.includes("/runs/test-run-1.json"), "should point at <runsDir>/<runId>.json");
+    assert.ok(content.includes(join("/runs", "test-run-1.json")), "should point at <runsDir>/<runId>.json");
     // The verdict summary itself is unchanged apart from the appended pointer.
     assert.ok(content.includes("All tests passed"), "verdict text preserved");
   });
@@ -275,7 +276,7 @@ describe("installResultDelivery", () => {
     const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
     assert.ok(/…\(truncated [\d.]+ (B|KB|MB)\)/.test(content), "the 50-char setting truncates a sub-400 dump");
     assert.ok(!content.includes("z".repeat(200)), "the body is cut at the configured threshold");
-    assert.ok(content.includes("/runs/test-run-1.json"), "pointer still appended");
+    assert.ok(content.includes(join("/runs", "test-run-1.json")), "pointer still appended");
   });
 
   // ── installResultDelivery: guard / stale ctx ──

--- a/tests/usage-limit-integration.test.ts
+++ b/tests/usage-limit-integration.test.ts
@@ -15,7 +15,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { WorkflowAgent } from "../src/agent.js";
 import { WorkflowErrorCode } from "../src/errors.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
@@ -38,7 +38,7 @@ async function loadFaux(): Promise<typeof import("@earendil-works/pi-ai/compat")
       import.meta.url,
     ),
   );
-  const entry = existsSync(nested) ? nested : "@earendil-works/pi-ai/compat";
+  const entry = existsSync(nested) ? pathToFileURL(nested).href : "@earendil-works/pi-ai/compat";
   return import(entry) as Promise<typeof import("@earendil-works/pi-ai/compat")>;
 }
 

--- a/tests/workflow-editor.test.ts
+++ b/tests/workflow-editor.test.ts
@@ -143,6 +143,49 @@ describe("hasTrigger", () => {
     assert.equal(hasTrigger("/workflow"), false);
   });
 
+  it("requires token boundaries for the built-in trigger", async () => {
+    const { hasTrigger } = await load();
+    for (const text of [
+      "myworkflow",
+      "workflows2",
+      "workflow_name",
+      "workflow-based",
+      "src/workflow-editor.ts",
+      "src\\workflow-editor.ts",
+    ]) {
+      assert.equal(hasTrigger(text), false, `${text} should not trigger`);
+    }
+    for (const text of ["workflow, please", "(workflows)", "WORKFLOW!", "Discuss workflows."]) {
+      assert.equal(hasTrigger(text), true, `${text} should trigger`);
+    }
+  });
+
+  it("rejects Unicode identifier and dollar boundaries on either side", async () => {
+    const { hasTrigger } = await load();
+    for (const text of [
+      "$workflow",
+      "workflow$",
+      "caféworkflow",
+      "workflowcafé",
+      "变量workflow变量",
+      "变量workflow",
+      "workflow变量",
+    ]) {
+      assert.equal(hasTrigger(text), false, `${text} should not trigger`);
+    }
+    for (const text of ["¿workflow?", "café, workflow!", "变量：workflow。", "workflow—please"]) {
+      assert.equal(hasTrigger(text), true, `${text} should trigger`);
+    }
+  });
+
+  it("applies path and Unicode identifier boundaries to custom triggers", async () => {
+    const { hasTrigger } = await load();
+    for (const text of ["xpi-workflow", "pi-workflow变量", "src/pi-workflow", "src\\pi-workflow"]) {
+      assert.equal(hasTrigger(text, "pi-workflow"), false, `${text} should not trigger`);
+    }
+    assert.equal(hasTrigger("run pi-workflow, please", "pi-workflow"), true);
+  });
+
   it("returns false for unrelated text", async () => {
     const { hasTrigger } = await load();
     assert.equal(hasTrigger("hello world"), false);
@@ -850,6 +893,34 @@ describe("installWorkflowEditor", () => {
 
     await command.handler("on", {});
     assert.match(sent.at(-1)?.content ?? "", /workflow\/workflows/);
+  });
+
+  it("keeps keyword triggering enabled when the setting is absent or loading fails", async () => {
+    const mod = await load();
+    const stores = [
+      { load: () => ({}), save: () => {} },
+      {
+        load: () => {
+          throw new Error("read failed");
+        },
+        save: () => {},
+      },
+    ];
+
+    for (const settingsStore of stores) {
+      const pi = {
+        on: () => {},
+        registerCommand: () => {},
+        getActiveTools: () => [],
+        setActiveTools: () => {},
+      } as unknown as ExtensionAPI;
+      const ui = { setEditorComponent: () => {} } as unknown as ExtensionUIContext;
+
+      const state = mod.installWorkflowEditor(pi, ui, undefined, { settingsStore });
+
+      assert.equal(state.keywordTriggerEnabled, true);
+      assert.equal(state.keywordTriggerWord, "workflow");
+    }
   });
 
   it("loads the persisted keyword trigger preference on install", async () => {


### PR DESCRIPTION
## Summary

Adds Unicode-aware identifier boundaries for workflow keyword matching while preserving the existing default-on auto-trigger behavior.

- matches the built-in and custom trigger words at identifier boundaries
- handles Unicode identifiers consistently
- treats POSIX and Windows path components as bounded contexts
- keeps interactive keyword triggering enabled by default

## Windows test portability

Full Windows validation identified three test-harness portability issues on current `main`: home-directory isolation across `HOME` and `USERPROFILE`, platform-aware expected paths with `node:path.join`, and file-URL conversion for absolute dynamic-import paths. The corrections are confined to test setup and path handling and preserve the existing assertions.

## Validation

- `npm test`: **899/899 passed**
- focused workflow-editor suite: **138/138 passed**
- Biome: passed
- TypeScript build: passed
- `git diff --check`: passed
- independent shortcut, quality, and spec reviews completed with no scoped implementation findings

Split from and supersedes the keyword-matching portion of #74.
