### PR TITLE
feat: add workflow_control and run observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ return await agent(
 
 For an always-on exhaustive mode, use `/ultracode`; `/effort high` is the lighter standing option.
 
-## Commands
+## Commands and run control
+
+Pi can manage background runs directly with the `workflow_control` tool instead of asking you to type a command. It supports `list`, `status`, `pause`, `resume`, and `stop`; run-specific actions use the canonical run ID returned when the workflow starts. Status output includes the run state, current phase, agent counts, active labels, and recorded token total.
 
 | Command | Purpose |
 | --- | --- |

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   createEffortState,
+  createWorkflowControlTool,
   createWorkflowStorage,
   createWorkflowTool,
   installResultDelivery,
@@ -33,7 +34,9 @@ export default function extension(pi: ExtensionAPI) {
   });
 
   const workflowTool = createWorkflowTool({ cwd, manager, storage });
+  const workflowControlTool = createWorkflowControlTool({ manager });
   pi.registerTool(workflowTool);
+  pi.registerTool(workflowControlTool);
   // Auto-resume runs that paused on a provider usage limit once the quota is
   // likely refilled. Standalone: only consumes the manager's public surface, so
   // it stays decoupled from manager/persistence internals. Its constructor also
@@ -68,9 +71,9 @@ export default function extension(pi: ExtensionAPI) {
     // advertise the shared registry's models.
     manager.setModelRegistry(ctx.modelRegistry);
     const active = pi.getActiveTools();
-    if (!active.includes(workflowTool.name)) {
-      pi.setActiveTools([...active, workflowTool.name]);
-    }
+    const workflowTools = [workflowTool.name, workflowControlTool.name];
+    const missing = workflowTools.filter((name) => !active.includes(name));
+    if (missing.length) pi.setActiveTools([...active, ...missing]);
     // Scope the /workflows history to this session: runs persist on disk across
     // sessions, but the navigator/task panel show only the current session's runs.
     // Switching back to a previous session re-shows that session's runs.

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,12 @@ export type {
 } from "./workflow.js";
 export { parseWorkflowScript, runWorkflow } from "./workflow.js";
 export { registerWorkflowCommands } from "./workflow-commands.js";
+export type {
+  WorkflowControlInput,
+  WorkflowControlRunDetails,
+  WorkflowControlToolOptions,
+} from "./workflow-control-tool.js";
+export { createWorkflowControlTool } from "./workflow-control-tool.js";
 export {
   buildForcedWorkflowPrompt,
   colorizeWorkflow,

--- a/src/workflow-control-tool.ts
+++ b/src/workflow-control-tool.ts
@@ -1,0 +1,216 @@
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { type Static, Type } from "typebox";
+import { aggregateAgentUsage, tokenFigures, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
+import type { PersistedRunState, RunStatus } from "./run-persistence.js";
+import type { WorkflowManager } from "./workflow-manager.js";
+
+const runActionSchema = Type.Union([
+  Type.Literal("status"),
+  Type.Literal("pause"),
+  Type.Literal("resume"),
+  Type.Literal("stop"),
+]);
+
+const workflowControlSchema = Type.Union([
+  Type.Object(
+    { action: Type.Literal("list", { description: "List workflow runs." }) },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      action: runActionSchema,
+      runId: Type.String({ minLength: 1, description: "Canonical workflow run ID." }),
+    },
+    { additionalProperties: false },
+  ),
+]);
+
+export type WorkflowControlInput = Static<typeof workflowControlSchema>;
+
+export interface WorkflowControlToolOptions {
+  manager: WorkflowManager;
+}
+
+export interface WorkflowControlRunDetails {
+  runId: string;
+  workflowName: string;
+  status: RunStatus;
+  phase: string | null;
+  counts: {
+    total: number;
+    done: number;
+    running: number;
+    queued: number;
+    error: number;
+    skipped: number;
+  };
+  activeLabels: string[];
+  tokenTotal: number;
+}
+
+type ControlResult = {
+  content: Array<{ type: "text"; text: string }>;
+  details: Record<string, unknown>;
+};
+
+export function createWorkflowControlTool(
+  options: WorkflowControlToolOptions,
+): ToolDefinition<typeof workflowControlSchema, Record<string, unknown>> {
+  const manager = options.manager;
+  return defineTool({
+    name: "workflow_control",
+    label: "Workflow Control",
+    description:
+      "List and inspect workflow runs, or pause, resume, and stop them without asking the user to run slash commands.",
+    promptSnippet: "Inspect and manage workflow runs directly by canonical run ID.",
+    promptGuidelines: [
+      "Use workflow_control for workflow lifecycle management; do not ask the user to type /workflows when this tool can perform the action.",
+      "Use stop to terminate or quit a run. Closing the navigator does not stop a run.",
+    ],
+    parameters: workflowControlSchema,
+    prepareArguments: normalizeInput,
+    async execute(_toolCallId, params) {
+      if (params.action === "list") {
+        const runs = manager.listRuns();
+        const summaries = runs.map((run) => summarizeRun(run, manager.getSnapshot(run.runId)));
+        return result(
+          summaries.length
+            ? `action=list result=ok runs=${summaries.length}\n${summaries.map(formatRun).join("\n")}`
+            : "action=list result=ok runs=0",
+          { action: "list", result: "ok", runs: summaries },
+        );
+      }
+
+      const run = findRun(manager, params.runId);
+      if (!run) return controlError(params.action, params.runId, "run not found", ["list"]);
+
+      switch (params.action) {
+        case "status": {
+          const summary = summarizeRun(run, manager.getSnapshot(run.runId));
+          return result(`action=status result=ok ${formatRun(summary)}`, {
+            action: "status",
+            result: "ok",
+            run: summary,
+          });
+        }
+        case "pause":
+          if (!manager.pause(run.runId)) return invalidTransition("pause", run);
+          return actionSuccess("pause", "paused", currentSummary(manager, run));
+        case "resume":
+          if (!(await manager.resume(run.runId))) return invalidTransition("resume", run);
+          return actionSuccess("resume", "resumed", currentSummary(manager, run));
+        case "stop":
+          if (!manager.stop(run.runId)) return invalidTransition("stop", run);
+          return actionSuccess("stop", "stopped", currentSummary(manager, run));
+      }
+    },
+  });
+}
+
+function normalizeInput(value: unknown): WorkflowControlInput {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("workflow_control requires an object argument");
+  }
+  const input = value as Record<string, unknown>;
+  const actions = new Set(["list", "status", "pause", "resume", "stop"]);
+  if (typeof input.action !== "string" || !actions.has(input.action)) {
+    throw new Error("workflow_control requires action: list|status|pause|resume|stop");
+  }
+
+  const allowedKeys = input.action === "list" ? new Set(["action"]) : new Set(["action", "runId"]);
+  const extraKey = Object.keys(input).find((key) => !allowedKeys.has(key));
+  if (extraKey) throw new Error(`workflow_control action "${input.action}" does not accept ${extraKey}`);
+
+  if (input.action !== "list" && (typeof input.runId !== "string" || !input.runId.trim())) {
+    throw new Error(`workflow_control action "${input.action}" requires runId`);
+  }
+  return input as WorkflowControlInput;
+}
+
+function result(text: string, details: Record<string, unknown>): ControlResult {
+  return { content: [{ type: "text", text }], details };
+}
+
+function findRun(manager: WorkflowManager, runId: string): PersistedRunState | undefined {
+  return manager.listRuns().find((candidate) => candidate.runId === runId);
+}
+
+function currentSummary(manager: WorkflowManager, fallback: PersistedRunState): WorkflowControlRunDetails {
+  const current = findRun(manager, fallback.runId) ?? fallback;
+  return summarizeRun(current, manager.getSnapshot(current.runId));
+}
+
+function actionSuccess(action: string, actionResult: string, run: WorkflowControlRunDetails): ControlResult {
+  return result(`action=${action} result=${actionResult} ${formatRun(run)}`, {
+    action,
+    result: actionResult,
+    run,
+  });
+}
+
+function invalidTransition(action: string, run: PersistedRunState): ControlResult {
+  return controlError(action, run.runId, `cannot ${action} run with status ${run.status}`, allowedActions(run.status));
+}
+
+function controlError(action: string, runId: string, message: string, allowed: string[]): ControlResult {
+  return result(
+    `action=${action} result=error runId=${runId} error=${message} allowed=${allowed.join(",") || "none"}`,
+    { action, result: "error", runId, error: message, allowedActions: allowed },
+  );
+}
+
+function allowedActions(status: RunStatus): string[] {
+  switch (status) {
+    case "running":
+      return ["status", "pause", "stop"];
+    case "paused":
+      return ["status", "resume", "stop"];
+    case "failed":
+    case "pending":
+      return ["status", "resume"];
+    case "completed":
+    case "aborted":
+      return ["status"];
+  }
+}
+
+function summarizeRun(run: PersistedRunState, live?: WorkflowSnapshot | null): WorkflowControlRunDetails {
+  const agents = live?.agents ?? run.agents;
+  const counts = countAgents(agents);
+  const liveUsage = tokenFigures(live?.tokenUsage);
+  const persistedUsage = tokenFigures(run.tokenUsage);
+  const agentUsage = aggregateAgentUsage(agents);
+  return {
+    runId: run.runId,
+    workflowName: live?.name ?? run.workflowName,
+    status: run.status,
+    phase: live?.currentPhase ?? run.currentPhase ?? null,
+    counts,
+    activeLabels: agents.filter((agent) => agent.status === "running").map((agent) => agent.label),
+    tokenTotal: Math.max(
+      liveUsage.fresh + liveUsage.cacheRead,
+      persistedUsage.fresh + persistedUsage.cacheRead,
+      agentUsage.fresh + agentUsage.cacheRead,
+    ),
+  };
+}
+
+function countAgents(agents: Array<Pick<WorkflowAgentSnapshot, "status">>): WorkflowControlRunDetails["counts"] {
+  return {
+    total: agents.length,
+    done: agents.filter((agent) => agent.status === "done").length,
+    running: agents.filter((agent) => agent.status === "running").length,
+    queued: agents.filter((agent) => agent.status === "queued").length,
+    error: agents.filter((agent) => agent.status === "error").length,
+    skipped: agents.filter((agent) => agent.status === "skipped").length,
+  };
+}
+
+function formatRun(run: WorkflowControlRunDetails): string {
+  const active = run.activeLabels.join(",") || "-";
+  return `runId=${run.runId} name=${quote(run.workflowName)} status=${run.status} phase=${quote(run.phase ?? "-")} total=${run.counts.total} done=${run.counts.done} running=${run.counts.running} queued=${run.counts.queued} error=${run.counts.error} skipped=${run.counts.skipped} active=${quote(active)} tokens=${run.tokenTotal}`;
+}
+
+function quote(value: string): string {
+  return JSON.stringify(value);
+}

--- a/tests/workflow-control-tool.test.ts
+++ b/tests/workflow-control-tool.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Check } from "typebox/value";
+import type { WorkflowSnapshot } from "../src/display.js";
+import type { PersistedRunState, RunStatus } from "../src/run-persistence.js";
+import { createWorkflowControlTool } from "../src/workflow-control-tool.js";
+import type { WorkflowManager } from "../src/workflow-manager.js";
+
+function run(status: RunStatus = "running", runId = "audit-abc123"): PersistedRunState {
+  return {
+    runId,
+    workflowName: "audit",
+    script: "export const meta = { name: 'audit', description: 'audit' }; return await agent('x')",
+    status,
+    phases: ["Inspect"],
+    currentPhase: "Inspect",
+    agents: [
+      { id: 1, label: "active scan", prompt: "scan", status: status === "running" ? "running" : "done", tokens: 30 },
+      { id: 2, label: "queued check", prompt: "check", status: "queued" },
+      { id: 3, label: "failed check", prompt: "fail", status: "error" },
+      { id: 4, label: "optional check", prompt: "optional", status: "skipped" },
+    ],
+    logs: [],
+    startedAt: "2026-07-14T00:00:00.000Z",
+    updatedAt: "2026-07-14T00:00:01.000Z",
+    tokenUsage: { input: 20, output: 10, total: 30 },
+  };
+}
+
+function fakeManager(initial: PersistedRunState[], liveSnapshots: Record<string, WorkflowSnapshot> = {}) {
+  const runs = new Map(initial.map((item) => [item.runId, item]));
+  const calls: Array<{ action: string; runId: string }> = [];
+  const manager = {
+    listRuns: () => [...runs.values()],
+    getSnapshot: (runId: string) => liveSnapshots[runId] ?? null,
+    pause(runId: string) {
+      calls.push({ action: "pause", runId });
+      const item = runs.get(runId);
+      if (item?.status !== "running") return false;
+      item.status = "paused";
+      return true;
+    },
+    async resume(runId: string) {
+      calls.push({ action: "resume", runId });
+      const item = runs.get(runId);
+      if (!item || (item.status !== "paused" && item.status !== "failed" && item.status !== "pending")) return false;
+      item.status = "running";
+      return true;
+    },
+    stop(runId: string) {
+      calls.push({ action: "stop", runId });
+      const item = runs.get(runId);
+      if (!item || (item.status !== "running" && item.status !== "paused")) return false;
+      item.status = "aborted";
+      return true;
+    },
+  } as unknown as WorkflowManager;
+  return { manager, calls };
+}
+
+async function execute(manager: WorkflowManager, params: Record<string, unknown>) {
+  const tool = createWorkflowControlTool({ manager });
+  return (tool.execute as any)("control-call", params, undefined, undefined, {});
+}
+
+function text(result: Awaited<ReturnType<typeof execute>>): string {
+  return result.content[0].text;
+}
+
+test("workflow_control exposes only list, status, pause, resume, and stop in a strict schema", () => {
+  const { manager } = fakeManager([]);
+  const tool = createWorkflowControlTool({ manager });
+
+  assert.equal(tool.name, "workflow_control");
+  assert.equal(Check(tool.parameters, { action: "list" }), true);
+  assert.equal(Check(tool.parameters, { action: "status", runId: "abc" }), true);
+  assert.equal(Check(tool.parameters, { action: "pause", runId: "abc" }), true);
+  assert.equal(Check(tool.parameters, { action: "resume", runId: "abc" }), true);
+  assert.equal(Check(tool.parameters, { action: "stop", runId: "abc" }), true);
+  assert.equal(Check(tool.parameters, { action: "restart", runId: "abc" }), false);
+  assert.equal(Check(tool.parameters, { action: "remove", runId: "abc" }), false);
+  assert.equal(Check(tool.parameters, { action: "set_concurrency", runId: "abc", concurrency: 2 }), false);
+  assert.equal(Check(tool.parameters, { action: "status" }), false);
+  assert.equal(Check(tool.parameters, { action: "list", runId: "abc" }), false);
+  assert.equal(Check(tool.parameters, { action: "status", runId: "abc", extra: true }), false);
+
+  const prepare = tool.prepareArguments as (value: unknown) => unknown;
+  assert.throws(() => prepare({ action: "pause" }), /requires runId/);
+  assert.throws(() => prepare({ action: "status", runId: "abc", extra: true }), /does not accept extra/);
+  assert.throws(() => prepare({ action: "restart", runId: "abc" }), /requires action/);
+});
+
+test("list and status return stable lifecycle and observability fields", async () => {
+  const { manager } = fakeManager([run()]);
+
+  const listed = await execute(manager, { action: "list" });
+  assert.match(text(listed), /^action=list result=ok runs=1\n/);
+  assert.match(text(listed), /runId=audit-abc123 name="audit" status=running phase="Inspect"/);
+  assert.match(text(listed), /total=4 done=0 running=1 queued=1 error=1 skipped=1/);
+  assert.match(text(listed), /active="active scan" tokens=30/);
+  assert.deepEqual(listed.details, {
+    action: "list",
+    result: "ok",
+    runs: [
+      {
+        runId: "audit-abc123",
+        workflowName: "audit",
+        status: "running",
+        phase: "Inspect",
+        counts: { total: 4, done: 0, running: 1, queued: 1, error: 1, skipped: 1 },
+        activeLabels: ["active scan"],
+        tokenTotal: 30,
+      },
+    ],
+  });
+
+  const status = await execute(manager, { action: "status", runId: "audit-abc123" });
+  assert.match(text(status), /^action=status result=ok /);
+  assert.equal(status.details.action, "status");
+  assert.equal((status.details.run as { runId: string }).runId, "audit-abc123");
+  assert.doesNotMatch(text(status), /\/workflows/);
+});
+
+test("status uses agent usage when the live run aggregate is lagging", async () => {
+  const live: WorkflowSnapshot = {
+    name: "audit",
+    phases: ["Inspect"],
+    currentPhase: "Inspect",
+    logs: [],
+    agents: [
+      { id: 1, label: "estimated", prompt: "scan", status: "running", tokens: 80 },
+      {
+        id: 2,
+        label: "reported",
+        prompt: "check",
+        status: "done",
+        tokens: 40,
+        tokenUsage: { input: 15, output: 5, total: 40, cacheRead: 20, cacheWrite: 0, cost: 0 },
+      },
+    ],
+    agentCount: 2,
+    runningCount: 1,
+    doneCount: 1,
+    errorCount: 0,
+    tokenUsage: { input: 0, output: 0, total: 0 },
+  };
+  const { manager } = fakeManager([run()], { "audit-abc123": live });
+
+  const status = await execute(manager, { action: "status", runId: "audit-abc123" });
+
+  assert.match(text(status), /tokens=120$/);
+  assert.equal((status.details.run as { tokenTotal: number }).tokenTotal, 120);
+});
+
+test("list reports an explicit empty result", async () => {
+  const { manager } = fakeManager([]);
+  const response = await execute(manager, { action: "list" });
+  assert.equal(text(response), "action=list result=ok runs=0");
+  assert.deepEqual(response.details, { action: "list", result: "ok", runs: [] });
+});
+
+test("pause, resume, and stop call the shared manager lifecycle methods", async () => {
+  const fixture = fakeManager([run()]);
+
+  assert.match(text(await execute(fixture.manager, { action: "pause", runId: "audit-abc123" })), /result=paused/);
+  assert.match(text(await execute(fixture.manager, { action: "resume", runId: "audit-abc123" })), /result=resumed/);
+  assert.match(text(await execute(fixture.manager, { action: "stop", runId: "audit-abc123" })), /result=stopped/);
+  assert.deepEqual(
+    fixture.calls.map((call) => call.action),
+    ["pause", "resume", "stop"],
+  );
+});
+
+test("unknown IDs and illegal transitions return explicit errors with allowed actions", async () => {
+  const fixture = fakeManager([run("completed"), run("running", "live-123")]);
+
+  const unknown = text(await execute(fixture.manager, { action: "status", runId: "missing" }));
+  assert.match(unknown, /result=error runId=missing error=run not found allowed=list/);
+
+  const pauseCompleted = text(await execute(fixture.manager, { action: "pause", runId: "audit-abc123" }));
+  assert.match(pauseCompleted, /cannot pause run with status completed/);
+  assert.match(pauseCompleted, /allowed=status/);
+
+  await execute(fixture.manager, { action: "stop", runId: "live-123" });
+  const stopAborted = text(await execute(fixture.manager, { action: "stop", runId: "live-123" }));
+  assert.match(stopAborted, /cannot stop run with status aborted/);
+  assert.match(stopAborted, /allowed=status/);
+});

