### PR TITLE
feat: resize live workflow concurrency within the existing cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ return await agent(
 
 For an always-on exhaustive mode, use `/ultracode`; `/effort high` is the lighter standing option.
 
-## Commands
+## Commands and run control
+
+Pi can manage background runs directly with the `workflow_control` tool instead of asking you to type a command. It supports `list`, `status`, `pause`, `resume`, and `stop`; run-specific actions use the canonical run ID returned when the workflow starts. Status output includes the run state, current phase, agent counts, active labels, and recorded token total.
 
 | Command | Purpose |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -109,13 +109,14 @@ For an always-on exhaustive mode, use `/ultracode`; `/effort high` is the lighte
 
 ## Commands and run control
 
-Pi can manage background runs directly with the `workflow_control` tool instead of asking you to type a command. It supports `list`, `status`, `pause`, `resume`, and `stop`; run-specific actions use the canonical run ID returned when the workflow starts. Status output includes the run state, current phase, agent counts, active labels, and recorded token total.
+Pi can manage background runs directly with the `workflow_control` tool instead of asking you to type a command. It supports `list`, `status`, `set_concurrency`, `pause`, `resume`, and `stop`; run-specific actions use the canonical run ID returned when the workflow starts. Status output includes the run state, current phase, agent counts, active labels, effective concurrency, and recorded token total.
 
 | Command | Purpose |
 | --- | --- |
 | `/workflows` | Open the interactive run navigator |
 | `/workflows run <prompt>` | Force a workflow even when keyword triggering is off |
 | `/workflows status <id>` | Watch a run and print its result when complete |
+| `/workflows concurrency <id> <n>` | Resize a running workflow (clamped to `1..16`) |
 | `/workflows pause\|resume\|stop\|rm <id>` | Control a run |
 | `/workflows save <name>` | Save the latest script as a reusable command |
 | `/workflows-trigger off\|on\|status` | Control automatic keyword triggering |
@@ -171,7 +172,7 @@ Model tiers live at `~/.pi/workflows/model-tiers.json` and accept Pi CLI-style t
 
 Use `/workflows-models` to edit them interactively. Without a config, the extension ranks authenticated models by capability hints and assigns distinct models when possible.
 
-Runs have no default token budget or per-agent hard timeout. Add `tokenBudget`, `agentTimeoutMs`, phase budgets, or agent `timeoutMs` when you need explicit gates. `concurrency` is clamped to 16; `agentRetries` retries only recoverable failures. Defaults can be set in `~/.pi/workflows/settings.json`.
+Runs have no default token budget or per-agent hard timeout. Add `tokenBudget`, `agentTimeoutMs`, phase budgets, or agent `timeoutMs` when you need explicit gates. `concurrency` is clamped to `1..16`; `agentRetries` retries only recoverable failures. Defaults can be set in `~/.pi/workflows/settings.json`. Resize a running workflow with `/workflows concurrency <id> <n>` or `workflow_control set_concurrency`: raising the cap releases queued agents in FIFO order, while lowering it lets active agents finish without starting replacements until activity falls below the new cap.
 
 </details>
 

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   createEffortState,
+  createWorkflowControlTool,
   createWorkflowStorage,
   createWorkflowTool,
   installResultDelivery,
@@ -33,7 +34,9 @@ export default function extension(pi: ExtensionAPI) {
   });
 
   const workflowTool = createWorkflowTool({ cwd, manager, storage });
+  const workflowControlTool = createWorkflowControlTool({ manager });
   pi.registerTool(workflowTool);
+  pi.registerTool(workflowControlTool);
   // Auto-resume runs that paused on a provider usage limit once the quota is
   // likely refilled. Standalone: only consumes the manager's public surface, so
   // it stays decoupled from manager/persistence internals. Its constructor also
