### PR TITLE
feat: resume a workflow with an edited script (cached-prefix reuse)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ return await agent(
 
 - **Real parallel orchestration** — fan out up to 16 concurrent and 1000 total subagents from one orchestration script.
 - **Per-agent model routing** — use `small`, `medium`, or `big` tiers, or choose an exact provider/model and thinking level.
-- **Journaled resume** — replay completed agents after interruption without rerunning them or spending their tokens again.
+- **Journaled resume** — replay completed agents after interruption without rerunning them or spending their tokens again. The orchestrator can also resume with an **edited script** (`resumeFromRunId`): unchanged `agent()` calls replay from cache and only edited/new ones re-run — so a single bad prompt no longer means paying to re-run the whole workflow.
 - **Git worktree isolation** — let parallel agents edit safely on throwaway branches with `isolation: "worktree"`.
 - **Measured usage** — report real tokens and cost from each subagent session; add run, phase, or agent budgets only when you want them.
 - **Visible background runs** — track phases, agents, models, fresh/cache tokens, cost, and live tok/s from the progress panel or `/workflows` navigator.
@@ -212,7 +212,7 @@ The default `workflow` also matches `workflows`; a custom word matches exactly. 
 | Isolated subagent contexts | Fresh in-memory Pi sessions; results remain in variables |
 | Structured outputs | JSON Schema validation with bounded repair |
 | Background runs | Non-blocking run, live panel, and automatic result delivery |
-| Resume | Journaled replay of the unchanged completed prefix |
+| Resume | Journaled replay of the unchanged completed prefix, including edit-and-resume with a revised script (`resumeFromRunId`) |
 | Model selection | Per-agent and per-phase routing across authenticated providers |
 | Ultracode | `/ultracode` or `/effort ultra` |
 | Additional Pi features | Worktree isolation, real cost accounting, deep research, and quality-pattern helpers |
@@ -222,6 +222,8 @@ The default `workflow` also matches `workflows`; a custom word matches exactly. 
 ## Determinism and limits
 
 Workflow scripts run in a Node `vm` sandbox. `Date.now()`, `Math.random()`, `new Date()`, `require`, `import`, filesystem access, and network access are unavailable inside the orchestration script. Subagents use their assigned tools; keeping the orchestrator deterministic is what makes journal replay reliable.
+
+Journal replay — including edit-and-resume via `resumeFromRunId` — matches cached agent results by **positional call index** (the order in which `agent()` calls execute), the same contract Claude Code uses. Editing an `agent()` prompt in place reuses the cache up to that call and re-runs it and everything after. Inserting, removing, or reordering an `agent()` call before others shifts their positions and invalidates the cache from that point on (mismatched calls simply re-run — no crash). To preserve the cached prefix, keep the earlier still-good `agent()` calls unchanged and in the same order.
 
 ## Development
 

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -349,6 +349,11 @@ export class WorkflowManager extends EventEmitter {
       const result = await runWorkflow(script, {
         cwd: this.cwd,
         args,
+        // Use the managed run's persisted id as the workflow runId so the value
+        // returned in result.runId matches the id that listRuns()/resume() use.
+        // Otherwise runWorkflow mints an ephemeral `run-<ts>` id and the sync
+        // path would surface a non-resumable id to the model.
+        runId: managed.runId,
         agent: this.agent,
         mainModel: this.mainModel,
         modelRegistry: this.modelRegistry,
@@ -564,8 +569,18 @@ export class WorkflowManager extends EventEmitter {
   /**
    * Resume an interrupted run: replay journaled results for the unchanged prefix
    * and run the rest live. Returns false if there is nothing resumable.
+   *
+   * `opts.script` lets the orchestrating model resume with an EDITED script
+   * (cached-prefix reuse / iteration): unchanged agent() calls whose content
+   * hash still matches the journal entry at their positional callIndex replay
+   * from cache, while the first changed or newly inserted call — and everything
+   * after it — re-runs live. When `opts.script` is omitted, resume behaves
+   * exactly as before and uses the persisted script (auto-resume, TUI resume);
+   * this keeps the existing single-arg `resume(runId)` callers (e.g. the
+   * UsageLimitScheduler) unchanged. `opts.args` overrides the persisted args
+   * only when provided; otherwise the persisted args are kept.
    */
-  async resume(runId: string): Promise<boolean> {
+  async resume(runId: string, opts?: { script?: string; args?: unknown }): Promise<boolean> {
     // Guard: refuse to resume a run that is already running, or one that was
     // intentionally aborted (pause/stop/Esc). Paused and failed runs can restart.
     const active = this.runs.get(runId);
@@ -576,6 +591,10 @@ export class WorkflowManager extends EventEmitter {
     if (!persisted?.script || persisted.status === "completed" || persisted.status === "aborted") return false;
     const lease = this.persistence.acquireRunLease(runId);
     if (!lease) return false;
+
+    // Use the edited script when supplied, else the persisted one (backward-compat).
+    const script = opts?.script ?? persisted.script;
+    const args = opts?.args !== undefined ? opts.args : persisted.args;
 
     const controller = new AbortController();
     const managed: ManagedRun = {
@@ -593,8 +612,10 @@ export class WorkflowManager extends EventEmitter {
       },
       controller,
       startedAt: new Date(),
-      script: persisted.script,
-      args: persisted.args,
+      // The (possibly edited) script + args become the run's own — persistRun()
+      // writes them below, so a later resume of this run sees the edited script.
+      script,
+      args,
       journal: persisted.journal ?? [],
       background: true,
       lease,
@@ -610,7 +631,7 @@ export class WorkflowManager extends EventEmitter {
     const resumeJournal = new Map((persisted.journal ?? []).map((e) => [e.index, e] as const));
     this.emit("resumed", { runId });
     // Run in the background; executeRun records status/errors on the managed run.
-    void this.executeRun(managed, persisted.script, persisted.args, { resumeJournal }).catch(() => {});
+    void this.executeRun(managed, script, args, { resumeJournal }).catch(() => {});
     return true;
   }
 

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -104,6 +104,15 @@ const workflowToolSchema = Type.Object({
         "Hard total-token budget for the whole run. Once spent reaches it, further agent() calls fail and the run stops. Omit for no limit. Set it when the user asks to cap spend.",
     }),
   ),
+  resumeFromRunId: Type.Optional(
+    Type.String({
+      description: [
+        "Resume a prior run (this ID) with an edited `script` instead of starting a new run.",
+        "Unchanged agent() calls replay from that run's cache; the first changed/new call onward re-runs.",
+        "Calls match by position: keep earlier good calls identical and in order. Always background.",
+      ].join(" "),
+    }),
+  ),
 });
 
 export type WorkflowToolInput = {
@@ -115,6 +124,7 @@ export type WorkflowToolInput = {
   agentRetries?: number;
   agentTimeoutMs?: number;
   tokenBudget?: number;
+  resumeFromRunId?: string;
 };
 
 export interface WorkflowToolOptions {
@@ -192,6 +202,23 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
       const script = normalizeWorkflowScript(params.script);
       const parsed = parseWorkflowScript(script);
+
+      // Iteration / cached-prefix reuse: resume a prior run with THIS (edited)
+      // script instead of creating a brand-new run. Unchanged agent() calls
+      // replay from the prior run's journal; the first edited/new call and
+      // everything after it re-run live. Always background (the resumed run is
+      // detached and its result is delivered back into the conversation).
+      if (params.resumeFromRunId) {
+        const runId = params.resumeFromRunId;
+        const resumed = await manager.resume(runId, { script, args: params.args });
+        if (!resumed) {
+          throw new Error(resumeFailureText(manager, runId));
+        }
+        return {
+          content: [{ type: "text", text: resumedText(parsed.meta.name, runId) }],
+          details: { runId, background: true, resumedFrom: runId },
+        };
+      }
 
       // checkpoint() reaches the human only on a UI-bearing foreground run; a
       // background run is detached, so checkpoint() falls back to its headless
@@ -288,7 +315,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
         content: [
           {
             type: "text",
-            text: `Workflow **${result.meta.name}** completed with **${result.agentCount}** agent(s).${tokenInfo}\n\n## Result${formattedResult}`,
+            text: `Workflow **${result.meta.name}** completed with **${result.agentCount}** agent(s).${tokenInfo}\n\n## Result${formattedResult}\n\n${reviseHint(result.runId)}`,
           },
         ],
         details: {
@@ -358,7 +385,60 @@ export function backgroundStartedText(name: string, runId: string): string {
     "resume the conversation by itself), or keep chatting / working on other things",
     "in the meantime; either way the result will come back to this conversation.",
     `They can also track or cancel it with /workflows status ${runId} or /workflows stop ${runId}.`,
+    reviseHint(runId),
   ].join("\n");
+}
+
+/**
+ * One-line hint telling the model it can iterate on a finished/running run by
+ * resuming it with an edited script instead of re-running the whole workflow.
+ * Unchanged agent() calls replay from the journal (cache); only edited/new ones
+ * re-run. Omitted when there is no runId to reference.
+ */
+export function reviseHint(runId: string | undefined): string {
+  if (!runId) return "";
+  return `To revise without re-running everything: re-call workflow with resumeFromRunId="${runId}" and an edited script — unchanged agent() calls replay from cache, only edited/new ones re-run.`;
+}
+
+/**
+ * The tool result returned when the model resumes a run with an edited script.
+ * The resumed run is always background, so its result is delivered back later.
+ */
+export function resumedText(name: string, runId: string): string {
+  return [
+    `Workflow "${name}" resumed from run ${runId} with your edited script.`,
+    "Unchanged agent() calls replay from that run's journal (cache); the first",
+    "edited or newly inserted agent() call — and everything after it — re-runs live.",
+    "It runs in the background; the result is delivered back here when it finishes,",
+    "and the conversation continues automatically. The user can wait or keep working.",
+    `Track or cancel it with /workflows status ${runId} or /workflows stop ${runId}.`,
+  ].join("\n");
+}
+
+/**
+ * Explain why a resumeFromRunId could not be resumed, so the model gets a clear
+ * tool error instead of a silent failure. Inspects live + persisted state to
+ * name the concrete reason (not found / running / completed / stopped).
+ */
+export function resumeFailureText(manager: WorkflowManager, runId: string): string {
+  const active = manager.getRun(runId);
+  if (active?.status === "running") {
+    return `Cannot resume workflow run "${runId}": it is still running. Wait for it to finish (or /workflows stop ${runId}) before resuming with an edited script.`;
+  }
+  const persisted = manager.getPersistence().load(runId);
+  if (!persisted) {
+    return `Cannot resume workflow run "${runId}": no run with that ID was found. Use the runId from a prior workflow result, or omit resumeFromRunId to start a new run.`;
+  }
+  if (persisted.status === "completed") {
+    return `Cannot resume workflow run "${runId}": it already completed. Start a new run instead (omit resumeFromRunId).`;
+  }
+  if (persisted.status === "aborted" || active?.status === "aborted") {
+    return `Cannot resume workflow run "${runId}": it was stopped/aborted and is not resumable. Start a new run instead (omit resumeFromRunId).`;
+  }
+  if (!persisted.script) {
+    return `Cannot resume workflow run "${runId}": it has no persisted script to resume. Start a new run instead (omit resumeFromRunId).`;
+  }
+  return `Cannot resume workflow run "${runId}": it is not currently resumable (it may be busy under another process). Try again shortly, or start a new run.`;
 }
 
 function normalizeWorkflowToolArgs(args: unknown): WorkflowToolInput {

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -1930,6 +1930,116 @@ test(
     assert.equal(result.agentCount, 1);
     assert.equal(seen.length, 1);
     assert.equal(seen[0].label, "a");
-    assert.match(seen[0].sessionName ?? "", /^workflow:run-[a-z0-9]+ a$/);
+    // runWorkflow now uses the managed run's persisted id (slug + generateRunId)
+    // so result.runId / session names line up with listRuns()/resume().
+    assert.match(seen[0].sessionName ?? "", /^workflow:tracked-demo-[a-z0-9-]+ a$/);
+  }),
+);
+
+// ─── Edited-script resume (cached-prefix reuse / model iteration) ───────────────
+// resume(runId, { script }) lets the orchestrating model re-run with an EDITED
+// script: the unchanged agent() prefix replays from the journal (cache hit), and
+// the first edited/new call — plus everything after — re-runs live. resume(runId)
+// with NO opts stays backward-compatible (uses the persisted script) so #78's
+// auto-resume (UsageLimitScheduler calls resume(runId)) is unaffected.
+
+const editResumeScriptV1 = `export const meta = { name: 'edit_resume', description: 'two agents' }
+const a = await agent('FIRST', { label: 'first' })
+const b = await agent('SECOND-ORIGINAL', { label: 'second' })
+return { a, b }`;
+
+/** Runner that records prompts and pauses (usage limit) on the original 2nd prompt. */
+function editResumeRunner() {
+  const seen: string[] = [];
+  const state = { failOriginalSecond: true };
+  return {
+    seen,
+    state,
+    runner: {
+      async run(prompt: string) {
+        seen.push(prompt);
+        if (prompt.includes("SECOND-ORIGINAL") && state.failOriginalSecond) {
+          throw new WorkflowError("usage limit reached", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, {
+            recoverable: false,
+            resetHint: "Resets soon",
+          });
+        }
+        return `ran:${prompt}`;
+      },
+    },
+  };
+}
+
+test(
+  "resume with an edited script replays the unchanged prefix and re-runs only the edited call",
+  withTempCwd(async (cwd) => {
+    const { seen, runner } = editResumeRunner();
+    const manager = new WorkflowManager({ cwd, agent: runner });
+    manager.on("paused", () => {});
+    manager.on("error", () => {});
+
+    // First run: agent 1 completes + journals, agent 2 hits a usage limit -> paused.
+    const { runId, promise } = manager.startInBackground(editResumeScriptV1);
+    await promise.catch(() => {});
+    assert.equal(manager.getRun(runId)?.status, "paused", "run pauses on the usage limit");
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.ok((persisted?.journal?.length ?? 0) >= 1, "agent 1 should be journaled");
+
+    // Resume with an EDITED script: agent 1 unchanged, agent 2's prompt changed.
+    const editResumeScriptV2 = `export const meta = { name: 'edit_resume', description: 'two agents' }
+const a = await agent('FIRST', { label: 'first' })
+const b = await agent('SECOND-EDITED', { label: 'second' })
+return { a, b }`;
+
+    const seenBeforeResume = seen.length;
+    const resumed = await manager.resume(runId, { script: editResumeScriptV2 });
+    assert.equal(resumed, true, "resume with edited script should succeed");
+    await new Promise((r) => setTimeout(r, 80));
+
+    const finalRun = manager.getRun(runId);
+    assert.equal(finalRun?.status, "completed", "resumed run completes");
+    assert.equal(finalRun?.result?.result?.a, "ran:FIRST", "agent 1 replays its cached journal result");
+    assert.equal(finalRun?.result?.result?.b, "ran:SECOND-EDITED", "edited agent 2 re-runs live");
+
+    // Cache proof: during the resume, the runner was NOT called for the unchanged
+    // agent 1, and WAS called for the edited agent 2.
+    const promptsDuringResume = seen.slice(seenBeforeResume);
+    assert.ok(!promptsDuringResume.includes("FIRST"), "unchanged agent 1 replayed from journal, not re-run");
+    assert.ok(promptsDuringResume.includes("SECOND-EDITED"), "edited agent 2 ran live");
+
+    // The edited script is persisted, so a later resume sees it.
+    const persistedAfter = manager.listRuns().find((r) => r.runId === runId);
+    assert.match(persistedAfter?.script ?? "", /SECOND-EDITED/, "edited script is persisted");
+  }),
+);
+
+test(
+  "resume(runId) with no opts uses the persisted script (auto-resume backward-compat)",
+  withTempCwd(async (cwd) => {
+    const { seen, state, runner } = editResumeRunner();
+    const manager = new WorkflowManager({ cwd, agent: runner });
+    manager.on("paused", () => {});
+    manager.on("error", () => {});
+
+    const { runId, promise } = manager.startInBackground(editResumeScriptV1);
+    await promise.catch(() => {});
+    assert.equal(manager.getRun(runId)?.status, "paused");
+
+    // Let the original second prompt succeed on the second attempt, then resume
+    // with NO opts — exactly how UsageLimitScheduler calls it.
+    state.failOriginalSecond = false;
+    const seenBeforeResume = seen.length;
+    const resumed = await manager.resume(runId);
+    assert.equal(resumed, true);
+    await new Promise((r) => setTimeout(r, 80));
+
+    const finalRun = manager.getRun(runId);
+    assert.equal(finalRun?.status, "completed");
+    assert.equal(finalRun?.result?.result?.a, "ran:FIRST", "agent 1 still replays from journal");
+    assert.equal(finalRun?.result?.result?.b, "ran:SECOND-ORIGINAL", "persisted (unedited) script runs agent 2");
+
+    const promptsDuringResume = seen.slice(seenBeforeResume);
+    assert.ok(!promptsDuringResume.includes("FIRST"), "agent 1 replayed from journal");
+    assert.ok(promptsDuringResume.includes("SECOND-ORIGINAL"), "persisted script's original agent 2 re-ran");
   }),
 );

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -14,8 +14,12 @@ import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 // Exact post-change measurements: ratchet only after reviewing a new accepted form.
 // The prompt baseline intentionally uses an empty agentType registry so user configuration cannot alter it.
+// Ratcheted for the resumeFromRunId (edited-script resume / cached-prefix reuse) tool surface:
+// one new optional schema param on the tool DEFINITION only. The always-on rendered
+// prompt is intentionally unchanged — discoverability comes from the tool-def
+// description plus the per-result revise hint, not an always-on guideline line.
 const RENDERED_PROMPT_BUDGET_BYTES = 6_500;
-const TOOL_DEFINITION_BUDGET_BYTES = 2_204;
+const TOOL_DEFINITION_BUDGET_BYTES = 2_529;
 
 test("rendered workflow prompt contribution stays within its accepted size", async () => {
   await withRenderedWorkflow(async ({ systemPrompt, promptLines }) => {

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import type { AgentUsage } from "../src/agent.js";
+import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
 import { backgroundStartedText, createWorkflowTool, modelRoutingGuideline } from "../src/workflow-tool.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 /** Minimal fake ModelRegistry, matching the shape the PR's existing tests use. */
 function fakeRegistry(models: Array<{ provider: string; id: string }>) {
@@ -221,3 +227,183 @@ test("createWorkflowTool prepareArguments passes through args", () => {
     assert.equal(result.agentRetries, 1);
   }
 });
+
+// ─── resumeFromRunId (edited-script iteration) ─────────────────────────────────
+
+const resumeToolScript = `export const meta = { name: 'resume_tool', description: 'one agent' }
+const a = await agent('do it', { label: 'a' })
+return { a }`;
+
+function toolFakeAgent(result: unknown = "ok") {
+  return {
+    async run(_prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+      options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
+      return result;
+    },
+  };
+}
+
+function deferredToolAgent() {
+  let resolveFn: ((v: unknown) => void) | null = null;
+  const promise = new Promise((resolve) => {
+    resolveFn = resolve;
+  });
+  return {
+    resolve: (v: unknown = "done") => resolveFn?.(v),
+    runner: {
+      async run() {
+        return promise;
+      },
+    },
+  };
+}
+
+function withToolTempCwd(fn: (cwd: string) => Promise<void>) {
+  return async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-dw-tool-"));
+    const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-tool-home-"));
+    try {
+      await withFakeHomeAsync(fakeHome, () => fn(cwd));
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  };
+}
+
+test("workflowToolSchema exposes resumeFromRunId as optional; script stays required", () => {
+  const tool = createWorkflowTool();
+  const schema = tool.parameters as { properties: Record<string, unknown>; required?: string[] };
+  assert.ok(schema.properties.resumeFromRunId, "resumeFromRunId should be a schema property");
+  assert.ok((schema.required ?? []).includes("script"), "script stays required");
+  assert.ok(!(schema.required ?? []).includes("resumeFromRunId"), "resumeFromRunId is optional");
+});
+
+test(
+  "workflow tool: resumeFromRunId pointing at a nonexistent run errors and creates no new run",
+  withToolTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: toolFakeAgent() });
+    const tool = createWorkflowTool({ cwd, manager });
+    await assert.rejects(
+      () =>
+        tool.execute(
+          "t1",
+          { script: resumeToolScript, resumeFromRunId: "no-such-run" },
+          undefined,
+          undefined,
+          undefined,
+        ),
+      /no run with that ID|not found/i,
+    );
+    assert.equal(manager.listRuns().length, 0, "no new run should be created on a failed resume");
+  }),
+);
+
+test(
+  "workflow tool: resumeFromRunId pointing at a completed run errors clearly",
+  withToolTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: toolFakeAgent() });
+    const tool = createWorkflowTool({ cwd, manager });
+    // Create + complete a run.
+    const { runId, promise } = manager.startInBackground(resumeToolScript);
+    await promise;
+    assert.equal(manager.getRun(runId)?.status, "completed");
+    await assert.rejects(
+      () => tool.execute("t2", { script: resumeToolScript, resumeFromRunId: runId }, undefined, undefined, undefined),
+      /already completed/i,
+    );
+  }),
+);
+
+test(
+  "workflow tool: resumeFromRunId pointing at a running run errors clearly",
+  withToolTempCwd(async (cwd) => {
+    const da = deferredToolAgent();
+    const manager = new WorkflowManager({ cwd, agent: da.runner });
+    manager.on("error", () => {});
+    const tool = createWorkflowTool({ cwd, manager });
+    const { runId, promise } = manager.startInBackground(resumeToolScript);
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(manager.getRun(runId)?.status, "running");
+    await assert.rejects(
+      () => tool.execute("t3", { script: resumeToolScript, resumeFromRunId: runId }, undefined, undefined, undefined),
+      /still running/i,
+    );
+    da.resolve("ok");
+    await promise.catch(() => {});
+  }),
+);
+
+test(
+  "workflow tool: omitting resumeFromRunId preserves new-run background behavior",
+  withToolTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: toolFakeAgent() });
+    const tool = createWorkflowTool({ cwd, manager });
+    const res = await tool.execute("t4", { script: resumeToolScript }, undefined, undefined, undefined);
+    const details = res.details as { runId?: string; background?: boolean; resumedFrom?: string };
+    assert.ok(details.runId, "a new run id should be returned");
+    assert.equal(details.background, true);
+    assert.equal(details.resumedFrom, undefined, "a fresh run is not a resume");
+    assert.equal(manager.listRuns().length, 1, "exactly one new run created");
+    // The returned text advertises the revise/iterate path.
+    const text = res.content?.[0]?.type === "text" ? res.content[0].text : "";
+    assert.match(text, /resumeFromRunId/, "background text tells the model how to iterate");
+  }),
+);
+
+test(
+  "workflow tool: resumeFromRunId resumes a paused run with the edited script",
+  withToolTempCwd(async (cwd) => {
+    const seen: string[] = [];
+    let failSecond = true;
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string) {
+          seen.push(prompt);
+          if (prompt.includes("SECOND-ORIG") && failSecond) {
+            throw new WorkflowError("usage limit", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, {
+              recoverable: false,
+              resetHint: "soon",
+            });
+          }
+          return `ran:${prompt}`;
+        },
+      },
+    });
+    manager.on("paused", () => {});
+    manager.on("error", () => {});
+    const tool = createWorkflowTool({ cwd, manager });
+
+    const v1 = `export const meta = { name: 'iter', description: 'two' }
+const a = await agent('FIRST', { label: 'first' })
+const b = await agent('SECOND-ORIG', { label: 'second' })
+return { a, b }`;
+    const { runId, promise } = manager.startInBackground(v1);
+    await promise.catch(() => {});
+    assert.equal(manager.getRun(runId)?.status, "paused");
+
+    failSecond = false;
+    const v2 = `export const meta = { name: 'iter', description: 'two' }
+const a = await agent('FIRST', { label: 'first' })
+const b = await agent('SECOND-EDITED', { label: 'second' })
+return { a, b }`;
+    const seenBefore = seen.length;
+    const res = await tool.execute("t5", { script: v2, resumeFromRunId: runId }, undefined, undefined, undefined);
+    const details = res.details as { runId?: string; resumedFrom?: string };
+    assert.equal(details.runId, runId, "resumed run keeps the same run id");
+    assert.equal(details.resumedFrom, runId);
+    const text = res.content?.[0]?.type === "text" ? res.content[0].text : "";
+    assert.match(text, new RegExp(`resumed from run ${runId}`), "text names the resumed run");
+
+    await new Promise((r) => setTimeout(r, 80));
+    const finalRun = manager.getRun(runId);
+    assert.equal(finalRun?.status, "completed");
+    assert.equal(finalRun?.result?.result?.b, "ran:SECOND-EDITED");
+    const during = seen.slice(seenBefore);
+    assert.ok(!during.includes("FIRST"), "unchanged agent 1 replays from journal");
+    assert.ok(during.includes("SECOND-EDITED"), "edited agent 2 re-runs live");
+    // No extra run created — resume reuses the same id.
+    assert.equal(manager.listRuns().length, 1, "resume does not create a second run");
+  }),
+);