--- a/tests/workflow-tools-available.test.ts
+++ b/tests/workflow-tools-available.test.ts
@@ -14,9 +14,13 @@
  */
 
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, mock } from "node:test";
 import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { buildForcedWorkflowPrompt, WORKFLOW_TOOL_NAME, type WorkflowModeState } from "../src/workflow-editor.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 // ---------------------------------------------------------------------------
 // Default Pi tools that every Pi install provides (plugin-independent)
@@ -33,6 +37,7 @@ const DEFAULT_PI_TOOLS = [
   "advisor",
   "subagent",
   "workflow",
+  "workflow_control",
 ];
 
 // Additional tools from context-mode plugin (common but not guaranteed)
@@ -141,7 +146,7 @@ describe("installWorkflowEditor - tool availability", () => {
     const { installWorkflowEditor } = await import("../src/workflow-editor.js");
 
     // Add a bonus tool to simulate a plugin adding a tool
-    const originalTools = ["bash", "read", "edit", "write", "custom-plugin-tool", "workflow"];
+    const originalTools = ["bash", "read", "edit", "write", "custom-plugin-tool", "workflow", "workflow_control"];
     const mockPi = createMockPi(originalTools);
 
     const ui = {
@@ -448,5 +453,57 @@ describe("installWorkflowEditor - tool availability", () => {
 
     assert.equal(typeof state.active, "boolean");
     assert.equal(state.active, false);
+  });
+});
+
+describe("workflow extension - control tool availability", () => {
+  it("registers and activates workflow and workflow_control together", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-control-extension-"));
+    try {
+      await withFakeHomeAsync(fakeHome, async () => {
+        const registeredTools: string[] = [];
+        const activeTools = ["bash", "read"];
+        const handlers: Record<string, Array<(...args: any[]) => any>> = {};
+        const pi = {
+          registerTool: (tool: { name: string }) => registeredTools.push(tool.name),
+          registerCommand: () => {},
+          getCommands: () => [],
+          on: (event: string, handler: (...args: any[]) => any) => {
+            if (!handlers[event]) handlers[event] = [];
+            handlers[event].push(handler);
+          },
+          getActiveTools: () => [...activeTools],
+          setActiveTools: (tools: string[]) => {
+            activeTools.splice(0, activeTools.length, ...tools);
+          },
+          sendMessage: () => {},
+        } as unknown as ExtensionAPI;
+        const { default: installExtension } = await import("../extensions/workflow.js");
+
+        installExtension(pi);
+
+        assert.deepEqual(registeredTools.slice(0, 2), ["workflow", "workflow_control"]);
+        assert.equal(handlers.session_start.length, 1);
+        handlers.session_start[0](
+          {},
+          {
+            model: undefined,
+            modelRegistry: {},
+            sessionManager: { getSessionId: () => "session-1" },
+            ui: {
+              setWidget: () => {},
+              getEditorComponent: () => undefined,
+              setEditorComponent: () => {},
+            },
+          },
+        );
+
+        assert.ok(activeTools.includes("workflow"));
+        assert.ok(activeTools.includes("workflow_control"));
+        handlers.session_shutdown?.[0]?.();
+      });
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Adds a model-facing `workflow_control` tool with structured run and agent observability, built on the lifecycle methods in `WorkflowManager`.

Supported actions:

- `list`
- `status`
- `pause`
- `resume`
- `stop`

Status reports the canonical run ID, workflow name, lifecycle state, current phase, agent counts, active labels, and the most complete token total available across live, persisted, and per-agent usage.

## Validation

- `npm test`: **908/908 passed** across 64 suites
- Biome: passed
- TypeScript build: passed
- `git diff --check`: passed
- independent shortcut, quality, and spec review completed; the token-aggregation finding was addressed

This focused PR is split from and supersedes the control and observability portion of #74.