@@ -68,9 +71,9 @@ export default function extension(pi: ExtensionAPI) {
     // advertise the shared registry's models.
     manager.setModelRegistry(ctx.modelRegistry);
     const active = pi.getActiveTools();
-    if (!active.includes(workflowTool.name)) {
-      pi.setActiveTools([...active, workflowTool.name]);
-    }
+    const workflowTools = [workflowTool.name, workflowControlTool.name];
+    const missing = workflowTools.filter((name) => !active.includes(name));
+    if (missing.length) pi.setActiveTools([...active, ...missing]);
     // Scope the /workflows history to this session: runs persist on disk across
     // sessions, but the navigator/task panel show only the current session's runs.
     // Switching back to a previous session re-shows that session's runs.

--- a/src/display.ts
+++ b/src/display.ts
@@ -46,6 +46,10 @@ export interface WorkflowSnapshot {
     cacheRead?: number;
     cacheWrite?: number;
   };
+  /** Caller-selected concurrency before the runtime cap is applied. */
+  requestedConcurrency?: number;
+  /** Active runtime limit after clamping to the supported range. */
+  effectiveConcurrency?: number;
   runId?: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,12 @@ export type {
 } from "./workflow.js";
 export { parseWorkflowScript, runWorkflow } from "./workflow.js";
 export { registerWorkflowCommands } from "./workflow-commands.js";
+export type {
+  WorkflowControlInput,
+  WorkflowControlRunDetails,
+  WorkflowControlToolOptions,
+} from "./workflow-control-tool.js";
+export { createWorkflowControlTool } from "./workflow-control-tool.js";
 export {
   buildForcedWorkflowPrompt,
   colorizeWorkflow,

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -28,6 +28,7 @@ import { shortModel } from "./workflow-ui.js";
 // as tokens accrue (not only on agent start/end). It is harmless in compact mode —
 // it redraws identical content.
 const RUN_EVENTS = [
+  "agentQueued",
   "agentStart",
   "agentEnd",
   "phase",
@@ -38,6 +39,7 @@ const RUN_EVENTS = [
   "stopped",
   "paused",
   "resumed",
+  "concurrencyChanged",
 ];
 /** Events after which a run is gone and its token-rate samples can be dropped. */
 const RUN_END_EVENTS = ["complete", "error", "stopped"] as const;
@@ -227,9 +229,14 @@ export function renderPanel(manager: WorkflowManager, theme: Theme, width?: numb
     const live = manager.getRun(r.runId);
     const agents = live?.snapshot.agents ?? r.agents;
     const done = agents.filter((a) => a.status === "done").length;
+    const running = agents.filter((a) => a.status === "running").length;
+    const queued = agents.filter((a) => a.status === "queued").length;
     const icon = r.status === "paused" ? "⏸" : "◆";
     const phase = live?.snapshot.currentPhase ? ` · ${live.snapshot.currentPhase}` : "";
-    return `  ${icon} ${r.workflowName}  ${done}/${agents.length} agents${phase}`;
+    const cap = live?.snapshot.effectiveConcurrency;
+    const activity = running ? ` · ${running}/${cap ?? running} running` : "";
+    const waiting = queued ? ` · ${queued} queued` : "";
+    return `  ${icon} ${r.workflowName}  ${done}/${agents.length} agents${activity}${waiting}${phase}`;
   });
   // Finished runs leave this live panel but are kept in the navigator. Tell the
   // user so a completed run doesn't look like it vanished.
@@ -370,6 +377,8 @@ export function renderPanelDetailed(
     const snap = live?.snapshot;
     const agents = (snap?.agents ?? r.agents) as WorkflowAgentSnapshot[];
     const done = agents.filter((a) => a.status === "done").length;
+    const running = agents.filter((a) => a.status === "running").length;
+    const queued = agents.filter((a) => a.status === "queued").length;
     const icon = r.status === "paused" ? "⏸" : "◆";
     const usage = snap?.tokenUsage ?? r.tokenUsage;
     // The run-level tokenUsage aggregate is only finalized when the run ends, so
@@ -385,6 +394,8 @@ export function renderPanelDetailed(
     const rate = r.status === "running" ? tokensPerSecond(r.runId) : 0;
     const meta = [
       `${done}/${agents.length} agents`,
+      running ? `${running}/${snap?.effectiveConcurrency ?? running} running` : "",
+      queued ? `${queued} queued` : "",
       snap?.currentPhase || "",
       fmtTokenSegment(runUsage, fmtTokensShort),
       // (cost is only known once the run finalizes its usage.)

--- a/src/workflow-commands.ts
+++ b/src/workflow-commands.ts
@@ -30,7 +30,7 @@ const STATUS_ICON: Record<string, string> = {
 };
 
 const USAGE =
-  "Usage: /workflows [list] | run <prompt> | status <id> | watch <id> | stop <id> | pause <id> | resume <id> | rm <id> | save <name> [runId]";
+  "Usage: /workflows [list] | run <prompt> | status <id> | watch <id> | concurrency <id> <n> | stop <id> | pause <id> | resume <id> | rm <id> | save <name> [runId]";
 
 const RUN_USAGE = "Usage: /workflows run <prompt> — force a dynamic workflow from the prompt";
 
@@ -73,7 +73,7 @@ function watchRun(manager: WorkflowManager, pi: ExtensionAPI, ctx: ExtensionComm
     if (!e || e.runId === id) update();
   };
   let settled = false;
-  const progressEvents = ["agentStart", "agentEnd", "phase", "log"];
+  const progressEvents = ["agentQueued", "agentStart", "agentEnd", "phase", "log", "concurrencyChanged"];
   const finalEvents = ["complete", "error", "stopped", "paused"];
   const finish = (e: { runId?: string }) => {
     if (e && e.runId !== id) return;
@@ -135,7 +135,7 @@ export function registerWorkflowCommands(
 
   pi.registerCommand("workflows", {
     description:
-      "Manage workflow runs — no args (opens navigator) | run <prompt> | status/stop/pause/resume <id> | rm <id> | save <name> [runId]",
+      "Manage workflow runs — no args (opens navigator) | run <prompt> | status/stop/pause/resume <id> | concurrency <id> <n> | rm <id> | save <name> [runId]",
     async handler(args: string, ctx: ExtensionCommandContext) {
       const parts = args.trim().split(/\s+/).filter(Boolean);
       const sub = (parts[0] ?? "list").toLowerCase();
@@ -219,6 +219,21 @@ export function registerWorkflowCommands(
             return;
           }
           await print(renderPersistedStatus(run));
+          return;
+        }
+        case "concurrency": {
+          const concurrency = Number(parts[2]);
+          if (!id || !Number.isInteger(concurrency) || concurrency < 1) {
+            ctx.ui.notify("Usage: /workflows concurrency <id> <positive integer>", "warning");
+            return;
+          }
+          const updated = manager.setConcurrency(id, concurrency);
+          ctx.ui.notify(
+            updated
+              ? `Concurrency for ${id}: ${updated.previousConcurrency} → requested ${updated.requestedConcurrency}, effective ${updated.effectiveConcurrency}`
+              : `Cannot change concurrency for ${id}`,
+            updated ? "info" : "warning",
+          );
           return;
         }
         case "stop": {

--- a/src/workflow-control-tool.ts
+++ b/src/workflow-control-tool.ts
@@ -1,0 +1,216 @@
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { type Static, Type } from "typebox";
+import { aggregateAgentUsage, tokenFigures, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
+import type { PersistedRunState, RunStatus } from "./run-persistence.js";
+import type { WorkflowManager } from "./workflow-manager.js";
+
+const runActionSchema = Type.Union([
+  Type.Literal("status"),
+  Type.Literal("pause"),
+  Type.Literal("resume"),
+  Type.Literal("stop"),
+]);
+
+const workflowControlSchema = Type.Union([
+  Type.Object(
+    { action: Type.Literal("list", { description: "List workflow runs." }) },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      action: runActionSchema,
+      runId: Type.String({ minLength: 1, description: "Canonical workflow run ID." }),
+    },
+    { additionalProperties: false },
+  ),
+]);
+
+export type WorkflowControlInput = Static<typeof workflowControlSchema>;
+
+export interface WorkflowControlToolOptions {
+  manager: WorkflowManager;
+}
+
+export interface WorkflowControlRunDetails {
+  runId: string;
+  workflowName: string;
+  status: RunStatus;
+  phase: string | null;
+  counts: {
+    total: number;
+    done: number;
+    running: number;
+    queued: number;
+    error: number;
+    skipped: number;
+  };
+  activeLabels: string[];
+  tokenTotal: number;
+}
+
+type ControlResult = {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+};
+
+export function createWorkflowControlTool(
+  options: WorkflowControlToolOptions,
+): ToolDefinition<typeof workflowControlSchema, Record<string, unknown>> {
+  const manager = options.manager;
+  return defineTool({
+    name: "workflow_control",
+    label: "Workflow Control",
+    description:
+      "List and inspect workflow runs, or pause, resume, and stop them without asking the user to run slash commands.",
+    promptSnippet: "Inspect and manage workflow runs directly by canonical run ID.",
+    promptGuidelines: [
+      "Use workflow_control for workflow lifecycle management; do not ask the user to type /workflows when this tool can perform the action.",
+      "Use stop to terminate or quit a run. Closing the navigator does not stop a run.",
+    ],
+    parameters: workflowControlSchema,
+    prepareArguments: normalizeInput,
+    async execute(_toolCallId, params) {
+      if (params.action === "list") {
+        const runs = manager.listRuns();
+        const summaries = runs.map((run) => summarizeRun(run, manager.getSnapshot(run.runId)));
+        return result(
+          summaries.length
+            ? `action=list result=ok runs=${summaries.length}\n${summaries.map(formatRun).join("\n")}`
+            : "action=list result=ok runs=0",
+          { action: "list", result: "ok", runs: summaries },
+        );
+      }
+
+      const run = findRun(manager, params.runId);
+      if (!run) return controlError(params.action, params.runId, "run not found", ["list"]);
+
+      switch (params.action) {
+        case "status": {
+          const summary = summarizeRun(run, manager.getSnapshot(run.runId));
+          return result(`action=status result=ok ${formatRun(summary)}`, {
+            action: "status",
+            result: "ok",
+            run: summary,
+          });
+        }
+        case "pause":
+          if (!manager.pause(run.runId)) return invalidTransition("pause", run);
+          return actionSuccess("pause", "paused", currentSummary(manager, run));
+        case "resume":
+          if (!(await manager.resume(run.runId))) return invalidTransition("resume", run);
+          return actionSuccess("resume", "resumed", currentSummary(manager, run));
+        case "stop":
+          if (!manager.stop(run.runId)) return invalidTransition("stop", run);
+          return actionSuccess("stop", "stopped", currentSummary(manager, run));
+      }
+    },
+  });
+}
+
+function normalizeInput(value: unknown): WorkflowControlInput {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("workflow_control requires an object argument");
+  }
+  const input = value as Record<string, unknown>;
+  const actions = new Set(["list", "status", "pause", "resume", "stop"]);
+  if (typeof input.action !== "string" || !actions.has(input.action)) {
+    throw new Error("workflow_control requires action: list|status|pause|resume|stop");
+  }
+
+  const allowedKeys = input.action === "list" ? new Set(["action"]) : new Set(["action", "runId"]);
+  const extraKey = Object.keys(input).find((key) => !allowedKeys.has(key));
+  if (extraKey) throw new Error(`workflow_control action "${input.action}" does not accept ${extraKey}`);
+
+  if (input.action !== "list" && (typeof input.runId !== "string" || !input.runId.trim())) {
+    throw new Error(`workflow_control action "${input.action}" requires runId`);
+  }
+  return input as WorkflowControlInput;
+}
+
+function result(text: string, details: Record<string, unknown>): ControlResult {
+  return { content: [{ type: "text", text }], details };
+}
+
+function findRun(manager: WorkflowManager, runId: string): PersistedRunState | undefined {
+  return manager.listRuns().find((candidate) => candidate.runId === runId);
+}
+
+function currentSummary(manager: WorkflowManager, fallback: PersistedRunState): WorkflowControlRunDetails {
+  const current = findRun(manager, fallback.runId) ?? fallback;
+  return summarizeRun(current, manager.getSnapshot(current.runId));
+}
+
+function actionSuccess(action: string, actionResult: string, run: WorkflowControlRunDetails): ControlResult {
+  return result(`action=${action} result=${actionResult} ${formatRun(run)}`, {
+    action,
+    result: actionResult,
+    run,
+  });
+}
+
+function invalidTransition(action: string, run: PersistedRunState): ControlResult {
+  return controlError(action, run.runId, `cannot ${action} run with status ${run.status}`, allowedActions(run.status));
+}
+
+function controlError(action: string, runId: string, message: string, allowed: string[]): ControlResult {
+  return result(
+    `action=${action} result=error runId=${runId} error=${message} allowed=${allowed.join(",") || "none"}`,
+    { action, result: "error", runId, error: message, allowedActions: allowed },
+  );
+}
+
+function allowedActions(status: RunStatus): string[] {
+  switch (status) {
+    case "running":
+      return ["status", "pause", "stop"];
+    case "paused":
+      return ["status", "resume", "stop"];
+    case "failed":
+    case "pending":
+      return ["status", "resume"];
+    case "completed":
+    case "aborted":
+      return ["status"];
+  }
+}
+
+function summarizeRun(run: PersistedRunState, live?: WorkflowSnapshot | null): WorkflowControlRunDetails {
+  const agents = live?.agents ?? run.agents;
+  const counts = countAgents(agents);
+  const liveUsage = tokenFigures(live?.tokenUsage);
+  const persistedUsage = tokenFigures(run.tokenUsage);
+  const agentUsage = aggregateAgentUsage(agents);
+  return {
+    runId: run.runId,
+    workflowName: live?.name ?? run.workflowName,
+    status: run.status,
+    phase: live?.currentPhase ?? run.currentPhase ?? null,
+    counts,
+    activeLabels: agents.filter((agent) => agent.status === "running").map((agent) => agent.label),
+    tokenTotal: Math.max(
+      liveUsage.fresh + liveUsage.cacheRead,
+      persistedUsage.fresh + persistedUsage.cacheRead,
+      agentUsage.fresh + agentUsage.cacheRead,
+    ),
+  };
+}
+
+function countAgents(agents: Array<Pick<WorkflowAgentSnapshot, "status">>): WorkflowControlRunDetails["counts"] {
+  return {
+    total: agents.length,
+    done: agents.filter((agent) => agent.status === "done").length,
+    running: agents.filter((agent) => agent.status === "running").length,
+    queued: agents.filter((agent) => agent.status === "queued").length,
+    error: agents.filter((agent) => agent.status === "error").length,
+    skipped: agents.filter((agent) => agent.status === "skipped").length,
+  };
+}
+
+function formatRun(run: WorkflowControlRunDetails): string {
+  const active = run.activeLabels.join(",") || "-";
+  return `runId=${run.runId} name=${quote(run.workflowName)} status=${run.status} phase=${quote(run.phase ?? "-")} total=${run.counts.total} done=${run.counts.done} running=${run.counts.running} queued=${run.counts.queued} error=${run.counts.error} skipped=${run.counts.skipped} active=${quote(active)} tokens=${run.tokenTotal}`;
+}
+
+function quote(value: string): string {
+  return JSON.stringify(value);
+}

--- a/src/workflow-control-tool.ts
+++ b/src/workflow-control-tool.ts
@@ -23,6 +23,14 @@ const workflowControlSchema = Type.Union([
     },
     { additionalProperties: false },
   ),
+  Type.Object(
+    {
+      action: Type.Literal("set_concurrency", { description: "Resize a live workflow run." }),
+      runId: Type.String({ minLength: 1, description: "Canonical workflow run ID." }),
+      concurrency: Type.Integer({ minimum: 1, description: "New concurrency limit (capped at 16)." }),
+    },
+    { additionalProperties: false },
+  ),
 ]);
 
 export type WorkflowControlInput = Static<typeof workflowControlSchema>;
@@ -46,6 +54,8 @@ export interface WorkflowControlRunDetails {
   };
   activeLabels: string[];
   tokenTotal: number;
+  requestedConcurrency: number | null;
+  effectiveConcurrency: number | null;
 }
 
 type ControlResult = {
@@ -61,10 +71,11 @@ export function createWorkflowControlTool(
     name: "workflow_control",
     label: "Workflow Control",
     description:
-      "List and inspect workflow runs, or pause, resume, and stop them without asking the user to run slash commands.",
+      "List and inspect workflow runs, resize live concurrency, or pause, resume, and stop them without asking the user to run slash commands.",
     promptSnippet: "Inspect and manage workflow runs directly by canonical run ID.",
     promptGuidelines: [
       "Use workflow_control for workflow lifecycle management; do not ask the user to type /workflows when this tool can perform the action.",
+      "Use set_concurrency to resize a running workflow. Increasing releases queued agents immediately; decreasing does not abort agents already running.",
       "Use stop to terminate or quit a run. Closing the navigator does not stop a run.",
     ],
     parameters: workflowControlSchema,
@@ -93,6 +104,14 @@ export function createWorkflowControlTool(
             run: summary,
           });
         }
+        case "set_concurrency": {
+          const updated = manager.setConcurrency(run.runId, params.concurrency);
+          if (!updated) return invalidTransition("set_concurrency", run);
+          return result(
+            `action=set_concurrency result=updated previous=${updated.previousConcurrency} ${formatRun(currentSummary(manager, run))}`,
+            { action: "set_concurrency", result: "updated", runId: run.runId, ...updated },
+          );
+        }
         case "pause":
           if (!manager.pause(run.runId)) return invalidTransition("pause", run);
           return actionSuccess("pause", "paused", currentSummary(manager, run));
@@ -112,17 +131,28 @@ function normalizeInput(value: unknown): WorkflowControlInput {
     throw new Error("workflow_control requires an object argument");
   }
   const input = value as Record<string, unknown>;
-  const actions = new Set(["list", "status", "pause", "resume", "stop"]);
+  const actions = new Set(["list", "status", "set_concurrency", "pause", "resume", "stop"]);
   if (typeof input.action !== "string" || !actions.has(input.action)) {
-    throw new Error("workflow_control requires action: list|status|pause|resume|stop");
+    throw new Error("workflow_control requires action: list|status|set_concurrency|pause|resume|stop");
   }
 
-  const allowedKeys = input.action === "list" ? new Set(["action"]) : new Set(["action", "runId"]);
+  const allowedKeys =
+    input.action === "list"
+      ? new Set(["action"])
+      : input.action === "set_concurrency"
+        ? new Set(["action", "runId", "concurrency"])
+        : new Set(["action", "runId"]);
   const extraKey = Object.keys(input).find((key) => !allowedKeys.has(key));
   if (extraKey) throw new Error(`workflow_control action "${input.action}" does not accept ${extraKey}`);
 
   if (input.action !== "list" && (typeof input.runId !== "string" || !input.runId.trim())) {
     throw new Error(`workflow_control action "${input.action}" requires runId`);
+  }
+  if (
+    input.action === "set_concurrency" &&
+    (typeof input.concurrency !== "number" || !Number.isInteger(input.concurrency) || input.concurrency < 1)
+  ) {
+    throw new Error('workflow_control action "set_concurrency" requires a positive integer concurrency');
   }
   return input as WorkflowControlInput;
 }
@@ -162,7 +192,7 @@ function controlError(action: string, runId: string, message: string, allowed: s
 function allowedActions(status: RunStatus): string[] {
   switch (status) {
     case "running":
-      return ["status", "pause", "stop"];
+      return ["status", "set_concurrency", "pause", "stop"];
     case "paused":
       return ["status", "resume", "stop"];
     case "failed":
@@ -192,6 +222,8 @@ function summarizeRun(run: PersistedRunState, live?: WorkflowSnapshot | null): W
       persistedUsage.fresh + persistedUsage.cacheRead,
       agentUsage.fresh + agentUsage.cacheRead,
     ),
+    requestedConcurrency: live?.requestedConcurrency ?? null,
+    effectiveConcurrency: live?.effectiveConcurrency ?? null,
   };
 }
 
@@ -208,7 +240,7 @@ function countAgents(agents: Array<Pick<WorkflowAgentSnapshot, "status">>): Work
 
 function formatRun(run: WorkflowControlRunDetails): string {
   const active = run.activeLabels.join(",") || "-";
-  return `runId=${run.runId} name=${quote(run.workflowName)} status=${run.status} phase=${quote(run.phase ?? "-")} total=${run.counts.total} done=${run.counts.done} running=${run.counts.running} queued=${run.counts.queued} error=${run.counts.error} skipped=${run.counts.skipped} active=${quote(active)} tokens=${run.tokenTotal}`;
+  return `runId=${run.runId} name=${quote(run.workflowName)} status=${run.status} phase=${quote(run.phase ?? "-")} total=${run.counts.total} done=${run.counts.done} running=${run.counts.running} queued=${run.counts.queued} error=${run.counts.error} skipped=${run.counts.skipped} active=${quote(active)} concurrency=${run.effectiveConcurrency ?? "-"} requestedConcurrency=${run.requestedConcurrency ?? "-"} tokens=${run.tokenTotal}`;
 }
 
 function quote(value: string): string {

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -15,7 +15,14 @@ import {
   type RunPersistence,
   type RunStatus,
 } from "./run-persistence.js";
-import { type JournalEntry, parseWorkflowScript, runWorkflow, type WorkflowRunResult } from "./workflow.js";
+import {
+  createConcurrencyLimiter,
+  type JournalEntry,
+  parseWorkflowScript,
+  runWorkflow,
+  type WorkflowConcurrencyLimiter,
+  type WorkflowRunResult,
+} from "./workflow.js";
 
 export interface ManagedRun {
   runId: string;
@@ -32,6 +39,12 @@ export interface ManagedRun {
   journal: JournalEntry[];
   /** Cross-process execution lease for this run, when it is actively executing. */
   lease?: RunLease;
+  /** FIFO gate shared by this run and its nested workflows. */
+  concurrencyLimiter: WorkflowConcurrencyLimiter;
+  /** Caller-selected concurrency before the runtime cap is applied. */
+  requestedConcurrency: number;
+  /** Active runtime limit after clamping to the supported range. */
+  effectiveConcurrency: number;
   /**
    * True when the run was started in the background (or resumed) and the caller is
    * not awaiting its result inline. Only background runs deliver their result back
@@ -74,6 +87,12 @@ export interface ExecOptions {
    * it too. See usage-limit-scheduler.ts.
    */
   autoResume?: boolean;
+}
+
+export interface ConcurrencyUpdate {
+  previousConcurrency: number;
+  requestedConcurrency: number;
+  effectiveConcurrency: number;
 }
 
 export interface WorkflowManagerOptions {
@@ -206,6 +225,9 @@ export class WorkflowManager extends EventEmitter {
     const controller = new AbortController();
     const lease = this.persistence.acquireRunLease(runId);
     if (!lease) throw new Error(`Could not acquire workflow run lease for ${runId}`);
+    const requestedConcurrency = exec.concurrency ?? this.concurrency;
+    const concurrencyLimiter = createConcurrencyLimiter(requestedConcurrency);
+    const effectiveConcurrency = concurrencyLimiter.getLimit();
 
     const managed: ManagedRun = {
       runId,
@@ -220,6 +242,8 @@ export class WorkflowManager extends EventEmitter {
         runningCount: 0,
         doneCount: 0,
         errorCount: 0,
+        requestedConcurrency,
+        effectiveConcurrency,
       },
       controller,
       startedAt: new Date(),
@@ -228,6 +252,9 @@ export class WorkflowManager extends EventEmitter {
       journal: [],
       background: true,
       lease,
+      concurrencyLimiter,
+      requestedConcurrency,
+      effectiveConcurrency,
       autoResume: exec.autoResume,
     };
 
@@ -273,7 +300,7 @@ export class WorkflowManager extends EventEmitter {
    * a caller (e.g. the workflow tool) drive its own inline display.
    */
   async runSync(script: string, args?: unknown, exec: ExecOptions = {}): Promise<WorkflowRunResult> {
-    const managed = this.createManaged(script, args);
+    const managed = this.createManaged(script, args, exec.concurrency);
     const lease = this.persistence.acquireRunLease(managed.runId);
     if (!lease) throw new Error(`Could not acquire workflow run lease for ${managed.runId}`);
     managed.lease = lease;
@@ -286,7 +313,7 @@ export class WorkflowManager extends EventEmitter {
   }
 
   /** Build a fresh managed run with an empty snapshot. */
-  private createManaged(script: string, args?: unknown): ManagedRun {
+  private createManaged(script: string, args: unknown, concurrency: number | undefined): ManagedRun {
     const parsed = parseWorkflowScript(script);
     const slug = parsed.meta.name
       ? parsed.meta.name
@@ -296,6 +323,9 @@ export class WorkflowManager extends EventEmitter {
           .slice(0, 40) || "workflow"
       : "";
     const runId = slug ? `${slug}-${generateRunId()}` : generateRunId();
+    const requestedConcurrency = concurrency ?? this.concurrency;
+    const concurrencyLimiter = createConcurrencyLimiter(requestedConcurrency);
+    const effectiveConcurrency = concurrencyLimiter.getLimit();
     return {
       runId,
       status: "running",
@@ -309,6 +339,8 @@ export class WorkflowManager extends EventEmitter {
         runningCount: 0,
         doneCount: 0,
         errorCount: 0,
+        requestedConcurrency,
+        effectiveConcurrency,
       },
       controller: new AbortController(),
       startedAt: new Date(),
@@ -316,6 +348,9 @@ export class WorkflowManager extends EventEmitter {
       args,
       journal: [],
       background: false,
+      concurrencyLimiter,
+      requestedConcurrency,
+      effectiveConcurrency,
     };
   }
 
@@ -325,19 +360,9 @@ export class WorkflowManager extends EventEmitter {
     args?: unknown,
     exec: ExecOptions = {},
   ): Promise<WorkflowRunResult> {
-    const {
-      resumeJournal,
-      maxAgents,
-      agentTimeoutMs,
-      externalSignal,
-      onProgress,
-      tokenBudget,
-      concurrency,
-      agentRetries,
-      confirm,
-    } = exec;
+    const { resumeJournal, maxAgents, agentTimeoutMs, externalSignal, onProgress, tokenBudget, agentRetries, confirm } =
+      exec;
     const resolvedAgentTimeoutMs = agentTimeoutMs !== undefined ? agentTimeoutMs : this.defaultAgentTimeoutMs;
-    const resolvedConcurrency = concurrency ?? this.concurrency;
     const resolvedAgentRetries = agentRetries ?? this.defaultAgentRetries;
     const progress = () => onProgress?.(managed.snapshot);
     // Let a host abort (e.g. Esc during a blocking tool call) cancel this run.
@@ -359,7 +384,8 @@ export class WorkflowManager extends EventEmitter {
         modelRegistry: this.modelRegistry,
         persistAgentSessions: this.persistAgentSessions,
         signal: managed.controller.signal,
-        concurrency: resolvedConcurrency,
+        concurrency: managed.effectiveConcurrency,
+        concurrencyLimiter: managed.concurrencyLimiter,
         agentRetries: resolvedAgentRetries,
         maxAgents,
         agentTimeoutMs: resolvedAgentTimeoutMs,
@@ -387,15 +413,35 @@ export class WorkflowManager extends EventEmitter {
           this.emit("phase", { runId: managed.runId, title });
           progress();
         },
-        onAgentStart: (event) => {
+        onAgentQueued: (event) => {
           managed.snapshot.agents.push({
             id: managed.snapshot.agents.length + 1,
             label: event.label,
             phase: event.phase,
             prompt: event.prompt,
-            status: "running",
+            status: "queued",
             model: event.model,
           });
+          this.emit("agentQueued", { runId: managed.runId, ...event });
+          progress();
+        },
+        onAgentStart: (event) => {
+          const queued = managed.snapshot.agents.find(
+            (agent) => agent.status === "queued" && agent.label === event.label && agent.prompt === event.prompt,
+          );
+          if (queued) {
+            queued.status = "running";
+            if (event.model) queued.model = event.model;
+          } else {
+            managed.snapshot.agents.push({
+              id: managed.snapshot.agents.length + 1,
+              label: event.label,
+              phase: event.phase,
+              prompt: event.prompt,
+              status: "running",
+              model: event.model,
+            });
+          }
           this.emit("agentStart", { runId: managed.runId, ...event });
           progress();
         },
@@ -597,6 +643,9 @@ export class WorkflowManager extends EventEmitter {
     const args = opts?.args !== undefined ? opts.args : persisted.args;
 
     const controller = new AbortController();
+    const requestedConcurrency = this.concurrency;
+    const concurrencyLimiter = createConcurrencyLimiter(requestedConcurrency);
+    const effectiveConcurrency = concurrencyLimiter.getLimit();
     const managed: ManagedRun = {
       runId,
       status: "running",
@@ -609,6 +658,8 @@ export class WorkflowManager extends EventEmitter {
         runningCount: 0,
         doneCount: 0,
         errorCount: 0,
+        requestedConcurrency,
+        effectiveConcurrency,
       },
       controller,
       startedAt: new Date(),
@@ -619,6 +670,9 @@ export class WorkflowManager extends EventEmitter {
       journal: persisted.journal ?? [],
       background: true,
       lease,
+      concurrencyLimiter,
+      requestedConcurrency,
+      effectiveConcurrency,
       // Carry the original opt-out forward across resumes; it's fixed at
       // run-start and persistRun() re-persists it on every subsequent write.
       autoResume: persisted.autoResume,
@@ -633,6 +687,27 @@ export class WorkflowManager extends EventEmitter {
     // Run in the background; executeRun records status/errors on the managed run.
     void this.executeRun(managed, script, args, { resumeJournal }).catch(() => {});
     return true;
+  }
+
+  /** Resize a live workflow without aborting agents already running. */
+  setConcurrency(runId: string, concurrency: number): ConcurrencyUpdate | null {
+    if (!Number.isFinite(concurrency) || !Number.isInteger(concurrency) || concurrency < 1) return null;
+    const managed = this.runs.get(runId);
+    if (managed?.status !== "running") return null;
+
+    const previousConcurrency = managed.effectiveConcurrency;
+    managed.requestedConcurrency = concurrency;
+    managed.concurrencyLimiter.setLimit(concurrency);
+    managed.effectiveConcurrency = managed.concurrencyLimiter.getLimit();
+    managed.snapshot.requestedConcurrency = concurrency;
+    managed.snapshot.effectiveConcurrency = managed.effectiveConcurrency;
+    const update = {
+      previousConcurrency,
+      requestedConcurrency: concurrency,
+      effectiveConcurrency: managed.effectiveConcurrency,
+    };
+    this.emit("concurrencyChanged", { runId, ...update });
+    return update;
   }
 
   /**

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -54,8 +54,16 @@ export interface JournalEntry {
  * the 16-concurrent / 1000-total caps and the token budget hold across nesting
  * instead of each level getting its own limiter and counters.
  */
+export interface WorkflowConcurrencyLimiter {
+  <T>(fn: () => Promise<T>): Promise<T>;
+  setLimit(limit: number): void;
+  getLimit(): number;
+  getActive(): number;
+  getQueued(): number;
+}
+
 export interface SharedRuntime {
-  limiter: <T>(fn: () => Promise<T>) => Promise<T>;
+  limiter: WorkflowConcurrencyLimiter;
   agentCount: number;
   spent: number;
   tokenUsage: { input: number; output: number; total: number; cost: number; cacheRead: number; cacheWrite: number };
@@ -95,6 +103,8 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   onAgentJournal?: (entry: JournalEntry) => void;
   /** Internal: shared runtime inherited by a nested workflow() call. */
   sharedRuntime?: SharedRuntime;
+  /** Internal: manager-owned limiter used for live concurrency changes. */
+  concurrencyLimiter?: WorkflowConcurrencyLimiter;
   /**
    * Shared store for this run. One instance is created per top-level run and
    * propagated into nested workflow() calls. Pass an existing instance to share
@@ -111,6 +121,7 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   confirm?: (promptText: string, options: CheckpointOptions) => Promise<unknown>;
   onLog?: (message: string) => void;
   onPhase?: (title: string) => void;
+  onAgentQueued?: (event: { label: string; phase?: string; prompt: string; model?: string }) => void;
   onAgentStart?: (event: { label: string; phase?: string; prompt: string; model?: string }) => void;
   onAgentEnd?: (event: {
     label: string;
@@ -302,7 +313,7 @@ export async function runWorkflow<T = unknown>(
   );
   // Global caps + budget are shared with any nested workflow() so they hold across nesting.
   const shared: SharedRuntime = options.sharedRuntime ?? {
-    limiter: createLimiter(concurrency),
+    limiter: options.concurrencyLimiter ?? createConcurrencyLimiter(concurrency),
     agentCount: 0,
     spent: 0,
     tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
@@ -449,7 +460,9 @@ export async function runWorkflow<T = unknown>(
     // unchanged prefix ends; this call and every later one then run live.
     if (!hashMatches || cachedEmptyOutput) state.firstMiss = Math.min(state.firstMiss, callIndex);
 
+    options.onAgentQueued?.({ label, phase: assignedPhase, prompt, model: displayModel });
     return limiter(async () => {
+      throwIfAborted();
       const timeout = agentOptions.timeoutMs !== undefined ? agentOptions.timeoutMs : agentTimeoutMs;
       const retryAttempts = normalizeAgentRetries(agentOptions.retries ?? options.agentRetries ?? 0);
       const maxAttempts = retryAttempts + 1;
@@ -1066,22 +1079,36 @@ function validateMeta(meta: unknown): asserts meta is WorkflowMeta {
   }
 }
 
-function createLimiter(limit: number) {
+export function createConcurrencyLimiter(initialLimit: number): WorkflowConcurrencyLimiter {
+  let limit = normalizeConcurrency(initialLimit);
   let active = 0;
   const queue: Array<() => void> = [];
-  const next = () => {
-    active--;
-    queue.shift()?.();
+  const drain = () => {
+    while (active < limit && queue.length > 0) {
+      active++;
+      queue.shift()?.();
+    }
   };
-  return async <T>(fn: () => Promise<T>): Promise<T> => {
-    if (active >= limit) await new Promise<void>((resolve) => queue.push(resolve));
-    active++;
+  const limiter = (async <T>(fn: () => Promise<T>): Promise<T> => {
+    await new Promise<void>((resolve) => {
+      queue.push(resolve);
+      drain();
+    });
     try {
       return await fn();
     } finally {
-      next();
+      active--;
+      drain();
     }
+  }) as WorkflowConcurrencyLimiter;
+  limiter.setLimit = (value: number) => {
+    limit = normalizeConcurrency(value);
+    drain();
   };
+  limiter.getLimit = () => limit;
+  limiter.getActive = () => active;
+  limiter.getQueued = () => queue.length;
+  return limiter;
 }
 
 function defaultAgentLabel(phase: string | undefined, index: number): string {

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -147,9 +147,11 @@ describe("loadAgentRegistry", () => {
   it("default userDir resolution uses getAgentDir() (~/.pi/agent/agents) with no injected opts", () => {
     const tmpHome = mkdtempSync(join(tmpdir(), "pi-home-"));
     const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
     const originalAgentDirEnv = process.env.PI_CODING_AGENT_DIR;
     delete process.env.PI_CODING_AGENT_DIR;
     process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
     try {
       const expectedUserDir = join(getAgentDir(), "agents");
       assert.equal(expectedUserDir, join(tmpHome, ".pi", "agent", "agents"), "sanity: HOME override took effect");
@@ -163,6 +165,8 @@ describe("loadAgentRegistry", () => {
     } finally {
       if (originalHome === undefined) delete process.env.HOME;
       else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
       if (originalAgentDirEnv === undefined) delete process.env.PI_CODING_AGENT_DIR;
       else process.env.PI_CODING_AGENT_DIR = originalAgentDirEnv;
       rmSync(tmpHome, { recursive: true, force: true });

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
+import { join } from "node:path";
 import { before, describe, it } from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
@@ -242,7 +243,7 @@ describe("installResultDelivery", () => {
 
     const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
     assert.ok(content.includes("Full result:"), "should include the pointer label");
-    assert.ok(content.includes("/runs/test-run-1.json"), "should point at <runsDir>/<runId>.json");
+    assert.ok(content.includes(join("/runs", "test-run-1.json")), "should point at <runsDir>/<runId>.json");
     // The verdict summary itself is unchanged apart from the appended pointer.
     assert.ok(content.includes("All tests passed"), "verdict text preserved");
   });
@@ -275,7 +276,7 @@ describe("installResultDelivery", () => {
     const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
     assert.ok(/…\(truncated [\d.]+ (B|KB|MB)\)/.test(content), "the 50-char setting truncates a sub-400 dump");
     assert.ok(!content.includes("z".repeat(200)), "the body is cut at the configured threshold");
-    assert.ok(content.includes("/runs/test-run-1.json"), "pointer still appended");
+    assert.ok(content.includes(join("/runs", "test-run-1.json")), "pointer still appended");
   });
 
   // ── installResultDelivery: guard / stale ctx ──

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -508,6 +508,22 @@ describe("renderPanel", () => {
     );
   });
 
+  it("shows running agents against the effective cap and separates queued work", async () => {
+    const { renderPanel } = await import("../src/task-panel.js");
+    const snapshot = {
+      currentPhase: "Scan",
+      effectiveConcurrency: 3,
+      agents: [{ status: "running" }, { status: "running" }, { status: "queued" }, { status: "done" }],
+    };
+    const manager = {
+      listRuns: () => [{ runId: "a", workflowName: "live", status: "running", agents: snapshot.agents, logs: [] }],
+      getRun: () => ({ snapshot }),
+    };
+    const text = renderPanel(manager as never, theme as never).join("\n");
+    assert.match(text, /2\/3 running/);
+    assert.match(text, /1 queued/);
+  });
+
   it("renders nothing when no run is active", async () => {
     const { renderPanel } = await import("../src/task-panel.js");
     const manager = {

--- a/tests/usage-limit-integration.test.ts
+++ b/tests/usage-limit-integration.test.ts
@@ -15,7 +15,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { WorkflowAgent } from "../src/agent.js";
 import { WorkflowErrorCode } from "../src/errors.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
@@ -38,7 +38,7 @@ async function loadFaux(): Promise<typeof import("@earendil-works/pi-ai/compat")
       import.meta.url,
     ),
   );
-  const entry = existsSync(nested) ? nested : "@earendil-works/pi-ai/compat";
+  const entry = existsSync(nested) ? pathToFileURL(nested).href : "@earendil-works/pi-ai/compat";
   return import(entry) as Promise<typeof import("@earendil-works/pi-ai/compat")>;
 }
 

--- a/tests/workflow-commands.test.ts
+++ b/tests/workflow-commands.test.ts
@@ -63,6 +63,10 @@ function harness(
       calls.push(`resume:${id}`);
       return false;
     },
+    setConcurrency: (id: string, concurrency: number) => {
+      calls.push(`concurrency:${id}:${concurrency}`);
+      return { previousConcurrency: 4, requestedConcurrency: concurrency, effectiveConcurrency: concurrency };
+    },
     deleteRun: (id: string) => {
       calls.push(`rm:${id}`);
       return true;
@@ -145,6 +149,29 @@ test("/workflows stop <id> calls manager.stop", async () => {
   const h = harness();
   await h.run("stop run-9");
   assert.deepEqual(h.calls, ["stop:run-9"]);
+});
+
+test("/workflows concurrency resizes a live run and reports the effective value", async () => {
+  const h = harness({
+    setConcurrency: (id: string, concurrency: number) => {
+      h.calls.push(`concurrency:${id}:${concurrency}`);
+      return { previousConcurrency: 4, requestedConcurrency: concurrency, effectiveConcurrency: 16 };
+    },
+  });
+  await h.run("concurrency run-c1 17");
+  assert.deepEqual(h.calls, ["concurrency:run-c1:17"]);
+  assert.match(h.notified[0].message, /4 → requested 17, effective 16/);
+  assert.equal(h.notified[0].type, "info");
+});
+
+test("/workflows concurrency requires a positive integer", async () => {
+  for (const args of ["concurrency", "concurrency run-c1", "concurrency run-c1 0", "concurrency run-c1 1.5"]) {
+    const h = harness();
+    await h.run(args);
+    assert.equal(h.calls.length, 0);
+    assert.equal(h.notified[0].type, "warning");
+    assert.match(h.notified[0].message, /positive integer/);
+  }
 });
 
 test("/workflows status <id> renders a persisted run", async () => {

--- a/tests/workflow-control-tool.test.ts
+++ b/tests/workflow-control-tool.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Check } from "typebox/value";
+import type { WorkflowSnapshot } from "../src/display.js";
+import type { PersistedRunState, RunStatus } from "../src/run-persistence.js";
+import { createWorkflowControlTool } from "../src/workflow-control-tool.js";
+import type { WorkflowManager } from "../src/workflow-manager.js";
+
+function run(status: RunStatus = "running", runId = "audit-abc123"): PersistedRunState {
+  return {
+    runId,
+    workflowName: "audit",
+    script: "export const meta = { name: 'audit', description: 'audit' }; return await agent('x')",
+    status,
+    phases: ["Inspect"],
+    currentPhase: "Inspect",
+    agents: [
+      { id: 1, label: "active scan", prompt: "scan", status: status === "running" ? "running" : "done", tokens: 30 },
+      { id: 2, label: "queued check", prompt: "check", status: "queued" },
+      { id: 3, label: "failed check", prompt: "fail", status: "error" },
+      { id: 4, label: "optional check", prompt: "optional", status: "skipped" },
+    ],
+    logs: [],
+    startedAt: "2026-07-14T00:00:00.000Z",
+    updatedAt: "2026-07-14T00:00:01.000Z",
+    tokenUsage: { input: 20, output: 10, total: 30 },
+  };
+}
+
+function fakeManager(initial: PersistedRunState[], liveSnapshots: Record<string, WorkflowSnapshot> = {}) {
+  const runs = new Map(initial.map((item) => [item.runId, item]));
+  const calls: Array<{ action: string; runId: string }> = [];
+  const manager = {
+    listRuns: () => [...runs.values()],
+    getSnapshot: (runId: string) => liveSnapshots[runId] ?? null,
+    pause(runId: string) {
+      calls.push({ action: "pause", runId });
+      const item = runs.get(runId);
+      if (item?.status !== "running") return false;
+      item.status = "paused";
+      return true;
+    },
+    async resume(runId: string) {
+      calls.push({ action: "resume", runId });
+      const item = runs.get(runId);
+      if (!item || (item.status !== "paused" && item.status !== "failed" && item.status !== "pending")) return false;
+      item.status = "running";
+      return true;
+    },
+    stop(runId: string) {
+      calls.push({ action: "stop", runId });
+      const item = runs.get(runId);
+      if (!item || (item.status !== "running" && item.status !== "paused")) return false;
+      item.status = "aborted";
+      return true;
+    },
+  } as unknown as WorkflowManager;
+  return { manager, calls };
+}
+
+async function execute(manager: WorkflowManager, params: Record<string, unknown>) {
+  const tool = createWorkflowControlTool({ manager });
+  return (tool.execute as any)("control-call", params, undefined, undefined, {});
+}
+
+function text(result: Awaited<ReturnType<typeof execute>>): string {
+  return result.content[0].text;
+}
+
+test("workflow_control exposes only list, status, pause, resume, and stop in a strict schema", () => {
+  const { manager } = fakeManager([]);
+  const tool = createWorkflowControlTool({ manager });
+
+  assert.equal(tool.name, "workflow_control");
+  assert.equal(Check(tool.parameters, { action: "list" }), true);
+  assert.equal(Check(tool.parameters, { action: "status", runId: "abc" }), true);
+  assert.equal(Check(tool.parameters, { action: "pause", runId: "abc" }), true);
+  assert.equal(Check(tool.parameters, { action: "resume", runId: "abc" }), true);
+  assert.equal(Check(tool.parameters, { action: "stop", runId: "abc" }), true);
+  assert.equal(Check(tool.parameters, { action: "restart", runId: "abc" }), false);
+  assert.equal(Check(tool.parameters, { action: "remove", runId: "abc" }), false);
+  assert.equal(Check(tool.parameters, { action: "set_concurrency", runId: "abc", concurrency: 2 }), false);
+  assert.equal(Check(tool.parameters, { action: "status" }), false);
+  assert.equal(Check(tool.parameters, { action: "list", runId: "abc" }), false);
+  assert.equal(Check(tool.parameters, { action: "status", runId: "abc", extra: true }), false);
+
+  const prepare = tool.prepareArguments as (value: unknown) => unknown;
+  assert.throws(() => prepare({ action: "pause" }), /requires runId/);
+  assert.throws(() => prepare({ action: "status", runId: "abc", extra: true }), /does not accept extra/);
+  assert.throws(() => prepare({ action: "restart", runId: "abc" }), /requires action/);
+});
+
+test("list and status return stable lifecycle and observability fields", async () => {
+  const { manager } = fakeManager([run()]);
+
+  const listed = await execute(manager, { action: "list" });
+  assert.match(text(listed), /^action=list result=ok runs=1\n/);
+  assert.match(text(listed), /runId=audit-abc123 name="audit" status=running phase="Inspect"/);
+  assert.match(text(listed), /total=4 done=0 running=1 queued=1 error=1 skipped=1/);
+  assert.match(text(listed), /active="active scan" tokens=30/);
+  assert.deepEqual(listed.details, {
+    action: "list",
+    result: "ok",
+    runs: [
+      {
+        runId: "audit-abc123",
+        workflowName: "audit",
+        status: "running",
+        phase: "Inspect",
+        counts: { total: 4, done: 0, running: 1, queued: 1, error: 1, skipped: 1 },
+        activeLabels: ["active scan"],
+        tokenTotal: 30,
+      },
+    ],
+  });
+
+  const status = await execute(manager, { action: "status", runId: "audit-abc123" });
+  assert.match(text(status), /^action=status result=ok /);
+  assert.equal(status.details.action, "status");
+  assert.equal((status.details.run as { runId: string }).runId, "audit-abc123");
+  assert.doesNotMatch(text(status), /\/workflows/);
+});
+
+test("status uses agent usage when the live run aggregate is lagging", async () => {
+  const live: WorkflowSnapshot = {
+    name: "audit",
+    phases: ["Inspect"],
+    currentPhase: "Inspect",
+    logs: [],
+    agents: [
+      { id: 1, label: "estimated", prompt: "scan", status: "running", tokens: 80 },
+      {
+        id: 2,
+        label: "reported",
+        prompt: "check",
+        status: "done",
+        tokens: 40,
+        tokenUsage: { input: 15, output: 5, total: 40, cacheRead: 20, cacheWrite: 0, cost: 0 },
+      },
+    ],
+    agentCount: 2,
+    runningCount: 1,
+    doneCount: 1,
+    errorCount: 0,
+    tokenUsage: { input: 0, output: 0, total: 0 },
+  };
+  const { manager } = fakeManager([run()], { "audit-abc123": live });
+
+  const status = await execute(manager, { action: "status", runId: "audit-abc123" });
+
+  assert.match(text(status), /tokens=120$/);
+  assert.equal((status.details.run as { tokenTotal: number }).tokenTotal, 120);
+});
+
+test("list reports an explicit empty result", async () => {
+  const { manager } = fakeManager([]);
+  const response = await execute(manager, { action: "list" });
+  assert.equal(text(response), "action=list result=ok runs=0");
+  assert.deepEqual(response.details, { action: "list", result: "ok", runs: [] });
+});
+
+test("pause, resume, and stop call the shared manager lifecycle methods", async () => {
+  const fixture = fakeManager([run()]);
+
+  assert.match(text(await execute(fixture.manager, { action: "pause", runId: "audit-abc123" })), /result=paused/);
+  assert.match(text(await execute(fixture.manager, { action: "resume", runId: "audit-abc123" })), /result=resumed/);
+  assert.match(text(await execute(fixture.manager, { action: "stop", runId: "audit-abc123" })), /result=stopped/);
+  assert.deepEqual(
+    fixture.calls.map((call) => call.action),
+    ["pause", "resume", "stop"],
+  );
+});
+
+test("unknown IDs and illegal transitions return explicit errors with allowed actions", async () => {
+  const fixture = fakeManager([run("completed"), run("running", "live-123")]);
+
+  const unknown = text(await execute(fixture.manager, { action: "status", runId: "missing" }));
+  assert.match(unknown, /result=error runId=missing error=run not found allowed=list/);
+
+  const pauseCompleted = text(await execute(fixture.manager, { action: "pause", runId: "audit-abc123" }));
+  assert.match(pauseCompleted, /cannot pause run with status completed/);
+  assert.match(pauseCompleted, /allowed=status/);
+
+  await execute(fixture.manager, { action: "stop", runId: "live-123" });
+  const stopAborted = text(await execute(fixture.manager, { action: "stop", runId: "live-123" }));
+  assert.match(stopAborted, /cannot stop run with status aborted/);
+  assert.match(stopAborted, /allowed=status/);
+});

--- a/tests/workflow-control-tool.test.ts
+++ b/tests/workflow-control-tool.test.ts
@@ -33,6 +33,20 @@ function fakeManager(initial: PersistedRunState[], liveSnapshots: Record<string,
   const manager = {
     listRuns: () => [...runs.values()],
     getSnapshot: (runId: string) => liveSnapshots[runId] ?? null,
+    setConcurrency(runId: string, concurrency: number) {
+      calls.push({ action: "set_concurrency", runId });
+      const item = runs.get(runId);
+      const snapshot = liveSnapshots[runId];
+      if (item?.status !== "running" || !snapshot) return null;
+      const previousConcurrency = snapshot.effectiveConcurrency ?? 1;
+      snapshot.requestedConcurrency = concurrency;
+      snapshot.effectiveConcurrency = Math.min(16, concurrency);
+      return {
+        previousConcurrency,
+        requestedConcurrency: concurrency,
+        effectiveConcurrency: snapshot.effectiveConcurrency,
+      };
+    },
     pause(runId: string) {
       calls.push({ action: "pause", runId });
       const item = runs.get(runId);
@@ -67,7 +81,7 @@ function text(result: Awaited<ReturnType<typeof execute>>): string {
   return result.content[0].text;
 }
 
-test("workflow_control exposes only list, status, pause, resume, and stop in a strict schema", () => {
+test("workflow_control exposes list, status, live concurrency, pause, resume, and stop in a strict schema", () => {
   const { manager } = fakeManager([]);
   const tool = createWorkflowControlTool({ manager });
 
@@ -79,7 +93,8 @@ test("workflow_control exposes only list, status, pause, resume, and stop in a s
   assert.equal(Check(tool.parameters, { action: "stop", runId: "abc" }), true);
   assert.equal(Check(tool.parameters, { action: "restart", runId: "abc" }), false);
   assert.equal(Check(tool.parameters, { action: "remove", runId: "abc" }), false);
-  assert.equal(Check(tool.parameters, { action: "set_concurrency", runId: "abc", concurrency: 2 }), false);
+  assert.equal(Check(tool.parameters, { action: "set_concurrency", runId: "abc", concurrency: 2 }), true);
+  assert.equal(Check(tool.parameters, { action: "set_concurrency", runId: "abc", concurrency: 0 }), false);
   assert.equal(Check(tool.parameters, { action: "status" }), false);
   assert.equal(Check(tool.parameters, { action: "list", runId: "abc" }), false);
   assert.equal(Check(tool.parameters, { action: "status", runId: "abc", extra: true }), false);
@@ -88,6 +103,10 @@ test("workflow_control exposes only list, status, pause, resume, and stop in a s
   assert.throws(() => prepare({ action: "pause" }), /requires runId/);
   assert.throws(() => prepare({ action: "status", runId: "abc", extra: true }), /does not accept extra/);
   assert.throws(() => prepare({ action: "restart", runId: "abc" }), /requires action/);
+  assert.throws(
+    () => prepare({ action: "set_concurrency", runId: "abc", concurrency: 1.5 }),
+    /positive integer concurrency/,
+  );
 });
 
 test("list and status return stable lifecycle and observability fields", async () => {
@@ -97,7 +116,7 @@ test("list and status return stable lifecycle and observability fields", async (
   assert.match(text(listed), /^action=list result=ok runs=1\n/);
   assert.match(text(listed), /runId=audit-abc123 name="audit" status=running phase="Inspect"/);
   assert.match(text(listed), /total=4 done=0 running=1 queued=1 error=1 skipped=1/);
-  assert.match(text(listed), /active="active scan" tokens=30/);
+  assert.match(text(listed), /active="active scan" concurrency=- requestedConcurrency=- tokens=30/);
   assert.deepEqual(listed.details, {
     action: "list",
     result: "ok",
@@ -110,6 +129,8 @@ test("list and status return stable lifecycle and observability fields", async (
         counts: { total: 4, done: 0, running: 1, queued: 1, error: 1, skipped: 1 },
         activeLabels: ["active scan"],
         tokenTotal: 30,
+        requestedConcurrency: null,
+        effectiveConcurrency: null,
       },
     ],
   });
@@ -159,15 +180,36 @@ test("list reports an explicit empty result", async () => {
   assert.deepEqual(response.details, { action: "list", result: "ok", runs: [] });
 });
 
-test("pause, resume, and stop call the shared manager lifecycle methods", async () => {
-  const fixture = fakeManager([run()]);
+test("set_concurrency, pause, resume, and stop call the shared manager lifecycle methods", async () => {
+  const live: WorkflowSnapshot = {
+    name: "audit",
+    phases: ["Inspect"],
+    currentPhase: "Inspect",
+    logs: [],
+    agents: run().agents,
+    agentCount: 4,
+    runningCount: 1,
+    doneCount: 0,
+    errorCount: 1,
+    requestedConcurrency: 4,
+    effectiveConcurrency: 4,
+  };
+  const fixture = fakeManager([run()], { "audit-abc123": live });
+
+  const resized = await execute(fixture.manager, {
+    action: "set_concurrency",
+    runId: "audit-abc123",
+    concurrency: 17,
+  });
+  assert.match(text(resized), /result=updated previous=4/);
+  assert.match(text(resized), /concurrency=16 requestedConcurrency=17/);
 
   assert.match(text(await execute(fixture.manager, { action: "pause", runId: "audit-abc123" })), /result=paused/);
   assert.match(text(await execute(fixture.manager, { action: "resume", runId: "audit-abc123" })), /result=resumed/);
   assert.match(text(await execute(fixture.manager, { action: "stop", runId: "audit-abc123" })), /result=stopped/);
   assert.deepEqual(
     fixture.calls.map((call) => call.action),
-    ["pause", "resume", "stop"],
+    ["set_concurrency", "pause", "resume", "stop"],
   );
 });
 
@@ -180,6 +222,11 @@ test("unknown IDs and illegal transitions return explicit errors with allowed ac
   const pauseCompleted = text(await execute(fixture.manager, { action: "pause", runId: "audit-abc123" }));
   assert.match(pauseCompleted, /cannot pause run with status completed/);
   assert.match(pauseCompleted, /allowed=status/);
+
+  const resizeCompleted = text(
+    await execute(fixture.manager, { action: "set_concurrency", runId: "audit-abc123", concurrency: 2 }),
+  );
+  assert.match(resizeCompleted, /cannot set_concurrency run with status completed/);
 
   await execute(fixture.manager, { action: "stop", runId: "live-123" });
   const stopAborted = text(await execute(fixture.manager, { action: "stop", runId: "live-123" }));

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -171,6 +171,62 @@ return xs`;
 );
 
 test(
+  "setConcurrency resizes a live FIFO run and clamps the effective value to 16",
+  withTempCwd(async (cwd) => {
+    const started: string[] = [];
+    const releases = new Map<string, () => void>();
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string) {
+          started.push(prompt);
+          await new Promise<void>((resolve) => releases.set(prompt, resolve));
+          return `ok:${prompt}`;
+        },
+      },
+    });
+    const script = `export const meta = { name: 'live_resize', description: 'live resize' }
+return await parallel(['a','b','c','d'].map((p) => () => agent(p, { label: p })))`;
+    const changes: number[] = [];
+    manager.on("concurrencyChanged", (event: { effectiveConcurrency: number }) =>
+      changes.push(event.effectiveConcurrency),
+    );
+
+    const { runId, promise } = manager.startInBackground(script, undefined, { concurrency: 1 });
+    while (started.length < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(manager.getSnapshot(runId)?.agents.filter((agent) => agent.status === "queued").length, 3);
+
+    assert.deepEqual(manager.setConcurrency(runId, 3), {
+      previousConcurrency: 1,
+      requestedConcurrency: 3,
+      effectiveConcurrency: 3,
+    });
+    while (started.length < 3) await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepEqual(started, ["a", "b", "c"]);
+
+    assert.equal(manager.setConcurrency(runId, 1)?.effectiveConcurrency, 1);
+    releases.get("b")?.();
+    releases.get("c")?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepEqual(started, ["a", "b", "c"], "lowering must not start queued work above the new limit");
+
+    releases.get("a")?.();
+    while (started.length < 4) await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(manager.getSnapshot(runId)?.agents.find((agent) => agent.label === "d")?.status, "running");
+    assert.deepEqual(manager.setConcurrency(runId, 17), {
+      previousConcurrency: 1,
+      requestedConcurrency: 17,
+      effectiveConcurrency: 16,
+    });
+    assert.equal(manager.getSnapshot(runId)?.effectiveConcurrency, 16);
+    releases.get("d")?.();
+    await promise;
+    assert.deepEqual(changes, [3, 1, 16]);
+    assert.equal(manager.setConcurrency(runId, 2), null, "completed runs are not live-resizable");
+  }),
+);
+
+test(
   "manager defaultAgentRetries applies when run options omit agentRetries",
   withTempCwd(async (cwd) => {
     let calls = 0;

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
-import { type JournalEntry, runWorkflow } from "../src/workflow.js";
+import { createConcurrencyLimiter, type JournalEntry, runWorkflow } from "../src/workflow.js";
 
 /** Agent runner that counts real invocations and echoes a per-call result. */
 function countingAgent() {
@@ -77,6 +77,102 @@ return xs`;
   assert.equal(maxActive, 2);
   assert.deepEqual(result.result, ["ok:a", "ok:b", "ok:c", "ok:d"]);
   assert.equal(result.agentCount, 4);
+});
+
+test("queued agents do not start after the run is aborted", async () => {
+  const controller = new AbortController();
+  const release = createDeferred<void>();
+  const invoked: string[] = [];
+  const started: string[] = [];
+  const runner = {
+    async run(prompt: string) {
+      invoked.push(prompt);
+      await release.promise;
+      return `ok:${prompt}`;
+    },
+  };
+  const script = `export const meta = { name: 'abort_queue', description: 'abort queued work' }
+return await parallel(['a','b','c'].map((p) => () => agent(p, { label: p })))`;
+
+  const run = runWorkflow(script, {
+    agent: runner,
+    concurrency: 1,
+    signal: controller.signal,
+    persistLogs: false,
+    onAgentStart: ({ label }) => started.push(label),
+  });
+  while (invoked.length < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  controller.abort();
+  release.resolve();
+  await run.catch(() => undefined);
+
+  assert.deepEqual(invoked, ["a"]);
+  assert.deepEqual(started, ["a"]);
+});
+
+test("mutable concurrency limiter releases FIFO and drains after scale-down without aborting", async () => {
+  const limiter = createConcurrencyLimiter(1);
+  const started: string[] = [];
+  const releases = new Map<string, ReturnType<typeof createDeferred<void>>>();
+  const runner = {
+    async run(prompt: string) {
+      started.push(prompt);
+      const release = createDeferred<void>();
+      releases.set(prompt, release);
+      await release.promise;
+      return `ok:${prompt}`;
+    },
+  };
+  const script = `export const meta = { name: 'resize', description: 'resize concurrency' }
+return await parallel(['a','b','c','d'].map((p) => () => agent(p, { label: p })))`;
+
+  const run = runWorkflow(script, { agent: runner, concurrencyLimiter: limiter, persistLogs: false });
+  while (started.length < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(started, ["a"]);
+
+  limiter.setLimit(3);
+  while (started.length < 3) await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(started, ["a", "b", "c"], "raising the limit should release queued work in FIFO order");
+
+  limiter.setLimit(1);
+  releases.get("b")?.resolve();
+  releases.get("c")?.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(started, ["a", "b", "c"], "scale-down should wait for active work to drain");
+
+  releases.get("a")?.resolve();
+  while (started.length < 4) await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(started, ["a", "b", "c", "d"]);
+  releases.get("d")?.resolve();
+  assert.deepEqual((await run).result, ["ok:a", "ok:b", "ok:c", "ok:d"]);
+});
+
+test("nested workflows share the mutable concurrency limiter", async () => {
+  const limiter = createConcurrencyLimiter(2);
+  let active = 0;
+  let maxActive = 0;
+  const runner = {
+    async run(prompt: string) {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active--;
+      return `ok:${prompt}`;
+    },
+  };
+  const child = `export const meta = { name: 'child', description: 'nested child' }
+return await parallel(['child-a','child-b'].map((p) => () => agent(p, { label: p })))`;
+  const parent = `export const meta = { name: 'parent', description: 'nested parent' }
+return await parallel([() => workflow('child'), () => agent('parent', { label: 'parent' })])`;
+
+  await runWorkflow(parent, {
+    agent: runner,
+    concurrencyLimiter: limiter,
+    loadSavedWorkflow: (name) => (name === "child" ? child : undefined),
+    persistLogs: false,
+  });
+
+  assert.equal(maxActive, 2);
 });
 
 test("runWorkflow retries recoverable empty output then succeeds", async () => {

--- a/tests/workflow-tools-available.test.ts
+++ b/tests/workflow-tools-available.test.ts
@@ -14,9 +14,13 @@
  */
 
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, mock } from "node:test";
 import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { buildForcedWorkflowPrompt, WORKFLOW_TOOL_NAME, type WorkflowModeState } from "../src/workflow-editor.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 // ---------------------------------------------------------------------------
 // Default Pi tools that every Pi install provides (plugin-independent)
@@ -33,6 +37,7 @@ const DEFAULT_PI_TOOLS = [
   "advisor",
   "subagent",
   "workflow",
+  "workflow_control",
 ];
 
 // Additional tools from context-mode plugin (common but not guaranteed)
@@ -141,7 +146,7 @@ describe("installWorkflowEditor - tool availability", () => {
     const { installWorkflowEditor } = await import("../src/workflow-editor.js");
 
     // Add a bonus tool to simulate a plugin adding a tool
-    const originalTools = ["bash", "read", "edit", "write", "custom-plugin-tool", "workflow"];
+    const originalTools = ["bash", "read", "edit", "write", "custom-plugin-tool", "workflow", "workflow_control"];
     const mockPi = createMockPi(originalTools);
 
     const ui = {
@@ -448,5 +453,57 @@ describe("installWorkflowEditor - tool availability", () => {
 
     assert.equal(typeof state.active, "boolean");
     assert.equal(state.active, false);
+  });
+});
+
+describe("workflow extension - control tool availability", () => {
+  it("registers and activates workflow and workflow_control together", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-control-extension-"));
+    try {
+      await withFakeHomeAsync(fakeHome, async () => {
+        const registeredTools: string[] = [];
+        const activeTools = ["bash", "read"];
+        const handlers: Record<string, Array<(...args: any[]) => any>> = {};
+        const pi = {
+          registerTool: (tool: { name: string }) => registeredTools.push(tool.name),
+          registerCommand: () => {},
+          getCommands: () => [],
+          on: (event: string, handler: (...args: any[]) => any) => {
+            if (!handlers[event]) handlers[event] = [];
+            handlers[event].push(handler);
+          },
+          getActiveTools: () => [...activeTools],
+          setActiveTools: (tools: string[]) => {
+            activeTools.splice(0, activeTools.length, ...tools);
+          },
+          sendMessage: () => {},
+        } as unknown as ExtensionAPI;
+        const { default: installExtension } = await import("../extensions/workflow.js");
+
+        installExtension(pi);
+
+        assert.deepEqual(registeredTools.slice(0, 2), ["workflow", "workflow_control"]);
+        assert.equal(handlers.session_start.length, 1);
+        handlers.session_start[0](
+          {},
+          {
+            model: undefined,
+            modelRegistry: {},
+            sessionManager: { getSessionId: () => "session-1" },
+            ui: {
+              setWidget: () => {},
+              getEditorComponent: () => undefined,
+              setEditorComponent: () => {},
+            },
+          },
+        );
+
+        assert.ok(activeTools.includes("workflow"));
+        assert.ok(activeTools.includes("workflow_control"));
+        handlers.session_shutdown?.[0]?.();
+      });
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Adds mutable FIFO concurrency control for live workflow runs.

- `workflow_control set_concurrency`
- `/workflows concurrency <id> <positive integer>`
- requested and effective concurrency reporting
- scale-up releases queued work immediately in FIFO order
- scale-down lets active work finish while new starts honor the lower limit
- nested workflows share the same mutable limiter
- queued work checks cancellation before entering the running state
- requests use the existing supported range of `1..16`

## Temporary stack

This draft builds on #83 because live resizing extends its control and observability contract. Review the concurrency commit after #83, or wait until #83 lands and this branch is rebased.

## Validation

- `npm test`: **909/909 passed** across 64 suites
- focused concurrency and control suites: passed
- Biome: passed
- TypeScript build: passed
- `git diff --check`: passed
- independent shortcut, quality, and spec reviews completed; abort-before-start and requested/effective reporting findings were addressed and re-reviewed

Split from and supersedes the live-concurrency portion of #74.