### PR DESCRIPTION
## What
The `workflow` tool's orchestrating model can now iterate on a run cheaply: re-call `workflow` with `resumeFromRunId` + an edited `script`, and unchanged `agent()` calls replay from the run's journal (cache) while only edited/new ones re-run — instead of re-running the whole workflow to fix one bad prompt in one `agent()` call. This closes the biggest capability gap vs Claude Code's own workflow tool; the journal/callHash replay machinery already existed here, it just had no model-facing entry point (only the TUI `/workflows resume`, which reused the same script).

## Design
- **`WorkflowManager.resume(runId, opts?: { script?; args? })`** — optional edited-script override. **With no opts it is byte-for-byte the old behavior** (persisted script), so #78 auto-resume and the TUI `/workflows resume` path are untouched.
- **Tool**: optional `resumeFromRunId`. When set, resume that run with THIS call's (edited) `script` instead of starting a new run. `resume()`→false returns a clear reason (not found / running / completed / stopped / busy), never a silent no-op or a stray new run.
- Not `scriptPath` (Claude Code's form): this repo stores scripts inline in the run JSON, not as standalone files, so `resumeFromRunId` + the re-passed edited `script` is the fitting shape.

## Kept the always-on prompt flat (respects #66)
Discoverability comes from the `resumeFromRunId` **tool-definition description** + a **per-result revise hint** — not an always-on guideline. The rendered-prompt byte budget is **unchanged at 6500**; only the tool definition grows (+325B for the new optional param). I dropped an always-on guideline line an initial pass had added, since it duplicated the tool-def/hint and would have partly undone #66's prompt-size reduction.

## runId alignment (one pre-existing fix)
`executeRun` now passes `managed.runId` into `runWorkflow`, so the sync path's `result.runId` is the real resumable id rather than an ephemeral `run-<ts>`. Without this the sync-path revise hint would reference an id `resume()` can't find. The only test fallout was one `sessionName` assertion, now matching the more-correct value.

## Limitation (documented)
callIndex is positional: inserting/removing/reordering an `agent()` call before an unchanged one invalidates the cache from that point on (same as Claude Code). It degrades correctly (hash mismatch → re-run, no crash) and is documented in the tool description + README.

## Tests
Manager-level (edited-script prefix replay is a cache hit / the edited call re-runs; no-opts resume uses the persisted script — auto-resume back-compat) + tool-level (schema optionality; nonexistent/completed/running run → clear error and no new run; end-to-end resume-with-edited-script reuses the same run). **895 pass; tsc + biome clean.**

## Edges (unchanged from prior resume behavior)
Resumed runs are always background, and a resume doesn't re-apply per-call caps (maxAgents/concurrency/tokenBudget) — same as the existing resume path. Noted for a possible follow-up if per-run caps on resume are wanted.
