### PR TITLE
feat: add AI Code Flow workflow compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ For an always-on exhaustive mode, use `/ultracode`; `/effort high` is the lighte
 | `/workflows` | Open the interactive run navigator |
 | `/workflows run <prompt>` | Force a workflow even when keyword triggering is off |
 | `/workflows status <id>` | Watch a run and print its result when complete |
+| `/workflows report <id>` | Print persisted per-agent routing, context, tool, telemetry, and usage details |
 | `/workflows pause\|resume\|stop\|rm <id>` | Control a run |
 | `/workflows save <name>` | Save the latest script as a reusable command |
 | `/workflows-trigger off\|on\|status` | Control automatic keyword triggering |
@@ -136,7 +137,7 @@ In the navigator: `↑/↓` select · `enter/→` open · `esc/←` back · `p` 
 | `phase(title, { budget? })` | Group work in the live view and optionally set a phase budget |
 | `verify` / `judgePanel` | Cross-check a result or choose the best candidate |
 | `loopUntilDry` / `completenessCheck` | Repeat discovery until no new findings remain |
-| `workflow(name, args)` | Run a saved workflow inline |
+| `workflow(nameOrSourceOrDescriptor, args)` | Run a saved name, raw source, or cwd-contained `{ scriptPath }` inline |
 | `checkpoint(prompt, opts)` | Add a journaled human-approval gate |
 | `budget` | Inspect real tokens spent and remaining |
 
@@ -144,9 +145,10 @@ In the navigator: `↑/↓` select · `enter/→` open · `esc/←` back · `p` 
 | --- | --- |
 | `tier` | `small`, `medium`, or `big` model routing |
 | `model` | Exact `provider/modelId` or `provider/modelId:thinking`; overrides `tier` |
-| `agentType` | Named role, tool, and model definition |
+| `effort` | Explicit Pi thinking level; overrides model suffix and inherited thinking |
+| `agentType` | Named role, tool, skill policy, and model definition |
 | `isolation` | Use `"worktree"` for conflict-free parallel edits |
-| `schema` | JSON Schema for a validated structured result |
+| `schema` | TypeBox or literal JSON Schema for a validated structured result |
 | `label` / `phase` | Display label and phase override |
 | `timeoutMs` / `retries` | Optional per-agent timeout and recoverable-failure retries |
 
@@ -169,6 +171,17 @@ Model tiers live at `~/.pi/workflows/model-tiers.json` and accept Pi CLI-style t
 
 Use `/workflows-models` to edit them interactively. Without a config, the extension ranks authenticated models by capability hints and assigns distinct models when possible.
 
+Exact, case-insensitive symbolic aliases and strict resolution can be configured globally or per project:
+
+```json
+{
+  "modelAliases": { "haiku": "openai-codex/gpt-5.4-mini" },
+  "strictModelResolution": true
+}
+```
+
+Alias targets, configured tiers, the implicit medium tier, phase/default routes, and effective thinking participate in resume identity. Changing an effective route reruns affected work; unrelated alias edits do not invalidate direct `agent()` calls.
+
 Runs have no default token budget or per-agent hard timeout. Add `tokenBudget`, `agentTimeoutMs`, phase budgets, or agent `timeoutMs` when you need explicit gates. `concurrency` is clamped to 16; `agentRetries` retries only recoverable failures. Defaults can be set in `~/.pi/workflows/settings.json`.
 
 </details>
@@ -184,7 +197,13 @@ Extension state lives outside the repository under `~/.pi/workflows`:
 
 Subagents are in-memory by default. Set `persistAgentSessions: true` to retain full transcripts in Pi's standard session directory. This creates one file per agent and may store sensitive material that an agent read, so enable it deliberately.
 
-Completed background runs persist their full result in the project run JSON. The conversation delivery includes a pointer to that file when the visible summary is shortened.
+Completed background runs persist their full result in the project run JSON. The conversation delivery includes a pointer to that file when the visible summary is shortened. Execution cwd and limits are also persisted, so cold resume keeps the original policy and consumed token-budget semantics.
+
+The top-level tool supports `run`, `resume`, and `status` actions. `run` accepts exactly one of raw `script` or a `scriptPath` contained by the realpath of `ctx.cwd`; files are read fresh, and traversal, symlink escapes, missing paths, and directories are rejected. `resume` accepts a run ID plus an optional safe shallow args patch. The edit-and-resume compatibility form uses `resumeFromRunId` with a revised `script` or `scriptPath`.
+
+Nested workflow calls are atomic journal entries. Their deterministic result, shared-store delta, logical agent count, and child telemetry are replayed without rerunning or double-counting agents. Nesting is limited to one level; child args must be deterministic JSON-serializable values, and `{ scriptPath }` resolves from the workflow cwd.
+
+`WorkflowManager.resume(runId, { argsPatch })` performs the same safe shallow patch used by the tool. Set `agentTypePolicy: "error"` to reject unknown named agent definitions instead of using the compatibility fallback. Structured output accepts TypeBox or plain JSON Schema.
 
 </details>
 
@@ -222,6 +241,10 @@ The default `workflow` also matches `workflows`; a custom word matches exactly. 
 ## Determinism and limits
 
 Workflow scripts run in a Node `vm` sandbox. `Date.now()`, `Math.random()`, `new Date()`, `require`, `import`, filesystem access, and network access are unavailable inside the orchestration script. Subagents use their assigned tools; keeping the orchestrator deterministic is what makes journal replay reliable.
+
+Named agent definitions are loaded from project `.pi/agents`, primary user `~/.pi/agent/agents`, and the deprecated `~/.pi/agents` fallback. Literal boolean `skills: false` disables skill loading for that subagent while preserving normal extensions, context, prompts, themes, settings, model registration, and tools.
+
+`/workflows report <runId>` shows live/replay/legacy execution markers, requested and resolved models, effective thinking, skills, tools, system/context sizes, and exact provider usage when available. Missing legacy telemetry remains explicitly unavailable rather than being fabricated.
 
 Journal replay — including edit-and-resume via `resumeFromRunId` — matches cached agent results by **positional call index** (the order in which `agent()` calls execute), the same contract Claude Code uses. Editing an `agent()` prompt in place reuses the cache up to that call and re-runs it and everything after. Inserting, removing, or reordering an `agent()` call before others shifts their positions and invalidates the cache from that point on (mismatched calls simply re-run — no crash). To preserve the cached prefix, keep the earlier still-good `agent()` calls unchanged and in the same order.
 

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -30,6 +30,8 @@ export default function extension(pi: ExtensionAPI) {
     concurrency: settings.defaultConcurrency,
     defaultAgentRetries: settings.defaultAgentRetries,
     persistAgentSessions: settings.persistAgentSessions,
+    modelAliases: settings.modelAliases,
+    strictModelResolution: settings.strictModelResolution,
   });
 
   const workflowTool = createWorkflowTool({ cwd, manager, storage });

--- a/src/agent-registry.ts
+++ b/src/agent-registry.ts
@@ -17,7 +17,7 @@
  * tools+model+system-prompt, not a prose hint.
  *
  * Bound today: `tools` (allowlist), `disallowedTools` (denylist), `model`,
- * and the markdown body (`prompt`). Parsed-but-ignored for now (documented): `mcp`, `skills`, `background`.
+ * boolean `skills`, and the markdown body (`prompt`). Parsed-but-ignored for now (documented): `mcp`, `background`.
  * Wired: `isolation` ("worktree") → createWorktree() in workflow.ts.
  */
 
@@ -38,6 +38,8 @@ export interface AgentDefinition {
   disallowedTools?: string[];
   /** Model spec (`provider/modelId` or bare id) for this subagent. */
   model?: string;
+  /** Whether SDK skills are enabled for this subagent. Only literal booleans bind. */
+  skills?: boolean;
   /** Isolation mode. When "worktree", agents using this type run in a git worktree. */
   isolation?: "worktree";
   /** Markdown body, prepended to the subagent's task as role guidance. */
@@ -95,6 +97,7 @@ export function parseAgentDefinition(
     tools: toStringArray(fm.tools),
     disallowedTools: toStringArray(fm.disallowedTools),
     model: typeof fm.model === "string" ? fm.model.trim() || undefined : undefined,
+    skills: typeof fm.skills === "boolean" ? fm.skills : undefined,
     isolation:
       typeof fm.isolation === "string" && fm.isolation.toLowerCase().trim() === "worktree" ? "worktree" : undefined,
     prompt,
@@ -210,6 +213,7 @@ export function agentDefinitionKey(def: AgentDefinition | undefined): string | n
     tools: def.tools ?? null,
     disallowedTools: def.disallowedTools ?? null,
     model: def.model ?? null,
+    skills: def.skills ?? null,
     isolation: def.isolation ?? null,
     prompt: def.prompt,
   });

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -5,20 +5,23 @@ import type { AssistantMessage, Model, TextContent } from "@earendil-works/pi-ai
 import {
   AuthStorage,
   type CreateAgentSessionOptions,
+  type CreateAgentSessionResult,
   createAgentSession,
   createCodingTools,
+  DefaultResourceLoader,
   getAgentDir,
   ModelRegistry,
+  type ResourceLoader,
   SessionManager,
   SettingsManager,
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
-import type { Static, TSchema } from "typebox";
+import type { TSchema } from "typebox";
 import { Check, Convert } from "typebox/value";
 import { type AgentHistoryEntry, compactAgentHistory } from "./agent-history.js";
 import { applyToolPolicy } from "./agent-registry.js";
 import { classifyProviderLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
-import { canonicalModelSpec, resolveModelSpecWithThinking } from "./model-spec.js";
+import { canonicalModelSpec, type ModelThinkingLevel, resolveModelSpecWithThinking } from "./model-spec.js";
 import {
   formatTierFallbackNotice,
   loadModelTierConfig,
@@ -26,7 +29,12 @@ import {
   type RankableModel,
   resolveTierModel,
 } from "./model-tier-config.js";
-import { createStructuredOutputTool, type StructuredOutputCapture } from "./structured-output.js";
+import {
+  createStructuredOutputTool,
+  type SchemaOutput,
+  type StructuredOutputCapture,
+  type WorkflowSchema,
+} from "./structured-output.js";
 
 /**
  * Find a JSON object/array in free-form text: a fenced ```json block if present,
@@ -53,7 +61,7 @@ function findJsonBlock(text: string): string | undefined {
  * it toward the schema, and accept it only if it then validates. Never fabricates
  * — returns undefined unless the parsed value genuinely satisfies the schema.
  */
-export function extractValidated<T>(text: string, schema: TSchema): T | undefined {
+export function extractValidated<T>(text: string, schema: WorkflowSchema): T | undefined {
   const json = findJsonBlock(text);
   if (json === undefined) return undefined;
   let parsed: unknown;
@@ -63,8 +71,8 @@ export function extractValidated<T>(text: string, schema: TSchema): T | undefine
     return undefined;
   }
   try {
-    const converted = Convert(schema, parsed);
-    if (Check(schema, converted)) return converted as T;
+    const converted = Convert(schema as TSchema, parsed);
+    if (Check(schema as TSchema, converted)) return converted as T;
   } catch {
     // typebox can throw on exotic schemas; treat as no match.
   }
@@ -122,7 +130,7 @@ export interface StructuredSession {
 export async function resolveStructuredOutput<T>(
   session: StructuredSession,
   capture: StructuredOutputCapture<T>,
-  schema: TSchema,
+  schema: WorkflowSchema,
   options: { maxSchemaRetries?: number; signal?: AbortSignal; label?: string },
   lastText: (messages: unknown[]) => string,
 ): Promise<T> {
@@ -201,6 +209,18 @@ export function resolveAgentModelSpec(
   return undefined;
 }
 
+export function resolveAgentThinkingLevel(
+  effort: ModelThinkingLevel | undefined,
+  modelThinking: ModelThinkingLevel | undefined,
+  inheritedThinking: CreateAgentSessionOptions["thinkingLevel"] | undefined,
+): CreateAgentSessionOptions["thinkingLevel"] | undefined {
+  return effort ?? modelThinking ?? inheritedThinking;
+}
+
+export type WorkflowSessionFactory = (options?: CreateAgentSessionOptions) => Promise<CreateAgentSessionResult>;
+export type WorkflowResourceLoaderOptions = ConstructorParameters<typeof DefaultResourceLoader>[0];
+export type WorkflowResourceLoaderFactory = (options: WorkflowResourceLoaderOptions) => ResourceLoader;
+
 export interface WorkflowAgentOptions {
   cwd?: string;
   /** Extra tools available to the subagent in addition to the structured output tool. */
@@ -231,6 +251,14 @@ export interface WorkflowAgentOptions {
    * Default: false (current behavior).
    */
   persistAgentSessions?: boolean;
+  /** Exact, case-insensitive symbolic model aliases supplied by workflow settings. */
+  modelAliases?: Record<string, string>;
+  /** Reject unresolved requested model specs instead of using the session default. */
+  strictModelResolution?: boolean;
+  /** Test/embedder seam for session creation. */
+  sessionFactory?: WorkflowSessionFactory;
+  /** Test/embedder seam for resource-loader construction. */
+  resourceLoaderFactory?: WorkflowResourceLoaderFactory;
 }
 
 /**
@@ -268,12 +296,17 @@ export function listAvailableModelSpecs(registry?: ModelRegistry): string[] {
   return listAvailableModels(registry).map((model) => model.spec);
 }
 
-/**
- * Emitted at most once per process: when an agent asks for a tier but no
- * model-tiers.json exists, the tier silently falls back to the session model.
- * Surface that once (with the mapping the user would get by configuring) so the
- * no-op is discoverable. Diagnostics only — never lets a failure break a run.
- */
+/** Resolve only an exact symbolic alias (case-insensitive); all other specs are unchanged. */
+export function resolveModelAlias(spec: string, aliases: Record<string, string> | undefined): string {
+  const key = spec.trim().toLowerCase();
+  if (!key || !aliases) return spec.trim();
+  for (const [alias, target] of Object.entries(aliases)) {
+    if (alias.trim().toLowerCase() === key && target.trim()) return target.trim();
+  }
+  return spec.trim();
+}
+
+/** Emit the unconfigured tier fallback diagnostic at most once per process. */
 let warnedTierUnconfigured = false;
 function warnTierUnconfiguredOnce(mainModel: string | undefined, registry: ModelRegistry): void {
   if (warnedTierUnconfigured) return;
@@ -285,12 +318,7 @@ function warnTierUnconfiguredOnce(mainModel: string | undefined, registry: Model
   }
 }
 
-/**
- * Emitted at most once per process when persistAgentSessions is enabled and a
- * session is actually persisted: full subagent transcripts (which may include
- * secrets or other sensitive context) are being written to disk. Surface the
- * privacy trade-off at run time, not only in the docs.
- */
+/** Warn once when persisted subagent sessions may contain sensitive context. */
 let warnedPersistSecrets = false;
 function warnPersistSecretsOnce(sessionDir: string): void {
   if (warnedPersistSecrets) return;
@@ -310,12 +338,7 @@ export interface AgentUsage {
   cost: number;
 }
 
-/**
- * Map session stats to an AgentUsage, or undefined when the provider reported
- * no usage at all (all-zero stats). Returning undefined — instead of a zero
- * breakdown — lets displays fall back to their scalar token count, so setups
- * on non-reporting providers render the same as before the split existed.
- */
+/** Map non-zero session stats to the normalized usage shared by callbacks and telemetry. */
 export function usageFromStats(stats: {
   tokens: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
   cost: number;
@@ -332,7 +355,26 @@ export function usageFromStats(stats: {
   };
 }
 
-export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefined> {
+export interface AgentTelemetry {
+  execution: "live" | "replay";
+  requestedModelSpec?: string;
+  resolvedModel?: string;
+  effectiveThinkingLevel?: string;
+  skillsEnabled?: boolean;
+  loadedSkillCount?: number;
+  activeToolNames?: string[];
+  activeToolCount?: number;
+  systemPromptChars?: number;
+  projectContextFileCount?: number;
+  projectContextChars?: number;
+  usage?: AgentUsage;
+  /** Whether all retry attempts settled and their captured usage can be accounted without races. */
+  accountingStatus?: "exact" | "incomplete";
+  /** Attempts that exceeded the bounded post-abort cleanup grace. */
+  accountingIncompleteAttempts?: number;
+}
+
+export interface AgentRunOptions<TSchemaDef extends WorkflowSchema | undefined = undefined> {
   label?: string;
   /**
    * Display name recorded on the persisted session (session_info entry) when
@@ -352,6 +394,8 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
    * (all-zero stats), so consumers keep their scalar fallback.
    */
   onUsage?: (usage: AgentUsage) => void;
+  /** Called once with exact live session/resource telemetry before disposal. */
+  onTelemetry?: (telemetry: AgentTelemetry) => void;
   /**
    * Model spec for this subagent: either `provider/modelId` (unambiguous) or a
    * bare `modelId`. When it can't be resolved, the session default is used and
@@ -367,6 +411,11 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
    * caring which concrete model backs that tier.
    */
   tier?: string;
+  /**
+   * Explicit Pi thinking level for this agent. Wins over a model `:thinking`
+   * suffix and over the inherited session thinking level.
+   */
+  effort?: ModelThinkingLevel;
   /** Called with the resolved model id once known (for display/telemetry). */
   onModelResolved?: (modelId: string) => void;
   /** Called when `model`/`tier`/phase resolved to a spec that wasn't found (fell back to session default). */
@@ -405,10 +454,18 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
    * omitted.
    */
   modelRegistry?: ModelRegistry;
+  /** Boolean skill policy bound from an agent definition. */
+  skills?: boolean;
+  /** Tier config snapshotted by the workflow runtime; null means no configured tiers. */
+  modelTierConfig?: ModelTierConfig | null;
+  /** Per-run aliases override constructor aliases. */
+  modelAliases?: Record<string, string>;
+  /** Per-run strictness overrides constructor strictness. */
+  strictModelResolution?: boolean;
 }
 
-export type AgentRunResult<TSchemaDef extends TSchema | undefined> = TSchemaDef extends TSchema
-  ? Static<TSchemaDef>
+export type AgentRunResult<TSchemaDef extends WorkflowSchema | undefined> = TSchemaDef extends WorkflowSchema
+  ? SchemaOutput<TSchemaDef>
   : string;
 
 export class WorkflowAgent {
@@ -420,6 +477,10 @@ export class WorkflowAgent {
   private readonly mainModel?: string;
   /** Shared registry from the host session, when provided. */
   private readonly sharedRegistry?: ModelRegistry;
+  private readonly modelAliases?: Record<string, string>;
+  private readonly strictModelResolution: boolean;
+  private readonly sessionFactory: WorkflowSessionFactory;
+  private readonly resourceLoaderFactory: WorkflowResourceLoaderFactory;
   /** Lazily built once; shares the SDK's agentDir/auth so resolved models are authed. */
   private registry?: ModelRegistry;
 
@@ -431,6 +492,11 @@ export class WorkflowAgent {
     this.instructions = options.instructions;
     this.mainModel = options.mainModel;
     this.sharedRegistry = options.modelRegistry;
+    this.modelAliases = options.modelAliases;
+    this.strictModelResolution = options.strictModelResolution ?? false;
+    this.sessionFactory = options.sessionFactory ?? createAgentSession;
+    this.resourceLoaderFactory =
+      options.resourceLoaderFactory ?? ((loaderOptions) => new DefaultResourceLoader(loaderOptions));
   }
 
   /**
@@ -453,6 +519,11 @@ export class WorkflowAgent {
       this.registry = ModelRegistry.create(auth, join(dir, "models.json"));
     }
     return this.registry;
+  }
+
+  /** Resolve the exact registry this runner will use, for deterministic replay hashing. */
+  getModelRegistry(perRunRegistry?: ModelRegistry): ModelRegistry {
+    return this.getRegistry(perRunRegistry);
   }
 
   /**
@@ -492,7 +563,7 @@ export class WorkflowAgent {
     unlinkSync(probePath);
   }
 
-  async run<TSchemaDef extends TSchema | undefined = undefined>(
+  async run<TSchemaDef extends WorkflowSchema | undefined = undefined>(
     prompt: string,
     options: AgentRunOptions<TSchemaDef> = {},
   ): Promise<AgentRunResult<TSchemaDef>> {
@@ -521,19 +592,31 @@ export class WorkflowAgent {
     // Resolve the model spec (explicit model > tier > session default). This
     // composes with phase-based routing in workflow.ts, which only supplies
     // options.model when a phase pattern matches — so an explicit model wins.
-    const modelSpec = resolveAgentModelSpec(options, this.mainModel, loadModelTierConfig, () =>
-      warnTierUnconfiguredOnce(this.mainModel, this.getRegistry(options.modelRegistry)),
+    const modelSpec = resolveAgentModelSpec(
+      options,
+      this.mainModel,
+      () => (options.modelTierConfig === undefined ? loadModelTierConfig() : options.modelTierConfig),
+      () => warnTierUnconfiguredOnce(this.mainModel, this.getRegistry(options.modelRegistry)),
     );
 
-    // Resolve a requested model spec to a Model object. Specs use Pi CLI-style
-    // parsing, including an optional :thinking suffix such as gpt-5.5:xhigh.
-    // A given-but-unresolved spec falls back to the session default (with a
-    // warning) rather than failing.
+    // Resolve an exact symbolic alias before the existing CLI-style parsing and
+    // fuzzy matching. The original requested spec remains untouched for telemetry.
+    const aliases = options.modelAliases ?? this.modelAliases;
+    const effectiveModelSpec = modelSpec ? resolveModelAlias(modelSpec, aliases) : undefined;
+    const strictModelResolution = options.strictModelResolution ?? this.strictModelResolution;
     const modelRegistry = this.getRegistry(options.modelRegistry);
     let resolvedModel: Model<any> | undefined;
     let resolvedThinkingLevel: CreateAgentSessionOptions["thinkingLevel"] | undefined;
-    if (modelSpec) {
-      const resolved = resolveModelSpecWithThinking(modelSpec, modelRegistry);
+    if (effectiveModelSpec) {
+      const resolved = resolveModelSpecWithThinking(effectiveModelSpec, modelRegistry);
+      const syntheticCustomModel = resolved.warning?.includes("Using custom model id") ?? false;
+      if (strictModelResolution && (!resolved.model || syntheticCustomModel)) {
+        throw new WorkflowError(
+          `Model "${modelSpec}" resolved to "${effectiveModelSpec}" but was not found`,
+          WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+          { recoverable: false, agentLabel: options.label },
+        );
+      }
       if (resolved.warning) console.warn(`[workflow] ${resolved.warning}`);
       if (resolved.model) {
         resolvedModel = resolved.model;
@@ -541,25 +624,49 @@ export class WorkflowAgent {
         options.onModelResolved?.(resolved.resolvedSpec ?? canonicalModelSpec(resolved.model));
       } else {
         console.warn(`[workflow] model "${modelSpec}" not found; using session default`);
-        options.onModelFallback?.(modelSpec);
+        options.onModelFallback?.(modelSpec ?? effectiveModelSpec);
       }
     }
+    const thinkingLevel = resolveAgentThinkingLevel(
+      options.effort,
+      resolvedThinkingLevel,
+      this.sessionOptions.thinkingLevel,
+    );
 
     const agentDir = getAgentDir();
+    const injectedResourceLoader = this.sessionOptions.resourceLoader;
+    if (options.skills === false && injectedResourceLoader) {
+      throw new WorkflowError(
+        "skills:false cannot be enforced with an explicitly injected session.resourceLoader",
+        WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+        { recoverable: false, agentLabel: options.label },
+      );
+    }
+    // Use one real SettingsManager for both loader and session so extensions,
+    // prompts, themes, project context, model settings, and custom tools retain
+    // the SDK's default discovery behavior. Only skills are suppressed.
+    const settingsManager = this.sessionOptions.settingsManager ?? SettingsManager.create(this.cwd, agentDir);
+    const resourceLoader =
+      injectedResourceLoader ??
+      this.resourceLoaderFactory({
+        cwd: runCwd,
+        agentDir,
+        settingsManager,
+        ...(options.skills === false ? { noSkills: true } : {}),
+      });
+    if (!injectedResourceLoader) await resourceLoader.reload();
+
     // Key persisted sessions by the runner's project cwd (this.cwd), NOT the
     // per-call runCwd: agents working in short-lived git worktrees should still
     // group under the project's session dir instead of scattering across
     // temporary worktree paths.
     const sessionManager = this.createSessionManager();
-    const { session } = await createAgentSession({
+    const { session } = await this.sessionFactory({
       cwd: runCwd,
       agentDir,
       sessionManager,
-      // Use real SettingsManager to inherit user's default provider/model settings.
-      // SettingsManager.inMemory() doesn't load ~/.pi/settings.json, so subagents
-      // would fall back to the first available model (e.g. openai-codex) which may
-      // not have valid auth, causing silent empty responses.
-      settingsManager: SettingsManager.create(this.cwd, agentDir),
+      settingsManager,
+      resourceLoader,
       customTools,
       // Per-run modelRegistry wins over the constructor's shared registry
       // (see getRegistry() precedence above).
@@ -569,7 +676,7 @@ export class WorkflowAgent {
       ...this.sessionOptions,
       // Per-call model/thinking wins over any sessionOptions defaults.
       ...(resolvedModel ? { model: resolvedModel } : {}),
-      ...(resolvedThinkingLevel ? { thinkingLevel: resolvedThinkingLevel } : {}),
+      ...(thinkingLevel !== undefined ? { thinkingLevel } : {}),
     });
 
     // Name the persisted session so it's identifiable in session pickers.
@@ -636,13 +743,35 @@ export class WorkflowAgent {
       } catch {
         // History is diagnostic only; never let it mask the real result/error.
       }
-      // Read real usage before disposing — dispose tears down the session state.
-      if (options.onUsage) {
+      // Read stats exactly once, then feed the same normalized value to both
+      // callbacks so accounting and telemetry can never diverge.
+      let usage: AgentUsage | undefined;
+      try {
+        usage = usageFromStats(session.getSessionStats());
+        if (usage) options.onUsage?.(usage);
+      } catch {
+        // Diagnostics are best-effort; never mask the real result/error.
+      }
+      if (options.onTelemetry) {
         try {
-          const usage = usageFromStats(session.getSessionStats());
-          if (usage) options.onUsage(usage);
+          const contextFiles = resourceLoader.getAgentsFiles().agentsFiles;
+          const activeToolNames = session.getActiveToolNames();
+          options.onTelemetry({
+            execution: "live",
+            requestedModelSpec: modelSpec,
+            resolvedModel: session.model ? canonicalModelSpec(session.model) : undefined,
+            effectiveThinkingLevel: session.thinkingLevel,
+            skillsEnabled: options.skills !== false,
+            loadedSkillCount: resourceLoader.getSkills().skills.length,
+            activeToolNames,
+            activeToolCount: activeToolNames.length,
+            systemPromptChars: session.systemPrompt.length,
+            projectContextFileCount: contextFiles.length,
+            projectContextChars: contextFiles.reduce((total, file) => total + file.content.length, 0),
+            usage,
+          });
         } catch {
-          // Usage is best-effort; never let stats failure mask the real result/error.
+          // Telemetry is diagnostic only; never mask the real result/error.
         }
       }
       session.dispose();

--- a/src/display.ts
+++ b/src/display.ts
@@ -1,5 +1,5 @@
 import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
-import type { AgentUsage } from "./agent.js";
+import type { AgentTelemetry, AgentUsage } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import type { WorkflowErrorCode } from "./errors.js";
 import type { WorkflowMeta } from "./workflow.js";
@@ -8,6 +8,8 @@ export type WorkflowAgentStatus = "queued" | "running" | "done" | "error" | "ski
 
 export interface WorkflowAgentSnapshot {
   id: number;
+  /** Internal deterministic invocation identity for duplicate-label correlation. */
+  callId?: string;
   label: string;
   phase?: string;
   prompt: string;
@@ -23,6 +25,8 @@ export interface WorkflowAgentSnapshot {
   tokenUsage?: AgentUsage;
   /** The model this agent ran on (provider/id), when known. */
   model?: string;
+  /** Exact live telemetry, or persisted telemetry explicitly marked as replayed. */
+  telemetry?: AgentTelemetry;
 }
 
 export interface WorkflowSnapshot {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,24 @@
 export type { AdversarialReviewConfig } from "./adversarial-review.js";
 export { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
-export type { AgentRunOptions, AgentRunResult, WorkflowAgentOptions } from "./agent.js";
-export { listAvailableModelSpecs, listAvailableModels, WorkflowAgent } from "./agent.js";
+export type {
+  AgentRunOptions,
+  AgentRunResult,
+  AgentTelemetry,
+  AgentUsage,
+  WorkflowAgentOptions,
+  WorkflowResourceLoaderFactory,
+  WorkflowResourceLoaderOptions,
+  WorkflowSessionFactory,
+} from "./agent.js";
+export {
+  listAvailableModelSpecs,
+  listAvailableModels,
+  resolveAgentModelSpec,
+  resolveAgentThinkingLevel,
+  resolveModelAlias,
+  usageFromStats,
+  WorkflowAgent,
+} from "./agent.js";
 export type { AgentHistoryEntry, AgentHistoryKind, AgentHistoryRole } from "./agent-history.js";
 export { compactAgentHistory } from "./agent-history.js";
 export type { AgentDefinition, AgentRegistry } from "./agent-registry.js";
@@ -66,15 +83,28 @@ export {
   saveModelTierConfig,
   sortedTierNames,
 } from "./model-tier-config.js";
-export type { PersistedRunState, RunPersistence, RunStatus } from "./run-persistence.js";
-export { createRunPersistence, generateRunId } from "./run-persistence.js";
+export type {
+  PersistedExecutionPolicy,
+  PersistedRunState,
+  RunPersistence,
+  RunStatus,
+} from "./run-persistence.js";
+export { assertValidRunId, createRunPersistence, generateRunId, RUN_ID_PATTERN } from "./run-persistence.js";
 export {
   parseCommandArgs,
   registerAllSavedWorkflows,
   registerSavedWorkflow,
 } from "./saved-commands.js";
 export { createSharedStoreTools, SharedStore } from "./shared-store.js";
-export type { StructuredOutputCapture, StructuredOutputToolOptions } from "./structured-output.js";
+export type {
+  LiteralJsonSchema,
+  LiteralSchemaOutput,
+  LiteralStructuredOutputToolOptions,
+  SchemaOutput,
+  StructuredOutputCapture,
+  StructuredOutputToolOptions,
+  WorkflowSchema,
+} from "./structured-output.js";
 export { createStructuredOutputTool } from "./structured-output.js";
 export { deliverText, installResultDelivery, installTaskPanel, type TaskPanelOptions } from "./task-panel.js";
 export type {
@@ -87,12 +117,14 @@ export { computeAutoResumeDelayMs, parseResetHintMs, UsageLimitScheduler } from 
 export { createWebFetchTool, createWebSearchTool, createWebTools } from "./web-tools.js";
 export type {
   AgentOptions,
+  AgentTypePolicy,
   JournalEntry,
   SharedRuntime,
   WorkflowMeta,
   WorkflowMetaPhase,
   WorkflowRunOptions,
   WorkflowRunResult,
+  WorkflowScriptDescriptor,
 } from "./workflow.js";
 export { parseWorkflowScript, runWorkflow } from "./workflow.js";
 export { registerWorkflowCommands } from "./workflow-commands.js";
@@ -110,7 +142,7 @@ export {
   WorkflowEditor,
   type WorkflowModeState,
 } from "./workflow-editor.js";
-export type { ManagedRun, WorkflowManagerOptions } from "./workflow-manager.js";
+export type { ManagedRun, ResumeOptions, WorkflowManagerOptions } from "./workflow-manager.js";
 export { WorkflowManager } from "./workflow-manager.js";
 export type { WorkflowProjectPaths } from "./workflow-paths.js";
 export {
@@ -121,6 +153,7 @@ export {
   workflowProjectPaths,
   workflowUserSavedDir,
 } from "./workflow-paths.js";
+export { formatWorkflowReport } from "./workflow-report.js";
 export type { SavedWorkflow, WorkflowStorage } from "./workflow-saved.js";
 export { assertSafeSavedWorkflowName, createWorkflowStorage, isSafeSavedWorkflowName } from "./workflow-saved.js";
 export type { WorkflowSettings, WorkflowSettingsOptions, WorkflowSettingsStore } from "./workflow-settings.js";

--- a/src/json-value.ts
+++ b/src/json-value.ts
@@ -1,0 +1,97 @@
+const UNSAFE_JSON_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export interface JsonTreePrototypes {
+  arrayPrototype: object;
+  objectPrototype: object;
+}
+
+const HOST_PROTOTYPES: JsonTreePrototypes = {
+  arrayPrototype: Array.prototype,
+  objectPrototype: Object.prototype,
+};
+
+/**
+ * Clone a value into the exact tree semantics preserved by JSON persistence.
+ * Repeated references are cloned independently, matching JSON.stringify/parse;
+ * cycles, custom prototypes, toJSON hooks, accessors, sparse arrays, and lossy
+ * scalar values are rejected instead of being silently changed.
+ */
+export function normalizeJsonTree(value: unknown, prototypes: JsonTreePrototypes = HOST_PROTOTYPES): JsonValue {
+  return normalizeValue(value, prototypes, new WeakSet<object>(), false);
+}
+
+/** Normalize workflow child arguments using JSON.stringify's object-property omission semantics. */
+export function normalizeJsonChildArgs(value: unknown, prototypes: JsonTreePrototypes = HOST_PROTOTYPES): JsonValue {
+  return normalizeValue(value, prototypes, new WeakSet<object>(), true);
+}
+
+/** Snapshot a result exactly as JSON object persistence represents it. */
+export function normalizeJsonResult(value: unknown, prototypes: JsonTreePrototypes = HOST_PROTOTYPES): JsonValue {
+  return normalizeJsonChildArgs(value, prototypes);
+}
+
+function normalizeValue(
+  value: unknown,
+  prototypes: JsonTreePrototypes,
+  ancestors: WeakSet<object>,
+  omitUndefinedProperties: boolean,
+): JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("non-finite numbers are not JSON values");
+    return Object.is(value, -0) ? 0 : value;
+  }
+  if (typeof value !== "object") throw new TypeError(`${typeof value} is not a JSON value`);
+  if (ancestors.has(value)) throw new TypeError("cyclic references are not JSON values");
+  if ("toJSON" in value) throw new TypeError("toJSON hooks are not JSON values");
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const arrayPrototype = Object.getPrototypeOf(value);
+      if (arrayPrototype !== prototypes.arrayPrototype && arrayPrototype !== HOST_PROTOTYPES.arrayPrototype) {
+        throw new TypeError("custom array prototypes are not JSON values");
+      }
+      const keys = Reflect.ownKeys(value).filter((key) => key !== "length");
+      if (keys.length !== value.length) throw new TypeError("sparse arrays are not JSON values");
+      const normalized: JsonValue[] = [];
+      for (let index = 0; index < value.length; index++) {
+        const key = String(index);
+        if (!Object.hasOwn(value, key)) throw new TypeError("sparse arrays are not JSON values");
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (!descriptor?.enumerable || !("value" in descriptor)) {
+          throw new TypeError("array accessors and hidden entries are not JSON values");
+        }
+        normalized.push(normalizeValue(descriptor.value, prototypes, ancestors, omitUndefinedProperties));
+      }
+      return normalized;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (
+      prototype !== prototypes.objectPrototype &&
+      prototype !== HOST_PROTOTYPES.objectPrototype &&
+      prototype !== null
+    ) {
+      throw new TypeError("custom prototypes are not JSON values");
+    }
+    const normalized: Record<string, JsonValue> = {};
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== "string" || UNSAFE_JSON_KEYS.has(key)) {
+        throw new TypeError("unsafe object keys are not JSON values");
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor?.enumerable || !("value" in descriptor)) {
+        throw new TypeError("object accessors and hidden properties are not JSON values");
+      }
+      if (omitUndefinedProperties && descriptor.value === undefined) continue;
+      normalized[key] = normalizeValue(descriptor.value, prototypes, ancestors, omitUndefinedProperties);
+    }
+    return normalized;
+  } finally {
+    ancestors.delete(value);
+  }
+}

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -4,15 +4,35 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import type { AgentUsage } from "./agent.js";
+import type { AgentTelemetry, AgentUsage } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import type { WorkflowErrorCode } from "./errors.js";
 import { workflowProjectPaths } from "./workflow-paths.js";
 
 export type RunStatus = "pending" | "running" | "paused" | "completed" | "failed" | "aborted";
 
+export const RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+export function assertValidRunId(runId: string): void {
+  if (!RUN_ID_PATTERN.test(runId)) {
+    throw new Error("Invalid workflow run ID");
+  }
+}
+
+export interface PersistedExecutionPolicy {
+  cwd: string;
+  maxAgents: number;
+  agentTimeoutMs: number | null;
+  tokenBudget: number | null;
+  concurrency: number;
+  agentRetries: number;
+  agentTypePolicy: "fallback" | "error";
+}
+
 export interface PersistedAgentState {
   id: number;
+  /** Internal deterministic invocation identity for duplicate-label correlation. */
+  callId?: string;
   label: string;
   phase?: string;
   prompt: string;
@@ -30,6 +50,7 @@ export interface PersistedAgentState {
   tokenUsage?: AgentUsage;
   /** The model this agent ran on (provider/id), when known. */
   model?: string;
+  telemetry?: AgentTelemetry;
 }
 
 export interface PersistedRunState {
@@ -37,6 +58,12 @@ export interface PersistedRunState {
   workflowName: string;
   script: string;
   args?: unknown;
+  /** Working directory used by this run. Optional only for legacy records. */
+  cwd?: string;
+  /** Effective limits and policy used by this run. Optional only for legacy records. */
+  executionPolicy?: PersistedExecutionPolicy;
+  /** Effective unknown-agent policy for this execution, including per-run overrides. */
+  agentTypePolicy?: "fallback" | "error";
   /** The pi session this run belongs to. Runs persist on disk across sessions but
    * the navigator shows only the current session's runs (undefined = legacy/global). */
   sessionId?: string;
@@ -62,19 +89,35 @@ export interface PersistedRunState {
     cacheRead?: number;
     cacheWrite?: number;
   };
-  /** Cached agent results for resume, keyed by deterministic call index. */
-  journal?: Array<{ index: number; hash: string; result: unknown }>;
-  /**
-   * Opt-out of auto-resume for this run (default true, i.e. eligible unless
-   * explicitly set to false via ExecOptions.autoResume). Set once at run start
-   * and carried through resumes; see UsageLimitScheduler.
-   */
+  /** Cached agent/atomic-child results for resume, keyed by deterministic call index. */
+  journal?: Array<{
+    index: number;
+    hash: string;
+    result: unknown;
+    storeDelta?: Record<string, unknown>;
+    storeVersions?: Record<string, number>;
+    telemetry?: AgentTelemetry;
+    agentCount?: number;
+    resultKind?: "void";
+    childAgents?: Array<{
+      /** Internal deterministic invocation identity for duplicate-label correlation. */
+      callId?: string;
+      label: string;
+      phase?: string;
+      prompt: string;
+      result: unknown;
+      tokens?: number;
+      tokenUsage?: AgentUsage;
+      model?: string;
+      error?: string;
+      errorCode?: WorkflowErrorCode;
+      recoverable?: boolean;
+      telemetry?: AgentTelemetry;
+    }>;
+  }>;
+  /** Whether usage-limit auto-resume is enabled for this run. */
   autoResume?: boolean;
-  /**
-   * Auto-resume attempt counter for the current usage_limit pause-cycle, owned
-   * and persisted by UsageLimitScheduler (best-effort). Absent/0 means no
-   * auto-resume attempt has been recorded yet.
-   */
+  /** Auto-resume attempts for the current usage-limit pause cycle. */
   autoResumeAttempts?: number;
 }
 
@@ -85,8 +128,8 @@ export interface RunPersistence {
   load(runId: string): PersistedRunState | null;
   /** List all persisted runs. */
   list(): PersistedRunState[];
-  /** Delete a persisted run. */
-  delete(runId: string): boolean;
+  /** Delete a persisted run, optionally retaining its active execution lease. */
+  delete(runId: string, options?: { preserveLock?: boolean }): boolean;
   /**
    * Acquire an exclusive cross-process lease for a run. Returns null when another
    * live process owns the run; stale/corrupt lock files are removed and retried.
@@ -187,6 +230,7 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
 
   return {
     save(state: PersistedRunState) {
+      assertValidRunId(state.runId);
       ensureDir();
       state.updatedAt = new Date().toISOString();
       const path = primaryRunPath(state.runId);
@@ -204,6 +248,7 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     },
 
     load(runId: string): PersistedRunState | null {
+      assertValidRunId(runId);
       // Try the primary, then the .bak — so a corrupt primary doesn't lose the run.
       for (const path of candidateRunPaths(runId)) {
         for (const candidate of [path, `${path}.bak`]) {
@@ -239,13 +284,17 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
       return [...byRunId.values()].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
     },
 
-    delete(runId: string): boolean {
+    delete(runId: string, options: { preserveLock?: boolean } = {}): boolean {
+      assertValidRunId(runId);
       let deleted = false;
       try {
         for (const path of candidateRunPaths(runId)) {
           const dir = path === primaryRunPath(runId) ? runsDir : legacyRunsDir;
-          // Best-effort cleanup of the sidecar files alongside the primary.
-          for (const sidecar of [`${path}.bak`, `${path}.tmp`, lockPath(dir, runId)]) {
+          // Best-effort cleanup of sidecars. An active deletion retains the
+          // token-owned lock until the cancelled execution settles and releases it.
+          const sidecars = [`${path}.bak`, `${path}.tmp`];
+          if (!options.preserveLock) sidecars.push(lockPath(dir, runId));
+          for (const sidecar of sidecars) {
             try {
               if (_existsSync(sidecar)) _unlinkSync(sidecar);
             } catch {
@@ -268,6 +317,7 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     },
 
     acquireRunLease(runId: string): RunLease | null {
+      assertValidRunId(runId);
       ensureDir();
       const path = primaryRunPath(runId);
       const lock = primaryLockPath(runId);
@@ -302,6 +352,7 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     },
 
     releaseRunLease(lease: RunLease): void {
+      assertValidRunId(lease.runId);
       try {
         const existing = readLock(lease.runId);
         if (existing?.token === lease.token) _unlinkSync(primaryLockPath(lease.runId));

--- a/src/shared-store.ts
+++ b/src/shared-store.ts
@@ -7,104 +7,221 @@
  * intermediate state without coordinating through the script itself.
  *
  * Journal integration: callers capture `store.commitDelta(deltaKey)` alongside
- * each agent result in the journal. On resume, `store.applyDelta(delta)` rebuilds
- * the store state additively in callSeq order, so parallel-agent writes are
- * replayed correctly without the last-complete-wins ordering bug that a
- * whole-Map restore() would cause.
+ * each successful agent result. Failed attempts call `discardDelta(deltaKey)` so
+ * unjournaled writes do not remain observable. Atomic child workflows use a
+ * child scope: they can read parent state, but their execution-ordered final
+ * delta is applied to the parent only after the whole child succeeds.
  *
- * `deltaKey` must be unique across every run that shares this store instance,
- * not just within one run's callSeq. A nested `workflow()` call restarts its own
- * callSeq at 0 while inheriting the parent's store (so parent and nested-run
- * agents can share state), so a bare callIndex would collide between a parent
- * agent and a concurrently-running nested-run agent that both got index 0 —
- * whichever commits its delta last would clobber the other's entry in
- * `agentDeltas`. Callers compose `deltaKey` as `${runId}:${callIndex}`, and
- * since every run (including each nested run) gets its own distinct `runId`,
- * the composite key is unique across the whole store's lifetime.
+ * `deltaKey` must be unique across every invocation sharing a store scope, not
+ * just within one run's callSeq. Callers compose it from the run ID and call
+ * index; nested children additionally receive a call-index-based invocation ID.
  */
 
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 
-export class SharedStore {
-  private readonly map = new Map<string, unknown>();
-  // Per-agent write deltas for delta-journaling; keyed by a run-unique
-  // `${runId}:${callIndex}` string (see class doc) so nested workflow() runs
-  // sharing this store can't collide on a bare callIndex.
-  private readonly agentDeltas = new Map<string, Record<string, unknown>>();
+interface StoreWrite {
+  key: string;
+  value: unknown;
+  version: number;
+  deltaKey?: string;
+  committed: boolean;
+}
 
-  /** Store a value under `key`. Overwrites any existing value. */
+interface StoreClock {
+  nextVersion: number;
+}
+
+export interface StoreDelta {
+  values: Record<string, unknown>;
+  versions: Record<string, number>;
+}
+
+const UNSAFE_STORE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function validateStoreKey(key: string): void {
+  if (UNSAFE_STORE_KEYS.has(key)) throw new TypeError(`unsafe shared-store key: ${key}`);
+}
+
+export class SharedStore {
+  /** Writes use a scope-wide monotonic version assigned at store_put execution time. */
+  private writes: StoreWrite[] = [];
+  private readonly agentDeltas = new Map<string, StoreWrite[]>();
+  private readonly closedDeltas = new Set<string>();
+  private readonly clock: StoreClock;
+  private disposed = false;
+
+  constructor(private readonly parent?: SharedStore) {
+    this.clock = parent?.clock ?? { nextVersion: 0 };
+  }
+
+  /** Store a committed value under `key`. Overwrites any older write. */
   put(key: string, value: unknown): void {
-    this.map.set(key, value);
+    this.assertOpen();
+    validateStoreKey(key);
+    this.appendCommitted(key, value, ++this.clock.nextVersion);
   }
 
   /**
-   * Store a value and record the write in the per-agent delta for `deltaKey`
-   * (a run-unique `${runId}:${callIndex}` string — see class doc). Used by
-   * per-agent tools created via `createAgentStoreTools` so that each agent's
-   * writes can be journaled and replayed independently.
+   * Store a value and record the write in the per-attempt delta for `deltaKey`.
+   * Closed attempt scopes reject late writes, including work that outlives a timeout.
    */
   trackPut(key: string, value: unknown, deltaKey: string): void {
-    this.map.set(key, value);
-    let delta = this.agentDeltas.get(deltaKey);
-    if (!delta) {
-      delta = {};
-      this.agentDeltas.set(deltaKey, delta);
-    }
-    delta[key] = value;
+    this.assertOpen();
+    validateStoreKey(key);
+    if (this.closedDeltas.has(deltaKey)) throw new Error(`shared-store delta scope is closed: ${deltaKey}`);
+    const write = { key, value, version: ++this.clock.nextVersion, deltaKey, committed: false };
+    this.writes.push(write);
+    const delta = this.agentDeltas.get(deltaKey) ?? [];
+    delta.push(write);
+    this.agentDeltas.set(deltaKey, delta);
   }
 
-  /** Retrieve the value for `key`, or `undefined` when absent. */
-  get(key: string): unknown {
-    return this.map.get(key);
+  /** Retrieve committed state plus the calling attempt's own pending writes. */
+  get(key: string, deltaKey?: string): unknown {
+    this.assertOpen();
+    validateStoreKey(key);
+    return this.latestWrite(key, deltaKey)?.value;
   }
 
-  /** Whether `key` is present in the store. */
-  has(key: string): boolean {
-    return this.map.has(key);
+  /** Whether committed state or the calling attempt's own pending state contains `key`. */
+  has(key: string, deltaKey?: string): boolean {
+    this.assertOpen();
+    validateStoreKey(key);
+    return this.latestWrite(key, deltaKey) !== undefined;
   }
 
-  /** Return a deep-copied plain-object snapshot of all entries. */
+  /** Return a deep-copied plain-object snapshot of all observable entries. */
   snapshot(): Record<string, unknown> {
-    return structuredClone(Object.fromEntries(this.map));
+    this.assertOpen();
+    const snapshot: Record<string, unknown> = {};
+    for (const write of this.allWrites().sort((left, right) => left.version - right.version)) {
+      snapshot[write.key] = write.value;
+    }
+    return structuredClone(snapshot);
   }
 
-  /**
-   * Extract and clear the write delta accumulated for `deltaKey`.
-   * Called after an agent completes to get the set of keys it wrote.
-   */
+  /** Inspect an attempt's final per-key values without making it irrevocable. */
+  prepareDelta(deltaKey: string): StoreDelta {
+    this.assertOpen();
+    return this.deltaFromWrites(this.agentDeltas.get(deltaKey) ?? []);
+  }
+
+  /** Confirm an agent's writes and return its per-key final delta. */
   commitDelta(deltaKey: string): Record<string, unknown> {
-    const delta = this.agentDeltas.get(deltaKey) ?? {};
+    this.assertOpen();
+    const delta = this.prepareDelta(deltaKey);
+    for (const write of this.agentDeltas.get(deltaKey) ?? []) write.committed = true;
     this.agentDeltas.delete(deltaKey);
-    return delta;
+    this.closedDeltas.add(deltaKey);
+    return delta.values;
   }
 
-  /**
-   * Apply a write delta additively — sets each key without clearing others.
-   * Used during resume replay so parallel-agent deltas applied in callSeq
-   * order accumulate correctly regardless of original completion order.
-   */
-  applyDelta(delta: Record<string, unknown>): void {
-    for (const [k, v] of Object.entries(delta)) {
-      this.map.set(k, v);
+  /** Remove every still-uncommitted write made by a failed agent attempt. */
+  discardDelta(deltaKey: string): void {
+    this.assertOpen();
+    const discarded = this.agentDeltas.get(deltaKey) ?? [];
+    const discardedSet = new Set(discarded.filter((write) => !write.committed));
+    if (discardedSet.size > 0) this.writes = this.writes.filter((write) => !discardedSet.has(write));
+    this.agentDeltas.delete(deltaKey);
+    this.closedDeltas.add(deltaKey);
+  }
+
+  /** Create a child-scoped overlay whose writes are atomic at workflow success. */
+  createChildScope(): SharedStore {
+    this.assertOpen();
+    return new SharedStore(this);
+  }
+
+  /** Inspect this child's committed writes without exposing them to its parent. */
+  prepareChildScope(): StoreDelta {
+    this.assertOpen();
+    if (!this.parent) throw new Error("Only child-scoped stores can be committed");
+    return this.deltaFromWrites(this.writes.filter((write) => write.committed));
+  }
+
+  /** Commit a previously prepared child delta to its parent. */
+  commitChildScope(delta = this.prepareChildScope()): Record<string, unknown> {
+    this.assertOpen();
+    if (!this.parent) throw new Error("Only child-scoped stores can be committed");
+    this.parent.applyDelta(delta.values, delta.versions);
+    return delta.values;
+  }
+
+  /** Apply a committed replay delta additively, retaining captured write versions. */
+  applyDelta(delta: Record<string, unknown>, versions?: Record<string, number>): void {
+    this.assertOpen();
+    const entries = Object.entries(delta);
+    for (const [key] of entries) {
+      validateStoreKey(key);
+      const version = versions?.[key];
+      if (version !== undefined && (!Number.isSafeInteger(version) || version < 0)) {
+        throw new TypeError(`invalid shared-store write version for key: ${key}`);
+      }
+    }
+    for (const [key, value] of entries) {
+      const version = versions?.[key];
+      this.appendCommitted(key, value, version ?? ++this.clock.nextVersion);
     }
   }
 
-  /**
-   * Replace all entries with a snapshot (for full resets).
-   * Prefer `applyDelta` for resume replay — see journal integration above.
-   */
+  /** Replace all local entries with a committed snapshot. */
   restore(snap: Record<string, unknown>): void {
-    this.map.clear();
-    for (const [k, v] of Object.entries(snap)) {
-      this.map.set(k, v);
-    }
+    this.assertOpen();
+    this.writes = [];
+    this.agentDeltas.clear();
+    this.closedDeltas.clear();
+    this.applyDelta(snap);
   }
 
-  /** Clear all entries (called when the run ends). */
+  /** Permanently close this scope and clear all local entries and attempt tracking. */
   dispose(): void {
-    this.map.clear();
+    if (this.disposed) return;
+    this.disposed = true;
+    this.writes = [];
     this.agentDeltas.clear();
+    this.closedDeltas.clear();
+  }
+
+  private assertOpen(): void {
+    if (this.disposed) throw new Error("shared store is disposed");
+  }
+
+  private appendCommitted(key: string, value: unknown, version: number): void {
+    this.assertOpen();
+    this.clock.nextVersion = Math.max(this.clock.nextVersion, version);
+    this.writes.push({ key, value, version, committed: true });
+  }
+
+  private latestWrite(key: string, deltaKey?: string): StoreWrite | undefined {
+    this.assertOpen();
+    let latest = this.parent?.latestWrite(key);
+    for (const write of this.writes) {
+      if (!write.committed && write.deltaKey !== deltaKey) continue;
+      if (write.key === key && (!latest || write.version > latest.version)) latest = write;
+    }
+    return latest;
+  }
+
+  private allWrites(): StoreWrite[] {
+    this.assertOpen();
+    return [...(this.parent?.allWrites() ?? []), ...this.writes.filter((write) => write.committed)];
+  }
+
+  private deltaFromWrites(writes: StoreWrite[]): StoreDelta {
+    this.assertOpen();
+    const latestByKey = new Map<string, StoreWrite>();
+    for (const write of writes) {
+      const current = latestByKey.get(write.key);
+      if (!current || write.version > current.version) latestByKey.set(write.key, write);
+    }
+    const values: Record<string, unknown> = {};
+    const versions: Record<string, number> = {};
+    for (const write of [...latestByKey.values()].sort((left, right) => left.version - right.version)) {
+      values[write.key] = write.value;
+      versions[write.key] = write.version;
+    }
+    return { values, versions };
   }
 }
 
@@ -177,7 +294,7 @@ export function createAgentStoreTools(store: SharedStore, deltaKey: string): Too
     name: "store_put",
     label: "Store Put",
     description:
-      "Write a value to the shared run store. Any other agent in this workflow run can read it with store_get. Overwrites any existing value for the key. Note: when two parallel agents write the same key, the last write wins — no merge is performed.",
+      "Write a value to this agent attempt's shared-store scope. The value becomes visible to other agents only after this attempt commits.",
     promptSnippet: "Write a value to the shared store",
     parameters: Type.Object({
       key: Type.String({ description: "The key to store the value under." }),
@@ -196,14 +313,14 @@ export function createAgentStoreTools(store: SharedStore, deltaKey: string): Too
     name: "store_get",
     label: "Store Get",
     description:
-      "Read a value from the shared run store previously written by store_put. Returns the stored value, or null when the key does not exist.",
+      "Read committed shared-store state plus values written by this agent attempt. Returns null when the key does not exist.",
     promptSnippet: "Read a value from the shared store",
     parameters: Type.Object({
       key: Type.String({ description: "The key to read." }),
     }),
     async execute(_id: string, params: { key: string }) {
-      const found = store.has(params.key);
-      const value = store.get(params.key);
+      const found = store.has(params.key, deltaKey);
+      const value = store.get(params.key, deltaKey);
       const text = found
         ? `Value for key "${params.key}": ${JSON.stringify(value)}`
         : `Key "${params.key}" not found in store.`;

--- a/src/structured-output.ts
+++ b/src/structured-output.ts
@@ -1,14 +1,95 @@
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { Static, TSchema } from "typebox";
 
+export type LiteralJsonPrimitive = string | number | boolean | null;
+
+type LiteralSchemaMetadata = {
+  readonly description?: string;
+};
+
+/** Plain, readonly-friendly JSON Schema subset accepted in workflow scripts. */
+export type LiteralJsonSchema = LiteralSchemaMetadata &
+  (
+    | {
+        readonly enum: readonly LiteralJsonPrimitive[];
+        readonly type?: "string" | "number" | "integer" | "boolean" | "null";
+      }
+    | {
+        readonly type: "object";
+        readonly properties?: Readonly<Record<string, LiteralJsonSchema>>;
+        readonly required?: readonly string[];
+        readonly additionalProperties?: boolean;
+      }
+    | {
+        readonly type: "array";
+        readonly items: LiteralJsonSchema;
+      }
+    | { readonly type: "string" | "number" | "integer" | "boolean" | "null" }
+  );
+
+export type WorkflowSchema = TSchema | LiteralJsonSchema;
+
+type LiteralRequiredKeys<
+  TSchemaDef,
+  TProperties extends Readonly<Record<string, LiteralJsonSchema>>,
+> = TSchemaDef extends { readonly required: readonly (infer TRequired)[] }
+  ? Extract<TRequired, keyof TProperties>
+  : never;
+
+type LiteralObjectOutput<TSchemaDef, TProperties extends Readonly<Record<string, LiteralJsonSchema>>> = {
+  -readonly [TKey in LiteralRequiredKeys<TSchemaDef, TProperties>]-?: LiteralSchemaOutput<TProperties[TKey]>;
+} & {
+  -readonly [TKey in Exclude<keyof TProperties, LiteralRequiredKeys<TSchemaDef, TProperties>>]?: LiteralSchemaOutput<
+    TProperties[TKey]
+  >;
+};
+
+export type LiteralSchemaOutput<TSchemaDef> = TSchemaDef extends {
+  readonly enum: readonly (infer TValue)[];
+}
+  ? TValue
+  : TSchemaDef extends {
+        readonly type: "object";
+        readonly properties: infer TProperties extends Readonly<Record<string, LiteralJsonSchema>>;
+      }
+    ? LiteralObjectOutput<TSchemaDef, TProperties>
+    : TSchemaDef extends { readonly type: "object" }
+      ? Record<string, unknown>
+      : TSchemaDef extends { readonly type: "array"; readonly items: infer TItems }
+        ? LiteralSchemaOutput<TItems>[]
+        : TSchemaDef extends { readonly type: "string" }
+          ? string
+          : TSchemaDef extends { readonly type: "number" | "integer" }
+            ? number
+            : TSchemaDef extends { readonly type: "boolean" }
+              ? boolean
+              : TSchemaDef extends { readonly type: "null" }
+                ? null
+                : unknown;
+
+export type SchemaOutput<TSchemaDef extends WorkflowSchema> = TSchemaDef extends {
+  readonly "~unsafe": unknown;
+}
+  ? Static<Extract<TSchemaDef, TSchema>>
+  : TSchemaDef extends { readonly "~kind": string }
+    ? Static<Extract<TSchemaDef, TSchema>>
+    : LiteralSchemaOutput<TSchemaDef>;
+
 export interface StructuredOutputCapture<T = unknown> {
   value: T | undefined;
   called: boolean;
 }
 
+/** Upstream TypeBox options contract. Keep this generic exact. */
 export interface StructuredOutputToolOptions<TSchemaDef extends TSchema> {
   schema: TSchemaDef;
   capture: StructuredOutputCapture<Static<TSchemaDef>>;
+  name?: string;
+}
+
+export interface LiteralStructuredOutputToolOptions<TSchemaDef extends LiteralJsonSchema> {
+  schema: TSchemaDef extends { readonly "~kind": string } ? never : TSchemaDef;
+  capture: StructuredOutputCapture<LiteralSchemaOutput<TSchemaDef>>;
   name?: string;
 }
 
@@ -19,11 +100,21 @@ export interface StructuredOutputToolOptions<TSchemaDef extends TSchema> {
  * `terminate: true` lets the subagent finish on this tool call without paying for
  * an extra assistant follow-up turn.
  */
-export function createStructuredOutputTool<TSchemaDef extends TSchema>({
+export function createStructuredOutputTool<const TSchemaDef extends LiteralJsonSchema>(
+  options: LiteralStructuredOutputToolOptions<TSchemaDef>,
+): ToolDefinition<TSchema, LiteralSchemaOutput<TSchemaDef>>;
+export function createStructuredOutputTool<TSchemaDef extends TSchema>(
+  options: StructuredOutputToolOptions<TSchemaDef>,
+): ToolDefinition<TSchemaDef, Static<TSchemaDef>>;
+export function createStructuredOutputTool({
   schema,
   capture,
   name = "structured_output",
-}: StructuredOutputToolOptions<TSchemaDef>): ToolDefinition<TSchemaDef, Static<TSchemaDef>> {
+}: {
+  schema: WorkflowSchema;
+  capture: StructuredOutputCapture<unknown>;
+  name?: string;
+}): ToolDefinition<TSchema, unknown> {
   return defineTool({
     name,
     label: "Structured Output",
@@ -33,7 +124,9 @@ export function createStructuredOutputTool<TSchemaDef extends TSchema>({
       `${name} is the final answer channel for this task; call ${name} exactly once when done.`,
       `Do not write a prose final answer after calling ${name}.`,
     ],
-    parameters: schema,
+    // Pi and TypeBox's value helpers accept this JSON-Schema subset at runtime;
+    // the cast bridges TypeBox's symbol-bearing compile-time TSchema interface.
+    parameters: schema as TSchema,
     async execute(_toolCallId, params) {
       capture.value = params;
       capture.called = true;

--- a/src/workflow-commands.ts
+++ b/src/workflow-commands.ts
@@ -17,6 +17,7 @@ import type { PersistedRunState } from "./run-persistence.js";
 import { registerSavedWorkflow } from "./saved-commands.js";
 import { buildForcedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "./workflow-editor.js";
 import type { WorkflowManager } from "./workflow-manager.js";
+import { formatWorkflowReport } from "./workflow-report.js";
 import type { WorkflowStorage } from "./workflow-saved.js";
 import { openWorkflowNavigator } from "./workflow-ui.js";
 
@@ -30,7 +31,7 @@ const STATUS_ICON: Record<string, string> = {
 };
 
 const USAGE =
-  "Usage: /workflows [list] | run <prompt> | status <id> | watch <id> | stop <id> | pause <id> | resume <id> | rm <id> | save <name> [runId]";
+  "Usage: /workflows [list] | run <prompt> | status <id> | report <id> | watch <id> | stop <id> | pause <id> | resume <id> | rm <id> | save <name> [runId]";
 
 const RUN_USAGE = "Usage: /workflows run <prompt> — force a dynamic workflow from the prompt";
 
@@ -135,7 +136,7 @@ export function registerWorkflowCommands(
 
   pi.registerCommand("workflows", {
     description:
-      "Manage workflow runs — no args (opens navigator) | run <prompt> | status/stop/pause/resume <id> | rm <id> | save <name> [runId]",
+      "Manage workflow runs — no args (opens navigator) | run <prompt> | status/report/stop/pause/resume <id> | rm <id> | save <name> [runId]",
     async handler(args: string, ctx: ExtensionCommandContext) {
       const parts = args.trim().split(/\s+/).filter(Boolean);
       const sub = (parts[0] ?? "list").toLowerCase();
@@ -194,6 +195,25 @@ export function registerWorkflowCommands(
             return;
           }
           await print(["Workflow runs:", ...runs.map(summarizeRun), "", USAGE].join("\n"));
+          return;
+        }
+        case "report": {
+          if (!id) {
+            ctx.ui.notify(USAGE, "warning");
+            return;
+          }
+          let run: PersistedRunState | null;
+          try {
+            run = manager.getRunForReport(id);
+          } catch {
+            ctx.ui.notify("Invalid workflow run ID", "error");
+            return;
+          }
+          if (!run) {
+            ctx.ui.notify(`No workflow run "${id}"`, "error");
+            return;
+          }
+          await print(formatWorkflowReport(run));
           return;
         }
         case "watch":

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -5,17 +5,27 @@
 import { EventEmitter } from "node:events";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { WorkflowAgent } from "./agent.js";
+import { MAX_AGENT_RETRIES, MAX_AGENTS_PER_RUN, MAX_CONCURRENCY } from "./config.js";
 import { preview, type WorkflowSnapshot } from "./display.js";
 import { WorkflowError, WorkflowErrorCode } from "./errors.js";
+import { normalizeJsonTree } from "./json-value.js";
 import {
   createRunPersistence,
   generateRunId,
+  type PersistedExecutionPolicy,
   type PersistedRunState,
   type RunLease,
   type RunPersistence,
   type RunStatus,
 } from "./run-persistence.js";
-import { type JournalEntry, parseWorkflowScript, runWorkflow, type WorkflowRunResult } from "./workflow.js";
+import {
+  type AgentTypePolicy,
+  type JournalEntry,
+  parseWorkflowScript,
+  runWorkflow,
+  type WorkflowRunResult,
+  type WorkflowTokenUsage,
+} from "./workflow.js";
 
 export interface ManagedRun {
   runId: string;
@@ -28,10 +38,26 @@ export interface ManagedRun {
   /** The real script, kept so the run can be resumed. */
   script: string;
   args?: unknown;
+  /** Effective policy for this run; persisted so cold resume keeps strict overrides. */
+  agentTypePolicy: AgentTypePolicy;
+  /** Effective execution cwd and limits, persisted for cold resume. */
+  executionPolicy: PersistedExecutionPolicy;
+  /** Monotonic in-process generation used to reject stale persistence writes. */
+  generation: number;
+  /** Settlement of the currently active generation, including its final persistence write. */
+  settlement?: Promise<void>;
+  /** Bounded cancellation cleanup shared by pause/stop/resume. */
+  cancellationSettlement?: Promise<boolean>;
   /** Accumulated agent results for resume (deterministic call index -> result). */
   journal: JournalEntry[];
   /** Cross-process execution lease for this run, when it is actively executing. */
   lease?: RunLease;
+  /** Prevent stale execution settlement from releasing the lease before durable cleanup is safe. */
+  leaseReleaseBlocked?: boolean;
+  /** True when durable cleanup must remove the run rather than save an aborted marker. */
+  deletionRequested?: boolean;
+  /** Eventual retry loop that retains the lease until durable cleanup succeeds. */
+  durableCleanupSettlement?: Promise<void>;
   /**
    * True when the run was started in the background (or resumed) and the caller is
    * not awaiting its result inline. Only background runs deliver their result back
@@ -65,6 +91,10 @@ export interface ExecOptions {
   concurrency?: number;
   /** Retry attempts after recoverable agent failures for this execution. */
   agentRetries?: number;
+  /** Unknown explicit agentType behavior. Default: manager policy, then fallback. */
+  agentTypePolicy?: AgentTypePolicy;
+  /** Per-run execution cwd. Defaults to the manager construction cwd. */
+  cwd?: string;
   /** Resolve a checkpoint() question with a human reply (only for UI-bearing runs). */
   confirm?: (promptText: string, options: unknown) => Promise<unknown>;
   /**
@@ -97,15 +127,64 @@ export interface WorkflowManagerOptions {
   defaultAgentTimeoutMs?: number | null;
   /** Default retry attempts after recoverable agent failures. */
   defaultAgentRetries?: number;
+  /** Unknown explicit agentType behavior. Default: "fallback". */
+  agentTypePolicy?: AgentTypePolicy;
   /**
    * Persist each subagent transcript as a real pi session file under the
    * standard sessions directory. Default false (in-memory, discarded).
    */
   persistAgentSessions?: boolean;
+  /** Exact, case-insensitive symbolic model aliases from effective workflow settings. */
+  modelAliases?: Record<string, string>;
+  /** Reject unresolved requested model specs. */
+  strictModelResolution?: boolean;
+  /**
+   * Maximum time pause/stop/delete waits for an abort-ignoring generation before
+   * invalidating it and durably making it non-resumable. Default: 5 seconds.
+   */
+  cancellationGraceMs?: number;
+}
+
+export const DEFAULT_CANCELLATION_GRACE_MS = 5_000;
+
+const UNSAFE_MERGE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isSafePlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return false;
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== "string" || UNSAFE_MERGE_KEYS.has(key)) return false;
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor?.enumerable || !("value" in descriptor)) return false;
+  }
+  return true;
+}
+
+function resumeValidationError(message: string): WorkflowError {
+  return new WorkflowError(message, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, { recoverable: false });
+}
+
+export interface ResumeOptions {
+  script?: string;
+  args?: unknown;
+  argsPatch?: Record<string, unknown>;
+}
+
+function normalizeConcurrency(value: number): number {
+  if (!Number.isFinite(value) || value < 1) return 1;
+  return Math.min(MAX_CONCURRENCY, Math.floor(value));
+}
+
+function normalizeRetries(value: number): number {
+  if (!Number.isFinite(value) || value < 0) return 0;
+  return Math.min(MAX_AGENT_RETRIES, Math.floor(value));
 }
 
 export class WorkflowManager extends EventEmitter {
   private runs = new Map<string, ManagedRun>();
+  /** Run ids deleted while an execution may still be unwinding. */
+  private deletedRunIds = new Set<string>();
   private persistence: RunPersistence;
   private cwd: string;
   private concurrency: number;
@@ -119,7 +198,11 @@ export class WorkflowManager extends EventEmitter {
   private sessionId?: string;
   private defaultAgentTimeoutMs: number | null;
   private defaultAgentRetries: number;
+  private agentTypePolicy: AgentTypePolicy;
   private persistAgentSessions: boolean;
+  private modelAliases?: Record<string, string>;
+  private strictModelResolution: boolean;
+  private cancellationGraceMs: number;
 
   constructor(options: WorkflowManagerOptions = {}) {
     super();
@@ -132,7 +215,11 @@ export class WorkflowManager extends EventEmitter {
     this.sessionId = options.sessionId;
     this.defaultAgentTimeoutMs = options.defaultAgentTimeoutMs ?? null;
     this.defaultAgentRetries = options.defaultAgentRetries ?? 0;
+    this.agentTypePolicy = options.agentTypePolicy ?? "fallback";
     this.persistAgentSessions = options.persistAgentSessions ?? false;
+    this.modelAliases = options.modelAliases ? { ...options.modelAliases } : undefined;
+    this.strictModelResolution = options.strictModelResolution ?? false;
+    this.cancellationGraceMs = Math.max(1, Math.floor(options.cancellationGraceMs ?? DEFAULT_CANCELLATION_GRACE_MS));
     this.persistence = createRunPersistence(this.cwd);
     this.recoverStaleRuns();
   }
@@ -185,6 +272,156 @@ export class WorkflowManager extends EventEmitter {
     return this.modelRegistry;
   }
 
+  private resolveExecutionPolicy(exec: ExecOptions = {}, legacy?: PersistedRunState): PersistedExecutionPolicy {
+    const persisted = legacy?.executionPolicy;
+    if (persisted) return { ...persisted };
+    const cwd = exec.cwd ?? legacy?.cwd ?? this.cwd;
+    return {
+      cwd,
+      maxAgents: exec.maxAgents ?? MAX_AGENTS_PER_RUN,
+      agentTimeoutMs: exec.agentTimeoutMs !== undefined ? exec.agentTimeoutMs : this.defaultAgentTimeoutMs,
+      tokenBudget: exec.tokenBudget ?? null,
+      concurrency: normalizeConcurrency(exec.concurrency ?? this.concurrency),
+      agentRetries: normalizeRetries(exec.agentRetries ?? this.defaultAgentRetries),
+      agentTypePolicy: exec.agentTypePolicy ?? legacy?.agentTypePolicy ?? this.agentTypePolicy,
+    };
+  }
+
+  private trackExecution<T>(managed: ManagedRun, execution: Promise<T>): Promise<T> {
+    managed.settlement = execution.then(
+      () => undefined,
+      () => undefined,
+    );
+    return execution;
+  }
+
+  private ownsGeneration(managed: ManagedRun, generation: number): boolean {
+    return (
+      !this.deletedRunIds.has(managed.runId) &&
+      this.runs.get(managed.runId) === managed &&
+      managed.generation === generation
+    );
+  }
+
+  private settlementWithinGrace(settlement: Promise<void>): Promise<boolean> {
+    return new Promise((resolve) => {
+      let finished = false;
+      const timer = setTimeout(() => {
+        if (finished) return;
+        finished = true;
+        resolve(false);
+      }, this.cancellationGraceMs);
+      timer.unref?.();
+      settlement.then(() => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timer);
+        resolve(true);
+      });
+    });
+  }
+
+  /** Verify that persistence reflects the requested lifecycle state before releasing its lease. */
+  private durableCancellationCleanupIsSafe(managed: ManagedRun): boolean {
+    try {
+      const persisted = this.persistence.load(managed.runId);
+      if (managed.deletionRequested) return persisted === null;
+      if (managed.status === "paused") return persisted?.status === "paused";
+      return persisted === null || persisted.status === "aborted";
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Keep retrying the requested lifecycle marker/deletion while retaining the
+   * lease. A legitimate pause is never deleted as a persistence fallback because
+   * that would silently destroy resumability. An aborted run (stop or cancellation
+   * timeout) may fall back to deletion because both outcomes are non-resumable.
+   */
+  private retainLeaseUntilDurableCleanup(managed: ManagedRun): void {
+    managed.leaseReleaseBlocked = true;
+    if (managed.durableCleanupSettlement) return;
+
+    let attempt = () => {};
+    const settlement = new Promise<void>((resolve) => {
+      attempt = () => {
+        try {
+          if (managed.deletionRequested) {
+            this.persistence.delete(managed.runId, { preserveLock: true });
+          } else if (managed.status === "paused") {
+            this.persistRun(managed, true);
+          } else {
+            try {
+              this.persistRun(managed, true);
+            } catch {
+              this.persistence.delete(managed.runId, { preserveLock: true });
+            }
+          }
+        } catch {
+          // Verification below keeps the lease when cleanup remains unsafe.
+        }
+
+        if (this.durableCancellationCleanupIsSafe(managed)) {
+          managed.durableCleanupSettlement = undefined;
+          managed.leaseReleaseBlocked = false;
+          this.releaseRunLease(managed);
+          resolve();
+          return;
+        }
+
+        const timer = setTimeout(attempt, Math.min(this.cancellationGraceMs, 100));
+        timer.unref?.();
+      };
+    });
+    managed.durableCleanupSettlement = settlement;
+    attempt();
+  }
+
+  /**
+   * Bound cancellation settlement, but release paused/stopped/deleted runs only
+   * after persistence reflects a safe lifecycle marker. Failed pause writes keep
+   * retrying the paused marker; failed stop/delete cleanup retains the lease so a
+   * second process cannot recover or resume stale state.
+   */
+  private scheduleCancellationCleanup(managed: ManagedRun): Promise<boolean> {
+    const requiresDurableCleanup =
+      managed.deletionRequested || managed.status === "paused" || managed.status === "aborted";
+    if (requiresDurableCleanup && managed.lease) managed.leaseReleaseBlocked = true;
+    if (managed.cancellationSettlement) {
+      if (requiresDurableCleanup) {
+        void managed.cancellationSettlement.then(() => this.retainLeaseUntilDurableCleanup(managed));
+      }
+      return managed.cancellationSettlement;
+    }
+    const generation = managed.generation;
+    const settlement = managed.settlement;
+    if (!settlement) {
+      if (requiresDurableCleanup) this.retainLeaseUntilDurableCleanup(managed);
+      else this.releaseRunLease(managed);
+      return Promise.resolve(true);
+    }
+    managed.cancellationSettlement = this.settlementWithinGrace(settlement).then((settled) => {
+      if (settled) {
+        if (requiresDurableCleanup) this.retainLeaseUntilDurableCleanup(managed);
+        return true;
+      }
+      if (this.ownsGeneration(managed, generation)) {
+        managed.leaseReleaseBlocked = true;
+        managed.generation++;
+        managed.status = "aborted";
+        managed.error = new WorkflowError(
+          `Workflow cancellation did not settle within ${this.cancellationGraceMs}ms; the run was aborted and cannot be resumed safely.`,
+          WorkflowErrorCode.WORKFLOW_ABORTED,
+          { recoverable: false },
+        );
+      }
+      this.retainLeaseUntilDurableCleanup(managed);
+      return false;
+    });
+    return managed.cancellationSettlement;
+  }
+
   /**
    * Start a workflow in the background.
    * Returns immediately with a run ID; the workflow executes asynchronously.
@@ -195,6 +432,7 @@ export class WorkflowManager extends EventEmitter {
     exec: ExecOptions = {},
   ): { runId: string; promise: Promise<WorkflowRunResult> } {
     const parsed = parseWorkflowScript(script);
+    const executionPolicy = this.resolveExecutionPolicy(exec);
     const slug = parsed.meta.name
       ? parsed.meta.name
           .toLowerCase()
@@ -225,6 +463,9 @@ export class WorkflowManager extends EventEmitter {
       startedAt: new Date(),
       script,
       args,
+      agentTypePolicy: executionPolicy.agentTypePolicy,
+      executionPolicy,
+      generation: 1,
       journal: [],
       background: true,
       lease,
@@ -234,21 +475,7 @@ export class WorkflowManager extends EventEmitter {
     this.runs.set(runId, managed);
 
     try {
-      // Persist initial state
-      this.persistence.save({
-        runId,
-        workflowName: parsed.meta.name,
-        script,
-        args,
-        sessionId: this.sessionId,
-        status: "running",
-        phases: managed.snapshot.phases,
-        agents: [],
-        logs: [],
-        startedAt: managed.startedAt.toISOString(),
-        updatedAt: managed.startedAt.toISOString(),
-        autoResume: managed.autoResume,
-      });
+      this.persistRun(managed, true);
     } catch (err) {
       this.releaseRunLease(managed);
       this.runs.delete(runId);
@@ -260,7 +487,7 @@ export class WorkflowManager extends EventEmitter {
     // when a workflow is aborted/paused/stopped — executeRun()'s catch block
     // already records status/event/persist, but the promise still rejects.
     // The original promise is returned so callers can await it in try/catch.
-    const promise = this.executeRun(managed, script, args, exec);
+    const promise = this.trackExecution(managed, this.executeRun(managed, script, args, exec));
     promise.catch(() => {});
 
     return { runId, promise };
@@ -273,7 +500,8 @@ export class WorkflowManager extends EventEmitter {
    * a caller (e.g. the workflow tool) drive its own inline display.
    */
   async runSync(script: string, args?: unknown, exec: ExecOptions = {}): Promise<WorkflowRunResult> {
-    const managed = this.createManaged(script, args);
+    const executionPolicy = this.resolveExecutionPolicy(exec);
+    const managed = this.createManaged(script, args, executionPolicy);
     const lease = this.persistence.acquireRunLease(managed.runId);
     if (!lease) throw new Error(`Could not acquire workflow run lease for ${managed.runId}`);
     managed.lease = lease;
@@ -282,11 +510,11 @@ export class WorkflowManager extends EventEmitter {
     // Persist the initial state immediately so listRuns()/the task panel can see
     // the run the moment it starts, not only after the first agent journals.
     this.persistRun(managed);
-    return this.executeRun(managed, script, args, exec);
+    return this.trackExecution(managed, this.executeRun(managed, script, args, exec));
   }
 
   /** Build a fresh managed run with an empty snapshot. */
-  private createManaged(script: string, args?: unknown): ManagedRun {
+  private createManaged(script: string, args: unknown, executionPolicy: PersistedExecutionPolicy): ManagedRun {
     const parsed = parseWorkflowScript(script);
     const slug = parsed.meta.name
       ? parsed.meta.name
@@ -314,6 +542,9 @@ export class WorkflowManager extends EventEmitter {
       startedAt: new Date(),
       script,
       args,
+      agentTypePolicy: executionPolicy.agentTypePolicy,
+      executionPolicy,
+      generation: 1,
       journal: [],
       background: false,
     };
@@ -325,21 +556,17 @@ export class WorkflowManager extends EventEmitter {
     args?: unknown,
     exec: ExecOptions = {},
   ): Promise<WorkflowRunResult> {
-    const {
-      resumeJournal,
-      maxAgents,
-      agentTimeoutMs,
-      externalSignal,
-      onProgress,
-      tokenBudget,
-      concurrency,
-      agentRetries,
-      confirm,
-    } = exec;
-    const resolvedAgentTimeoutMs = agentTimeoutMs !== undefined ? agentTimeoutMs : this.defaultAgentTimeoutMs;
-    const resolvedConcurrency = concurrency ?? this.concurrency;
-    const resolvedAgentRetries = agentRetries ?? this.defaultAgentRetries;
+    const { resumeJournal, externalSignal, onProgress, confirm } = exec;
+    const generation = managed.generation;
+    const owns = () => this.ownsGeneration(managed, generation);
+    const policy = managed.executionPolicy;
     const progress = () => onProgress?.(managed.snapshot);
+    const updateTokenUsage = (usage: WorkflowTokenUsage) => {
+      if (!owns()) return;
+      managed.snapshot.tokenUsage = usage;
+      this.emit("tokenUsage", { runId: managed.runId, usage });
+      progress();
+    };
     // Let a host abort (e.g. Esc during a blocking tool call) cancel this run.
     if (externalSignal) {
       if (externalSignal.aborted) managed.controller.abort();
@@ -347,7 +574,7 @@ export class WorkflowManager extends EventEmitter {
     }
     try {
       const result = await runWorkflow(script, {
-        cwd: this.cwd,
+        cwd: policy.cwd,
         args,
         // Use the managed run's persisted id as the workflow runId so the value
         // returned in result.runId matches the id that listRuns()/resume() use.
@@ -358,28 +585,41 @@ export class WorkflowManager extends EventEmitter {
         mainModel: this.mainModel,
         modelRegistry: this.modelRegistry,
         persistAgentSessions: this.persistAgentSessions,
+        modelAliases: this.modelAliases,
+        strictModelResolution: this.strictModelResolution,
         signal: managed.controller.signal,
-        concurrency: resolvedConcurrency,
-        agentRetries: resolvedAgentRetries,
-        maxAgents,
-        agentTimeoutMs: resolvedAgentTimeoutMs,
-        tokenBudget,
+        concurrency: policy.concurrency,
+        agentRetries: policy.agentRetries,
+        agentTypePolicy: policy.agentTypePolicy,
+        maxAgents: policy.maxAgents,
+        agentTimeoutMs: policy.agentTimeoutMs,
+        tokenBudget: policy.tokenBudget,
+        initialTokenUsage: resumeJournal ? managed.snapshot.tokenUsage : undefined,
         confirm,
         loadSavedWorkflow: this.loadSavedWorkflow,
         resumeJournal,
         resumeFromRunId: resumeJournal ? managed.runId : undefined,
         onAgentJournal: (entry) => {
-          // Append (crash-safe-ish): keep the latest entry per index, then persist.
-          managed.journal = managed.journal.filter((e) => e.index !== entry.index);
-          managed.journal.push(entry);
-          this.persistRun(managed);
+          if (!owns()) return;
+          // The store commits only after this callback returns. Require the journal
+          // write and restore the in-memory journal if persistence fails.
+          const previous = managed.journal;
+          managed.journal = [...managed.journal.filter((e) => e.index !== entry.index), entry];
+          try {
+            this.persistRun(managed, true);
+          } catch (error) {
+            managed.journal = previous;
+            throw error;
+          }
         },
         onLog: (message) => {
+          if (!owns()) return;
           managed.snapshot.logs.push(message);
           this.emit("log", { runId: managed.runId, message });
           progress();
         },
         onPhase: (title) => {
+          if (!owns()) return;
           managed.snapshot.currentPhase = title;
           if (!managed.snapshot.phases.includes(title)) {
             managed.snapshot.phases.push(title);
@@ -388,8 +628,10 @@ export class WorkflowManager extends EventEmitter {
           progress();
         },
         onAgentStart: (event) => {
+          if (!owns()) return;
           managed.snapshot.agents.push({
             id: managed.snapshot.agents.length + 1,
+            callId: event.callId,
             label: event.label,
             phase: event.phase,
             prompt: event.prompt,
@@ -400,39 +642,53 @@ export class WorkflowManager extends EventEmitter {
           progress();
         },
         onAgentEnd: (event) => {
+          if (!owns()) return;
           const agent = [...managed.snapshot.agents]
             .reverse()
-            .find((a) => a.label === event.label && a.status === "running");
+            .find(
+              (candidate) =>
+                candidate.status === "running" &&
+                (event.callId ? candidate.callId === event.callId : candidate.label === event.label),
+            );
           if (agent) {
-            agent.status = event.result === null ? "error" : "done";
+            const hasErrorMetadata = event.error !== undefined || event.errorCode !== undefined;
+            agent.status = hasErrorMetadata ? "error" : "done";
             agent.resultPreview = preview(event.result);
             agent.error = event.error;
             agent.errorCode = event.errorCode;
             agent.recoverable = event.recoverable;
             agent.tokens = event.tokens;
             if (event.tokenUsage) agent.tokenUsage = event.tokenUsage;
+            agent.telemetry = event.telemetry;
             if (event.model) agent.model = event.model;
           }
           this.emit("agentEnd", { runId: managed.runId, ...event });
           progress();
         },
         onAgentHistory: (event) => {
+          if (!owns()) return;
           const agent = [...managed.snapshot.agents]
             .reverse()
-            .find((a) => a.label === event.label && a.status === "running");
+            .find(
+              (candidate) =>
+                candidate.status === "running" &&
+                (event.callId ? candidate.callId === event.callId : candidate.label === event.label),
+            );
           if (agent) {
             agent.history = event.history;
           }
           this.emit("agentHistory", { runId: managed.runId, ...event });
           progress();
         },
-        onTokenUsage: (usage) => {
-          managed.snapshot.tokenUsage = usage;
-          this.emit("tokenUsage", { runId: managed.runId, usage });
-          progress();
-        },
+        onTokenUsageProgress: updateTokenUsage,
+        onTokenUsage: updateTokenUsage,
       });
 
+      if (!owns()) {
+        throw new WorkflowError("Workflow generation no longer owns this run", WorkflowErrorCode.WORKFLOW_ABORTED, {
+          recoverable: false,
+        });
+      }
       managed.status = "completed";
       managed.result = result;
       this.emit("complete", { runId: managed.runId, result });
@@ -452,6 +708,11 @@ export class WorkflowManager extends EventEmitter {
               { recoverable: true },
             );
 
+      if (!owns()) {
+        this.releaseRunLease(managed);
+        throw workflowError;
+      }
+
       const usageLimitPaused =
         !managed.controller.signal.aborted && workflowError.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT;
       if (managed.controller.signal.aborted) {
@@ -464,6 +725,7 @@ export class WorkflowManager extends EventEmitter {
         // the persisted journal (completed agent results) is replayed by resume()
         // once the budget refills — instead of the user starting from scratch.
         managed.status = "paused";
+        managed.leaseReleaseBlocked = Boolean(managed.lease);
       } else {
         managed.status = "failed";
       }
@@ -475,13 +737,16 @@ export class WorkflowManager extends EventEmitter {
           error: workflowError,
           resetHint: workflowError.resetHint,
         });
-      } else {
+      } else if (this.listenerCount("error") > 0) {
         this.emit("error", { runId: managed.runId, error: workflowError });
       }
 
-      // Persist final state
+      // Persist final state. A usage-limit pause has no external cancellation
+      // cleanup callback, so it starts its own durable-marker retry before the
+      // execution lease can be released.
       this.persistRun(managed);
-      this.releaseRunLease(managed);
+      if (usageLimitPaused) this.retainLeaseUntilDurableCleanup(managed);
+      else this.releaseRunLease(managed);
 
       throw workflowError;
     }
@@ -489,11 +754,18 @@ export class WorkflowManager extends EventEmitter {
 
   private releaseRunLease(managed: ManagedRun): void {
     if (!managed.lease) return;
+    if (managed.leaseReleaseBlocked) {
+      if (!this.durableCancellationCleanupIsSafe(managed)) return;
+      managed.leaseReleaseBlocked = false;
+    }
     this.persistence.releaseRunLease(managed.lease);
     managed.lease = undefined;
   }
 
-  private persistRun(managed: ManagedRun) {
+  private persistRun(managed: ManagedRun, required = false) {
+    if (this.deletedRunIds.has(managed.runId)) return;
+    const current = this.runs.get(managed.runId);
+    if (current && current.generation !== managed.generation) return;
     try {
       this.persistence.save({
         runId: managed.runId,
@@ -502,6 +774,9 @@ export class WorkflowManager extends EventEmitter {
         // in workflow run storage — protect via directory permissions, not blanking.
         script: managed.script,
         args: managed.args,
+        cwd: managed.executionPolicy.cwd,
+        executionPolicy: managed.executionPolicy,
+        agentTypePolicy: managed.agentTypePolicy,
         sessionId: this.sessionId,
         journal: managed.journal,
         status: managed.status,
@@ -544,6 +819,7 @@ export class WorkflowManager extends EventEmitter {
         durationMs: managed.result?.durationMs,
       });
     } catch (err) {
+      if (required) throw err;
       // Persistence is best-effort: the run is still healthy in memory.
       // Log so an operator debugging state-loss has a lead, but never crash
       // the workflow over a disk-full situation.
@@ -560,79 +836,156 @@ export class WorkflowManager extends EventEmitter {
 
     managed.controller.abort();
     managed.status = "paused";
+    managed.leaseReleaseBlocked = Boolean(managed.lease);
     this.emit("paused", { runId });
     this.persistRun(managed);
-    this.releaseRunLease(managed);
+    // A normal pause remains resumable after settlement. The bounded cleanup
+    // invalidates an abort-ignoring generation and makes it durably non-resumable.
+    void this.scheduleCancellationCleanup(managed);
     return true;
   }
 
-  /**
-   * Resume an interrupted run: replay journaled results for the unchanged prefix
-   * and run the rest live. Returns false if there is nothing resumable.
-   *
-   * `opts.script` lets the orchestrating model resume with an EDITED script
-   * (cached-prefix reuse / iteration): unchanged agent() calls whose content
-   * hash still matches the journal entry at their positional callIndex replay
-   * from cache, while the first changed or newly inserted call — and everything
-   * after it — re-runs live. When `opts.script` is omitted, resume behaves
-   * exactly as before and uses the persisted script (auto-resume, TUI resume);
-   * this keeps the existing single-arg `resume(runId)` callers (e.g. the
-   * UsageLimitScheduler) unchanged. `opts.args` overrides the persisted args
-   * only when provided; otherwise the persisted args are kept.
-   */
-  async resume(runId: string, opts?: { script?: string; args?: unknown }): Promise<boolean> {
-    // Guard: refuse to resume a run that is already running, or one that was
-    // intentionally aborted (pause/stop/Esc). Paused and failed runs can restart.
-    const active = this.runs.get(runId);
-    if (active?.status === "running") return false;
-    if (active?.status === "aborted") return false;
+  /** Resume with the persisted input, an edited script/input replacement, or a safe shallow args patch. */
+  async resume(runId: string, options: ResumeOptions = {}): Promise<boolean> {
+    const hasArgs = Object.hasOwn(options, "args");
+    const hasArgsPatch = Object.hasOwn(options, "argsPatch");
+    if (hasArgs && hasArgsPatch) {
+      throw resumeValidationError("resume args and argsPatch are mutually exclusive");
+    }
+    if (hasArgsPatch && !isSafePlainObject(options.argsPatch)) {
+      throw resumeValidationError("resume argsPatch must be a safe plain object");
+    }
 
-    const persisted = this.persistence.load(runId);
-    if (!persisted?.script || persisted.status === "completed" || persisted.status === "aborted") return false;
+    const active = this.runs.get(runId);
+    if (active?.status === "running" || active?.status === "aborted") return false;
+    // A paused generation keeps exclusive ownership while it unwinds. This wait
+    // is bounded; timeout invalidates that generation and makes the run safely
+    // non-resumable instead of allowing overlap or hanging forever.
+    const settled = active?.cancellationSettlement
+      ? await active.cancellationSettlement
+      : active?.settlement
+        ? await this.settlementWithinGrace(active.settlement)
+        : true;
+    if (!settled) {
+      throw (
+        active?.error ??
+        new WorkflowError(
+          `Workflow cancellation did not settle within ${this.cancellationGraceMs}ms; the run cannot be resumed safely.`,
+          WorkflowErrorCode.WORKFLOW_ABORTED,
+          { recoverable: false },
+        )
+      );
+    }
+
+    // Acquire first, then reload every persisted field under the lease. This
+    // closes the status/script/args/journal/policy TOCTOU window between callers.
     const lease = this.persistence.acquireRunLease(runId);
     if (!lease) return false;
+    let leaseTransferred = false;
+    try {
+      const persisted = this.persistence.load(runId);
+      if (
+        !persisted?.script ||
+        persisted.status === "running" ||
+        persisted.status === "completed" ||
+        persisted.status === "aborted"
+      ) {
+        return false;
+      }
 
-    // Use the edited script when supplied, else the persisted one (backward-compat).
-    const script = opts?.script ?? persisted.script;
-    const args = opts?.args !== undefined ? opts.args : persisted.args;
+      let resumedArgs = hasArgs ? options.args : persisted.args;
+      if (hasArgsPatch) {
+        const argsPatch = options.argsPatch as Record<string, unknown>;
+        if (persisted.args !== undefined && !isSafePlainObject(persisted.args)) {
+          throw resumeValidationError("persisted workflow args are incompatible with argsPatch");
+        }
+        try {
+          const normalizedPatch = normalizeJsonTree(argsPatch) as Record<string, unknown>;
+          resumedArgs = normalizeJsonTree({
+            ...((persisted.args as Record<string, unknown> | undefined) ?? {}),
+            ...normalizedPatch,
+          });
+        } catch {
+          throw resumeValidationError("resume argsPatch must contain only plain JSON values");
+        }
+      }
 
-    const controller = new AbortController();
-    const managed: ManagedRun = {
-      runId,
-      status: "running",
-      snapshot: {
-        name: persisted.workflowName,
-        phases: persisted.phases ?? [],
-        logs: persisted.logs ?? [],
-        agents: [],
-        agentCount: 0,
-        runningCount: 0,
-        doneCount: 0,
-        errorCount: 0,
-      },
-      controller,
-      startedAt: new Date(),
-      // The (possibly edited) script + args become the run's own — persistRun()
-      // writes them below, so a later resume of this run sees the edited script.
-      script,
-      args,
-      journal: persisted.journal ?? [],
-      background: true,
-      lease,
-      // Carry the original opt-out forward across resumes; it's fixed at
-      // run-start and persistRun() re-persists it on every subsequent write.
-      autoResume: persisted.autoResume,
-    };
-    this.runs.set(runId, managed);
-    // Persist before notifying renderers: listRuns() is their source of truth for
-    // lifecycle status, while getRun() supplies the live in-memory snapshot.
-    this.persistRun(managed);
+      const script = options.script ?? persisted.script;
+      const parsed = parseWorkflowScript(script);
+      const executionPolicy = this.resolveExecutionPolicy({}, persisted);
+      const managed: ManagedRun = {
+        runId,
+        status: "running",
+        snapshot: {
+          name: parsed.meta.name,
+          phases: persisted.phases ?? [],
+          logs: persisted.logs ?? [],
+          agents: [],
+          agentCount: 0,
+          runningCount: 0,
+          doneCount: 0,
+          errorCount: 0,
+          tokenUsage: persisted.tokenUsage
+            ? {
+                input: persisted.tokenUsage.input,
+                output: persisted.tokenUsage.output,
+                total: persisted.tokenUsage.total,
+                cost: persisted.tokenUsage.cost,
+                cacheRead: persisted.tokenUsage.cacheRead,
+                cacheWrite: persisted.tokenUsage.cacheWrite,
+              }
+            : undefined,
+        },
+        controller: new AbortController(),
+        startedAt: new Date(),
+        script,
+        args: resumedArgs,
+        agentTypePolicy: executionPolicy.agentTypePolicy,
+        executionPolicy,
+        generation: (active?.generation ?? 0) + 1,
+        journal: persisted.journal ?? [],
+        background: true,
+        lease,
+        autoResume: persisted.autoResume,
+      };
+      this.runs.set(runId, managed);
+      try {
+        this.persistRun(managed, true);
+      } catch (error) {
+        if (active) this.runs.set(runId, active);
+        else this.runs.delete(runId);
+        throw error;
+      }
+      leaseTransferred = true;
 
-    const resumeJournal = new Map((persisted.journal ?? []).map((e) => [e.index, e] as const));
-    this.emit("resumed", { runId });
-    // Run in the background; executeRun records status/errors on the managed run.
-    void this.executeRun(managed, script, args, { resumeJournal }).catch(() => {});
-    return true;
+      const resumeJournal = new Map((persisted.journal ?? []).map((entry) => [entry.index, entry] as const));
+      this.emit("resumed", { runId });
+      const execution = this.trackExecution(managed, this.executeRun(managed, script, resumedArgs, { resumeJournal }));
+      execution.catch(() => {});
+      return true;
+    } finally {
+      if (!leaseTransferred) this.persistence.releaseRunLease(lease);
+    }
+  }
+
+  /** Acquire and revalidate a settled paused run before cross-process mutation. */
+  private acquireSettledPausedRunLease(managed: ManagedRun): boolean {
+    if (managed.status !== "paused" || managed.lease) return true;
+
+    let lease: RunLease | null = null;
+    try {
+      lease = this.persistence.acquireRunLease(managed.runId);
+      if (!lease) return false;
+      if (this.persistence.load(managed.runId)?.status !== "paused") {
+        this.persistence.releaseRunLease(lease);
+        return false;
+      }
+      managed.lease = lease;
+      return true;
+    } catch {
+      if (lease) this.persistence.releaseRunLease(lease);
+      return false;
+    }
   }
 
   /**
@@ -641,12 +994,14 @@ export class WorkflowManager extends EventEmitter {
   stop(runId: string): boolean {
     const managed = this.runs.get(runId);
     if (!managed || (managed.status !== "running" && managed.status !== "paused")) return false;
+    if (!this.acquireSettledPausedRunLease(managed)) return false;
 
     managed.controller.abort();
     managed.status = "aborted";
+    managed.leaseReleaseBlocked = Boolean(managed.lease);
     this.emit("stopped", { runId });
     this.persistRun(managed);
-    this.releaseRunLease(managed);
+    void this.scheduleCancellationCleanup(managed);
     return true;
   }
 
@@ -675,6 +1030,11 @@ export class WorkflowManager extends EventEmitter {
     return this.persistence.list();
   }
 
+  /** Resolve an explicit report ID without applying navigator session filtering. */
+  getRunForReport(runId: string): PersistedRunState | null {
+    return this.persistence.load(runId);
+  }
+
   /**
    * Get snapshot of a run.
    */
@@ -687,9 +1047,19 @@ export class WorkflowManager extends EventEmitter {
    */
   deleteRun(runId: string): boolean {
     const managed = this.runs.get(runId);
-    if (managed) this.releaseRunLease(managed);
+    if (managed && !this.acquireSettledPausedRunLease(managed)) return false;
+    if (managed) {
+      this.deletedRunIds.add(runId);
+      managed.deletionRequested = true;
+      managed.leaseReleaseBlocked = Boolean(managed.lease);
+      managed.controller.abort();
+      // Retain the token during the grace period and, if deletion fails, across
+      // retries so stale running state can never be resumed concurrently.
+      void this.scheduleCancellationCleanup(managed);
+      managed.generation++;
+    }
     this.runs.delete(runId);
-    return this.persistence.delete(runId);
+    return this.persistence.delete(runId, { preserveLock: Boolean(managed?.lease) });
   }
 
   /**

--- a/src/workflow-report.ts
+++ b/src/workflow-report.ts
@@ -1,0 +1,156 @@
+import type { AgentUsage } from "./agent.js";
+import type { PersistedRunState } from "./run-persistence.js";
+
+function number(value: number): string {
+  return value.toLocaleString("en-US");
+}
+
+function cost(value: number): string {
+  return `$${value.toFixed(4)}`;
+}
+
+function cacheRatio(usage: Pick<AgentUsage, "input" | "cacheRead">): string {
+  const denominator = usage.input + usage.cacheRead;
+  return denominator > 0 ? `${((usage.cacheRead / denominator) * 100).toFixed(1)}%` : "n/a";
+}
+
+function usageText(usage: AgentUsage): string {
+  return [
+    `input ${number(usage.input)}`,
+    `output ${number(usage.output)}`,
+    `cache read ${number(usage.cacheRead)}`,
+    `cache write ${number(usage.cacheWrite)}`,
+    `total ${number(usage.total)}`,
+    `cache ${cacheRatio(usage)}`,
+    cost(usage.cost),
+  ].join(" · ");
+}
+
+function persistedUsageText(usage: NonNullable<PersistedRunState["tokenUsage"]>): string {
+  const cache =
+    usage.cacheRead === undefined || usage.cacheWrite === undefined
+      ? "cache unavailable"
+      : `cache read ${number(usage.cacheRead)} · cache write ${number(usage.cacheWrite)} · cache ${cacheRatio({ input: usage.input, cacheRead: usage.cacheRead })}`;
+  return `input ${number(usage.input)} · output ${number(usage.output)} · ${cache} · total ${number(usage.total)} · ${usage.cost === undefined ? "cost unavailable" : cost(usage.cost)}`;
+}
+
+function sumUsage(values: AgentUsage[]): AgentUsage {
+  return values.reduce<AgentUsage>(
+    (sum, value) => ({
+      input: sum.input + value.input,
+      output: sum.output + value.output,
+      cacheRead: sum.cacheRead + value.cacheRead,
+      cacheWrite: sum.cacheWrite + value.cacheWrite,
+      total: sum.total + value.total,
+      cost: sum.cost + value.cost,
+    }),
+    { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 },
+  );
+}
+
+/** Deterministic persistent report formatter used by `/workflows report <runId>`. */
+export function formatWorkflowReport(run: PersistedRunState): string {
+  const capturedUsage = run.agents.flatMap((agent) => (agent.telemetry?.usage ? [agent.telemetry.usage] : []));
+  const aggregate = capturedUsage.length > 0 ? sumUsage(capturedUsage) : undefined;
+  const missingUsageCount = run.agents.length - capturedUsage.length;
+  const incompleteAccountingCount = run.agents.filter(
+    (agent) => agent.telemetry?.accountingStatus === "incomplete",
+  ).length;
+  const currentTelemetryAgents = run.agents.filter((agent) => agent.telemetry?.execution === "live");
+  const incompleteMissingUsage = currentTelemetryAgents.some(
+    (agent) => agent.telemetry?.accountingStatus === "incomplete" && agent.telemetry.usage === undefined,
+  );
+  const currentTelemetryMissingUsage = currentTelemetryAgents.length > 0 && capturedUsage.length === 0;
+  const usageUnavailable = incompleteMissingUsage || currentTelemetryMissingUsage;
+  const partialReasons = [
+    incompleteAccountingCount > 0
+      ? `accounting incomplete for ${number(incompleteAccountingCount)} agent${incompleteAccountingCount === 1 ? "" : "s"}`
+      : undefined,
+    missingUsageCount > 0
+      ? `${number(missingUsageCount)} agent${missingUsageCount === 1 ? "" : "s"} missing usage`
+      : undefined,
+  ].filter((reason): reason is string => reason !== undefined);
+  const lines = [`Workflow report: ${run.workflowName} (${run.runId}) [${run.status}]`];
+  const persistedSupersedesTelemetry = Boolean(
+    run.tokenUsage &&
+      aggregate &&
+      (run.tokenUsage.total > aggregate.total ||
+        run.tokenUsage.input > aggregate.input ||
+        run.tokenUsage.output > aggregate.output ||
+        (run.tokenUsage.cacheRead ?? 0) > aggregate.cacheRead ||
+        (run.tokenUsage.cacheWrite ?? 0) > aggregate.cacheWrite ||
+        (run.tokenUsage.cost ?? 0) > aggregate.cost),
+  );
+  if (persistedSupersedesTelemetry && run.tokenUsage) {
+    const qualifier = partialReasons.length > 0 ? `partial (${partialReasons.join("; ")}) · ` : "";
+    lines.push(`Usage: ${qualifier}${persistedUsageText(run.tokenUsage)}`);
+  } else if (aggregate && !usageUnavailable) {
+    const qualifier = partialReasons.length > 0 ? `partial (${partialReasons.join("; ")}) · ` : "";
+    lines.push(`Usage: ${qualifier}${usageText(aggregate)}`);
+  } else if (!usageUnavailable && run.tokenUsage) {
+    lines.push(`Usage: ${persistedUsageText(run.tokenUsage)}`);
+  } else {
+    const qualifier = usageUnavailable && partialReasons.length > 0 ? ` (${partialReasons.join("; ")})` : "";
+    lines.push(`Usage: unavailable${qualifier}`);
+  }
+  lines.push(`Agents: ${run.agents.length}`);
+
+  for (const agent of run.agents) {
+    const telemetry = agent.telemetry;
+    if (!telemetry) {
+      lines.push(`[${agent.id}] ${agent.label} · telemetry unavailable`);
+      continue;
+    }
+    const execution = telemetry.execution ?? "legacy";
+    const hasCapturedTelemetry =
+      telemetry.resolvedModel !== undefined ||
+      telemetry.effectiveThinkingLevel !== undefined ||
+      telemetry.skillsEnabled !== undefined ||
+      telemetry.activeToolCount !== undefined ||
+      telemetry.systemPromptChars !== undefined ||
+      telemetry.projectContextFileCount !== undefined ||
+      telemetry.usage !== undefined ||
+      telemetry.accountingStatus !== undefined;
+    if (!hasCapturedTelemetry) {
+      lines.push(
+        `[${agent.id}] ${agent.label} · ${execution} · requested ${telemetry.requestedModelSpec ?? "(default)"} · telemetry unavailable`,
+      );
+      continue;
+    }
+    const route = `${telemetry.requestedModelSpec ?? "(default)"} -> ${telemetry.resolvedModel ?? "unknown"}`;
+    const skills =
+      telemetry.skillsEnabled === undefined
+        ? "skills unknown"
+        : `skills ${telemetry.skillsEnabled ? "on" : "off"} (${telemetry.loadedSkillCount ?? "?"})`;
+    const tools = telemetry.activeToolCount ?? telemetry.activeToolNames?.length;
+    const contextChars =
+      telemetry.projectContextChars === undefined ? "unknown" : number(telemetry.projectContextChars);
+    const context = `${telemetry.projectContextFileCount ?? "?"} files/${contextChars} chars`;
+    const incompleteAttempts = telemetry.accountingIncompleteAttempts;
+    const accounting =
+      telemetry.accountingStatus === "incomplete"
+        ? `accounting incomplete${
+            incompleteAttempts ? ` (${number(incompleteAttempts)} attempt${incompleteAttempts === 1 ? "" : "s"})` : ""
+          }`
+        : undefined;
+    lines.push(
+      [
+        `[${agent.id}] ${agent.label}`,
+        execution,
+        route,
+        `thinking ${telemetry.effectiveThinkingLevel ?? "unknown"}`,
+        skills,
+        `tools ${tools ?? "?"}`,
+        `system ${telemetry.systemPromptChars === undefined ? "unknown" : number(telemetry.systemPromptChars)} chars`,
+        `context ${context}`,
+        accounting,
+      ]
+        .filter((part): part is string => part !== undefined)
+        .join(" · "),
+    );
+    lines.push(`    usage: ${telemetry.usage ? usageText(telemetry.usage) : "unavailable"}`);
+    if (telemetry.activeToolNames?.length) lines.push(`    tools: ${telemetry.activeToolNames.join(", ")}`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/workflow-settings.ts
+++ b/src/workflow-settings.ts
@@ -12,6 +12,10 @@ import { workflowHomeDir, workflowProjectPaths } from "./workflow-paths.js";
 
 export interface WorkflowSettings {
   keywordTriggerEnabled?: boolean;
+  /** Exact, case-insensitive symbolic model names mapped to concrete model specs. */
+  modelAliases?: Record<string, string>;
+  /** Reject unresolved requested model specs instead of falling back to the session default. */
+  strictModelResolution?: boolean;
   /** Literal keyword that arms workflows mode from interactive input. */
   keywordTriggerWord?: string;
   defaultAgentTimeoutMs?: number | null;
@@ -121,6 +125,11 @@ function normalizeSettings(value: unknown): WorkflowSettings {
   if (typeof raw.keywordTriggerEnabled === "boolean") {
     settings.keywordTriggerEnabled = raw.keywordTriggerEnabled;
   }
+  const modelAliases = normalizeModelAliases(raw.modelAliases);
+  if (modelAliases !== undefined) settings.modelAliases = modelAliases;
+  if (typeof raw.strictModelResolution === "boolean") {
+    settings.strictModelResolution = raw.strictModelResolution;
+  }
   const keywordTriggerWord = normalizeKeywordTriggerWord(raw.keywordTriggerWord);
   if (keywordTriggerWord !== undefined) settings.keywordTriggerWord = keywordTriggerWord;
   if (raw.defaultAgentTimeoutMs === null) {
@@ -152,6 +161,27 @@ function normalizeSettings(value: unknown): WorkflowSettings {
   const deliveredResultMaxChars = normalizeInteger(raw.deliveredResultMaxChars, 1, 1_000_000);
   if (deliveredResultMaxChars !== undefined) settings.deliveredResultMaxChars = deliveredResultMaxChars;
   return settings;
+}
+
+const UNSAFE_ALIAS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function normalizeModelAliases(value: unknown): Record<string, string> | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const aliases: Record<string, string> = {};
+  for (const [rawKey, rawValue] of Object.entries(value)) {
+    if (typeof rawValue !== "string") continue;
+    const key = rawKey.trim().toLowerCase();
+    const target = rawValue.trim();
+    if (!key || !target || UNSAFE_ALIAS_KEYS.has(key)) continue;
+    aliases[key] = target;
+  }
+  return aliases;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function normalizeInteger(value: unknown, min: number, max: number): number | undefined {

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -14,7 +14,8 @@ import {
   type WorkflowSnapshot,
 } from "./display.js";
 import { WorkflowError, WorkflowErrorCode } from "./errors.js";
-import { parseWorkflowScript, type WorkflowRunResult } from "./workflow.js";
+import { assertValidRunId } from "./run-persistence.js";
+import { parseWorkflowScript, resolveWorkflowScriptPath, type WorkflowRunResult } from "./workflow.js";
 import { WorkflowManager } from "./workflow-manager.js";
 import { createWorkflowStorage, type WorkflowStorage } from "./workflow-saved.js";
 import { loadWorkflowSettings } from "./workflow-settings.js";
@@ -58,21 +59,33 @@ export function agentTypeGuideline(cwd: string = process.cwd()): string | undefi
 }
 
 const workflowToolSchema = Type.Object({
-  script: Type.String({
-    description: [
-      "Required raw JavaScript workflow script, with no Markdown fences.",
-      "First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }",
-      "Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, and budget. The workflow must call agent() at least once.",
-      "parallel() requires functions, not promises: await parallel(items.map(item => () => agent(...))).",
-    ].join(" "),
-  }),
+  action: Type.Optional(
+    Type.Union([Type.Literal("run"), Type.Literal("resume"), Type.Literal("status")], {
+      description: "run starts (default), resume continues, status inspects.",
+    }),
+  ),
+  runId: Type.Optional(
+    Type.String({
+      description: "Run ID for resume and status.",
+    }),
+  ),
+  script: Type.Optional(
+    Type.String({
+      description:
+        "Raw JavaScript workflow source (no fences). Provide exactly one of script/scriptPath. First statement exports meta with name and description; the workflow must call agent() at least once.",
+    }),
+  ),
+  scriptPath: Type.Optional(
+    Type.String({
+      description: "Path to a workflow script, rooted at ctx.cwd. Provide exactly one of script or scriptPath.",
+    }),
+  ),
   args: Type.Optional(
     Type.Any({ description: "Optional JSON value exposed to the workflow script as global `args`." }),
   ),
   background: Type.Optional(
     Type.Boolean({
-      description:
-        "Run the workflow in the background. Default: true — the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when it finishes. Set to false only when you need the result inline in this same turn (the call will block until the workflow completes).",
+      description: "Background by default; false blocks and returns the result inline.",
     }),
   ),
   maxAgents: Type.Optional(
@@ -106,17 +119,17 @@ const workflowToolSchema = Type.Object({
   ),
   resumeFromRunId: Type.Optional(
     Type.String({
-      description: [
-        "Resume a prior run (this ID) with an edited `script` instead of starting a new run.",
-        "Unchanged agent() calls replay from that run's cache; the first changed/new call onward re-runs.",
-        "Calls match by position: keep earlier good calls identical and in order. Always background.",
-      ].join(" "),
+      description:
+        "Edit-resume this run ID: unchanged positional agent calls replay; changed/new calls rerun. Background only.",
     }),
   ),
 });
 
 export type WorkflowToolInput = {
-  script: string;
+  action?: "run" | "resume" | "status";
+  runId?: string;
+  script?: string;
+  scriptPath?: string;
   args?: unknown;
   background?: boolean;
   maxAgents?: number;
@@ -154,23 +167,23 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       loadSavedWorkflow: (name: string) => storage.load(name)?.script,
       defaultAgentTimeoutMs: defaults.agentTimeoutMs,
       defaultAgentRetries: defaults.agentRetries,
+      modelAliases: defaults.modelAliases,
+      strictModelResolution: defaults.strictModelResolution,
     });
 
   return defineTool({
     name: "workflow",
     label: "Workflow",
-    description: [
-      "Execute a deterministic JavaScript workflow that orchestrates multiple subagents with agent(), parallel(), and pipeline().",
-      "script is required raw JavaScript. It must start with export const meta = { name, description, phases? } and must call agent() at least once.",
-    ].join(" "),
-    promptSnippet:
-      "Run a deterministic JavaScript workflow. Required script header: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }.",
+    description:
+      "Run, resume, or inspect a deterministic JavaScript workflow that orchestrates subagents with agent(), parallel(), and pipeline().",
+    promptSnippet: "workflow agents.",
     // Lazy accessor: the SDK re-reads definition.promptGuidelines on every
     // tool-registry refresh, so changes to the agentType registry are reflected.
     get promptGuidelines() {
       return [
         "Use workflow only when the user explicitly asks for a workflow, workflows, fan-out, or multi-agent orchestration.",
-        "For workflow, always pass one raw JavaScript string in the required script parameter; do not include Markdown fences or prose around the script.",
+        "For workflow actions: run needs script or scriptPath; resume needs runId and optional args patch; status needs runId.",
+        "For workflow, raw script must not include Markdown fences or prose around it; scriptPath is read fresh for each call and must be a file inside ctx.cwd (no traversal or symlink escapes).",
         "For workflow, the script's first statement must be `export const meta = { name: 'short_snake_case', description: 'non-empty human description', phases: [{ title: 'Phase name' }] }`; meta.name and meta.description are required non-empty strings.",
         "For workflow, write plain JavaScript after the meta export. Do not use TypeScript syntax, imports, require(), fs, Date.now(), Math.random(), or new Date().",
         "For workflow, available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), args, cwd, process.cwd(), and budget. Every workflow must call agent() at least once; do not use workflow only to declare phases or return a static object.",
@@ -200,7 +213,45 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       return normalizeWorkflowToolArgs(args);
     },
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
-      const script = normalizeWorkflowScript(params.script);
+      const executionCwd = (ctx as { cwd?: string } | undefined)?.cwd ?? cwd;
+      const normalized = normalizeWorkflowToolArgs(params);
+
+      if (normalized.action === "status") {
+        const details = workflowRunStatus(manager, normalized.runId as string);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Workflow **${details.workflowName}** run \`${details.runId}\` is **${details.status}**${
+                details.currentPhase ? ` in phase **${details.currentPhase}**` : ""
+              } (${details.agentCount} agent(s)).`,
+            },
+          ],
+          details,
+        };
+      }
+
+      if (normalized.action === "resume") {
+        const runId = normalized.runId as string;
+        const resumed = Object.hasOwn(normalized, "args")
+          ? await manager.resume(runId, { argsPatch: normalized.args as Record<string, unknown> })
+          : await manager.resume(runId);
+        if (!resumed) {
+          const status = manager.getRunForReport(runId)?.status ?? "not found";
+          throw new Error(`Workflow run ${runId} is not resumable (status: ${status})`);
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Workflow run \`${runId}\` resumed in the background. Its result will be delivered when it finishes.`,
+            },
+          ],
+          details: { runId, background: true, resumed: true },
+        };
+      }
+
+      const script = resolveWorkflowToolSource(normalized, executionCwd);
       const parsed = parseWorkflowScript(script);
 
       // Iteration / cached-prefix reuse: resume a prior run with THIS (edited)
@@ -210,7 +261,8 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       // detached and its result is delivered back into the conversation).
       if (params.resumeFromRunId) {
         const runId = params.resumeFromRunId;
-        const resumed = await manager.resume(runId, { script, args: params.args });
+        const resumeOptions = Object.hasOwn(params, "args") ? { script, args: params.args } : { script };
+        const resumed = await manager.resume(runId, resumeOptions);
         if (!resumed) {
           throw new Error(resumeFailureText(manager, runId));
         }
@@ -242,6 +294,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
           agentRetries: params.agentRetries,
           agentTimeoutMs: params.agentTimeoutMs,
           tokenBudget: params.tokenBudget,
+          cwd: executionCwd,
         });
         return {
           content: [{ type: "text", text: backgroundStartedText(parsed.meta.name, runId) }],
@@ -269,6 +322,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
           agentRetries: params.agentRetries,
           agentTimeoutMs: params.agentTimeoutMs,
           tokenBudget: params.tokenBudget,
+          cwd: executionCwd,
           confirm,
           externalSignal: signal,
           onProgress(live) {
@@ -357,7 +411,13 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
 function resolveWorkflowToolDefaults(
   options: WorkflowToolOptions,
   cwd: string,
-): { agentTimeoutMs: number | null; concurrency?: number; agentRetries: number } {
+): {
+  agentTimeoutMs: number | null;
+  concurrency?: number;
+  agentRetries: number;
+  modelAliases?: Record<string, string>;
+  strictModelResolution?: boolean;
+} {
   const settings = loadWorkflowSettings({ cwd });
   return {
     agentTimeoutMs:
@@ -366,6 +426,8 @@ function resolveWorkflowToolDefaults(
         : (settings.defaultAgentTimeoutMs ?? null),
     concurrency: options.defaultConcurrency ?? options.concurrency ?? settings.defaultConcurrency,
     agentRetries: options.defaultAgentRetries ?? settings.defaultAgentRetries ?? 0,
+    modelAliases: settings.modelAliases,
+    strictModelResolution: settings.strictModelResolution,
   };
 }
 
@@ -389,21 +451,12 @@ export function backgroundStartedText(name: string, runId: string): string {
   ].join("\n");
 }
 
-/**
- * One-line hint telling the model it can iterate on a finished/running run by
- * resuming it with an edited script instead of re-running the whole workflow.
- * Unchanged agent() calls replay from the journal (cache); only edited/new ones
- * re-run. Omitted when there is no runId to reference.
- */
+/** Hint that a run can be resumed with an edited script and cached prefix. */
 export function reviseHint(runId: string | undefined): string {
   if (!runId) return "";
   return `To revise without re-running everything: re-call workflow with resumeFromRunId="${runId}" and an edited script — unchanged agent() calls replay from cache, only edited/new ones re-run.`;
 }
 
-/**
- * The tool result returned when the model resumes a run with an edited script.
- * The resumed run is always background, so its result is delivered back later.
- */
 export function resumedText(name: string, runId: string): string {
   return [
     `Workflow "${name}" resumed from run ${runId} with your edited script.`,
@@ -415,12 +468,8 @@ export function resumedText(name: string, runId: string): string {
   ].join("\n");
 }
 
-/**
- * Explain why a resumeFromRunId could not be resumed, so the model gets a clear
- * tool error instead of a silent failure. Inspects live + persisted state to
- * name the concrete reason (not found / running / completed / stopped).
- */
 export function resumeFailureText(manager: WorkflowManager, runId: string): string {
+  assertValidRunId(runId);
   const active = manager.getRun(runId);
   if (active?.status === "running") {
     return `Cannot resume workflow run "${runId}": it is still running. Wait for it to finish (or /workflows stop ${runId}) before resuming with an edited script.`;
@@ -441,11 +490,74 @@ export function resumeFailureText(manager: WorkflowManager, runId: string): stri
   return `Cannot resume workflow run "${runId}": it is not currently resumable (it may be busy under another process). Try again shortly, or start a new run.`;
 }
 
+function workflowRunStatus(manager: WorkflowManager, runId: string) {
+  assertValidRunId(runId);
+  const persisted = manager.getRunForReport(runId);
+  const active = typeof manager.getRun === "function" ? manager.getRun(runId) : undefined;
+  if (!persisted && !active) throw new Error(`Workflow run ${runId} was not found`);
+  return {
+    runId,
+    workflowName: active?.snapshot.name ?? persisted?.workflowName ?? "workflow",
+    status: active?.status ?? persisted?.status ?? "unknown",
+    currentPhase: active?.snapshot.currentPhase ?? persisted?.currentPhase,
+    phases: active?.snapshot.phases ?? persisted?.phases ?? [],
+    agentCount: active?.snapshot.agents.length ?? persisted?.agents?.length ?? 0,
+    startedAt: active?.startedAt.toISOString() ?? persisted?.startedAt,
+    updatedAt: persisted?.updatedAt,
+  };
+}
+
 function normalizeWorkflowToolArgs(args: unknown): WorkflowToolInput {
-  if (!args || typeof args !== "object") throw new Error("workflow requires an object argument with a script string");
+  if (!args || typeof args !== "object") throw new Error("workflow requires an object argument");
   const value = args as Record<string, unknown>;
-  if (typeof value.script !== "string") throw new Error("workflow requires `script` to be a string");
-  return { ...value, script: normalizeWorkflowScript(value.script) } as WorkflowToolInput;
+  const action = value.action ?? "run";
+  if (action !== "run" && action !== "resume" && action !== "status") {
+    throw new Error("workflow `action` must be run, resume, or status");
+  }
+
+  const hasScript = Object.hasOwn(value, "script");
+  const hasScriptPath = Object.hasOwn(value, "scriptPath");
+  const hasRunId = Object.hasOwn(value, "runId");
+
+  if (action === "run") {
+    if (hasRunId) throw new Error("workflow action=run must not include `runId`");
+    if (hasScript === hasScriptPath) throw new Error("workflow requires exactly one of `script` or `scriptPath`");
+    if (hasScript && typeof value.script !== "string") throw new Error("workflow `script` must be a string");
+    if (hasScriptPath && (typeof value.scriptPath !== "string" || value.scriptPath.trim().length === 0)) {
+      throw new Error("workflow `scriptPath` must be a non-empty string");
+    }
+    if (value.resumeFromRunId !== undefined) {
+      if (typeof value.resumeFromRunId !== "string") throw new Error("workflow `resumeFromRunId` must be a string");
+      assertValidRunId(value.resumeFromRunId);
+    }
+    return {
+      ...value,
+      ...(hasScript ? { script: normalizeWorkflowScript(value.script as string) } : {}),
+    } as WorkflowToolInput;
+  }
+
+  if (hasScript || hasScriptPath) {
+    throw new Error(`workflow action=${action} must not include \`script\` or \`scriptPath\``);
+  }
+  if (!hasRunId || typeof value.runId !== "string" || value.runId.trim().length === 0) {
+    throw new Error(`workflow action=${action} requires a non-empty \`runId\``);
+  }
+  if (action === "status" && Object.hasOwn(value, "args")) {
+    throw new Error("workflow action=status must not include `args`");
+  }
+  const runOnly = ["background", "maxAgents", "concurrency", "agentRetries", "agentTimeoutMs", "tokenBudget"];
+  const invalid = runOnly.find((key) => Object.hasOwn(value, key));
+  if (invalid) throw new Error(`workflow action=${action} must not include run-only \`${invalid}\``);
+
+  const runId = value.runId.trim();
+  assertValidRunId(runId);
+  return { ...value, action, runId } as WorkflowToolInput;
+}
+
+function resolveWorkflowToolSource(params: WorkflowToolInput, cwd: string): string {
+  const normalized = normalizeWorkflowToolArgs(params);
+  if (normalized.script !== undefined) return normalized.script;
+  return resolveWorkflowScriptPath(normalized.scriptPath as string, cwd).script;
 }
 
 function normalizeWorkflowScript(script: string): string {

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -228,6 +228,7 @@ function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
       tokens: a.tokens,
       tokenUsage: a.tokenUsage,
       model: a.model,
+      telemetry: a.telemetry,
     })),
     agentCount: p.agents.length,
     runningCount: p.agents.filter((a) => a.status === "running").length,
@@ -513,7 +514,7 @@ function rightAgentRow(
   const statsStyled = theme.fg("dim", stats);
 
   // Assemble with explicit cell padding (visibleWidth-driven gaps).
-  let out = marker + dot + " " + nameStyled;
+  let out = `${marker + dot} ${nameStyled}`;
   const afterName = nameStart + visibleWidth(nameOut);
   if (modelOut) {
     out += " ".repeat(Math.max(0, modelStart - afterName)) + modelStyled;
@@ -826,6 +827,44 @@ export function renderNavigator(
       const body: string[] = [];
       body.push(dim("Status: ") + (a.status ?? ""));
       if (a.model) body.push(dim("Model: ") + (shortModel(a.model) ?? ""));
+      if (a.telemetry) {
+        const telemetry = a.telemetry;
+        body.push(dim("Execution: ") + telemetry.execution);
+        body.push(
+          dim("Routing: ") +
+            `${telemetry.requestedModelSpec ?? "(default)"} -> ${telemetry.resolvedModel ?? "unknown"}`,
+        );
+        body.push(dim("Thinking: ") + (telemetry.effectiveThinkingLevel ?? "unknown"));
+        body.push(
+          dim("Skills: ") +
+            (telemetry.skillsEnabled === undefined
+              ? "unknown"
+              : `${telemetry.skillsEnabled ? "on" : "off"} (${telemetry.loadedSkillCount ?? "?"} loaded)`),
+        );
+        body.push(dim("Tools: ") + String(telemetry.activeToolCount ?? telemetry.activeToolNames?.length ?? "?"));
+        body.push(
+          dim("Prompt chars: ") +
+            (telemetry.systemPromptChars === undefined ? "unknown" : telemetry.systemPromptChars.toLocaleString()),
+        );
+        body.push(
+          dim("Context: ") +
+            `${telemetry.projectContextFileCount ?? "?"} files · ${
+              telemetry.projectContextChars === undefined ? "unknown" : telemetry.projectContextChars.toLocaleString()
+            } chars`,
+        );
+        if (telemetry.usage) {
+          const usage = telemetry.usage;
+          body.push(
+            dim("Usage: ") +
+              `input ${usage.input.toLocaleString()} · output ${usage.output.toLocaleString()} · ` +
+              `cache read ${usage.cacheRead.toLocaleString()} · cache write ${usage.cacheWrite.toLocaleString()} · ` +
+              `total ${usage.total.toLocaleString()} · $${usage.cost.toFixed(4)}`,
+          );
+        }
+        if (telemetry.activeToolNames?.length) {
+          body.push(dim("Tool names: ") + telemetry.activeToolNames.join(", "));
+        }
+      }
       if (a.error) body.push(dim("Error: ") + a.error);
       if (a.errorCode) body.push(`${dim("Error code: ")}${a.errorCode}${a.recoverable ? " (recoverable)" : ""}`);
       body.push("", dim("Prompt:"));

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,10 +1,28 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash } from "node:crypto";
+import {
+  closeSync,
+  constants as fsConstants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  type Stats,
+  statSync,
+} from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
 import vm from "node:vm";
 import type { Node } from "acorn";
 import { parse } from "acorn";
-import type { TSchema } from "typebox";
-import type { AgentUsage } from "./agent.js";
-import { WorkflowAgent, type WorkflowAgentOptions } from "./agent.js";
+import type { AgentTelemetry, AgentUsage } from "./agent.js";
+import {
+  resolveAgentModelSpec,
+  resolveAgentThinkingLevel,
+  resolveModelAlias,
+  WorkflowAgent,
+  type WorkflowAgentOptions,
+} from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import {
   type AgentDefinition,
@@ -15,9 +33,24 @@ import {
 } from "./agent-registry.js";
 import { DEFAULT_AGENT_TIMEOUT_MS, MAX_AGENT_RETRIES, MAX_AGENTS_PER_RUN, MAX_CONCURRENCY } from "./config.js";
 import { WorkflowError, WorkflowErrorCode, wrapError } from "./errors.js";
+import {
+  type JsonTreePrototypes,
+  normalizeJsonChildArgs,
+  normalizeJsonResult,
+  normalizeJsonTree,
+} from "./json-value.js";
 import { createWorkflowLogger } from "./logger.js";
 import { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.js";
+import {
+  canonicalModelSpec,
+  isThinkingLevel,
+  type ModelThinkingLevel,
+  resolveModelSpecWithThinking,
+  splitModelSpecThinking,
+} from "./model-spec.js";
+import { loadModelTierConfig, type ModelTierConfig } from "./model-tier-config.js";
 import { createAgentStoreTools, SharedStore } from "./shared-store.js";
+import type { WorkflowSchema } from "./structured-output.js";
 import { createWorktree, removeWorktree, type Worktree } from "./worktree.js";
 
 export interface WorkflowMetaPhase {
@@ -25,6 +58,23 @@ export interface WorkflowMetaPhase {
   detail?: string;
   model?: string;
 }
+
+export interface WorkflowScriptDescriptor {
+  scriptPath: string;
+}
+
+/** Injectable secure-open filesystem seam used by deterministic TOCTOU tests. */
+export interface WorkflowScriptFsLayer {
+  realpathSync(path: string): string;
+  lstatSync(path: string): Stats;
+  statSync(path: string): Stats;
+  openSync(path: string, flags: number): number;
+  fstatSync(fd: number): Stats;
+  readFileSync(fd: number, encoding: "utf8"): string;
+  closeSync(fd: number): void;
+}
+
+export type AgentTypePolicy = "fallback" | "error";
 
 export interface WorkflowMeta {
   name: string;
@@ -47,6 +97,32 @@ export interface JournalEntry {
    * which agent finished first. Absent on older journal entries.
    */
   storeDelta?: Record<string, unknown>;
+  /** Monotonic execution-time version for each storeDelta key. */
+  storeVersions?: Record<string, number>;
+  /** Exact telemetry captured when this entry last ran live. */
+  telemetry?: AgentTelemetry;
+  /** Logical child agents represented by an atomic workflow() entry. */
+  agentCount?: number;
+  /** Explicit encoding for an atomic child that completed with no return value. */
+  resultKind?: "void";
+  /** Child agent events needed to reconstruct a fresh manager report on atomic replay. */
+  childAgents?: JournaledChildAgent[];
+}
+
+export interface JournaledChildAgent {
+  /** Internal deterministic invocation identity used to correlate duplicate labels. */
+  callId?: string;
+  label: string;
+  phase?: string;
+  prompt: string;
+  result: unknown;
+  tokens?: number;
+  tokenUsage?: AgentUsage;
+  model?: string;
+  error?: string;
+  errorCode?: WorkflowErrorCode;
+  recoverable?: boolean;
+  telemetry?: AgentTelemetry;
 }
 
 /**
@@ -74,6 +150,8 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
    * fallback). Injectable for tests.
    */
   agentRegistry?: AgentRegistry;
+  /** Unknown explicit agentType behavior. Default: "fallback". */
+  agentTypePolicy?: AgentTypePolicy;
   concurrency?: number;
   /** Retry attempts after a recoverable agent failure. Default 0. */
   agentRetries?: number;
@@ -93,8 +171,14 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   resumeFromRunId?: string;
   /** Called after each live agent completes so the caller can persist the journal. */
   onAgentJournal?: (entry: JournalEntry) => void;
+  /** Internal: require this invocation's result to be an exact persisted JSON snapshot. */
+  requireJsonResult?: boolean;
   /** Internal: shared runtime inherited by a nested workflow() call. */
   sharedRuntime?: SharedRuntime;
+  /** Internal: cumulative usage restored before a cold resume. */
+  initialTokenUsage?: Partial<SharedRuntime["tokenUsage"]>;
+  /** Internal: tier configuration snapshotted by the parent atomic workflow. */
+  modelTierConfig?: ModelTierConfig | null;
   /**
    * Shared store for this run. One instance is created per top-level run and
    * propagated into nested workflow() calls. Pass an existing instance to share
@@ -111,8 +195,9 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   confirm?: (promptText: string, options: CheckpointOptions) => Promise<unknown>;
   onLog?: (message: string) => void;
   onPhase?: (title: string) => void;
-  onAgentStart?: (event: { label: string; phase?: string; prompt: string; model?: string }) => void;
+  onAgentStart?: (event: { callId?: string; label: string; phase?: string; prompt: string; model?: string }) => void;
   onAgentEnd?: (event: {
+    callId?: string;
     label: string;
     phase?: string;
     result: unknown;
@@ -123,16 +208,21 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
     error?: string;
     errorCode?: WorkflowErrorCode;
     recoverable?: boolean;
+    telemetry?: AgentTelemetry;
   }) => void;
-  onAgentHistory?: (event: { label: string; phase?: string; history: AgentHistoryEntry[] }) => void;
-  onTokenUsage?: (usage: {
-    input: number;
-    output: number;
-    total: number;
-    cost: number;
-    cacheRead?: number;
-    cacheWrite?: number;
-  }) => void;
+  onAgentHistory?: (event: { callId?: string; label: string; phase?: string; history: AgentHistoryEntry[] }) => void;
+  onTokenUsage?: (usage: WorkflowTokenUsage) => void;
+  /** Internal cumulative accounting snapshots emitted after each finalized attempt. */
+  onTokenUsageProgress?: (usage: WorkflowTokenUsage) => void;
+}
+
+export interface WorkflowTokenUsage {
+  input: number;
+  output: number;
+  total: number;
+  cost: number;
+  cacheRead?: number;
+  cacheWrite?: number;
 }
 
 export interface WorkflowRunResult<T = unknown> {
@@ -153,7 +243,7 @@ export interface WorkflowRunResult<T = unknown> {
   };
 }
 
-export interface AgentOptions<TSchemaDef extends TSchema | undefined = TSchema | undefined> {
+export interface AgentOptions<TSchemaDef extends WorkflowSchema | undefined = WorkflowSchema | undefined> {
   label?: string;
   phase?: string;
   schema?: TSchemaDef;
@@ -171,6 +261,8 @@ export interface AgentOptions<TSchemaDef extends TSchema | undefined = TSchema |
    * no configured entry it falls back to the session's main model.
    */
   tier?: string;
+  /** Explicit Pi thinking level; wins over model suffix and inherited thinking. */
+  effort?: ModelThinkingLevel;
   isolation?: "worktree";
   /**
    * Name of a registered subagent definition (`.pi/agents/<name>.md`, project >
@@ -225,7 +317,44 @@ interface RuntimeState {
 type AnyNode = Node & { [key: string]: any; start: number; end: number };
 
 // Parse-time author hint (fast feedback). The real enforcement is DETERMINISM_PRELUDE.
-const DETERMINISM_BLOCKLIST = /\bDate\s*\.\s*now\b|\bMath\s*\.\s*random\b|\bnew\s+Date\s*\(\s*\)/;
+// This intentionally covers the same dot-property and zero-argument constructor
+// forms as the former source-text blocklist. Computed and optional-chaining forms
+// remain outside this parse-time check; the runtime prelude remains authoritative.
+function isNondeterministicCall(node: AnyNode): boolean {
+  if (node.type === "NewExpression") {
+    const callee = node.callee as AnyNode;
+    return callee.type === "Identifier" && callee.name === "Date" && (node.arguments as AnyNode[]).length === 0;
+  }
+
+  if (node.type !== "CallExpression") return false;
+  const callee = node.callee as AnyNode;
+  if (callee.type !== "MemberExpression" || callee.computed) return false;
+  const object = callee.object as AnyNode;
+  const property = callee.property as AnyNode;
+  return (
+    object.type === "Identifier" &&
+    property.type === "Identifier" &&
+    ((object.name === "Date" && property.name === "now") || (object.name === "Math" && property.name === "random"))
+  );
+}
+
+function containsNondeterministicCall(node: AnyNode): boolean {
+  if (isNondeterministicCall(node)) return true;
+  for (const value of Object.values(node)) {
+    if (value && typeof value === "object") {
+      if (Array.isArray(value)) {
+        if (
+          value.some((child) => child && typeof child === "object" && containsNondeterministicCall(child as AnyNode))
+        ) {
+          return true;
+        }
+      } else if (containsNondeterministicCall(value as AnyNode)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 /**
  * Runtime determinism hardening, run inside the vm realm BEFORE the user script.
@@ -267,10 +396,27 @@ export async function runWorkflow<T = unknown>(
   const { meta, body } = parseWorkflowScript(script);
   // Per-phase model routing from meta.phases[].model, with meta.model as the default.
   const routingConfig = parseModelRoutingFromMeta(meta.phases, meta.model);
+  // Snapshot effective settings once so external mutation cannot change routing
+  // between agents while leaving their deterministic call hashes unchanged.
+  const modelAliases = options.modelAliases ? { ...options.modelAliases } : undefined;
+  const strictModelResolution = options.strictModelResolution ?? false;
+  const modelTierConfig = options.modelTierConfig === undefined ? loadModelTierConfig() : options.modelTierConfig;
+  const sessionModel = options.session?.model ? canonicalModelSpec(options.session.model) : undefined;
+  // mainModel is the tier fallback, while session.model is the actual default
+  // used by an untagged agent when no configured medium tier applies.
+  const effectiveMainModel = options.mainModel ?? sessionModel;
   const maxAgents = options.maxAgents ?? MAX_AGENTS_PER_RUN;
   const agentTimeoutMs = options.agentTimeoutMs !== undefined ? options.agentTimeoutMs : DEFAULT_AGENT_TIMEOUT_MS;
   const runId = options.runId ?? `run-${started.toString(36)}`;
   const baseCwd = options.cwd ?? process.cwd();
+  const agentTypePolicy = options.agentTypePolicy ?? "fallback";
+  if (agentTypePolicy !== "fallback" && agentTypePolicy !== "error") {
+    throw new WorkflowError(
+      'agentTypePolicy must be "fallback" or "error"',
+      WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+      { recoverable: false },
+    );
+  }
   // Snapshot the agentType registry ONCE per run so two agent() calls can't
   // observe a mid-run edit (determinism); a later resume re-reads it.
   const agentRegistry = options.agentRegistry ?? loadAgentRegistry(baseCwd);
@@ -296,23 +442,52 @@ export async function runWorkflow<T = unknown>(
     firstMiss: Number.POSITIVE_INFINITY,
   };
 
-  const agentRunner = options.agent ?? new WorkflowAgent(options);
+  const agentRunner = options.agent ?? new WorkflowAgent({ ...options, modelAliases, strictModelResolution });
   const concurrency = normalizeConcurrency(
     options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2),
   );
+  const runReplayIdentity = JSON.stringify({
+    args: normalizedReplayValue(options.args),
+    cwd: baseCwd,
+    maxAgents,
+    agentTimeoutMs,
+    tokenBudget: options.tokenBudget ?? null,
+    concurrency,
+    agentRetries: normalizeAgentRetries(options.agentRetries ?? 0),
+    agentTypePolicy,
+    instructions: options.instructions ?? null,
+    toolNames: options.tools?.map((tool) => tool.name).sort() ?? [],
+  });
+  const restoredUsage = options.initialTokenUsage;
   // Global caps + budget are shared with any nested workflow() so they hold across nesting.
   const shared: SharedRuntime = options.sharedRuntime ?? {
     limiter: createLimiter(concurrency),
     agentCount: 0,
-    spent: 0,
-    tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
+    spent: restoredUsage?.total ?? 0,
+    tokenUsage: {
+      input: restoredUsage?.input ?? 0,
+      output: restoredUsage?.output ?? 0,
+      total: restoredUsage?.total ?? 0,
+      cost: restoredUsage?.cost ?? 0,
+      cacheRead: restoredUsage?.cacheRead ?? 0,
+      cacheWrite: restoredUsage?.cacheWrite ?? 0,
+    },
     depth: 0,
   };
   const limiter = shared.limiter;
+  const runSignal = options.signal ?? new AbortController().signal;
+  // Async context gives each parallel/pipeline operation a cancellable signal
+  // without poisoning the workflow-wide signal when user code catches its error.
+  const operationSignals = new AsyncLocalStorage<AbortSignal>();
+  const currentSignal = () => operationSignals.getStore() ?? runSignal;
+  // Unlike shared.agentCount, this counter belongs only to this invocation. It is
+  // what an atomic parent journal records, so concurrent parent work is excluded.
+  let localAgentCount = 0;
 
   // One store instance per run; nested workflow() calls inherit the parent's store
   // so all agents across nesting levels share the same key-value space.
   const store: SharedStore = options.sharedStore ?? new SharedStore();
+  let scriptJsonPrototypes: JsonTreePrototypes | undefined;
 
   const log = (message: string) => {
     const text = String(message);
@@ -338,14 +513,15 @@ export async function runWorkflow<T = unknown>(
     remaining: () => (options.tokenBudget == null ? Infinity : Math.max(0, options.tokenBudget - shared.spent)),
   });
 
-  const throwIfAborted = () => {
-    if (options.signal?.aborted) {
+  const throwIfAborted = (signal = currentSignal()) => {
+    if (signal.aborted) {
       throw new WorkflowError("workflow aborted", WorkflowErrorCode.WORKFLOW_ABORTED, { recoverable: true });
     }
   };
 
   const agent = async (prompt: string, agentOptions: AgentOptions = {}) => {
-    throwIfAborted();
+    const executionSignal = currentSignal();
+    throwIfAborted(executionSignal);
 
     // Check agent limit
     if (shared.agentCount >= maxAgents) {
@@ -387,10 +563,27 @@ export async function runWorkflow<T = unknown>(
     }
 
     const requestedLabel = agentOptions.label?.trim();
+    if (
+      agentOptions.effort !== undefined &&
+      (typeof agentOptions.effort !== "string" || !isThinkingLevel(agentOptions.effort))
+    ) {
+      throw new WorkflowError(
+        `Unknown effort "${String(agentOptions.effort)}"`,
+        WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+        { recoverable: false },
+      );
+    }
 
     // Resolve a named agentType to its bound definition (tools/model/prompt).
     const agentDef = resolveAgentType(agentOptions.agentType, agentRegistry);
     if (agentOptions.agentType && !agentDef) {
+      if (agentTypePolicy === "error") {
+        throw new WorkflowError(
+          `Unknown agentType "${agentOptions.agentType}"`,
+          WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+          { recoverable: false },
+        );
+      }
       log(`unknown agentType "${agentOptions.agentType}"; using default tools/model`);
     }
 
@@ -404,12 +597,39 @@ export async function runWorkflow<T = unknown>(
     // For display in /workflows: the model this agent runs on — its explicit/phase
     // spec, else the session's main model. The real resolved id overrides this via
     // onModelResolved once the subagent session is created.
-    let displayModel = modelSpec ?? options.mainModel;
+    let displayModel = modelSpec ?? effectiveMainModel;
+    const timeout = agentOptions.timeoutMs !== undefined ? agentOptions.timeoutMs : agentTimeoutMs;
+    const retryAttempts = normalizeAgentRetries(agentOptions.retries ?? options.agentRetries ?? 0);
+    const resolvedIsolation = agentOptions.isolation ?? agentDef?.isolation;
+    const routeIdentity = effectiveRouteIdentity({
+      modelSpec,
+      tier: agentOptions.tier,
+      aliases: modelAliases,
+      strict: strictModelResolution,
+      tierConfig: modelTierConfig,
+      mainModel: effectiveMainModel,
+      sessionModel,
+      effort: agentOptions.effort,
+      inheritedThinking: options.session?.thinkingLevel,
+      modelRegistry:
+        options.modelRegistry ?? (agentRunner instanceof WorkflowAgent ? agentRunner.getModelRegistry() : undefined),
+    });
 
     // Deterministic resume key: assigned at lexical call time, before the limiter,
     // so parallel()/pipeline() fan-out is reproducible for a fixed script.
     const callIndex = state.callSeq++;
-    const callHash = hashAgentCall(prompt, modelSpec, assignedPhase, agentOptions, agentDefinitionKey(agentDef));
+    const callHash = hashAgentCall(
+      prompt,
+      modelSpec,
+      assignedPhase,
+      agentOptions,
+      agentDefinitionKey(agentDef),
+      routeIdentity,
+      runReplayIdentity,
+      timeout,
+      retryAttempts,
+      resolvedIsolation,
+    );
     // Store delta key: callIndex alone is NOT run-unique. A nested workflow()
     // call (see workflowFn below) shares this run's SharedStore instance but
     // restarts its own callSeq at 0, so a parent agent and a concurrently
@@ -426,6 +646,7 @@ export async function runWorkflow<T = unknown>(
     // spent accrues after each agent, matching Claude Code; in-flight agents may
     // push slightly past total, then further agent() calls throw.)
     shared.agentCount++;
+    localAgentCount++;
     const label = requestedLabel || defaultAgentLabel(assignedPhase, shared.agentCount);
 
     // Longest-unchanged-prefix resume: replay a cached result only while the
@@ -437,12 +658,23 @@ export async function runWorkflow<T = unknown>(
     const hashMatches = cached != null && cached.hash === callHash;
     const cachedEmptyOutput = hashMatches && isEmptyTextAgentResult(cached.result, agentOptions.schema);
     if (hashMatches && !cachedEmptyOutput && callIndex < state.firstMiss) {
-      options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
-      options.onAgentEnd?.({ label, phase: assignedPhase, result: cached.result, tokens: 0, model: displayModel });
-      // Apply this agent's write delta so live agents later in the run see a
-      // consistent store. Additive apply preserves parallel-agent writes that
-      // came from higher-callIndex agents finishing before this one.
-      if (cached.storeDelta) store.applyDelta(cached.storeDelta);
+      const replayTelemetry: AgentTelemetry = cached.telemetry
+        ? { ...cached.telemetry, execution: "replay" }
+        : { execution: "replay", requestedModelSpec: modelSpec };
+      displayModel = replayTelemetry.resolvedModel ?? displayModel;
+      options.onAgentStart?.({ callId: deltaKey, label, phase: assignedPhase, prompt, model: displayModel });
+      options.onAgentEnd?.({
+        callId: deltaKey,
+        label,
+        phase: assignedPhase,
+        result: cached.result,
+        tokens: 0,
+        model: displayModel,
+        telemetry: replayTelemetry,
+      });
+      // Captured write versions preserve live execution order even though replay
+      // visits calls in lexical call-index order.
+      if (cached.storeDelta) store.applyDelta(cached.storeDelta, cached.storeVersions);
       return cached.result;
     }
     // A genuine miss (no journal entry, or the hash changed) marks where the
@@ -450,11 +682,10 @@ export async function runWorkflow<T = unknown>(
     if (!hashMatches || cachedEmptyOutput) state.firstMiss = Math.min(state.firstMiss, callIndex);
 
     return limiter(async () => {
-      const timeout = agentOptions.timeoutMs !== undefined ? agentOptions.timeoutMs : agentTimeoutMs;
-      const retryAttempts = normalizeAgentRetries(agentOptions.retries ?? options.agentRetries ?? 0);
+      throwIfAborted(executionSignal);
       const maxAttempts = retryAttempts + 1;
 
-      options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
+      options.onAgentStart?.({ callId: deltaKey, label, phase: assignedPhase, prompt, model: displayModel });
 
       // Optional per-agent worktree isolation (deterministic name -> stable resume keys).
       // Precedence: explicit call-site isolation > agentDef isolation.
@@ -462,18 +693,17 @@ export async function runWorkflow<T = unknown>(
       // is no sentinel to suppress a def's isolation at the call site. Remove the agentType
       // or override with a def that has no isolation field if opt-out is needed.
       let worktree: Worktree | undefined;
-      const resolvedIsolation = agentOptions.isolation ?? agentDef?.isolation;
       if (resolvedIsolation === "worktree") {
         worktree = await createWorktree(baseCwd, `${runId}-${callIndex}-${label}`);
         if (!worktree.isolated) log(`isolation ignored for "${label}" (${worktree.reason})`);
       }
       const runCwd = worktree?.isolated ? worktree.cwd : undefined;
 
-      // Captured from the subagent's real session usage; falls back to an
-      // estimate when the provider reports no usage (total === 0). Usage is reset
-      // per retry attempt so a failed attempt does not double-count the next one.
-      let usage: AgentUsage | undefined;
-      const recordTokens = (result: unknown): number => {
+      // Aggregate only finalized attempt-local telemetry. A timed-out runner can
+      // keep invoking callbacks after retry starts, so callbacks must never write
+      // directly into state shared by attempts.
+      let telemetry: AgentTelemetry | undefined;
+      const recordTokens = (result: unknown, usage: AgentUsage | undefined): number => {
         const tokens = usage && usage.total > 0 ? usage.total : estimateTokens(result) + estimateTokens(prompt);
         if (usage) {
           shared.tokenUsage.input += usage.input;
@@ -484,54 +714,94 @@ export async function runWorkflow<T = unknown>(
         }
         shared.tokenUsage.total += tokens;
         shared.spent += tokens;
+        // Publish cumulative usage as soon as an attempt is finalized. Journal
+        // persistence may fail before onAgentEnd or the normal workflow return,
+        // but the manager still needs the exact consumed budget for its failure
+        // snapshot and a later cold resume.
+        options.onTokenUsageProgress?.({ ...shared.tokenUsage });
         return tokens;
       };
 
       try {
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-          usage = undefined;
+          const attemptDeltaKey = `${deltaKey}:attempt${attempt}`;
+          const attemptController = new AbortController();
+          const attemptSignal = combineAbortSignals(executionSignal, attemptController.signal);
+          let callbacksOpen = true;
+          let attemptDisplayModel = displayModel;
+          let attemptUsage: AgentUsage | undefined;
+          let attemptTelemetry: AgentTelemetry | undefined;
+          let accountedUsage: AgentUsage | undefined;
+          let usageRecorded = false;
+          let accountedTokens = 0;
+          let journalFailure: unknown;
+          const finalizeAttempt = (settled: boolean) => {
+            callbacksOpen = false;
+            if (settled) displayModel = attemptDisplayModel;
+            accountedUsage = attemptUsage ?? attemptTelemetry?.usage;
+            if (!attemptTelemetry && !accountedUsage && settled) return;
+            const finalized: AgentTelemetry = {
+              ...(attemptTelemetry ?? { execution: "live", requestedModelSpec: modelSpec }),
+              usage: accountedUsage ? { ...accountedUsage } : undefined,
+              accountingStatus: settled && accountedUsage ? "exact" : "incomplete",
+              accountingIncompleteAttempts: settled ? undefined : 1,
+            };
+            telemetry = mergeAgentTelemetry(telemetry, finalized);
+          };
           try {
-            throwIfAborted();
+            throwIfAborted(executionSignal);
 
-            // Run agent with timeout
-            const result = await withTimeout(
-              agentRunner.run(prompt, {
-                label,
-                // Identifiable name for persisted sessions (persistAgentSessions).
-                sessionName: `workflow:${runId} ${label}`,
-                schema: agentOptions.schema,
-                signal: options.signal,
-                instructions: buildAgentInstructions(assignedPhase, agentOptions, agentDef, resolvedIsolation),
-                model: modelSpec,
-                tier: agentOptions.tier,
-                modelRegistry: options.modelRegistry,
-                toolNames: agentDef?.tools,
-                disallowedToolNames: agentDef?.disallowedTools,
-                // Per-agent store tools track this agent's writes by the
-                // run-unique deltaKey so the delta can be journaled and replayed
-                // correctly on resume, even when a nested workflow() run shares
-                // this store concurrently with the parent run.
-                systemTools: createAgentStoreTools(store, deltaKey),
-                cwd: runCwd,
-                onModelResolved: (id: string) => {
-                  displayModel = id;
-                },
-                onModelFallback: (spec: string) => {
-                  // Make the silent degrade visible in /workflows, not just console.
-                  log(`${label}: model "${spec}" unavailable — using the session default`);
-                },
-                onUsage: (u: AgentUsage) => {
-                  usage = u;
-                },
-                onHistory: (history: AgentHistoryEntry[]) => {
-                  options.onAgentHistory?.({ label, phase: assignedPhase, history });
-                },
-              }),
-              timeout,
+            // Each retry has its own cancellation signal and store scope. A timed-out
+            // runner may ignore cancellation, but its closed tools cannot contaminate
+            // a later attempt.
+            const runnerPromise = agentRunner.run(prompt, {
               label,
-            );
+              // Identifiable name for persisted sessions (persistAgentSessions).
+              sessionName: `workflow:${runId} ${label}`,
+              schema: agentOptions.schema,
+              signal: attemptSignal,
+              instructions: buildAgentInstructions(assignedPhase, agentOptions, agentDef, resolvedIsolation),
+              model: modelSpec,
+              tier: agentOptions.tier,
+              effort: agentOptions.effort,
+              modelRegistry: options.modelRegistry,
+              modelTierConfig,
+              modelAliases,
+              strictModelResolution,
+              skills: agentDef?.skills,
+              toolNames: agentDef?.tools,
+              disallowedToolNames: agentDef?.disallowedTools,
+              systemTools: createAgentStoreTools(store, attemptDeltaKey),
+              cwd: runCwd,
+              onModelResolved: (id: string) => {
+                if (callbacksOpen) attemptDisplayModel = id;
+              },
+              onModelFallback: (spec: string) => {
+                // Make the silent degrade visible in /workflows, not just console.
+                if (callbacksOpen) log(`${label}: model "${spec}" unavailable — using the session default`);
+              },
+              onUsage: (usage: AgentUsage) => {
+                if (callbacksOpen) attemptUsage = { ...usage };
+              },
+              onTelemetry: (value: AgentTelemetry) => {
+                if (callbacksOpen) attemptTelemetry = mergeAgentTelemetry(attemptTelemetry, value);
+              },
+              onHistory: (history: AgentHistoryEntry[]) => {
+                if (callbacksOpen) options.onAgentHistory?.({ callId: deltaKey, label, phase: assignedPhase, history });
+              },
+            });
+            let result: unknown;
+            try {
+              result = await withTimeout(runnerPromise, timeout, label, () => attemptController.abort());
+            } catch (error) {
+              attemptController.abort();
+              const settled = await waitForRunnerSettlement(runnerPromise, RUNNER_CLEANUP_GRACE_MS);
+              finalizeAttempt(settled);
+              throw error;
+            }
+            finalizeAttempt(true);
 
-            throwIfAborted();
+            throwIfAborted(executionSignal);
             if (isEmptyTextAgentResult(result, agentOptions.schema)) {
               throw new WorkflowError("Subagent produced no assistant output", WorkflowErrorCode.AGENT_EMPTY_OUTPUT, {
                 recoverable: true,
@@ -539,29 +809,49 @@ export async function runWorkflow<T = unknown>(
               });
             }
 
-            const tokens = recordTokens(result);
-            options.onAgentJournal?.({
-              index: callIndex,
-              hash: callHash,
-              result,
-              storeDelta: store.commitDelta(deltaKey),
-            });
+            accountedTokens = recordTokens(result, accountedUsage);
+            usageRecorded = true;
+            const preparedDelta = store.prepareDelta(attemptDeltaKey);
+            try {
+              options.onAgentJournal?.({
+                index: callIndex,
+                hash: callHash,
+                result,
+                storeDelta: preparedDelta.values,
+                storeVersions: preparedDelta.versions,
+                telemetry,
+              });
+            } catch (error) {
+              journalFailure = error;
+              throw error;
+            }
+            store.commitDelta(attemptDeltaKey);
             options.onAgentEnd?.({
+              callId: deltaKey,
               label,
               phase: assignedPhase,
               result,
-              tokens,
-              tokenUsage: usage,
+              tokens: accountedTokens,
+              tokenUsage: accountedUsage,
               worktree: runCwd,
               model: displayModel,
+              telemetry,
             });
             return result;
           } catch (error) {
-            if (options.signal?.aborted) throw error;
+            attemptController.abort();
+            // A failed attempt has no durable journal entry, so its writes must not
+            // remain observable or contaminate a retry/child invocation delta.
+            store.discardDelta(attemptDeltaKey);
+            if (!usageRecorded && (accountedUsage || !executionSignal.aborted)) {
+              accountedTokens = recordTokens(null, accountedUsage);
+              usageRecorded = true;
+            }
+            if (executionSignal.aborted) throw error;
+            if (journalFailure !== undefined) throw journalFailure;
 
             const workflowError = wrapError(error, { agentLabel: label });
             logger.error(`agent ${label} attempt ${attempt}/${maxAttempts} failed: ${workflowError.message}`);
-            const tokens = recordTokens(null);
 
             if (workflowError.recoverable && attempt < maxAttempts) {
               log(
@@ -571,16 +861,18 @@ export async function runWorkflow<T = unknown>(
             }
 
             options.onAgentEnd?.({
+              callId: deltaKey,
               label,
               phase: assignedPhase,
               result: null,
-              tokens,
-              tokenUsage: usage,
+              tokens: accountedTokens,
+              tokenUsage: accountedUsage,
               worktree: runCwd,
               model: displayModel,
               error: workflowError.message,
               errorCode: workflowError.code,
               recoverable: workflowError.recoverable,
+              telemetry,
             });
 
             if (workflowError.recoverable) {
@@ -601,51 +893,68 @@ export async function runWorkflow<T = unknown>(
   };
 
   const parallel = async (thunks: Array<() => Promise<unknown>>) => {
-    throwIfAborted();
+    const parentSignal = currentSignal();
+    throwIfAborted(parentSignal);
     if (!Array.isArray(thunks)) throw new TypeError("parallel() expects an array of functions");
     if (thunks.some((thunk) => typeof thunk !== "function")) {
       throw new TypeError("parallel() expects an array of functions, not promises. Wrap each call: () => agent(...)");
     }
-    return Promise.all(
-      thunks.map(async (thunk, index) => {
+    const operationController = new AbortController();
+    const operationSignal = combineAbortSignals(parentSignal, operationController.signal);
+    let terminalFailure: WorkflowError | undefined;
+    const branches = thunks.map((thunk, index) =>
+      operationSignals.run(operationSignal, async () => {
         try {
           return await thunk();
         } catch (error) {
-          if (options.signal?.aborted) throw error;
+          if (parentSignal.aborted || operationController.signal.aborted) throw error;
           const workflowError = wrapError(error);
-          // Non-recoverable failures (token budget / agent limit exhausted) must
-          // halt the whole run, exactly like a directly-awaited agent() — not be
-          // swallowed into a null in the result array.
-          if (!workflowError.recoverable) throw workflowError;
+          if (!workflowError.recoverable) {
+            terminalFailure ??= workflowError;
+            operationController.abort();
+            throw workflowError;
+          }
           log(`parallel[${index}] failed: ${workflowError.message}`);
           return null;
         }
       }),
     );
+    const settled = await Promise.allSettled(branches);
+    const failure = settled.find((result): result is PromiseRejectedResult => result.status === "rejected");
+    if (terminalFailure) throw terminalFailure;
+    if (failure) throw failure.reason;
+    return settled.map((result) => (result as PromiseFulfilledResult<unknown>).value);
   };
 
   const pipeline = async (
     items: unknown[],
     ...stages: Array<(prev: unknown, original: unknown, index: number) => unknown>
   ) => {
-    throwIfAborted();
+    const parentSignal = currentSignal();
+    throwIfAborted(parentSignal);
     if (!Array.isArray(items)) throw new TypeError("pipeline() expects an array as the first argument");
     if (stages.some((stage) => typeof stage !== "function")) {
       throw new TypeError("pipeline() stages must be functions: pipeline(items, item => ..., result => ...)");
     }
-    return Promise.all(
-      items.map(async (item, index) => {
+    const operationController = new AbortController();
+    const operationSignal = combineAbortSignals(parentSignal, operationController.signal);
+    let terminalFailure: WorkflowError | undefined;
+    const branches = items.map((item, index) =>
+      operationSignals.run(operationSignal, async () => {
         let value: unknown = item;
         for (const stage of stages) {
           try {
-            throwIfAborted();
+            throwIfAborted(operationSignal);
             value = await stage(value, item, index);
-            throwIfAborted();
+            throwIfAborted(operationSignal);
           } catch (error) {
-            if (options.signal?.aborted) throw error;
+            if (parentSignal.aborted || operationController.signal.aborted) throw error;
             const workflowError = wrapError(error);
-            // Non-recoverable failures halt the whole run (see parallel()).
-            if (!workflowError.recoverable) throw workflowError;
+            if (!workflowError.recoverable) {
+              terminalFailure ??= workflowError;
+              operationController.abort();
+              throw workflowError;
+            }
             log(`pipeline[${index}] failed: ${workflowError.message}`);
             return null;
           }
@@ -653,35 +962,161 @@ export async function runWorkflow<T = unknown>(
         return value;
       }),
     );
+    const settled = await Promise.allSettled(branches);
+    const failure = settled.find((result): result is PromiseRejectedResult => result.status === "rejected");
+    if (terminalFailure) throw terminalFailure;
+    if (failure) throw failure.reason;
+    return settled.map((result) => (result as PromiseFulfilledResult<unknown>).value);
   };
 
-  // Nested workflow(): run a saved workflow (or a raw script) inline, sharing this
-  // run's limiter/counters/budget so the global caps hold. One level deep only.
-  const workflowFn = async (nameOrScript: string, childArgs?: unknown) => {
+  // Nested workflow(): run a saved workflow, raw script, or cwd-contained script
+  // path inline. The completed child is one atomic parent journal entry: a crash
+  // during the child leaves no partial parent entry, so resume reruns it entirely.
+  const workflowFn = async (nameOrDescriptor: string | WorkflowScriptDescriptor, ...childArgList: unknown[]) => {
     throwIfAborted();
     if (shared.depth >= 1) {
       throw new WorkflowError("workflow() can nest only one level deep", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
         recoverable: false,
       });
     }
-    const resolved = options.loadSavedWorkflow?.(String(nameOrScript));
-    const childScript = resolved ?? String(nameOrScript);
+    if (childArgList.length > 1) {
+      throw scriptValidationError("workflow() accepts at most one child args value");
+    }
+    const childArgsSupplied = childArgList.length === 1;
+    let childArgs: unknown;
+    if (childArgsSupplied) {
+      try {
+        childArgs = normalizeJsonChildArgs(childArgList[0], scriptJsonPrototypes);
+      } catch {
+        throw scriptValidationError("workflow() child args must be deterministic JSON-serializable values");
+      }
+    }
+
+    const resolved = resolveChildWorkflow(nameOrDescriptor, baseCwd, options.loadSavedWorkflow);
+    const callIndex = state.callSeq++;
+    const callHash = hashWorkflowCall(
+      resolved.identity,
+      resolved.script,
+      childArgsSupplied,
+      childArgs,
+      agentRegistrySnapshotKey(agentRegistry),
+      agentTypePolicy,
+      childEffectiveRoutesIdentity(resolved.script, {
+        agentRegistry,
+        aliases: modelAliases,
+        strict: strictModelResolution,
+        tierConfig: modelTierConfig,
+        mainModel: effectiveMainModel,
+        sessionModel,
+        inheritedThinking: options.session?.thinkingLevel,
+        modelRegistry:
+          options.modelRegistry ?? (agentRunner instanceof WorkflowAgent ? agentRunner.getModelRegistry() : undefined),
+      }),
+      runReplayIdentity,
+    );
+    const cached = options.resumeJournal?.get(callIndex);
+    const hashMatches = cached != null && cached.hash === callHash;
+    if (hashMatches && callIndex < state.firstMiss) {
+      const childAgentCount = validateReplayedAgentCount(cached.agentCount);
+      let replayResult: unknown;
+      if (cached.resultKind === "void") {
+        if (cached.result !== null) {
+          throw scriptValidationError("replayed atomic void child result must use the canonical null encoding");
+        }
+        replayResult = undefined;
+      } else {
+        try {
+          replayResult = normalizeJsonResult(cached.result);
+        } catch {
+          throw scriptValidationError("replayed atomic child result must be deterministic JSON-serializable values");
+        }
+      }
+      if (shared.agentCount + childAgentCount > maxAgents) {
+        throw new WorkflowError(
+          `Agent limit exceeded (${maxAgents}). Use maxAgents option to increase the limit.`,
+          WorkflowErrorCode.AGENT_LIMIT_EXCEEDED,
+          { recoverable: false },
+        );
+      }
+      shared.agentCount += childAgentCount;
+      localAgentCount += childAgentCount;
+      for (const childAgent of cached.childAgents ?? []) {
+        const telemetry: AgentTelemetry = childAgent.telemetry
+          ? { ...childAgent.telemetry, execution: "replay" }
+          : { execution: "replay" };
+        options.onAgentStart?.({
+          callId: childAgent.callId,
+          label: childAgent.label,
+          phase: childAgent.phase,
+          prompt: childAgent.prompt,
+          model: childAgent.model,
+        });
+        options.onAgentEnd?.({
+          ...childAgent,
+          tokens: 0,
+          tokenUsage: undefined,
+          telemetry,
+        });
+      }
+      if (cached.storeDelta) store.applyDelta(cached.storeDelta, cached.storeVersions);
+      return replayResult;
+    }
+    if (!hashMatches) state.firstMiss = Math.min(state.firstMiss, callIndex);
+
+    const childStore = store.createChildScope();
+    const childAgents: JournaledChildAgent[] = [];
+    // callIndex is unique for every child invocation in this parent, including
+    // sequential failed children at the same nesting depth.
+    const childRunId = `${runId}-child${callIndex}`;
     shared.depth++;
     try {
-      const child = await runWorkflow(childScript, {
+      const child = await runWorkflow(resolved.script, {
         ...options,
-        args: childArgs,
+        args: childArgsSupplied ? childArgs : undefined,
+        mainModel: effectiveMainModel,
+        modelAliases,
+        strictModelResolution,
+        agentRegistry,
+        modelTierConfig,
         sharedRuntime: shared,
-        // Propagate the parent's store so nested agents share the same key-value space.
-        sharedStore: store,
-        // A nested run is its own script; never reuse the parent's resume journal.
+        // Child writes remain in an overlay until the entire invocation succeeds.
+        sharedStore: childStore,
         resumeJournal: undefined,
         resumeFromRunId: undefined,
-        runId: `${runId}-nested${shared.depth}`,
+        onAgentJournal: () => {},
+        onAgentStart: (event) => {
+          childAgents.push({ ...event, result: undefined });
+          options.onAgentStart?.(event);
+        },
+        onAgentEnd: (event) => {
+          const captured = childAgents.find((agent) => agent.callId === event.callId);
+          if (captured) Object.assign(captured, event);
+          options.onAgentEnd?.(event);
+        },
+        requireJsonResult: true,
+        runId: childRunId,
         persistLogs: false,
       });
-      return child.result;
+      const childAgentCount = child.agentCount;
+      const isVoidResult = child.result === undefined;
+      const journalResult = isVoidResult ? null : normalizeJsonTree(child.result);
+      const returnedResult = isVoidResult ? undefined : normalizeJsonTree(journalResult);
+      const preparedDelta = childStore.prepareChildScope();
+      options.onAgentJournal?.({
+        index: callIndex,
+        hash: callHash,
+        result: journalResult,
+        storeDelta: preparedDelta.values,
+        storeVersions: preparedDelta.versions,
+        agentCount: childAgentCount,
+        resultKind: isVoidResult ? "void" : undefined,
+        childAgents,
+      });
+      childStore.commitChildScope(preparedDelta);
+      localAgentCount += childAgentCount;
+      return returnedResult;
     } finally {
+      childStore.dispose();
       shared.depth--;
     }
   };
@@ -856,14 +1291,16 @@ export async function runWorkflow<T = unknown>(
       );
     }
     const callIndex = state.callSeq++;
-    const callHash = hashCheckpoint(promptText, checkpointOptions);
+    const callHash = hashCheckpoint(promptText, checkpointOptions, runReplayIdentity);
     const cached = options.resumeJournal?.get(callIndex);
     if (cached != null && cached.hash === callHash && callIndex < state.firstMiss) {
       shared.agentCount++;
+      localAgentCount++;
       return cached.result; // replay the journaled human reply
     }
     if (cached == null || cached.hash !== callHash) state.firstMiss = Math.min(state.firstMiss, callIndex);
     shared.agentCount++;
+    localAgentCount++;
 
     let reply: unknown;
     if (options.confirm) {
@@ -912,9 +1349,21 @@ export async function runWorkflow<T = unknown>(
     // neutered in-realm by DETERMINISM_PRELUDE below.
   });
 
+  scriptJsonPrototypes = new vm.Script(
+    "({ arrayPrototype: Array.prototype, objectPrototype: Object.prototype })",
+  ).runInContext(context) as JsonTreePrototypes;
+
   const wrapped = `${DETERMINISM_PRELUDE}\n(async () => {\n${body}\n})()`;
   try {
-    const result = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context);
+    const rawResult = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context);
+    let result = rawResult;
+    if (options.requireJsonResult && rawResult !== undefined) {
+      try {
+        result = normalizeJsonResult(rawResult, scriptJsonPrototypes);
+      } catch {
+        throw scriptValidationError("workflow() child result must be deterministic JSON-serializable values");
+      }
+    }
 
     // Persist logs
     const logFile = logger.persist();
@@ -930,7 +1379,7 @@ export async function runWorkflow<T = unknown>(
       result: result as T,
       logs: state.logs,
       phases: state.phases,
-      agentCount: shared.agentCount,
+      agentCount: options.sharedRuntime ? localAgentCount : shared.agentCount,
       durationMs: Date.now() - started,
       runId,
       tokenUsage: shared.tokenUsage,
@@ -943,14 +1392,6 @@ export async function runWorkflow<T = unknown>(
 }
 
 export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body: string } {
-  if (DETERMINISM_BLOCKLIST.test(script)) {
-    throw new WorkflowError(
-      "Workflow scripts must be deterministic: Date.now()/Math.random()/new Date() are unavailable",
-      WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
-      { recoverable: false },
-    );
-  }
-
   const ast = parse(script, {
     ecmaVersion: "latest",
     sourceType: "module",
@@ -958,6 +1399,14 @@ export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body:
     allowReturnOutsideFunction: true,
     ranges: false,
   }) as AnyNode;
+
+  if (containsNondeterministicCall(ast)) {
+    throw new WorkflowError(
+      "Workflow scripts must be deterministic: Date.now()/Math.random()/new Date() are unavailable",
+      WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+      { recoverable: false },
+    );
+  }
 
   const first = ast.body?.[0] as AnyNode | undefined;
   if (first?.type !== "ExportNamedDeclaration") {
@@ -1088,12 +1537,445 @@ function defaultAgentLabel(phase: string | undefined, index: number): string {
   return phase ? `${phase} agent ${index}` : `agent ${index}`;
 }
 
+function scriptValidationError(message: string): WorkflowError {
+  return new WorkflowError(message, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, { recoverable: false });
+}
+
+export function resolveWorkflowScriptPath(
+  scriptPath: string,
+  cwd: string,
+  fsOverride: Partial<WorkflowScriptFsLayer> = {},
+): { script: string; identity: string } {
+  if (typeof scriptPath !== "string" || scriptPath.trim().length === 0) {
+    throw scriptValidationError("workflow() scriptPath must be a non-empty string");
+  }
+  const fs: WorkflowScriptFsLayer = {
+    realpathSync,
+    lstatSync,
+    statSync,
+    openSync,
+    fstatSync,
+    readFileSync: (fd, encoding) => readFileSync(fd, encoding),
+    closeSync,
+    ...fsOverride,
+  };
+  let root: string;
+  try {
+    root = fs.realpathSync(cwd);
+  } catch {
+    throw scriptValidationError("workflow cwd does not exist");
+  }
+  const candidate = resolve(root, scriptPath);
+  if (!isPathInside(root, candidate)) {
+    throw scriptValidationError("workflow() scriptPath escapes workflow cwd");
+  }
+
+  let realPath: string;
+  let expected: Stats;
+  try {
+    const candidateStat = fs.lstatSync(candidate);
+    realPath = fs.realpathSync(candidate);
+    if (!isPathInside(root, realPath)) {
+      throw scriptValidationError("workflow() scriptPath escapes workflow cwd");
+    }
+    // Because candidate is rooted at the canonical cwd, a different canonical
+    // path means at least one path component was a symlink.
+    if (candidateStat.isSymbolicLink() || realPath !== candidate) {
+      throw scriptValidationError("workflow() scriptPath must not contain symlinks");
+    }
+    expected = fs.statSync(realPath);
+  } catch (error) {
+    if (error instanceof WorkflowError) throw error;
+    throw scriptValidationError("workflow() scriptPath does not exist");
+  }
+  if (!expected.isFile()) {
+    throw scriptValidationError("workflow() scriptPath must reference a file");
+  }
+  if (typeof fsConstants.O_NOFOLLOW !== "number") {
+    throw scriptValidationError("secure workflow scriptPath loading is not supported on this platform");
+  }
+
+  let fd: number;
+  try {
+    fd = fs.openSync(candidate, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  } catch (error) {
+    if ((error as { code?: string }).code === "ELOOP") {
+      throw scriptValidationError("workflow() scriptPath must not contain symlinks");
+    }
+    throw scriptValidationError("workflow() scriptPath could not be opened securely");
+  }
+
+  let result: { script: string; identity: string } | undefined;
+  let secureReadError: WorkflowError | undefined;
+  try {
+    const opened = fs.fstatSync(fd);
+    if (!opened.isFile()) {
+      throw scriptValidationError("workflow() scriptPath must reference a file");
+    }
+    if (!sameFileIdentity(expected, opened)) {
+      throw scriptValidationError("workflow() scriptPath changed during secure open");
+    }
+    let currentPath: string;
+    let current: Stats;
+    try {
+      currentPath = fs.realpathSync(candidate);
+      current = fs.statSync(currentPath);
+    } catch {
+      throw scriptValidationError("workflow() scriptPath changed during secure open");
+    }
+    if (currentPath !== realPath || !isPathInside(root, currentPath) || !sameFileIdentity(opened, current)) {
+      throw scriptValidationError("workflow() scriptPath changed during secure open");
+    }
+    result = { script: fs.readFileSync(fd, "utf8"), identity: `path:${realPath}` };
+  } catch (error) {
+    secureReadError =
+      error instanceof WorkflowError
+        ? error
+        : scriptValidationError("workflow() scriptPath could not be read securely");
+  }
+  try {
+    fs.closeSync(fd);
+  } catch {
+    secureReadError ??= scriptValidationError("workflow() scriptPath descriptor could not be closed");
+  }
+  if (secureReadError) throw secureReadError;
+  if (!result) throw scriptValidationError("workflow() scriptPath could not be read securely");
+  return result;
+}
+
+function resolveChildWorkflow(
+  reference: string | WorkflowScriptDescriptor,
+  cwd: string,
+  loadSavedWorkflow: ((name: string) => string | undefined) | undefined,
+): { script: string; identity: string } {
+  if (typeof reference === "string") {
+    const saved = loadSavedWorkflow?.(reference);
+    return saved === undefined
+      ? { script: reference, identity: `raw:${reference}` }
+      : { script: saved, identity: `saved:${reference}` };
+  }
+
+  if (!isWorkflowScriptDescriptor(reference)) {
+    throw scriptValidationError("workflow() descriptor must contain exactly one string scriptPath");
+  }
+
+  return resolveWorkflowScriptPath(reference.scriptPath, cwd);
+}
+
+function isWorkflowScriptDescriptor(value: unknown): value is WorkflowScriptDescriptor {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const keys = Reflect.ownKeys(value);
+  if (keys.length !== 1 || keys[0] !== "scriptPath") return false;
+  const scriptPath = (value as { scriptPath?: unknown }).scriptPath;
+  return typeof scriptPath === "string" && scriptPath.trim().length > 0;
+}
+
+function sameFileIdentity(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return (
+    rel === "" ||
+    (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`))
+  );
+}
+
+function hashWorkflowCall(
+  identity: string,
+  script: string,
+  argsSupplied: boolean,
+  args: unknown,
+  agentRegistryKey: string,
+  agentTypePolicy: AgentTypePolicy,
+  routeIdentity: string,
+  runIdentity: string,
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        identity,
+        script,
+        argsSupplied,
+        args: argsSupplied ? args : null,
+        agentRegistry: agentRegistryKey,
+        agentTypePolicy,
+        routeIdentity,
+        runIdentity,
+      }),
+    )
+    .digest("hex");
+}
+
+function agentRegistrySnapshotKey(registry: AgentRegistry): string {
+  return JSON.stringify(
+    [...registry.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, definition]) => [name, agentDefinitionKey(definition)]),
+  );
+}
+
+function validateReplayedAgentCount(value: unknown): number {
+  if (value === undefined) return 0;
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw scriptValidationError("replayed atomic child agentCount must be a non-negative integer");
+  }
+  return value as number;
+}
+
+function normalizedReplayValue(value: unknown): unknown {
+  if (value === undefined) return { kind: "undefined" };
+  try {
+    return { kind: "json", value: normalizeJsonTree(value) };
+  } catch {
+    return { kind: "unsupported", type: Object.prototype.toString.call(value) };
+  }
+}
+
+function effectiveRouteIdentity(options: {
+  modelSpec?: string;
+  tier?: string;
+  aliases?: Record<string, string>;
+  strict: boolean;
+  tierConfig: ModelTierConfig | null;
+  mainModel?: string;
+  sessionModel?: string;
+  effort?: ModelThinkingLevel;
+  inheritedThinking?: string;
+  modelRegistry?: WorkflowAgentOptions["modelRegistry"];
+}): string {
+  const requested =
+    resolveAgentModelSpec(
+      { model: options.modelSpec, tier: options.tier },
+      options.mainModel,
+      () => options.tierConfig,
+    ) ??
+    options.sessionModel ??
+    options.mainModel;
+  const aliased = requested ? resolveModelAlias(requested, options.aliases) : undefined;
+  const resolved =
+    aliased && options.modelRegistry ? resolveModelSpecWithThinking(aliased, options.modelRegistry) : undefined;
+  const fallbackParsed = aliased && !options.modelRegistry ? splitModelSpecThinking(aliased) : undefined;
+  const resolvedModel = resolved?.model ? `${resolved.model.provider}/${resolved.model.id}` : undefined;
+  const thinking = resolveAgentThinkingLevel(
+    options.effort,
+    resolved?.thinkingLevel ?? fallbackParsed?.thinkingLevel,
+    options.inheritedThinking as ModelThinkingLevel | undefined,
+  );
+  return JSON.stringify({
+    requested: requested ?? null,
+    aliased: aliased ?? null,
+    resolved: resolvedModel ?? null,
+    thinking: thinking ?? null,
+    strict: options.strict,
+  });
+}
+
+function childEffectiveRoutesIdentity(
+  script: string,
+  options: {
+    agentRegistry: AgentRegistry;
+    aliases?: Record<string, string>;
+    strict: boolean;
+    tierConfig: ModelTierConfig | null;
+    mainModel?: string;
+    sessionModel?: string;
+    inheritedThinking?: string;
+    modelRegistry?: WorkflowAgentOptions["modelRegistry"];
+  },
+): string {
+  const { meta, body } = parseWorkflowScript(script);
+  const routing = parseModelRoutingFromMeta(meta.phases, meta.model);
+  const program = parse(body, {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    allowReturnOutsideFunction: true,
+  }) as AnyNode;
+  let currentPhase = meta.phases?.[0]?.title;
+  let agentReferences = 0;
+  let directAgentCalls = 0;
+  let helperReferences = 0;
+  let directHelperCalls = 0;
+  let dynamicRoute = false;
+  const routes: string[] = [];
+  const agentBackedHelpers = new Set(["verify", "judgePanel", "completenessCheck"]);
+
+  const visit = (node: AnyNode): void => {
+    if (node.type === "Identifier" && node.name === "agent") agentReferences++;
+    if (node.type === "Identifier" && agentBackedHelpers.has(node.name)) helperReferences++;
+    if (node.type === "CallExpression" && node.callee?.type === "Identifier") {
+      if (node.callee.name === "phase") {
+        const title = literalString(node.arguments?.[0]);
+        if (title !== undefined) currentPhase = title;
+        else dynamicRoute = true;
+      } else if (node.callee.name === "agent") {
+        directAgentCalls++;
+        const optionsNode = node.arguments?.[1] as AnyNode | undefined;
+        dynamicRoute ||= hasDynamicAgentRouteOptions(optionsNode);
+        const agentOptions = literalAgentRouteOptions(optionsNode);
+        const assignedPhase = agentOptions.phase ?? currentPhase;
+        const agentDef = resolveAgentType(agentOptions.agentType, options.agentRegistry);
+        const explicitModel = agentOptions.model ?? agentDef?.model;
+        const modelSpec =
+          explicitModel ?? (agentOptions.tier ? undefined : resolveModelForPhase(assignedPhase, routing));
+        routes.push(
+          effectiveRouteIdentity({
+            modelSpec,
+            tier: agentOptions.tier,
+            aliases: options.aliases,
+            strict: options.strict,
+            tierConfig: options.tierConfig,
+            mainModel: options.mainModel,
+            sessionModel: options.sessionModel,
+            effort: agentOptions.effort,
+            inheritedThinking: options.inheritedThinking,
+            modelRegistry: options.modelRegistry,
+          }),
+        );
+      } else if (agentBackedHelpers.has(node.callee.name)) {
+        directHelperCalls++;
+        routes.push(
+          effectiveRouteIdentity({
+            modelSpec: resolveModelForPhase(currentPhase, routing),
+            aliases: options.aliases,
+            strict: options.strict,
+            tierConfig: options.tierConfig,
+            mainModel: options.mainModel,
+            sessionModel: options.sessionModel,
+            inheritedThinking: options.inheritedThinking,
+            modelRegistry: options.modelRegistry,
+          }),
+        );
+      }
+    }
+    for (const value of Object.values(node)) {
+      if (!value || typeof value !== "object") continue;
+      if (Array.isArray(value)) {
+        for (const child of value) if (child && typeof child === "object") visit(child as AnyNode);
+      } else if ("type" in value) {
+        visit(value as AnyNode);
+      }
+    }
+  };
+  visit(program);
+
+  const declaredRoutes = [meta.model, ...(meta.phases?.map((phase) => phase.model) ?? [])]
+    .filter((model): model is string => model !== undefined)
+    .map((modelSpec) =>
+      effectiveRouteIdentity({
+        modelSpec,
+        aliases: options.aliases,
+        strict: options.strict,
+        tierConfig: options.tierConfig,
+        mainModel: options.mainModel,
+        sessionModel: options.sessionModel,
+        inheritedThinking: options.inheritedThinking,
+        modelRegistry: options.modelRegistry,
+      }),
+    );
+  const dynamicAgentReference =
+    agentReferences > directAgentCalls || helperReferences > directHelperCalls || dynamicRoute;
+  return JSON.stringify({
+    routes,
+    declaredRoutes,
+    // Atomic children may invoke agent-backed globals through aliases, computed
+    // members, or user-defined wrappers that static syntax inspection cannot
+    // resolve soundly. Conservatively bind the child cache to the complete
+    // routing environment so no such call can replay across a route change.
+    routingEnvironment: {
+      aliases: modelAliasesIdentity(options.aliases),
+      tiers: options.tierConfig?.tiers ?? null,
+      models: modelRegistrySnapshotKey(options.modelRegistry),
+      mainModel: options.mainModel ?? null,
+      inheritedThinking: options.inheritedThinking ?? null,
+      strict: options.strict,
+    },
+    dynamic: dynamicAgentReference
+      ? {
+          aliases: modelAliasesIdentity(options.aliases),
+          tiers: options.tierConfig?.tiers ?? null,
+          models: modelRegistrySnapshotKey(options.modelRegistry),
+          defaultRoute: effectiveRouteIdentity({
+            aliases: options.aliases,
+            strict: options.strict,
+            tierConfig: options.tierConfig,
+            mainModel: options.mainModel,
+            sessionModel: options.sessionModel,
+            inheritedThinking: options.inheritedThinking,
+            modelRegistry: options.modelRegistry,
+          }),
+        }
+      : null,
+  });
+}
+
+function hasDynamicAgentRouteOptions(node: AnyNode | undefined): boolean {
+  if (!node) return false;
+  if (node.type !== "ObjectExpression") return true;
+  for (const property of node.properties as AnyNode[]) {
+    if (property.type !== "Property" || property.computed || property.kind !== "init") return true;
+    const key = propertyKey(property.key as AnyNode, "agent options");
+    if (!["model", "tier", "effort", "phase", "agentType"].includes(key)) continue;
+    if (literalString(property.value as AnyNode) === undefined) return true;
+  }
+  return false;
+}
+
+function literalAgentRouteOptions(node: AnyNode | undefined): {
+  model?: string;
+  tier?: string;
+  effort?: ModelThinkingLevel;
+  phase?: string;
+  agentType?: string;
+} {
+  if (node?.type !== "ObjectExpression") return {};
+  const result: { model?: string; tier?: string; effort?: ModelThinkingLevel; phase?: string; agentType?: string } = {};
+  for (const property of node.properties as AnyNode[]) {
+    if (property.type !== "Property" || property.computed || property.kind !== "init") continue;
+    const key = propertyKey(property.key as AnyNode, "agent options");
+    const value = literalString(property.value as AnyNode);
+    if (value === undefined) continue;
+    if (key === "model" || key === "tier" || key === "phase" || key === "agentType") result[key] = value;
+    if (key === "effort" && isThinkingLevel(value)) result.effort = value;
+  }
+  return result;
+}
+
+function literalString(node: AnyNode | undefined): string | undefined {
+  return node?.type === "Literal" && typeof node.value === "string" ? node.value : undefined;
+}
+
+function modelAliasesIdentity(aliases: Record<string, string> | undefined): string {
+  return JSON.stringify(
+    Object.entries(aliases ?? {})
+      .map(([key, value]) => [key.trim().toLowerCase(), value.trim()] as const)
+      .filter(([key, value]) => key && value)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function modelRegistrySnapshotKey(registry: WorkflowAgentOptions["modelRegistry"]): unknown {
+  if (!registry) return null;
+  try {
+    return registry
+      .getAll()
+      .map((model) => [model.provider, model.id, model.name ?? null])
+      .sort(([leftProvider, leftId], [rightProvider, rightId]) =>
+        `${leftProvider}/${leftId}`.localeCompare(`${rightProvider}/${rightId}`),
+      );
+  } catch {
+    return "unavailable";
+  }
+}
+
 /** Stable identity hash for an agent() call — a cache miss on resume when anything changes. */
-function hashCheckpoint(promptText: string, options: CheckpointOptions): string {
+function hashCheckpoint(promptText: string, options: CheckpointOptions, runIdentity: string): string {
   const identity = JSON.stringify({
     promptText,
     kind: options.kind ?? "confirm",
     choices: options.choices ?? null,
+    runIdentity,
   });
   return createHash("sha256").update(identity).digest("hex");
 }
@@ -1104,17 +1986,28 @@ function hashAgentCall(
   phase: string | undefined,
   options: AgentOptions,
   agentDefKey: string | null,
+  routeIdentity: string,
+  runIdentity: string,
+  timeout: number | null,
+  retries: number,
+  isolation: "worktree" | undefined,
 ): string {
   const identity = JSON.stringify({
     prompt,
+    label: options.label ?? null,
     model: model ?? null,
     tier: options.tier ?? null,
+    effort: options.effort ?? null,
     phase: phase ?? null,
     agentType: options.agentType ?? null,
-    // Resolved definition (tools/model/prompt) so editing an agent .md invalidates
-    // this call's cached result on a later resume.
+    // Resolved definition includes its prompt, skills, tools, model, and isolation.
     agentDef: agentDefKey,
     schema: options.schema ?? null,
+    routeIdentity,
+    runIdentity,
+    timeout,
+    retries,
+    isolation: isolation ?? null,
   });
   return createHash("sha256").update(identity).digest("hex");
 }
@@ -1138,8 +2031,43 @@ function buildAgentInstructions(
   return lines.length ? lines.join("\n\n") : undefined;
 }
 
-function isEmptyTextAgentResult(result: unknown, schema: TSchema | undefined): boolean {
+function isEmptyTextAgentResult(result: unknown, schema: WorkflowSchema | undefined): boolean {
   return schema === undefined && typeof result === "string" && result.trim().length === 0;
+}
+
+function mergeAgentTelemetry(current: AgentTelemetry | undefined, next: AgentTelemetry): AgentTelemetry {
+  if (!current) {
+    return {
+      ...next,
+      activeToolNames: next.activeToolNames ? [...next.activeToolNames] : undefined,
+      usage: next.usage ? { ...next.usage } : undefined,
+    };
+  }
+  const usage =
+    current.usage && next.usage
+      ? {
+          input: current.usage.input + next.usage.input,
+          output: current.usage.output + next.usage.output,
+          cacheRead: current.usage.cacheRead + next.usage.cacheRead,
+          cacheWrite: current.usage.cacheWrite + next.usage.cacheWrite,
+          total: current.usage.total + next.usage.total,
+          cost: current.usage.cost + next.usage.cost,
+        }
+      : (next.usage ?? current.usage);
+  const accountingIncompleteAttempts =
+    (current.accountingIncompleteAttempts ?? 0) + (next.accountingIncompleteAttempts ?? 0);
+  const accountingStatus =
+    current.accountingStatus === "incomplete" || next.accountingStatus === "incomplete"
+      ? "incomplete"
+      : (next.accountingStatus ?? current.accountingStatus);
+  return {
+    ...current,
+    ...next,
+    activeToolNames: next.activeToolNames ? [...next.activeToolNames] : current.activeToolNames,
+    usage: usage ? { ...usage } : undefined,
+    accountingStatus,
+    accountingIncompleteAttempts: accountingIncompleteAttempts || undefined,
+  };
 }
 
 function estimateTokens(value: unknown): number {
@@ -1159,13 +2087,45 @@ function normalizeAgentRetries(value: unknown): number {
 /**
  * Run a promise with a timeout.
  */
-async function withTimeout<T>(promise: Promise<T>, ms: number | null, label: string): Promise<T> {
+function combineAbortSignals(parent: AbortSignal | undefined, attempt: AbortSignal): AbortSignal {
+  return parent ? AbortSignal.any([parent, attempt]) : attempt;
+}
+
+// Give an aborted SDK session a short chance to finish its finally/dispose path
+// and publish exact usage before retrying. An injected runner may ignore abort,
+// so this wait is deliberately bounded and incomplete accounting is persisted.
+const RUNNER_CLEANUP_GRACE_MS = 50;
+
+async function waitForRunnerSettlement(promise: Promise<unknown>, graceMs: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    let finished = false;
+    const finish = (settled: boolean) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timeoutId);
+      resolve(settled);
+    };
+    const timeoutId = setTimeout(() => finish(false), graceMs);
+    void promise.then(
+      () => finish(true),
+      () => finish(true),
+    );
+  });
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number | null,
+  label: string,
+  onTimeout?: () => void,
+): Promise<T> {
   if (ms === null) return promise;
 
   let timeoutId: NodeJS.Timeout | undefined;
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
+      onTimeout?.();
       reject(
         new WorkflowError(
           `Agent "${label}" timed out after ${ms}ms; raise or omit timeoutMs/agentTimeoutMs to allow longer runs`,

--- a/tests/agent-effort.test.ts
+++ b/tests/agent-effort.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveAgentThinkingLevel } from "../src/agent.js";
+
+test("explicit effort wins over model suffix and inherited session thinking", () => {
+  assert.equal(resolveAgentThinkingLevel("minimal", "xhigh", "high"), "minimal");
+  assert.equal(resolveAgentThinkingLevel("off", "max", "high"), "off");
+  assert.equal(resolveAgentThinkingLevel("max", undefined, "low"), "max");
+});
+
+test("model suffix wins over inherited session thinking when effort is omitted", () => {
+  assert.equal(resolveAgentThinkingLevel(undefined, "xhigh", "low"), "xhigh");
+  assert.equal(resolveAgentThinkingLevel(undefined, undefined, "medium"), "medium");
+  assert.equal(resolveAgentThinkingLevel(undefined, undefined, undefined), undefined);
+});

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -75,6 +75,13 @@ describe("parseAgentDefinition", () => {
     assert.ok(def);
     assert.equal(def.isolation, undefined);
   });
+
+  it("binds only literal boolean skills frontmatter", () => {
+    assert.equal(parseAgentDefinition("---\nskills: false\n---\nBody.", "project", "off.md")?.skills, false);
+    assert.equal(parseAgentDefinition("---\nskills: true\n---\nBody.", "project", "on.md")?.skills, true);
+    assert.equal(parseAgentDefinition("---\nskills: 'false'\n---\nBody.", "project", "quoted.md")?.skills, undefined);
+    assert.equal(parseAgentDefinition("---\n---\nBody.", "project", "absent.md")?.skills, undefined);
+  });
 });
 
 // ── loadAgentRegistry (dir injection) ──────────────────────────────────────
@@ -327,6 +334,12 @@ describe("agentDefinitionKey", () => {
     const base: AgentDefinition = { name: "x", prompt: "p", source: "project" };
     assert.notEqual(agentDefinitionKey(base), agentDefinitionKey({ ...base, isolation: "worktree" }));
   });
+
+  it("changes when skills changes", () => {
+    const base: AgentDefinition = { name: "x", prompt: "p", source: "project" };
+    assert.notEqual(agentDefinitionKey(base), agentDefinitionKey({ ...base, skills: false }));
+    assert.notEqual(agentDefinitionKey({ ...base, skills: false }), agentDefinitionKey({ ...base, skills: true }));
+  });
 });
 
 // ── runtime integration: agentType binds tools/model/prompt via runWorkflow ──
@@ -340,6 +353,7 @@ function capturingAgent() {
     instructions?: string;
     cwd?: string;
     cwdExists?: boolean;
+    skills?: boolean;
   }> = [];
   const runner = {
     async run(_prompt: string, options: Record<string, unknown>) {
@@ -351,6 +365,7 @@ function capturingAgent() {
         instructions: options.instructions as string | undefined,
         cwd: options.cwd as string | undefined,
         cwdExists: typeof options.cwd === "string" ? existsSync(options.cwd) : undefined,
+        skills: options.skills as boolean | undefined,
       });
       return "ok";
     },
@@ -386,6 +401,19 @@ return r`;
     assert.deepEqual(seen[0].toolNames, ["read", "grep"], "allowlist forwarded");
     assert.deepEqual(seen[0].disallowedToolNames, ["write", "bash"], "denylist forwarded");
     assert.ok(seen[0].instructions?.includes("You are a security auditor."), "body prompt injected");
+  });
+
+  it("forwards skills:false from the resolved agent definition", async () => {
+    const { seen, runner } = capturingAgent();
+    const skillsRegistry: AgentRegistry = new Map([
+      ["no-skills", { name: "no-skills", prompt: "No skills.", skills: false, source: "project" } as AgentDefinition],
+    ]);
+    const script = `export const meta = { name: 'at', description: 'agentType' }
+await agent('audit', { label: 'a', agentType: 'no-skills' })
+return {}`;
+    await runWorkflow(script, { agent: runner, persistLogs: false, agentRegistry: skillsRegistry });
+
+    assert.equal(seen[0].skills, false);
   });
 
   it("explicit opts.model beats the agentType model", async () => {

--- a/tests/aicodeflow-compat.test.ts
+++ b/tests/aicodeflow-compat.test.ts
@@ -1,0 +1,428 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import test from "node:test";
+import type { AgentDefinition, AgentRegistry } from "../src/agent-registry.js";
+import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
+import { type JournalEntry, runWorkflow } from "../src/workflow.js";
+
+const childScript = `export const meta = { name: 'child', description: 'child workflow' }
+return { args }`;
+
+function parentScript(call: string): string {
+  return `export const meta = { name: 'parent', description: 'parent workflow' }
+return await ${call}`;
+}
+
+function withTempRoot(fn: (root: string) => Promise<void>) {
+  return async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-dw-compat-root-"));
+    try {
+      await fn(root);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  };
+}
+
+async function expectScriptValidation(script: string, cwd: string, message: string): Promise<void> {
+  await assert.rejects(
+    () => runWorkflow(script, { cwd, persistLogs: false }),
+    (error: unknown) => {
+      assert.ok(error instanceof WorkflowError);
+      assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+      assert.equal(error.message, message);
+      return true;
+    },
+  );
+}
+
+test(
+  "workflow({ scriptPath }) resolves relative and absolute paths inside the workflow cwd",
+  withTempRoot(async (root) => {
+    const path = join(root, "child.js");
+    writeFileSync(path, childScript);
+
+    const relativeRun = await runWorkflow<{ args: { mode: string } }>(
+      parentScript("workflow({ scriptPath: 'child.js' }, { mode: 'relative' })"),
+      { cwd: root, persistLogs: false },
+    );
+    assert.equal(relativeRun.result.args.mode, "relative");
+
+    const absoluteRun = await runWorkflow<{ args: { mode: string } }>(
+      parentScript(`workflow({ scriptPath: ${JSON.stringify(path)} }, { mode: 'absolute' })`),
+      { cwd: root, persistLogs: false },
+    );
+    assert.equal(absoluteRun.result.args.mode, "absolute");
+  }),
+);
+
+test(
+  "workflow({ scriptPath }) rejects traversal and symlink escapes with stable errors",
+  withTempRoot(async (root) => {
+    const outside = mkdtempSync(join(tmpdir(), "pi-dw-compat-outside-"));
+    try {
+      const outsidePath = join(outside, "outside.js");
+      writeFileSync(outsidePath, childScript);
+      const traversal = relative(root, outsidePath);
+      await expectScriptValidation(
+        parentScript(`workflow({ scriptPath: ${JSON.stringify(traversal)} })`),
+        root,
+        "workflow() scriptPath escapes workflow cwd",
+      );
+
+      const linkPath = join(root, "linked.js");
+      symlinkSync(outsidePath, linkPath);
+      await expectScriptValidation(
+        parentScript("workflow({ scriptPath: 'linked.js' })"),
+        root,
+        "workflow() scriptPath escapes workflow cwd",
+      );
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  }),
+);
+
+test(
+  "workflow({ scriptPath }) rejects missing paths, directories, and invalid descriptors",
+  withTempRoot(async (root) => {
+    mkdirSync(join(root, "child-dir"));
+    await expectScriptValidation(
+      parentScript("workflow({ scriptPath: 'missing.js' })"),
+      root,
+      "workflow() scriptPath does not exist",
+    );
+    await expectScriptValidation(
+      parentScript("workflow({ scriptPath: 'child-dir' })"),
+      root,
+      "workflow() scriptPath must reference a file",
+    );
+
+    for (const descriptor of [
+      "null",
+      "[]",
+      "{}",
+      "{ scriptPath: 1 }",
+      "{ scriptPath: '' }",
+      "{ scriptPath: '   ' }",
+      "{ scriptPath: 'x', extra: true }",
+    ]) {
+      await expectScriptValidation(
+        parentScript(`workflow(${descriptor})`),
+        root,
+        "workflow() descriptor must contain exactly one string scriptPath",
+      );
+    }
+  }),
+);
+
+test("workflow() preserves saved-name and raw-source strings", async () => {
+  const saved = await runWorkflow(parentScript("workflow('saved-child', { source: 'saved' })"), {
+    persistLogs: false,
+    loadSavedWorkflow: (name) => (name === "saved-child" ? childScript : undefined),
+  });
+  assert.equal(JSON.stringify(saved.result), JSON.stringify({ args: { source: "saved" } }));
+
+  const raw = await runWorkflow(parentScript(`workflow(${JSON.stringify(childScript)}, { source: 'raw' })`), {
+    persistLogs: false,
+  });
+  assert.equal(JSON.stringify(raw.result), JSON.stringify({ args: { source: "raw" } }));
+});
+
+test(
+  "workflow() allows exactly one nesting level for path descriptors too",
+  withTempRoot(async (root) => {
+    writeFileSync(
+      join(root, "grandchild.js"),
+      `export const meta = { name: 'grandchild', description: 'grandchild' }\nreturn true`,
+    );
+    writeFileSync(
+      join(root, "child.js"),
+      `export const meta = { name: 'child', description: 'child' }\nreturn await workflow({ scriptPath: 'grandchild.js' })`,
+    );
+    await assert.rejects(
+      () => runWorkflow(parentScript("workflow({ scriptPath: 'child.js' })"), { cwd: root, persistLogs: false }),
+      /one level deep/,
+    );
+  }),
+);
+
+test("workflow() rejects every non-JSON child-args form and still allows omitted args", async () => {
+  const invalidExpressions = [
+    "undefined",
+    "1n",
+    "() => 1",
+    "Symbol('x')",
+    "({ value: () => 1 })",
+    "({ value: Symbol('x') })",
+    "[undefined]",
+    "NaN",
+    "Infinity",
+    "(() => { const x = {}; x.self = x; return x })()",
+  ];
+  for (const expression of invalidExpressions) {
+    await expectScriptValidation(
+      parentScript(`workflow('child', ${expression})`),
+      process.cwd(),
+      "workflow() child args must be deterministic JSON-serializable values",
+    );
+  }
+
+  const omitted = await runWorkflow(parentScript("workflow('child')"), {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+  });
+  assert.equal(JSON.stringify(omitted.result), JSON.stringify({}));
+});
+
+interface StoreTool {
+  name: string;
+  execute(id: string, params: unknown): Promise<{ details?: { found?: boolean; value?: unknown } }>;
+}
+
+function storeAgent() {
+  const state = { calls: 0 };
+  return {
+    state,
+    runner: {
+      async run(prompt: string, options: { systemTools?: StoreTool[] }) {
+        state.calls++;
+        const [operation, key, value] = prompt.split(":");
+        if (operation === "put") {
+          await options.systemTools?.find((tool) => tool.name === "store_put")?.execute("", { key, value });
+          return `put:${key}`;
+        }
+        if (operation === "get") {
+          const read = await options.systemTools?.find((tool) => tool.name === "store_get")?.execute("", { key });
+          return { found: read?.details?.found, value: read?.details?.value };
+        }
+        return prompt;
+      },
+    },
+  };
+}
+
+const atomicChild = `export const meta = { name: 'atomic-child', description: 'atomic child' }
+await agent('put:child:key-from-child', { label: 'child-put' })
+return { child: args.version }`;
+
+const atomicParent = `export const meta = { name: 'atomic-parent', description: 'atomic parent' }
+await agent('put:parent:key-from-parent', { label: 'parent-put' })
+const child = await workflow('atomic-child', { version: 1 })
+const observed = await agent('get:child', { label: 'parent-read' })
+return { child, observed }`;
+
+test("a successful child workflow is one atomic parent journal entry and replays its state", async () => {
+  const firstAgent = storeAgent();
+  const journal: JournalEntry[] = [];
+  const first = await runWorkflow(atomicParent, {
+    agent: firstAgent.runner,
+    persistLogs: false,
+    loadSavedWorkflow: () => atomicChild,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+
+  assert.equal(firstAgent.state.calls, 3);
+  assert.deepEqual(
+    journal.map((entry) => entry.index),
+    [0, 1, 2],
+  );
+  assert.equal(journal[1].agentCount, 1, "the atomic child entry records its logical child-agent count");
+  assert.deepEqual(journal[1].storeDelta, { child: "key-from-child" });
+
+  const replayAgent = storeAgent();
+  const replay = await runWorkflow(atomicParent, {
+    agent: replayAgent.runner,
+    persistLogs: false,
+    loadSavedWorkflow: () => atomicChild,
+    resumeJournal: new Map(journal.slice(0, 2).map((entry) => [entry.index, entry])),
+  });
+
+  assert.equal(replayAgent.state.calls, 1, "parent put and the entire child replay; only the uncached read runs");
+  assert.equal(replay.agentCount, 3, "replay restores the logical child-agent count without counting the child twice");
+  assert.equal(JSON.stringify(replay.result), JSON.stringify(first.result));
+});
+
+test("child workflow source and args participate in the atomic journal hash", async () => {
+  const journal: JournalEntry[] = [];
+  const firstAgent = storeAgent();
+  await runWorkflow(parentScript("workflow('child', { version: 1 })"), {
+    agent: firstAgent.runner,
+    persistLogs: false,
+    loadSavedWorkflow: () => atomicChild,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  assert.equal(journal.length, 1);
+
+  const sameAgent = storeAgent();
+  await runWorkflow(parentScript("workflow('child', { version: 1 })"), {
+    agent: sameAgent.runner,
+    persistLogs: false,
+    loadSavedWorkflow: () => atomicChild,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+  assert.equal(sameAgent.state.calls, 0, "same source and args replay the atomic child");
+
+  const changedArgsAgent = storeAgent();
+  await runWorkflow(parentScript("workflow('child', { version: 2 })"), {
+    agent: changedArgsAgent.runner,
+    persistLogs: false,
+    loadSavedWorkflow: () => atomicChild,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+  assert.equal(changedArgsAgent.state.calls, 1, "changed args rerun the whole child");
+
+  const changedSourceAgent = storeAgent();
+  await runWorkflow(parentScript("workflow('child', { version: 1 })"), {
+    agent: changedSourceAgent.runner,
+    persistLogs: false,
+    loadSavedWorkflow: () => atomicChild.replace("key-from-child", "changed-source"),
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+  assert.equal(changedSourceAgent.state.calls, 1, "changed child source reruns the whole child");
+});
+
+test("a failed/interrupted child creates no parent entry and reruns entirely", async () => {
+  let calls = 0;
+  const journal: JournalEntry[] = [];
+  const failingChild = `export const meta = { name: 'failing-child', description: 'failing child' }
+await agent('first')
+await agent('second')
+return true`;
+  await assert.rejects(
+    () =>
+      runWorkflow(parentScript("workflow('child')"), {
+        persistLogs: false,
+        loadSavedWorkflow: () => failingChild,
+        onAgentJournal: (entry) => journal.push(entry),
+        agent: {
+          async run(prompt: string) {
+            calls++;
+            if (prompt === "second") {
+              throw new WorkflowError("interrupted", WorkflowErrorCode.WORKFLOW_ABORTED, { recoverable: false });
+            }
+            return "ok";
+          },
+        },
+      }),
+    /interrupted/,
+  );
+  assert.equal(calls, 2);
+  assert.equal(journal.length, 0, "partial child progress is not visible in the parent journal");
+
+  const rerunAgent = storeAgent();
+  await runWorkflow(parentScript("workflow('child')"), {
+    persistLogs: false,
+    loadSavedWorkflow: () => failingChild,
+    agent: rerunAgent.runner,
+    resumeJournal: new Map(),
+  });
+  assert.equal(rerunAgent.state.calls, 2, "the interrupted child reruns from its first agent");
+});
+
+test("agentTypePolicy defaults to fallback and strict mode fails unknown explicit types before runner start", async () => {
+  let calls = 0;
+  let starts = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return "ok";
+    },
+  };
+  const script = `export const meta = { name: 'agent-policy', description: 'agent policy' }
+return await agent('work', { agentType: 'missing' })`;
+
+  const fallback = await runWorkflow(script, { agent: runner, agentRegistry: new Map(), persistLogs: false });
+  assert.equal(fallback.result, "ok");
+  assert.equal(calls, 1);
+
+  await assert.rejects(
+    () =>
+      runWorkflow(script, {
+        agent: runner,
+        agentRegistry: new Map(),
+        agentTypePolicy: "error",
+        persistLogs: false,
+        onAgentStart: () => starts++,
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof WorkflowError);
+      assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+      assert.equal(error.message, 'Unknown agentType "missing"');
+      return true;
+    },
+  );
+  assert.equal(calls, 1, "strict rejection happens before the runner/session");
+  assert.equal(starts, 0, "strict rejection happens before onAgentStart");
+});
+
+test("agentTypePolicy error still permits registered and untyped agents", async () => {
+  let calls = 0;
+  const definition: AgentDefinition = {
+    name: "known",
+    prompt: "known role",
+    source: "project",
+  };
+  const registry: AgentRegistry = new Map([["known", definition]]);
+  const result = await runWorkflow(
+    `export const meta = { name: 'strict-known', description: 'strict known' }
+const typed = await agent('typed', { agentType: 'known' })
+const untyped = await agent('untyped')
+return { typed, untyped }`,
+    {
+      agentTypePolicy: "error",
+      agentRegistry: registry,
+      persistLogs: false,
+      agent: {
+        async run() {
+          calls++;
+          return "ok";
+        },
+      },
+    },
+  );
+  assert.equal(JSON.stringify(result.result), JSON.stringify({ typed: "ok", untyped: "ok" }));
+  assert.equal(calls, 2);
+});
+
+test("AgentOptions.effort forwards every Pi thinking level and participates in replay hashing", async () => {
+  const levels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+  const observed: string[] = [];
+  for (const effort of levels) {
+    await runWorkflow(parentScript(`agent('work', { model: 'provider/model:xhigh', effort: '${effort}' })`), {
+      persistLogs: false,
+      agent: {
+        async run(_prompt: string, options: { effort?: string }) {
+          observed.push(options.effort ?? "missing");
+          return "ok";
+        },
+      },
+    });
+  }
+  assert.deepEqual(observed, levels);
+
+  const journal: JournalEntry[] = [];
+  await runWorkflow(parentScript("agent('work', { effort: 'low' })"), {
+    persistLogs: false,
+    agent: {
+      async run() {
+        return "first";
+      },
+    },
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  let calls = 0;
+  await runWorkflow(parentScript("agent('work', { effort: 'high' })"), {
+    persistLogs: false,
+    agent: {
+      async run() {
+        calls++;
+        return "second";
+      },
+    },
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+  assert.equal(calls, 1, "changing effort invalidates the journal entry");
+});

--- a/tests/aicodeflow-docs.test.ts
+++ b/tests/aicodeflow-docs.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+test("README documents additive AI Code Flow compatibility APIs and limitations", () => {
+  const readme = readFileSync(join(process.cwd(), "README.md"), "utf8");
+  for (const expected of [
+    "{ scriptPath",
+    "agentTypePolicy",
+    "argsPatch",
+    "effort",
+    "plain JSON Schema",
+    "one level",
+    "JSON-serializable",
+    "workflow cwd",
+    "keywordTriggerWord",
+  ]) {
+    assert.match(readme, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i"), expected);
+  }
+});

--- a/tests/atomic-child-regressions.test.ts
+++ b/tests/atomic-child-regressions.test.ts
@@ -1,0 +1,1451 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { Model } from "@earendil-works/pi-ai";
+import type { AgentUsage } from "../src/agent.js";
+import type { AgentDefinition, AgentRegistry } from "../src/agent-registry.js";
+import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
+import { saveModelTierConfig } from "../src/model-tier-config.js";
+import type { JournalEntry } from "../src/workflow.js";
+import { runWorkflow } from "../src/workflow.js";
+import { WorkflowManager } from "../src/workflow-manager.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+interface StoreTool {
+  name: string;
+  execute(id: string, params: unknown): Promise<{ details?: { found?: boolean; value?: unknown } }>;
+}
+
+interface StoreAgentOptions {
+  systemTools?: StoreTool[];
+}
+
+async function put(options: StoreAgentOptions, key: string, value: unknown): Promise<void> {
+  await options.systemTools?.find((tool) => tool.name === "store_put")?.execute("", { key, value });
+}
+
+async function get(options: StoreAgentOptions, key: string): Promise<{ found: boolean; value: unknown }> {
+  const result = await options.systemTools?.find((tool) => tool.name === "store_get")?.execute("", { key });
+  return { found: result?.details?.found ?? false, value: result?.details?.value };
+}
+
+function parentScript(body: string): string {
+  return `export const meta = { name: 'parent', description: 'parent' }\n${body}`;
+}
+
+test("concurrent parent activity is excluded from atomic child accounting and replay", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+return await agent('child-agent')`;
+  const script = parentScript(`return await Promise.all([
+  workflow('child'),
+  agent('parent-agent'),
+])`);
+  const journal: JournalEntry[] = [];
+  let releaseChild!: () => void;
+  const childGate = new Promise<void>((resolve) => {
+    releaseChild = resolve;
+  });
+
+  const first = await runWorkflow(script, {
+    persistLogs: false,
+    maxAgents: 2,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: {
+      async run(prompt: string) {
+        if (prompt === "child-agent") await childGate;
+        if (prompt === "parent-agent") releaseChild();
+        return prompt;
+      },
+    },
+  });
+
+  const atomicChild = journal.find((entry) => entry.index === 0);
+  assert.equal(atomicChild?.agentCount, 1, "only the child's logical agent belongs to its atomic entry");
+  assert.equal(first.agentCount, 2);
+
+  let replayCalls = 0;
+  const replay = await runWorkflow(script, {
+    persistLogs: false,
+    maxAgents: 2,
+    loadSavedWorkflow: () => childScript,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+    agent: {
+      async run() {
+        replayCalls++;
+        return "unexpected";
+      },
+    },
+  });
+
+  assert.equal(replayCalls, 0);
+  assert.equal(replay.agentCount, 2, "replay charges exactly one child and one parent agent");
+});
+
+test("atomic child replay reconstructs child agents and replay telemetry in a fresh manager report", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-child-report-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-child-report-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const childScript = `export const meta = { name: 'child', description: 'child' }
+return await agent('child-agent', { label: 'child worker' })`;
+      const script = parentScript("return await workflow('child')");
+      const firstManager = new WorkflowManager({
+        cwd,
+        loadSavedWorkflow: () => childScript,
+        agent: {
+          async run(_prompt: string, options: any) {
+            const usage = { input: 3, output: 2, cacheRead: 0, cacheWrite: 0, total: 5, cost: 0.001 };
+            options.onUsage?.(usage);
+            options.onTelemetry?.({ execution: "live", resolvedModel: "mock/child", usage });
+            return "child-result";
+          },
+        },
+      });
+      await firstManager.runSync(script);
+      const persisted = firstManager.listRuns()[0];
+      firstManager.getPersistence().save({ ...persisted, status: "paused", agents: [] });
+
+      let replayCalls = 0;
+      const freshManager = new WorkflowManager({
+        cwd,
+        loadSavedWorkflow: () => childScript,
+        agent: {
+          async run() {
+            replayCalls++;
+            return "must-not-run";
+          },
+        },
+      });
+      const completed = new Promise<void>((resolve) => {
+        freshManager.on("complete", (event: { runId: string }) => event.runId === persisted.runId && resolve());
+      });
+      assert.equal(await freshManager.resume(persisted.runId), true);
+      await completed;
+
+      const replayed = freshManager.getPersistence().load(persisted.runId);
+      assert.equal(replayCalls, 0);
+      assert.equal(replayed?.agents.length, 1);
+      assert.equal(replayed?.agents[0].label, "child worker");
+      assert.equal(replayed?.agents[0].status, "done");
+      assert.equal(replayed?.agents[0].telemetry?.execution, "replay");
+      assert.equal(replayed?.agents[0].telemetry?.usage?.total, 5);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("recoverably failed child agents discard store writes before the child commits", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+const failed = await agent('write-then-fail')
+const observed = await agent('read-ghost')
+return { failed, observed }`;
+  const script = parentScript(`const child = await workflow('child')
+const observed = await agent('read-ghost')
+return { child, observed }`);
+  const journal: JournalEntry[] = [];
+
+  const result = await runWorkflow<{
+    child: { failed: null; observed: { found: boolean; value: unknown } };
+    observed: { found: boolean; value: unknown };
+  }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: {
+      async run(prompt: string, options: StoreAgentOptions) {
+        if (prompt === "write-then-fail") {
+          await put(options, "ghost", "must-not-commit");
+          throw new WorkflowError("recoverable child failure", WorkflowErrorCode.AGENT_EXECUTION_ERROR, {
+            recoverable: true,
+          });
+        }
+        if (prompt === "read-ghost") return get(options, "ghost");
+        return prompt;
+      },
+    },
+  });
+
+  assert.equal(result.result.child.failed, null);
+  assert.equal(result.result.child.observed.found, false);
+  assert.equal(result.result.observed.found, false);
+  assert.deepEqual(journal.find((entry) => entry.index === 0)?.storeDelta, {});
+});
+
+test("a failed child invocation cannot leak deltas into a later sequential child", async () => {
+  const failedChild = `export const meta = { name: 'failed-child', description: 'failed child' }
+await agent('failed-write')
+throw new Error('child invocation failed')`;
+  const successfulChild = `export const meta = { name: 'successful-child', description: 'successful child' }
+await agent('successful-write')
+return 'success'`;
+  const script = parentScript(`try { await workflow('failed-child') } catch {}
+const child = await workflow('successful-child')
+const failedValue = await agent('read-failed')
+const successfulValue = await agent('read-successful')
+return { child, failedValue, successfulValue }`);
+  const journal: JournalEntry[] = [];
+
+  const result = await runWorkflow<{
+    failedValue: { found: boolean; value: unknown };
+    successfulValue: { found: boolean; value: unknown };
+  }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: (name) => (name === "failed-child" ? failedChild : successfulChild),
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: {
+      async run(prompt: string, options: StoreAgentOptions) {
+        if (prompt === "failed-write") {
+          await put(options, "failed", "ghost");
+          throw new WorkflowError("recoverable write failure", WorkflowErrorCode.AGENT_EXECUTION_ERROR, {
+            recoverable: true,
+          });
+        }
+        if (prompt === "successful-write") {
+          await put(options, "successful", "kept");
+          return "wrote";
+        }
+        if (prompt === "read-failed") return get(options, "failed");
+        if (prompt === "read-successful") return get(options, "successful");
+        return prompt;
+      },
+    },
+  });
+
+  assert.equal(result.result.failedValue.found, false);
+  assert.deepEqual(result.result.successfulValue, { found: true, value: "kept" });
+  const successfulAtomicEntry = journal.find((entry) => entry.index === 1);
+  assert.deepEqual(successfulAtomicEntry?.storeDelta, { successful: "kept" });
+});
+
+test("atomic child delta preserves actual conflicting write order on replay", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+await Promise.all([agent('late-write'), agent('early-write')])
+return 'child-result'`;
+  const script = parentScript(`const child = await workflow('child')
+const observed = await agent('read-winner')
+return { child, observed }`);
+  const journal: JournalEntry[] = [];
+  let releaseLate!: () => void;
+  const earlyWritten = new Promise<void>((resolve) => {
+    releaseLate = resolve;
+  });
+  const runner = {
+    async run(prompt: string, options: StoreAgentOptions) {
+      if (prompt === "late-write") {
+        await earlyWritten;
+        await put(options, "winner", "late-call-index-but-last-write");
+        return "late";
+      }
+      if (prompt === "early-write") {
+        await put(options, "winner", "higher-call-index-but-first-write");
+        releaseLate();
+        return "early";
+      }
+      if (prompt === "read-winner") return get(options, "winner");
+      return prompt;
+    },
+  };
+
+  const first = await runWorkflow<{ observed: { found: boolean; value: unknown } }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: runner,
+  });
+  assert.deepEqual(first.result.observed, { found: true, value: "late-call-index-but-last-write" });
+  assert.deepEqual(journal.find((entry) => entry.index === 0)?.storeDelta, {
+    winner: "late-call-index-but-last-write",
+  });
+
+  const replay = await runWorkflow<{ observed: { found: boolean; value: unknown } }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    resumeJournal: new Map(journal.filter((entry) => entry.index === 0).map((entry) => [entry.index, entry])),
+    agent: runner,
+  });
+  assert.deepEqual(replay.result.observed, { found: true, value: "late-call-index-but-last-write" });
+});
+
+test("child args omit own enumerable undefined properties before execution and hashing", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+return args`;
+  const script = parentScript(`const args = { support: undefined, nested: { task: undefined, keep: true } }
+return await workflow('child', args)`);
+  const journal: JournalEntry[] = [];
+
+  const live = await runWorkflow(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+
+  assert.deepEqual(live.result, { nested: { keep: true } });
+
+  const normalizedArgsJournal: JournalEntry[] = [];
+  await runWorkflow(parentScript("return await workflow('child', { nested: { keep: true } })"), {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => normalizedArgsJournal.push(entry),
+  });
+  assert.equal(journal[0]?.hash, normalizedArgsJournal[0]?.hash);
+
+  let childCalls = 0;
+  const replay = await runWorkflow(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+    agent: {
+      async run() {
+        childCalls++;
+        return "must-not-run";
+      },
+    },
+  });
+
+  assert.deepEqual(replay.result, { nested: { keep: true } });
+  assert.equal(childCalls, 0, "the child hash must use the normalized args");
+});
+
+test("child args reject custom prototypes and normalize aliases to JSON-tree semantics", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+args.left.value = 2
+return { rightValue: args.right.value }`;
+  const aliasResult = await runWorkflow<{ rightValue: number }>(
+    parentScript(`const shared = { value: 1 }
+return await workflow('child', { left: shared, right: shared })`),
+    { persistLogs: false, loadSavedWorkflow: () => childScript },
+  );
+  assert.equal(aliasResult.result.rightValue, 1, "JSON aliases normalize to independent tree branches");
+
+  await assert.rejects(
+    () =>
+      runWorkflow(
+        parentScript(`const custom = Object.create({ inherited: true })
+custom.value = 1
+return await workflow('child', { left: custom, right: { value: 1 } })`),
+        { persistLogs: false, loadSavedWorkflow: () => childScript },
+      ),
+    (error: unknown) => {
+      assert.ok(error instanceof WorkflowError);
+      assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+      assert.equal(error.message, "workflow() child args must be deterministic JSON-serializable values");
+      return true;
+    },
+  );
+});
+
+test("concurrent parent and child conflicts preserve actual write order on live run and replay", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+await agent('child-write')
+return 'child-result'`;
+  const script = parentScript(`await Promise.all([workflow('child'), agent('parent-write')])
+return await agent('read-winner')`);
+  const journal: JournalEntry[] = [];
+  let childWritten!: () => void;
+  const childWriteComplete = new Promise<void>((resolve) => {
+    childWritten = resolve;
+  });
+
+  const runner = {
+    async run(prompt: string, options: StoreAgentOptions) {
+      if (prompt === "child-write") {
+        await put(options, "winner", "child-first");
+        childWritten();
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        return "child";
+      }
+      if (prompt === "parent-write") {
+        await childWriteComplete;
+        await put(options, "winner", "parent-last");
+        return "parent";
+      }
+      if (prompt === "read-winner") return get(options, "winner");
+      return prompt;
+    },
+  };
+
+  const first = await runWorkflow<{ found: boolean; value: unknown }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: runner,
+  });
+  assert.deepEqual(first.result, { found: true, value: "parent-last" });
+
+  const replay = await runWorkflow<{ found: boolean; value: unknown }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    resumeJournal: new Map(journal.filter((entry) => entry.index < 2).map((entry) => [entry.index, entry])),
+    agent: runner,
+  });
+  assert.deepEqual(replay.result, { found: true, value: "parent-last" });
+});
+
+test("a timed-out attempt cannot write into its retry attempt scope", async () => {
+  const script = parentScript(`await agent('retrying', { timeoutMs: 5, retries: 1 })
+return await agent('read-winner')`);
+  let staleOptions: StoreAgentOptions | undefined;
+  let attempts = 0;
+
+  const result = await runWorkflow<{ found: boolean; value: unknown }>(script, {
+    persistLogs: false,
+    agent: {
+      async run(prompt: string, options: StoreAgentOptions) {
+        if (prompt === "retrying") {
+          attempts++;
+          if (attempts === 1) {
+            staleOptions = options;
+            return new Promise<never>(() => {});
+          }
+          await put(options, "winner", "retry");
+          try {
+            await put(staleOptions ?? {}, "winner", "timed-out-late-write");
+          } catch {}
+          return "retry-complete";
+        }
+        if (prompt === "read-winner") return get(options, "winner");
+        return prompt;
+      },
+    },
+  });
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(result.result, { found: true, value: "retry" });
+});
+
+test("a late timed-out child runner cannot use its disposed store", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+await agent('late-child', { timeoutMs: 5 })
+return 'child-complete'`;
+  const script = parentScript(`await agent('seed-parent')
+const child = await workflow('child')
+const late = await agent('release-late-child')
+return { child, late }`);
+  let releaseLate!: () => void;
+  const lateGate = new Promise<void>((resolve) => {
+    releaseLate = resolve;
+  });
+  let lateFinished!: (value: { readRejected: boolean; writeRejected: boolean }) => void;
+  const lateResult = new Promise<{ readRejected: boolean; writeRejected: boolean }>((resolve) => {
+    lateFinished = resolve;
+  });
+
+  const result = await runWorkflow<{
+    child: string;
+    late: { readRejected: boolean; writeRejected: boolean; orphanFound: boolean; parentValue: unknown };
+  }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    agent: {
+      async run(prompt: string, options: StoreAgentOptions) {
+        if (prompt === "seed-parent") {
+          await put(options, "parent-secret", "parent-value");
+          return "seeded";
+        }
+        if (prompt === "late-child") {
+          await lateGate;
+          let readRejected = false;
+          let writeRejected = false;
+          try {
+            await get(options, "parent-secret");
+          } catch {
+            readRejected = true;
+          }
+          try {
+            await put(options, "orphan", "must-not-be-accepted");
+          } catch {
+            writeRejected = true;
+          }
+          lateFinished({ readRejected, writeRejected });
+          return "late-finished";
+        }
+        if (prompt === "release-late-child") {
+          releaseLate();
+          const late = await lateResult;
+          const orphan = await get(options, "orphan");
+          const parent = await get(options, "parent-secret");
+          return { ...late, orphanFound: orphan.found, parentValue: parent.value };
+        }
+        return prompt;
+      },
+    },
+  });
+
+  assert.equal(
+    JSON.stringify(result.result),
+    JSON.stringify({
+      child: "child-complete",
+      late: { readRejected: true, writeRejected: true, orphanFound: false, parentValue: "parent-value" },
+    }),
+  );
+});
+
+test("agent journal failure accounts usage once, rolls back store delta, and surfaces the original error", async () => {
+  const journalError = new Error("journal persistence failed exactly");
+  const script = parentScript(`let failure
+try { await agent('write-before-journal') } catch (error) { failure = error.message }
+const observed = await agent('inspect-after:' + budget.spent())
+return { failure, observed }`);
+  let rejectFirstJournal = true;
+
+  const result = await runWorkflow<{ failure: string; observed: { spentPrompt: string; found: boolean } }>(script, {
+    persistLogs: false,
+    onAgentJournal() {
+      if (rejectFirstJournal) {
+        rejectFirstJournal = false;
+        throw journalError;
+      }
+    },
+    agent: {
+      async run(prompt: string, options: StoreAgentOptions & { onUsage?: (usage: AgentUsage) => void }) {
+        if (prompt === "write-before-journal") {
+          await put(options, "uncommitted", true);
+          options.onUsage?.({ input: 6, output: 4, cacheRead: 0, cacheWrite: 0, total: 10, cost: 0 });
+          return "written";
+        }
+        const value = await get(options, "uncommitted");
+        return { spentPrompt: prompt, found: value.found };
+      },
+    },
+  });
+
+  assert.equal(
+    JSON.stringify(result.result),
+    JSON.stringify({
+      failure: journalError.message,
+      observed: { spentPrompt: "inspect-after:10", found: false },
+    }),
+  );
+});
+
+test("an atomic child journal callback failure leaves no child writes visible", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+await agent('child-write')
+return 'child-result'`;
+  const script = parentScript(`try { await workflow('child') } catch {}
+return await agent('read-child-write')`);
+  let rejectedChildJournal = false;
+
+  const result = await runWorkflow<{ found: boolean; value: unknown }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal(entry) {
+      if (entry.index === 0 && !rejectedChildJournal) {
+        rejectedChildJournal = true;
+        throw new Error("journal persistence failed");
+      }
+    },
+    agent: {
+      async run(prompt: string, options: StoreAgentOptions) {
+        if (prompt === "child-write") {
+          await put(options, "child", "must-rollback");
+          return "wrote";
+        }
+        if (prompt === "read-child-write") return get(options, "child");
+        return prompt;
+      },
+    },
+  });
+
+  assert.equal(rejectedChildJournal, true);
+  assert.deepEqual(result.result, { found: false, value: null });
+});
+
+test("child args reject custom-prototype arrays and spoofed inherited JSON semantics", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+return args`;
+  const invalidExpressions = [
+    `const value = []; Object.setPrototypeOf(value, Object.create(Array.prototype)); value`,
+    `const proto = Object.create(null); Object.defineProperty(proto, 'constructor', { value: Object, enumerable: false }); proto.toJSON = () => ({ spoofed: true }); const value = Object.create(proto); value.safe = true; value`,
+  ];
+
+  for (const expression of invalidExpressions) {
+    await assert.rejects(
+      () =>
+        runWorkflow(
+          parentScript(`const value = (() => { ${expression.includes("const value") ? `${expression}; return value` : `return ${expression}`} })()
+return await workflow('child', value)`),
+          {
+            persistLogs: false,
+            loadSavedWorkflow: () => childScript,
+          },
+        ),
+      (error: unknown) => {
+        assert.ok(error instanceof WorkflowError);
+        assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+        assert.equal(error.message, "workflow() child args must be deterministic JSON-serializable values");
+        return true;
+      },
+    );
+  }
+});
+
+test("atomic child execution and replay use the registry snapshot hashed by the parent", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-child-registry-"));
+  const agentsDir = join(cwd, ".pi", "agents");
+  mkdirSync(agentsDir, { recursive: true });
+  const definitionPath = join(agentsDir, "reviewer.md");
+  const firstDefinition = "---\nname: reviewer\n---\nFIRST SNAPSHOT";
+  const secondDefinition = "---\nname: reviewer\n---\nSECOND DISK VERSION";
+  writeFileSync(definitionPath, firstDefinition);
+
+  try {
+    const childScript = `export const meta = { name: 'child', description: 'child' }
+return await agent('task', { agentType: 'reviewer' })`;
+    const script = parentScript(`return await workflow('child')`);
+    const journal: JournalEntry[] = [];
+    let loaderCalls = 0;
+
+    const first = await runWorkflow<string>(script, {
+      cwd,
+      persistLogs: false,
+      loadSavedWorkflow: () => {
+        loaderCalls++;
+        writeFileSync(definitionPath, secondDefinition);
+        return childScript;
+      },
+      onAgentJournal: (entry) => journal.push(entry),
+      agent: {
+        async run(_prompt: string, options: { instructions?: string }) {
+          assert.match(options.instructions ?? "", /FIRST SNAPSHOT/);
+          assert.doesNotMatch(options.instructions ?? "", /SECOND DISK VERSION/);
+          return "ran-with-first-snapshot";
+        },
+      },
+    });
+
+    assert.equal(first.result, "ran-with-first-snapshot");
+    assert.equal(loaderCalls, 1);
+    assert.equal(journal.length, 1);
+
+    writeFileSync(definitionPath, firstDefinition);
+    let replayCalls = 0;
+    const replay = await runWorkflow<string>(script, {
+      cwd,
+      persistLogs: false,
+      loadSavedWorkflow: () => {
+        loaderCalls++;
+        writeFileSync(definitionPath, secondDefinition);
+        return childScript;
+      },
+      resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+      agent: {
+        async run() {
+          replayCalls++;
+          return "must-not-run";
+        },
+      },
+    });
+
+    assert.equal(replay.result, "ran-with-first-snapshot");
+    assert.equal(replayCalls, 0);
+    assert.equal(loaderCalls, 2);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("atomic child replay invalidates when a tier used only inside the child changes", async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-child-tier-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const childScript = `export const meta = { name: 'child', description: 'child' }
+return await agent('task', { tier: 'small' })`;
+      const script = parentScript(`return await workflow('child')`);
+      const journal: JournalEntry[] = [];
+      let calls = 0;
+      const runner = {
+        async run() {
+          calls++;
+          return `result-${calls}`;
+        },
+      };
+
+      saveModelTierConfig({ tiers: { small: "mock/small-one", medium: "mock/medium" } });
+      await runWorkflow(script, {
+        persistLogs: false,
+        loadSavedWorkflow: () => childScript,
+        onAgentJournal: (entry) => journal.push(entry),
+        agent: runner,
+      });
+      saveModelTierConfig({ tiers: { small: "mock/small-two", medium: "mock/medium" } });
+      const replay = await runWorkflow<string>(script, {
+        persistLogs: false,
+        loadSavedWorkflow: () => childScript,
+        resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+        agent: runner,
+      });
+
+      assert.equal(calls, 2);
+      assert.equal(replay.result, "result-2");
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("atomic child replay invalidates when the session main model changes without tier config", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+return await agent('task')`;
+  const script = parentScript(`return await workflow('child')`);
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+
+  await runWorkflow(script, {
+    mainModel: "mock/a",
+    modelTierConfig: null,
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: runner,
+  });
+  const replay = await runWorkflow<string>(script, {
+    mainModel: "mock/b",
+    modelTierConfig: null,
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+    agent: runner,
+  });
+
+  assert.equal(calls, 2);
+  assert.equal(replay.result, "result-2");
+});
+
+test("atomic child untagged replay uses the host session model instead of mainModel tier fallback", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+return await agent('task')`;
+  const script = parentScript(`return await workflow('child')`);
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+  const firstModel = { provider: "mock", id: "session-a", name: "Session A" } as Model<any>;
+  const secondModel = { provider: "mock", id: "session-b", name: "Session B" } as Model<any>;
+
+  await runWorkflow(script, {
+    agent: runner,
+    mainModel: "mock/tier-fallback",
+    session: { model: firstModel },
+    modelTierConfig: null,
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  const replay = await runWorkflow<string>(script, {
+    agent: runner,
+    mainModel: "mock/tier-fallback",
+    session: { model: secondModel },
+    modelTierConfig: null,
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+
+  assert.equal(calls, 2, "the child must rerun when its actual untagged session route changes");
+  assert.equal(replay.result, "result-2");
+});
+
+test("atomic child tier fallback remains bound to mainModel when the host session model changes", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+return await agent('task', { tier: 'custom' })`;
+  const script = parentScript(`return await workflow('child')`);
+  const journal: JournalEntry[] = [];
+  const tierConfig = { tiers: { medium: "mock/medium" } };
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+  const firstModel = { provider: "mock", id: "session-a", name: "Session A" } as Model<any>;
+  const secondModel = { provider: "mock", id: "session-b", name: "Session B" } as Model<any>;
+
+  await runWorkflow(script, {
+    agent: runner,
+    mainModel: "mock/tier-fallback",
+    session: { model: firstModel },
+    modelTierConfig: tierConfig,
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  const replay = await runWorkflow<string>(script, {
+    agent: runner,
+    mainModel: "mock/tier-fallback",
+    session: { model: secondModel },
+    modelTierConfig: tierConfig,
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+
+  assert.equal(calls, 1, "the child explicit tier must keep the stable mainModel fallback route");
+  assert.equal(replay.result, "result-1");
+});
+
+test("atomic child helper routes invalidate replay for direct, aliased, and member calls", async () => {
+  const script = parentScript(`return await workflow('child')`);
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return { real: true, reason: `result-${calls}` };
+    },
+  };
+  const bodies = [
+    "return await verify('claim', { reviewers: 1 })",
+    "const check = verify; return await check('claim', { reviewers: 1 })",
+    "return await globalThis.verify('claim', { reviewers: 1 })",
+    "return await globalThis['verify']('claim', { reviewers: 1 })",
+  ];
+
+  for (const body of bodies) {
+    const childScript = `export const meta = { name: 'child', description: 'child' }\n${body}`;
+    const journal: JournalEntry[] = [];
+    await runWorkflow(script, {
+      mainModel: "mock/a",
+      modelTierConfig: null,
+      persistLogs: false,
+      loadSavedWorkflow: () => childScript,
+      onAgentJournal: (entry) => journal.push(entry),
+      agent: runner,
+    });
+    await runWorkflow(script, {
+      mainModel: "mock/b",
+      modelTierConfig: null,
+      persistLogs: false,
+      loadSavedWorkflow: () => childScript,
+      resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+      agent: runner,
+    });
+  }
+
+  assert.equal(calls, 8);
+});
+
+test("atomic child indirect agent routes invalidate replay for aliases and computed members", async () => {
+  const script = parentScript(`return await workflow('child')`);
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+  const bodies = ["const invoke = agent; return await invoke('task')", "return await globalThis['agent']('task')"];
+
+  for (const body of bodies) {
+    const childScript = `export const meta = { name: 'child', description: 'child' }\n${body}`;
+    const journal: JournalEntry[] = [];
+    await runWorkflow(script, {
+      mainModel: "mock/a",
+      modelTierConfig: null,
+      persistLogs: false,
+      loadSavedWorkflow: () => childScript,
+      onAgentJournal: (entry) => journal.push(entry),
+      agent: runner,
+    });
+    await runWorkflow(script, {
+      mainModel: "mock/b",
+      modelTierConfig: null,
+      persistLogs: false,
+      loadSavedWorkflow: () => childScript,
+      resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+      agent: runner,
+    });
+  }
+
+  assert.equal(calls, 4);
+});
+
+test("atomic child dynamic unknown tiers hash the main-model fallback independently of medium", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+const invoke = agent
+return await invoke('task', { tier: 'custom' })`;
+  const script = parentScript(`return await workflow('child')`);
+  const journal: JournalEntry[] = [];
+  const tierConfig = { tiers: { medium: "mock/medium" } };
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+
+  await runWorkflow(script, {
+    mainModel: "mock/a",
+    modelTierConfig: tierConfig,
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: runner,
+  });
+  await runWorkflow(script, {
+    mainModel: "mock/b",
+    modelTierConfig: tierConfig,
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+    agent: runner,
+  });
+
+  assert.equal(calls, 2);
+});
+
+test("atomic child capture correlates concurrent duplicate labels by invocation", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+return await parallel([
+  () => agent('first prompt', { label: 'duplicate' }),
+  () => agent('second prompt', { label: 'duplicate' }),
+])`;
+  const script = parentScript(`return await workflow('child')`);
+  const journal: JournalEntry[] = [];
+  let releaseFirst!: () => void;
+  const secondFinished = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+
+  const live = await runWorkflow(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: {
+      async run(
+        prompt: string,
+        options: { onUsage?: (usage: AgentUsage) => void; onModelResolved?: (id: string) => void },
+      ) {
+        if (prompt === "first prompt") await secondFinished;
+        const amount = prompt === "first prompt" ? 11 : 22;
+        options.onUsage?.({
+          input: amount,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: amount,
+          cost: amount / 1000,
+        });
+        options.onModelResolved?.(`mock/${prompt.startsWith("first") ? "first" : "second"}`);
+        if (prompt === "second prompt") releaseFirst();
+        return `${prompt} result`;
+      },
+    },
+  });
+
+  assert.deepEqual(live.result, ["first prompt result", "second prompt result"]);
+  assert.deepEqual(
+    journal[0]?.childAgents?.map((agent) => [agent.prompt, agent.result, agent.tokenUsage?.total, agent.model]),
+    [
+      ["first prompt", "first prompt result", 11, "mock/first"],
+      ["second prompt", "second prompt result", 22, "mock/second"],
+    ],
+  );
+
+  const replayStarts: string[] = [];
+  const replayEnds: Array<{ result: unknown; tokens?: number; model?: string }> = [];
+  await runWorkflow(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+    onAgentStart: (event) => replayStarts.push(event.prompt),
+    onAgentEnd: (event) => replayEnds.push(event),
+    agent: {
+      async run() {
+        assert.fail("atomic child should replay");
+      },
+    },
+  });
+  assert.deepEqual(replayStarts, ["first prompt", "second prompt"]);
+  assert.deepEqual(
+    replayEnds.map((event) => [event.result, event.tokens, event.model]),
+    [
+      ["first prompt result", 0, "mock/first"],
+      ["second prompt result", 0, "mock/second"],
+    ],
+  );
+});
+
+test("nested workflow path reports a stable validation error when cwd was deleted", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-deleted-child-cwd-"));
+  rmSync(cwd, { recursive: true, force: true });
+
+  await assert.rejects(
+    () => runWorkflow(parentScript(`return await workflow({ scriptPath: 'child.js' })`), { cwd, persistLogs: false }),
+    (error: unknown) => {
+      assert.ok(error instanceof WorkflowError);
+      assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+      assert.match(error.message, /workflow cwd does not exist/);
+      return true;
+    },
+  );
+});
+
+test("atomic child replay invalidates when any model alias target changes", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }\nreturn await agent('task', { model: 'haiku' })`;
+  const script = parentScript(`return await workflow('child')`);
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+
+  const first = await runWorkflow<string>(script, {
+    loadSavedWorkflow: () => childScript,
+    modelAliases: { haiku: "mock/one", sonnet: "mock/sonnet" },
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: runner,
+  });
+  assert.equal(first.result, "result-1");
+
+  const replay = await runWorkflow<string>(script, {
+    loadSavedWorkflow: () => childScript,
+    modelAliases: { haiku: "mock/two", sonnet: "mock/sonnet" },
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+    agent: runner,
+  });
+
+  assert.equal(replay.result, "result-2");
+  assert.equal(calls, 2, "changing the child-used alias must rerun the atomic child");
+});
+
+test("atomic child replay invalidates when an effective agent definition changes", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+return await agent('task', { agentType: 'reviewer' })`;
+  const script = parentScript(`return await workflow('child')`);
+  const definition = (prompt: string): AgentDefinition => ({
+    name: "reviewer",
+    prompt,
+    source: "project",
+  });
+  const firstRegistry: AgentRegistry = new Map([["reviewer", definition("first definition")]]);
+  const secondRegistry: AgentRegistry = new Map([["reviewer", definition("changed definition")]]);
+  const journal: JournalEntry[] = [];
+
+  await runWorkflow(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    agentRegistry: firstRegistry,
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: {
+      async run() {
+        return "first";
+      },
+    },
+  });
+
+  let replayCalls = 0;
+  const replay = await runWorkflow(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    agentRegistry: secondRegistry,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+    agent: {
+      async run() {
+        replayCalls++;
+        return "changed";
+      },
+    },
+  });
+
+  assert.equal(replayCalls, 1);
+  assert.equal(replay.result, "changed");
+});
+
+test("atomic child replay invalidates when agentTypePolicy changes from fallback to error", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+return await agent('task', { agentType: 'missing' })`;
+  const script = parentScript(`return await workflow('child')`);
+  const journal: JournalEntry[] = [];
+
+  await runWorkflow(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    agentRegistry: new Map(),
+    agentTypePolicy: "fallback",
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: {
+      async run() {
+        return "fallback-result";
+      },
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      runWorkflow(script, {
+        persistLogs: false,
+        loadSavedWorkflow: () => childScript,
+        agentRegistry: new Map(),
+        agentTypePolicy: "error",
+        resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+        agent: {
+          async run() {
+            return "must-not-run";
+          },
+        },
+      }),
+    /Unknown agentType "missing"/,
+  );
+});
+
+test("atomic child result is snapshotted separately from the value returned to its parent", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+return { nested: { value: 1 } }`;
+  const script = parentScript(`const child = await workflow('child')
+child.nested.value = 2
+return child`);
+  const journal: JournalEntry[] = [];
+
+  const result = await runWorkflow<{ nested: { value: number } }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+
+  assert.equal(result.result.nested.value, 2);
+  assert.equal((journal[0]?.result as { nested: { value: number } }).nested.value, 1);
+  assert.notEqual(result.result, journal[0]?.result);
+
+  const replay = await runWorkflow<{ nested: { value: number } }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    resumeJournal: new Map([[journal[0].index, journal[0]]]),
+  });
+  assert.equal(replay.result.nested.value, 2);
+  assert.equal((journal[0]?.result as { nested: { value: number } }).nested.value, 1);
+  assert.notEqual(replay.result, journal[0]?.result);
+});
+
+test("void atomic children execute and replay atomically", async () => {
+  const childScript = `export const meta = { name: 'void-child', description: 'void child' }
+await agent('child-write')`;
+  const script = parentScript(`const child = await workflow('void-child')
+const observed = await agent('read-child-write')
+return { childIsUndefined: child === undefined, observed }`);
+  const journal: JournalEntry[] = [];
+  let childCalls = 0;
+  const runner = {
+    async run(prompt: string, options: StoreAgentOptions) {
+      if (prompt === "child-write") {
+        childCalls++;
+        await put(options, "void-child", "committed");
+        return "wrote";
+      }
+      if (prompt === "read-child-write") return get(options, "void-child");
+      return prompt;
+    },
+  };
+
+  const live = await runWorkflow<{
+    childIsUndefined: boolean;
+    observed: { found: boolean; value: unknown };
+  }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: runner,
+  });
+
+  assert.equal(
+    JSON.stringify(live.result),
+    JSON.stringify({
+      childIsUndefined: true,
+      observed: { found: true, value: "committed" },
+    }),
+  );
+  assert.equal(childCalls, 1);
+  assert.equal(journal[0]?.resultKind, "void");
+  assert.equal(journal[0]?.result, null);
+  assert.equal(JSON.parse(JSON.stringify(journal[0])).resultKind, "void");
+
+  const replay = await runWorkflow<{
+    childIsUndefined: boolean;
+    observed: { found: boolean; value: unknown };
+  }>(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+    agent: runner,
+  });
+
+  assert.equal(
+    JSON.stringify(replay.result),
+    JSON.stringify({
+      childIsUndefined: true,
+      observed: { found: true, value: "committed" },
+    }),
+  );
+  assert.equal(childCalls, 1, "replay must not rerun the void child");
+});
+
+test("unsupported atomic child results fail before committing child writes", async (t) => {
+  const cases = [
+    ["NaN", "return Number.NaN"],
+    ["cyclic", "const value = {}; value.self = value; return value"],
+    ["BigInt", "return 1n"],
+  ] as const;
+
+  for (const [name, childResultBody] of cases) {
+    await t.test(name, async () => {
+      const childScript = `export const meta = { name: 'child', description: 'child' }
+await agent('child-write')
+${childResultBody}`;
+      const script = parentScript(`let rejected = false
+try { await workflow('child') } catch { rejected = true }
+const observed = await agent('read-child-write')
+return { rejected, observed }`);
+      const journal: JournalEntry[] = [];
+      const result = await runWorkflow<{ rejected: boolean; observed: { found: boolean; value: unknown } }>(script, {
+        persistLogs: false,
+        loadSavedWorkflow: () => childScript,
+        onAgentJournal: (entry) => journal.push(entry),
+        agent: {
+          async run(prompt: string, options: StoreAgentOptions) {
+            if (prompt === "child-write") {
+              await put(options, "child", "must-not-commit");
+              return "wrote";
+            }
+            if (prompt === "read-child-write") return get(options, "child");
+            return prompt;
+          },
+        },
+      });
+
+      assert.equal(result.result.rejected, true);
+      assert.equal(result.result.observed.found, false);
+      assert.equal(result.result.observed.value, null);
+      assert.equal(
+        journal.some((entry) => entry.index === 0),
+        false,
+      );
+    });
+  }
+});
+
+test("atomic child replay rejects a malformed void-result encoding", async () => {
+  const childScript = `export const meta = { name: 'void-child', description: 'void child' }`;
+  const script = parentScript(`return await workflow('void-child')`);
+  const journal: JournalEntry[] = [];
+  await runWorkflow(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  assert.equal(journal[0]?.resultKind, "void");
+  journal[0].result = "not-the-canonical-null";
+
+  await assert.rejects(
+    () =>
+      runWorkflow(script, {
+        persistLogs: false,
+        loadSavedWorkflow: () => childScript,
+        resumeJournal: new Map([[journal[0].index, journal[0]]]),
+      }),
+    /atomic void child result must use the canonical null encoding/,
+  );
+});
+
+test("atomic child replay rejects a malformed negative agentCount", async () => {
+  const childScript = `export const meta = { name: 'child', description: 'child' }
+return await agent('task')`;
+  const script = parentScript(`return await workflow('child')`);
+  const journal: JournalEntry[] = [];
+  await runWorkflow(script, {
+    persistLogs: false,
+    loadSavedWorkflow: () => childScript,
+    onAgentJournal: (entry) => journal.push(entry),
+    agent: {
+      async run() {
+        return "done";
+      },
+    },
+  });
+  assert.ok(journal[0]);
+  journal[0].agentCount = -1;
+
+  await assert.rejects(
+    () =>
+      runWorkflow(script, {
+        persistLogs: false,
+        loadSavedWorkflow: () => childScript,
+        resumeJournal: new Map([[journal[0].index, journal[0]]]),
+        agent: {
+          async run() {
+            return "must-not-run";
+          },
+        },
+      }),
+    /agentCount.*non-negative integer/,
+  );
+});
+
+test("cold persistence preserves and replays a void atomic child", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-cold-void-child-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-cold-void-child-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const childScript = `export const meta = { name: 'void-child', description: 'void child' }
+await agent('child-write')`;
+      const script = parentScript(`const child = await workflow('void-child')
+await agent('interrupt-parent')
+const observed = await agent('read-child-write')
+return { childIsUndefined: child === undefined, observed }`);
+      const firstManager = new WorkflowManager({
+        cwd,
+        loadSavedWorkflow: () => childScript,
+        agent: {
+          async run(prompt: string, options: StoreAgentOptions) {
+            if (prompt === "child-write") {
+              await put(options, "void-child", "persisted");
+              return "wrote";
+            }
+            if (prompt === "interrupt-parent") {
+              throw new WorkflowError("interrupt", WorkflowErrorCode.WORKFLOW_ABORTED, { recoverable: false });
+            }
+            return prompt;
+          },
+        },
+      });
+      firstManager.on("error", () => {});
+      await assert.rejects(() => firstManager.runSync(script), /interrupt/);
+      const persisted = firstManager.listRuns().find((run) => run.workflowName === "parent");
+      assert.ok(persisted);
+      assert.equal(persisted.journal?.[0]?.resultKind, "void");
+      assert.equal(persisted.journal?.[0]?.result, null);
+
+      let childCalls = 0;
+      const resumedManager = new WorkflowManager({
+        cwd,
+        loadSavedWorkflow: () => childScript,
+        agent: {
+          async run(prompt: string, options: StoreAgentOptions) {
+            if (prompt === "child-write") childCalls++;
+            if (prompt === "interrupt-parent") return "continued";
+            if (prompt === "read-child-write") return get(options, "void-child");
+            return prompt;
+          },
+        },
+      });
+      const completed = new Promise<{ result: { childIsUndefined: boolean; observed: unknown } }>((resolve) => {
+        resumedManager.on("complete", (event: { runId: string; result: { result: never } }) => {
+          if (event.runId === persisted.runId) resolve(event.result);
+        });
+      });
+      assert.equal(await resumedManager.resume(persisted.runId), true);
+      const resumed = await completed;
+      assert.equal(childCalls, 0);
+      assert.equal(
+        JSON.stringify(resumed.result),
+        JSON.stringify({
+          childIsUndefined: true,
+          observed: { found: true, value: "persisted" },
+        }),
+      );
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("cold persistence replays the atomic child result and execution-order delta", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-cold-child-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-cold-child-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const childScript = `export const meta = { name: 'child', description: 'child' }
+await Promise.all([agent('late-write'), agent('early-write')])
+return { source: 'persisted-child' }`;
+      const script = parentScript(`const child = await workflow('child')
+await agent('interrupt-parent')
+const observed = await agent('read-winner')
+return { child, observed }`);
+      let releaseLate!: () => void;
+      const earlyWritten = new Promise<void>((resolve) => {
+        releaseLate = resolve;
+      });
+      const firstManager = new WorkflowManager({
+        cwd,
+        loadSavedWorkflow: () => childScript,
+        agent: {
+          async run(prompt: string, options: StoreAgentOptions) {
+            if (prompt === "late-write") {
+              await earlyWritten;
+              await put(options, "winner", "actual-last-write");
+              return "late";
+            }
+            if (prompt === "early-write") {
+              await put(options, "winner", "call-index-last");
+              releaseLate();
+              return "early";
+            }
+            if (prompt === "interrupt-parent") {
+              throw new WorkflowError("interrupt", WorkflowErrorCode.WORKFLOW_ABORTED, { recoverable: false });
+            }
+            return prompt;
+          },
+        },
+      });
+      firstManager.on("error", () => {});
+      await assert.rejects(() => firstManager.runSync(script), /interrupt/);
+      const persisted = firstManager.listRuns().find((run) => run.workflowName === "parent");
+      assert.ok(persisted);
+      assert.deepEqual(persisted.journal?.[0]?.result, { source: "persisted-child" });
+      assert.deepEqual(persisted.journal?.[0]?.storeDelta, { winner: "actual-last-write" });
+
+      let childCalls = 0;
+      const resumedManager = new WorkflowManager({
+        cwd,
+        loadSavedWorkflow: () => childScript,
+        agent: {
+          async run(prompt: string, options: StoreAgentOptions) {
+            if (prompt === "late-write" || prompt === "early-write") childCalls++;
+            if (prompt === "interrupt-parent") return "continued";
+            if (prompt === "read-winner") return get(options, "winner");
+            return prompt;
+          },
+        },
+      });
+      const completed = new Promise<{ result: { child: unknown; observed: unknown } }>((resolve) => {
+        resumedManager.on("complete", (event: { runId: string; result: { result: never } }) => {
+          if (event.runId === persisted.runId) resolve(event.result);
+        });
+      });
+      assert.equal(await resumedManager.resume(persisted.runId), true);
+      const resumed = await completed;
+      assert.equal(childCalls, 0, "the cold manager replays rather than reruns the child");
+      assert.equal(
+        JSON.stringify(resumed.result),
+        JSON.stringify({
+          child: { source: "persisted-child" },
+          observed: { found: true, value: "actual-last-write" },
+        }),
+      );
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/tests/fixtures/public-api-compat.ts
+++ b/tests/fixtures/public-api-compat.ts
@@ -1,0 +1,88 @@
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { type Static, Type } from "typebox";
+import {
+  type AgentOptions,
+  type AgentRunResult,
+  type AgentTypePolicy,
+  createStructuredOutputTool,
+  type LiteralJsonSchema,
+  runWorkflow,
+  type StructuredOutputCapture,
+  WorkflowManager,
+  type WorkflowRunOptions,
+  type WorkflowScriptDescriptor,
+} from "../../src/index.js";
+
+const descriptor: WorkflowScriptDescriptor = { scriptPath: "workflows/child.js" };
+const policy: AgentTypePolicy = "error";
+const schema: LiteralJsonSchema = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    rows: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { id: { type: "number" } },
+        required: ["id"],
+      },
+    },
+  },
+  required: ["title", "rows"],
+};
+const readonlyLiteralSchema = {
+  type: "object",
+  properties: {
+    status: { enum: ["ready", "blocked"] },
+    rows: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { priority: { enum: [1, 2, 3] } },
+        required: ["priority"],
+      },
+    },
+  },
+  required: ["status", "rows"],
+} as const satisfies LiteralJsonSchema;
+const agentOptions: AgentOptions = { schema: readonlyLiteralSchema, effort: "max" };
+const runOptions: WorkflowRunOptions = { agentTypePolicy: policy };
+
+const upstreamSchema = Type.Object({ ok: Type.Boolean() });
+const upstreamCapture: StructuredOutputCapture<Static<typeof upstreamSchema>> = {
+  called: false,
+  value: undefined,
+};
+const exactUpstreamTool: ToolDefinition<
+  typeof upstreamSchema,
+  Static<typeof upstreamSchema>
+> = createStructuredOutputTool({ schema: upstreamSchema, capture: upstreamCapture });
+
+const unsafeSchema = Type.Unsafe<{ exactUnsafe: string }>(Type.Object({ exactUnsafe: Type.String() }));
+type UnsafeAgentResult = AgentRunResult<typeof unsafeSchema>;
+type Equal<TLeft, TRight> = (<T>() => T extends TLeft ? 1 : 2) extends <T>() => T extends TRight ? 1 : 2 ? true : false;
+const exactUnsafeInference: Equal<UnsafeAgentResult, { exactUnsafe: string }> = true;
+const unsafeCapture: StructuredOutputCapture<Static<typeof unsafeSchema>> = {
+  called: false,
+  value: undefined,
+};
+const exactUnsafeTool: ToolDefinition<typeof unsafeSchema, Static<typeof unsafeSchema>> = createStructuredOutputTool({
+  schema: unsafeSchema,
+  capture: unsafeCapture,
+});
+
+const literalCapture: StructuredOutputCapture<{
+  status: "ready" | "blocked";
+  rows: Array<{ priority: 1 | 2 | 3 }>;
+}> = { called: false, value: undefined };
+const literalTool = createStructuredOutputTool({ schema: readonlyLiteralSchema, capture: literalCapture });
+
+void descriptor;
+void schema;
+void agentOptions;
+void exactUpstreamTool;
+void exactUnsafeInference;
+void exactUnsafeTool;
+void literalTool;
+void runWorkflow("export const meta = { name: 'compile', description: 'compile' }\nreturn true", runOptions);
+void new WorkflowManager().resume("run-id", { argsPatch: { supplied: true } });

--- a/tests/literal-schema.test.ts
+++ b/tests/literal-schema.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Type } from "typebox";
+import { extractValidated, resolveStructuredOutput, type StructuredSession } from "../src/agent.js";
+import type { StructuredOutputCapture } from "../src/structured-output.js";
+
+const literalSchema = {
+  type: "object" as const,
+  properties: {
+    name: { type: "string" as const },
+    items: {
+      type: "array" as const,
+      items: {
+        type: "object" as const,
+        properties: {
+          id: { type: "number" as const },
+          active: { type: "boolean" as const },
+        },
+        required: ["id", "active"],
+      },
+    },
+  },
+  required: ["name", "items"],
+};
+
+test("literal plain JSON Schema validates required object fields, arrays, and nested objects", async () => {
+  const capture: StructuredOutputCapture = { called: false, value: undefined };
+  const session: StructuredSession = {
+    async prompt() {},
+    messages: [],
+  };
+  const value = { name: "demo", items: [{ id: 1, active: true }] };
+
+  const result = await resolveStructuredOutput(session, capture, literalSchema, { maxSchemaRetries: 0 }, () =>
+    JSON.stringify(value),
+  );
+  assert.deepEqual(result, value);
+});
+
+test("literal plain JSON Schema rejects invalid nested output", () => {
+  assert.equal(extractValidated('{"name":"demo","items":[{"id":1}]}', literalSchema), undefined);
+  assert.equal(extractValidated('{"items":[]}', literalSchema), undefined);
+  assert.equal(extractValidated('{"name":"demo","items":"not-an-array"}', literalSchema), undefined);
+});
+
+test("literal schemas support enum-only nodes and readonly as-const nested definitions", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      status: { enum: ["ready", "blocked"] },
+      nested: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { priority: { enum: [1, 2, 3] } },
+          required: ["priority"],
+        },
+      },
+    },
+    required: ["status", "nested"],
+  } as const;
+
+  assert.deepEqual(extractValidated('{"status":"ready","nested":[{"priority":2}]}', schema), {
+    status: "ready",
+    nested: [{ priority: 2 }],
+  });
+  assert.equal(extractValidated('{"status":"unknown","nested":[{"priority":2}]}', schema), undefined);
+  assert.equal(extractValidated('{"status":"ready","nested":[{"priority":4}]}', schema), undefined);
+});
+
+test("TypeBox schema behavior remains unchanged", () => {
+  const typeBoxSchema = Type.Object({
+    name: Type.String(),
+    items: Type.Array(Type.Object({ id: Type.Number(), active: Type.Boolean() })),
+  });
+  assert.deepEqual(extractValidated('{"name":"demo","items":[{"id":1,"active":true}]}', typeBoxSchema), {
+    name: "demo",
+    items: [{ id: 1, active: true }],
+  });
+  assert.equal(extractValidated('{"name":"demo","items":[{"id":"bad","active":true}]}', typeBoxSchema), undefined);
+});

--- a/tests/public-api-compile.test.ts
+++ b/tests/public-api-compile.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import test from "node:test";
+
+test("AI Code Flow compatibility public API compiles for consumers", () => {
+  const tsc = join(process.cwd(), "node_modules", ".bin", "tsc");
+  const result = spawnSync(
+    tsc,
+    [
+      "--ignoreConfig",
+      "--noEmit",
+      "--strict",
+      "--skipLibCheck",
+      "--target",
+      "ES2022",
+      "--module",
+      "NodeNext",
+      "--moduleResolution",
+      "NodeNext",
+      "tests/fixtures/public-api-compat.ts",
+    ],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+});

--- a/tests/run-persistence.test.ts
+++ b/tests/run-persistence.test.ts
@@ -359,6 +359,37 @@ test(
   }),
 );
 
+test(
+  "run persistence rejects unsafe run IDs before save, load, delete, or lease paths are constructed",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    const invalidIds = ["", "../escape", "a/b", "a\\b", ".hidden", "line\nbreak", `a${"x".repeat(128)}`];
+    const base: PersistedRunState = {
+      runId: "valid",
+      workflowName: "wf",
+      script: "export const meta = { name: 'w', description: 'w' }",
+      status: "paused",
+      phases: [],
+      agents: [],
+      logs: [],
+      startedAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    };
+
+    for (const runId of invalidIds) {
+      assert.throws(() => rp.save({ ...base, runId }), /Invalid workflow run ID/);
+      assert.throws(() => rp.load(runId), /Invalid workflow run ID/);
+      assert.throws(() => rp.delete(runId), /Invalid workflow run ID/);
+      assert.throws(() => rp.acquireRunLease(runId), /Invalid workflow run ID/);
+      assert.throws(() => rp.releaseRunLease({ runId, token: "token" }), /Invalid workflow run ID/);
+    }
+
+    const longestValid = `a${"x".repeat(127)}`;
+    rp.save({ ...base, runId: longestValid });
+    assert.equal(rp.load(longestValid)?.runId, longestValid);
+  }),
+);
+
 test("generateRunId returns a string with timestamp and random parts", () => {
   const id = generateRunId();
   assert.equal(typeof id, "string");

--- a/tests/shared-store.test.ts
+++ b/tests/shared-store.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { AgentDefinition, AgentRegistry } from "../src/agent-registry.js";
 import { SharedStore } from "../src/shared-store.js";
-import { runWorkflow } from "../src/workflow.js";
+import { type JournalEntry, runWorkflow } from "../src/workflow.js";
 
 // ─── SharedStore unit tests ───────────────────────────────────────────────────
 
@@ -13,6 +13,18 @@ test("SharedStore.put / get / has basics", () => {
   store.put("x", 42);
   assert.equal(store.has("x"), true);
   assert.equal(store.get("x"), 42);
+});
+
+test("SharedStore rejects prototype-pollution keys without mutating object prototypes", () => {
+  const store = new SharedStore();
+  for (const key of ["__proto__", "prototype", "constructor"]) {
+    assert.throws(() => store.put(key, { polluted: true }), /unsafe shared-store key/);
+    assert.throws(() => store.trackPut(key, { polluted: true }, `scope:${key}`), /unsafe shared-store key/);
+    assert.throws(() => store.get(key), /unsafe shared-store key/);
+    assert.throws(() => store.has(key), /unsafe shared-store key/);
+  }
+  assert.equal(({} as { polluted?: boolean }).polluted, undefined);
+  assert.deepEqual(store.snapshot(), {});
 });
 
 test("SharedStore.snapshot returns deep copy", () => {
@@ -48,6 +60,18 @@ test("SharedStore.applyDelta adds keys without clearing", () => {
   assert.equal(store.get("newKey"), "added");
 });
 
+test("SharedStore.applyDelta validates the full delta before mutating", () => {
+  const store = new SharedStore();
+  store.put("existing", "keep");
+
+  assert.throws(
+    () => store.applyDelta({ valid: "must-not-apply", invalid: "rejected" }, { valid: 10, invalid: -1 }),
+    /invalid shared-store write version/,
+  );
+  assert.equal(store.has("valid"), false);
+  assert.equal(store.get("existing"), "keep");
+});
+
 test("SharedStore.applyDelta: replaying parallel-agent deltas in callSeq order is correct", () => {
   // Scenario: agents 2 and 3 run in parallel.
   // Agent 3 finishes first and writes {y: 2}; agent 2 writes {x: 1}.
@@ -67,13 +91,37 @@ test("SharedStore.applyDelta: replaying parallel-agent deltas in callSeq order i
   assert.equal(store.get("y"), 2, "agent 3 write must be present");
 });
 
-test("SharedStore.dispose clears map and agent deltas", () => {
-  const store = new SharedStore();
-  store.put("k", "v");
-  store.trackPut("k2", "v2", "run-1:1");
-  store.dispose();
-  assert.equal(store.get("k"), undefined);
-  assert.deepEqual(store.commitDelta("run-1:1"), {});
+test("disposed child stores are permanently closed and cannot read parents or accept writes", () => {
+  const parent = new SharedStore();
+  parent.put("parent-secret", "visible-only-while-active");
+  const child = parent.createChildScope();
+
+  assert.equal(child.get("parent-secret"), "visible-only-while-active");
+  child.put("local", "active-write");
+  assert.equal(child.get("local"), "active-write");
+
+  child.dispose();
+
+  const operations = [
+    () => child.get("parent-secret"),
+    () => child.has("parent-secret"),
+    () => child.put("orphan", "rejected"),
+    () => child.trackPut("orphan", "rejected", "late-attempt"),
+    () => child.snapshot(),
+    () => child.prepareDelta("late-attempt"),
+    () => child.commitDelta("late-attempt"),
+    () => child.discardDelta("late-attempt"),
+    () => child.createChildScope(),
+    () => child.prepareChildScope(),
+    () => child.commitChildScope(),
+    () => child.applyDelta({ orphan: "rejected" }),
+    () => child.restore({ orphan: "rejected" }),
+  ];
+  for (const operation of operations) assert.throws(operation, /shared store is disposed/);
+
+  assert.equal(parent.has("orphan"), false);
+  assert.equal(parent.get("parent-secret"), "visible-only-while-active");
+  assert.doesNotThrow(() => child.dispose(), "dispose remains idempotent");
 });
 
 // ─── Delta-key collision regression (defect: nested workflow() shares a store
@@ -148,6 +196,61 @@ test("each runWorkflow call gets an isolated SharedStore: run 2 does not see run
   await runWorkflow(getScript, { agent, cwd: process.cwd() });
 
   assert.equal(readsByRun.get, false, "a second, independent runWorkflow call must not see run 1's store writes");
+});
+
+test("parallel attempts cannot observe another attempt's uncommitted writes", async () => {
+  let writerHasPut!: () => void;
+  const writerPut = new Promise<void>((resolve) => {
+    writerHasPut = resolve;
+  });
+  let readerHasRead!: () => void;
+  const readerRead = new Promise<void>((resolve) => {
+    readerHasRead = resolve;
+  });
+  const script = `export const meta = { name: 'pending-isolation', description: 'pending isolation' }
+return await parallel([
+  () => agent('reader'),
+  () => agent('writer'),
+])`;
+
+  const journal: JournalEntry[] = [];
+  const runner = {
+    async run(
+      prompt: string,
+      options: {
+        systemTools?: Array<{
+          name: string;
+          execute: (id: string, params: unknown) => Promise<{ details?: Record<string, unknown> }>;
+        }>;
+      },
+    ) {
+      const putTool = options.systemTools?.find((tool) => tool.name === "store_put");
+      const getTool = options.systemTools?.find((tool) => tool.name === "store_get");
+      if (prompt === "writer") {
+        await putTool?.execute("", { key: "pending", value: "must-stay-private" });
+        writerHasPut();
+        await readerRead;
+        throw new Error("writer failed");
+      }
+      await writerPut;
+      const observed = await getTool?.execute("", { key: "pending" });
+      readerHasRead();
+      return observed?.details;
+    },
+  };
+  const result = await runWorkflow<Array<{ found: boolean; value: unknown } | null>>(script, {
+    persistLogs: false,
+    agent: runner,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+
+  assert.deepEqual(result.result, [{ key: "pending", found: false, value: null }, null]);
+  const replay = await runWorkflow<Array<{ found: boolean; value: unknown } | null>>(script, {
+    persistLogs: false,
+    agent: runner,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+  assert.deepEqual(replay.result, result.result, "replay must expose the same committed-only state as live execution");
 });
 
 test("store_put/store_get are injected as systemTools even under a restrictive agentType tools allowlist", async () => {

--- a/tests/workflow-commands.test.ts
+++ b/tests/workflow-commands.test.ts
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { createEffortState, effortDirective } from "../src/effort-command.js";
+import { createRunPersistence } from "../src/run-persistence.js";
 import { registerWorkflowCommands } from "../src/workflow-commands.js";
 import { buildForcedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "../src/workflow-editor.js";
-import type { WorkflowManager } from "../src/workflow-manager.js";
+import { WorkflowManager } from "../src/workflow-manager.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 type Handler = (args: string, ctx: any) => Promise<void>;
 
@@ -49,6 +54,10 @@ function harness(
 
   const manager: Partial<WorkflowManager> = {
     listRuns: () => [],
+    getRunForReport: (id: string) => {
+      const runs = typeof managerOverrides.listRuns === "function" ? managerOverrides.listRuns() : [];
+      return runs.find((run: { runId: string }) => run.runId === id) ?? null;
+    },
     getSnapshot: () => null,
     getRun: () => undefined,
     stop: (id: string) => {
@@ -164,6 +173,88 @@ test("/workflows status <id> renders a persisted run", async () => {
   await h.run("status run-7");
   assert.match(h.printed[0], /audit \(run-7\)/);
   assert.match(h.printed[0], /scan files/);
+});
+
+test("/workflows report <id> prints the persistent telemetry report", async () => {
+  const h = harness({
+    listRuns: () => [
+      {
+        runId: "run-report",
+        workflowName: "audit",
+        status: "completed",
+        script: "",
+        phases: [],
+        agents: [{ id: 1, label: "legacy", status: "done", prompt: "x" }],
+        logs: [],
+        startedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:01.000Z",
+      },
+    ],
+  });
+  await h.run("report run-report");
+  assert.match(h.printed[0], /Workflow report: audit \(run-report\)/);
+  assert.match(h.printed[0], /legacy .* telemetry unavailable/);
+});
+
+test("/workflows report resolves an explicit legacy run outside the bound session", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-report-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-report-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      createRunPersistence(cwd).save({
+        runId: "legacy-run",
+        workflowName: "legacy audit",
+        script: "",
+        status: "completed",
+        phases: [],
+        agents: [],
+        logs: [],
+        startedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:01.000Z",
+      });
+      const manager = new WorkflowManager({ cwd, sessionId: "current-session" });
+      assert.equal(manager.listRuns().length, 0, "the legacy run is intentionally hidden from session navigation");
+
+      const printed: string[] = [];
+      let handler: Handler | undefined;
+      const pi: Partial<ExtensionAPI> = {
+        getCommands: () => [],
+        registerCommand: (_name: string, options: { handler: Handler }) => {
+          handler = options.handler;
+        },
+        sendMessage: async (message) => {
+          if (typeof message.content === "string") printed.push(message.content);
+        },
+      };
+      registerWorkflowCommands(pi as ExtensionAPI, manager);
+      assert.ok(handler);
+      await handler("report legacy-run", { ui: { notify: () => {} } });
+      assert.match(printed[0], /Workflow report: legacy audit \(legacy-run\)/);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("/workflows report without id warns usage", async () => {
+  const h = harness();
+  await h.run("report");
+  assert.equal(h.notified[0].type, "warning");
+  assert.match(h.notified[0].message, /report <id>/);
+});
+
+test("/workflows report catches invalid run IDs and notifies a stable error", async () => {
+  const h = harness({
+    getRunForReport() {
+      throw new Error("Invalid workflow run ID");
+    },
+  });
+
+  await h.run("report ../escape");
+
+  assert.deepEqual(h.notified, [{ message: "Invalid workflow run ID", type: "error" }]);
+  assert.equal(h.printed.length, 0);
 });
 
 test("/workflows status without id warns", async () => {

--- a/tests/workflow-manager-abort.test.ts
+++ b/tests/workflow-manager-abort.test.ts
@@ -350,19 +350,13 @@ test(
     assert.equal(paused, true);
     assert.equal(manager.getRun(runId)?.status, "paused");
 
-    // Resume — replays journal (empty for single-agent that never completed) and
-    // re-runs the live agent with a fresh (non-aborted) controller.
-    const resumed = await manager.resume(runId);
-    assert.equal(resumed, true, "resume should succeed");
-
-    // The resumed run should be running
-    assert.equal(manager.getRun(runId)?.status, "running", "resumed run should be running");
-
-    // Resolve the deferred agent so the resumed run's agent completes
+    // Resume waits for the aborted execution to settle before starting a fresh
+    // generation, so release the old in-flight runner before awaiting it.
+    const resumePromise = manager.resume(runId);
     da.resolve("resumed-done");
-
-    // The original promise will reject (its controller was aborted). Suppress it.
     await origPromise.catch(() => {});
+    const resumed = await resumePromise;
+    assert.equal(resumed, true, "resume should succeed");
 
     // Wait for the resumed run to complete
     await new Promise((r) => setTimeout(r, 50));
@@ -438,6 +432,50 @@ test(
       const resumed = await manager.resume(runId);
       assert.equal(resumed, false, "cannot resume a completed run");
     }
+  }),
+);
+
+test(
+  "immediate resume waits for the paused generation to settle before starting a new generation",
+  withTempCwd(async (cwd) => {
+    let calls = 0;
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          calls++;
+          if (calls === 1) await firstGate;
+          return `result-${calls}`;
+        },
+      },
+    });
+    manager.on("error", () => {});
+    const started = new Promise<void>((resolve) => manager.once("agentStart", () => resolve()));
+    const { runId, promise: firstExecution } = manager.startInBackground(oneAgentScript);
+    await started;
+
+    assert.equal(manager.pause(runId), true);
+    const resumePromise = manager.resume(runId);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(calls, 1, "the new generation must not overlap the aborted runner");
+    assert.equal(manager.getRun(runId)?.status, "paused");
+
+    releaseFirst();
+    await firstExecution.catch(() => {});
+    assert.equal(await resumePromise, true);
+    await new Promise<void>((resolve) => {
+      const run = manager.getRun(runId);
+      if (run?.status === "completed") resolve();
+      else manager.on("complete", (event: { runId: string }) => event.runId === runId && resolve());
+    });
+
+    assert.equal(calls, 2);
+    assert.equal(manager.getPersistence().load(runId)?.status, "completed");
+    assert.equal(manager.getRun(runId)?.result?.result?.a, "result-2");
   }),
 );
 
@@ -534,9 +572,23 @@ test(
       runs.find((r) => r.runId === runId),
       undefined,
     );
+    assert.equal(
+      manager.getPersistence().acquireRunLease(runId),
+      null,
+      "the deleted execution retains its lease until cancellation settles",
+    );
 
     da.resolve("done");
     await promise.catch(() => {});
+
+    assert.equal(
+      manager.getPersistence().load(runId),
+      null,
+      "the deleted generation must not recreate persisted state",
+    );
+    const lease = manager.getPersistence().acquireRunLease(runId);
+    assert.ok(lease, "the deleted execution releases its lease after settling");
+    manager.getPersistence().releaseRunLease(lease);
   }),
 );
 
@@ -663,6 +715,7 @@ test(
     const _ac = new AbortController();
     const da = deferredAgent();
     const manager = new WorkflowManager({ cwd, agent: da.runner });
+    manager.on("error", () => {});
 
     // Track resumed event
     let resumedEvent: { runId: string } | null = null;
@@ -673,14 +726,14 @@ test(
     // Track resumed event on the pause→resume cycle
     const { runId, promise: origPromise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
-    manager.pause(runId);
-    await manager.resume(runId);
+    assert.equal(manager.pause(runId), true);
+    const resumePromise = manager.resume(runId);
+    da.resolve("done");
+    await origPromise.catch(() => {});
+    assert.equal(await resumePromise, true);
 
     assert.ok(resumedEvent, "resumed event should fire on resume");
     assert.equal(resumedEvent?.runId, runId);
-
-    da.resolve("done");
-    await origPromise.catch(() => {});
 
     // Now test error event on abort
     let capturedError: { runId: string; error: WorkflowError } | null = null;

--- a/tests/workflow-manager-policy-resume.test.ts
+++ b/tests/workflow-manager-policy-resume.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
+import { WorkflowManager } from "../src/workflow-manager.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+const strictScript = `export const meta = { name: 'strict-resume', description: 'strict resume' }
+return await agent('work', { agentType: 'missing' })`;
+
+test("cold resume restores execution limits and counts already-consumed token budget", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-limits-resume-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-limits-resume-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      let firstCalls = 0;
+      const firstManager = new WorkflowManager({
+        cwd,
+        concurrency: 8,
+        defaultAgentRetries: 0,
+        agent: {
+          async run(_prompt: string, options: any) {
+            firstCalls++;
+            if (firstCalls === 1) {
+              options.onUsage?.({ input: 3, output: 3, cacheRead: 0, cacheWrite: 0, total: 6, cost: 0 });
+              return "first";
+            }
+            options.onUsage?.({ input: 1, output: 0, cacheRead: 0, cacheWrite: 0, total: 1, cost: 0 });
+            throw new WorkflowError("quota", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, { recoverable: false });
+          },
+        },
+      });
+      firstManager.on("error", () => {});
+      await assert.rejects(() =>
+        firstManager.runSync(
+          `export const meta = { name: 'limit-resume', description: 'limits' }
+await agent('first')
+await agent('second')
+return await agent('third')`,
+          undefined,
+          {
+            maxAgents: 3,
+            agentTimeoutMs: 1234,
+            tokenBudget: 10,
+            concurrency: 1,
+            agentRetries: 2,
+            agentTypePolicy: "error",
+          },
+        ),
+      );
+      const persisted = firstManager.listRuns().find((run) => run.workflowName === "limit-resume");
+      assert.ok(persisted);
+      assert.deepEqual(persisted.executionPolicy, {
+        cwd,
+        maxAgents: 3,
+        agentTimeoutMs: 1234,
+        tokenBudget: 10,
+        concurrency: 1,
+        agentRetries: 2,
+        agentTypePolicy: "error",
+      });
+      assert.equal(persisted.tokenUsage?.total, 7);
+
+      let resumedCalls = 0;
+      const resumedManager = new WorkflowManager({
+        cwd,
+        concurrency: 9,
+        defaultAgentRetries: 0,
+        agent: {
+          async run(_prompt: string, options: any) {
+            resumedCalls++;
+            options.onUsage?.({ input: 2, output: 3, cacheRead: 0, cacheWrite: 0, total: 5, cost: 0 });
+            return "second";
+          },
+        },
+      });
+      const failed = new Promise<WorkflowError>((resolve) => {
+        resumedManager.on("error", (event: { runId: string; error: WorkflowError }) => {
+          if (event.runId === persisted.runId) resolve(event.error);
+        });
+      });
+      assert.equal(await resumedManager.resume(persisted.runId), true);
+      const error = await failed;
+      assert.equal(error.code, WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED);
+      assert.equal(resumedCalls, 1, "the third agent is blocked by 7 persisted + 5 resumed tokens");
+      assert.equal(resumedManager.getPersistence().load(persisted.runId)?.tokenUsage?.total, 12);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("per-run cwd is used for execution and restored by cold resume", async () => {
+  const storageCwd = mkdtempSync(join(tmpdir(), "pi-dw-storage-cwd-"));
+  const executionCwd = mkdtempSync(join(tmpdir(), "pi-dw-execution-cwd-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-cwd-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const prompts: string[] = [];
+      const manager = new WorkflowManager({
+        cwd: storageCwd,
+        agent: {
+          async run(prompt: string) {
+            prompts.push(prompt);
+            return "ok";
+          },
+        },
+      });
+      const script = `export const meta = { name: 'cwd-policy', description: 'cwd policy' }
+return await agent(cwd)`;
+      await manager.runSync(script, undefined, { cwd: executionCwd });
+      assert.equal(prompts[0], executionCwd);
+      const first = manager.listRuns()[0];
+      manager.getPersistence().save({ ...first, status: "paused", agents: [], journal: [] });
+
+      const coldPrompts: string[] = [];
+      const cold = new WorkflowManager({
+        cwd: storageCwd,
+        agent: {
+          async run(prompt: string) {
+            coldPrompts.push(prompt);
+            return "ok";
+          },
+        },
+      });
+      const completed = new Promise<void>((resolve) => {
+        cold.on("complete", (event: { runId: string }) => event.runId === first.runId && resolve());
+      });
+      assert.equal(await cold.resume(first.runId), true);
+      await completed;
+      assert.equal(coldPrompts[0], executionCwd);
+      assert.equal(cold.getPersistence().load(first.runId)?.cwd, executionCwd);
+    });
+  } finally {
+    rmSync(storageCwd, { recursive: true, force: true });
+    rmSync(executionCwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("a strict per-execution agentTypePolicy remains strict after cold resume", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-policy-resume-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-policy-resume-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const firstManager = new WorkflowManager({
+        cwd,
+        agentTypePolicy: "fallback",
+        agent: {
+          async run() {
+            return "ok";
+          },
+        },
+      });
+      firstManager.on("error", () => {});
+      await assert.rejects(
+        () => firstManager.runSync(strictScript, undefined, { agentTypePolicy: "error" }),
+        (error: unknown) => {
+          assert.ok(error instanceof WorkflowError);
+          assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+          assert.equal(error.message, 'Unknown agentType "missing"');
+          return true;
+        },
+      );
+
+      const persisted = firstManager.listRuns().find((run) => run.workflowName === "strict-resume");
+      assert.ok(persisted);
+      assert.equal(
+        (persisted as typeof persisted & { agentTypePolicy?: string }).agentTypePolicy,
+        "error",
+        "the effective execution policy is durable",
+      );
+
+      let calls = 0;
+      const resumedManager = new WorkflowManager({
+        cwd,
+        agentTypePolicy: "fallback",
+        agent: {
+          async run() {
+            calls++;
+            return "must-not-run";
+          },
+        },
+      });
+      const outcome = new Promise<{ type: "complete" | "error"; error?: WorkflowError }>((resolve) => {
+        resumedManager.on("complete", (event: { runId: string }) => {
+          if (event.runId === persisted.runId) resolve({ type: "complete" });
+        });
+        resumedManager.on("error", (event: { runId: string; error: WorkflowError }) => {
+          if (event.runId === persisted.runId) resolve({ type: "error", error: event.error });
+        });
+      });
+
+      assert.equal(await resumedManager.resume(persisted.runId), true);
+      const resumed = await outcome;
+      assert.equal(resumed.type, "error");
+      assert.equal(resumed.error?.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+      assert.equal(resumed.error?.message, 'Unknown agentType "missing"');
+      assert.equal(calls, 0, "resume must not fall back to the new manager's permissive policy");
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/tests/workflow-manager-resume-args.test.ts
+++ b/tests/workflow-manager-resume-args.test.ts
@@ -1,0 +1,269 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
+import type { PersistedRunState } from "../src/run-persistence.js";
+import { WorkflowManager } from "../src/workflow-manager.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+const resumeScript = `export const meta = { name: 'resume-args', description: 'resume args' }
+return await agent(JSON.stringify(args), { label: 'capture' })`;
+
+function withTempCwd(fn: (cwd: string) => Promise<void>) {
+  return async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-dw-resume-args-"));
+    const home = mkdtempSync(join(tmpdir(), "pi-dw-resume-home-"));
+    try {
+      await withFakeHomeAsync(home, () => fn(cwd));
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  };
+}
+
+function persistedRun(runId: string, args: unknown): PersistedRunState {
+  const now = new Date().toISOString();
+  return {
+    runId,
+    workflowName: "resume-args",
+    script: resumeScript,
+    args,
+    status: "paused",
+    phases: [],
+    agents: [],
+    logs: [],
+    startedAt: now,
+    updatedAt: now,
+  };
+}
+
+function waitForComplete(manager: WorkflowManager, runId: string): Promise<void> {
+  return new Promise((resolve) => {
+    manager.on("complete", (event: { runId: string }) => {
+      if (event.runId === runId) resolve();
+    });
+  });
+}
+
+test(
+  "resume(runId, { argsPatch }) safely shallow-merges plain objects, supplied keys win, and persists before execution",
+  withTempCwd(async (cwd) => {
+    const runId = "resume-safe-patch";
+    let prompt = "";
+    let persistedAtRunnerStart: unknown;
+    let manager!: WorkflowManager;
+    manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(value: string) {
+          prompt = value;
+          persistedAtRunnerStart = manager.getPersistence().load(runId)?.args;
+          return "ok";
+        },
+      },
+    });
+    manager.getPersistence().save(persistedRun(runId, { keep: 1, override: "old" }));
+    const completed = waitForComplete(manager, runId);
+
+    assert.equal(await manager.resume(runId, { argsPatch: { override: "new", added: true } }), true);
+    await completed;
+
+    const expected = { keep: 1, override: "new", added: true };
+    assert.deepEqual(JSON.parse(prompt), expected);
+    assert.deepEqual(persistedAtRunnerStart, expected, "the merged args are durable before the runner starts");
+    assert.deepEqual(manager.getPersistence().load(runId)?.args, expected);
+  }),
+);
+
+test(
+  "resume(runId) keeps the existing no-patch behavior even for non-object persisted args",
+  withTempCwd(async (cwd) => {
+    const runId = "resume-no-patch";
+    let prompt = "";
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(value: string) {
+          prompt = value;
+          return "ok";
+        },
+      },
+    });
+    manager.getPersistence().save(persistedRun(runId, ["legacy", 1]));
+    const completed = waitForComplete(manager, runId);
+
+    assert.equal(await manager.resume(runId), true);
+    await completed;
+    assert.deepEqual(JSON.parse(prompt), ["legacy", 1]);
+  }),
+);
+
+test(
+  "resume script plus args replaces persisted input and rejects simultaneous argsPatch",
+  withTempCwd(async (cwd) => {
+    const runId = "resume-replace-input";
+    const prompts: string[] = [];
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(value: string) {
+          prompts.push(value);
+          return "ok";
+        },
+      },
+    });
+    manager.getPersistence().save(persistedRun(runId, { old: true }));
+    const editedScript = `export const meta = { name: 'resume-args', description: 'edited' }
+return await agent('edited:' + JSON.stringify(args), { label: 'capture' })`;
+    const completed = waitForComplete(manager, runId);
+
+    assert.equal(await manager.resume(runId, { script: editedScript, args: ["replacement"] }), true);
+    await completed;
+    assert.deepEqual(prompts, ['edited:["replacement"]']);
+    assert.equal(manager.getPersistence().load(runId)?.script, editedScript);
+    assert.deepEqual(manager.getPersistence().load(runId)?.args, ["replacement"]);
+
+    const otherRunId = "resume-mutually-exclusive";
+    manager.getPersistence().save(persistedRun(otherRunId, { old: true }));
+    await assert.rejects(
+      () => manager.resume(otherRunId, { args: { replacement: true }, argsPatch: { patch: true } }),
+      /mutually exclusive/,
+    );
+    assert.equal(manager.getPersistence().load(otherRunId)?.status, "paused");
+  }),
+);
+
+test(
+  "resume argsPatch rejects arrays, null, non-objects, and prototype-pollution keys before execution",
+  withTempCwd(async (cwd) => {
+    const runId = "resume-invalid-patch";
+    let calls = 0;
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          calls++;
+          return "unexpected";
+        },
+      },
+    });
+    manager.getPersistence().save(persistedRun(runId, { existing: true }));
+
+    const customPrototype = Object.create({ polluted: true }) as Record<string, unknown>;
+    customPrototype.safe = true;
+    const invalidPatches: unknown[] = [
+      null,
+      [],
+      "value",
+      42,
+      customPrototype,
+      JSON.parse('{"__proto__":{"polluted":true}}'),
+      { constructor: { prototype: { polluted: true } } },
+      { prototype: { polluted: true } },
+    ];
+
+    for (const patch of invalidPatches) {
+      await assert.rejects(
+        () => manager.resume(runId, { argsPatch: patch as never }),
+        (error: unknown) => {
+          assert.ok(error instanceof WorkflowError);
+          assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+          assert.equal(error.message, "resume argsPatch must be a safe plain object");
+          return true;
+        },
+      );
+    }
+    assert.equal(calls, 0);
+    assert.equal(manager.getPersistence().load(runId)?.status, "paused");
+    assert.equal(({} as { polluted?: boolean }).polluted, undefined);
+  }),
+);
+
+test(
+  "resume argsPatch recursively rejects lossy JSON values before persistence or execution",
+  withTempCwd(async (cwd) => {
+    let calls = 0;
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          calls++;
+          return "unexpected";
+        },
+      },
+    });
+    const customPrototype = Object.create({ inherited: true }) as Record<string, unknown>;
+    customPrototype.value = "own";
+    const sparse = Array(2) as unknown[];
+    sparse[1] = "present";
+    const customArray = [] as unknown[];
+    Object.setPrototypeOf(customArray, Object.create(Array.prototype));
+    const spoofPrototype = Object.create(null) as Record<string, unknown>;
+    Object.defineProperty(spoofPrototype, "constructor", { value: Object, enumerable: false });
+    spoofPrototype.toJSON = () => ({ spoofed: true });
+    const spoofedObject = Object.create(spoofPrototype) as Record<string, unknown>;
+    spoofedObject.safe = true;
+    const lossyPatches: Record<string, unknown>[] = [
+      { nested: { omitted: undefined } },
+      { nested: { callable: () => true } },
+      { nested: { invalidNumber: Number.NaN } },
+      { nested: { invalidNumber: Number.POSITIVE_INFINITY } },
+      { nested: customPrototype },
+      { nested: sparse },
+      { nested: customArray },
+      { nested: spoofedObject },
+    ];
+
+    for (const [index, patch] of lossyPatches.entries()) {
+      const runId = `resume-lossy-${index}`;
+      manager.getPersistence().save(persistedRun(runId, { existing: true }));
+      await assert.rejects(
+        () => manager.resume(runId, { argsPatch: patch }),
+        (error: unknown) => {
+          assert.ok(error instanceof WorkflowError);
+          assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+          assert.equal(error.message, "resume argsPatch must contain only plain JSON values");
+          return true;
+        },
+      );
+      assert.deepEqual(manager.getPersistence().load(runId)?.args, { existing: true });
+      assert.equal(manager.getPersistence().load(runId)?.status, "paused");
+    }
+    assert.equal(calls, 0);
+  }),
+);
+
+test(
+  "resume argsPatch rejects incompatible persisted args before execution",
+  withTempCwd(async (cwd) => {
+    let calls = 0;
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          calls++;
+          return "unexpected";
+        },
+      },
+    });
+
+    for (const [index, args] of [null, [], "legacy", 1].entries()) {
+      const runId = `resume-incompatible-${index}`;
+      manager.getPersistence().save(persistedRun(runId, args));
+      await assert.rejects(
+        () => manager.resume(runId, { argsPatch: { added: true } }),
+        (error: unknown) => {
+          assert.ok(error instanceof WorkflowError);
+          assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+          assert.equal(error.message, "persisted workflow args are incompatible with argsPatch");
+          return true;
+        },
+      );
+      assert.equal(manager.getPersistence().load(runId)?.status, "paused");
+    }
+    assert.equal(calls, 0);
+  }),
+);

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -268,6 +268,42 @@ test(
 );
 
 test(
+  "runSync correlates duplicate-label histories by invocation",
+  withTempCwd(async (cwd) => {
+    let arrivals = 0;
+    let release!: () => void;
+    const bothStarted = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string, options: { onHistory?: (history: unknown[]) => void }) {
+          arrivals++;
+          if (arrivals === 2) release();
+          await bothStarted;
+          options.onHistory?.([{ role: "assistant", kind: "text", text: `history:${prompt}` }]);
+          return `result:${prompt}`;
+        },
+      },
+    });
+    const script = `export const meta = { name: 'duplicate-history', description: 'history correlation' }
+return await parallel([
+  () => agent('first prompt', { label: 'duplicate' }),
+  () => agent('second prompt', { label: 'duplicate' }),
+])`;
+
+    await manager.runSync(script);
+
+    const run = manager.listRuns().find((candidate) => candidate.workflowName === "duplicate-history");
+    assert.equal(run?.agents.length, 2);
+    for (const agent of run?.agents ?? []) {
+      assert.equal(agent.history?.[0]?.text, `history:${agent.prompt}`);
+    }
+  }),
+);
+
+test(
   "startInBackground returns immediately with runId and promise",
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({ cwd, agent: fakeAgent() });
@@ -471,6 +507,43 @@ test(
 );
 
 test(
+  "resume acquires the lease before reloading and revalidating persisted state",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    const persistence = manager.getPersistence();
+    const runId = "resume-toctou";
+    persistence.save({
+      runId,
+      workflowName: "resume race",
+      script: oneAgentScript,
+      args: { stale: true },
+      status: "paused",
+      phases: [],
+      agents: [],
+      logs: [],
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    const acquire = persistence.acquireRunLease.bind(persistence);
+    const load = persistence.load.bind(persistence);
+    persistence.acquireRunLease = (id: string) => {
+      const lease = acquire(id);
+      const stale = load(id);
+      assert.ok(stale);
+      persistence.save({ ...stale, status: "completed", script: "" });
+      return lease;
+    };
+
+    assert.equal(await manager.resume(runId), false, "state changed at lease acquisition is reloaded and rejected");
+    persistence.acquireRunLease = acquire;
+    const lease = persistence.acquireRunLease(runId);
+    assert.ok(lease, "resume releases the lease when reloaded state is no longer resumable");
+    persistence.releaseRunLease(lease);
+    assert.equal(manager.getRun(runId), undefined);
+  }),
+);
+
+test(
   "manager emits complete event with runId",
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({ cwd, agent: fakeAgent() });
@@ -502,6 +575,609 @@ test(
     await promise; // wait for completion
     const paused = manager.pause(runId);
     assert.equal(paused, false, "cannot pause completed run");
+  }),
+);
+
+test(
+  "resume fails within the cancellation grace when a paused agent ignores abort and prevents overlap",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    let calls = 0;
+    const manager = new WorkflowManager({
+      cwd,
+      cancellationGraceMs: 20,
+      agent: {
+        async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+          calls++;
+          return da.runner.run(prompt, options);
+        },
+      },
+    });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(manager.pause(runId), true);
+
+    const resume = manager.resume(runId);
+    try {
+      await assert.rejects(
+        Promise.race([
+          resume,
+          new Promise<never>((_resolve, reject) =>
+            setTimeout(() => reject(new Error("resume hung past its cancellation grace")), 200),
+          ),
+        ]),
+        /did not settle within 20ms/,
+      );
+      assert.equal(calls, 1, "an unsafe timed-out generation is never overlapped by a resumed generation");
+      assert.equal(manager.getRun(runId)?.status, "aborted");
+      const lease = manager.getPersistence().acquireRunLease(runId);
+      assert.ok(lease, "timed-out cancellation releases its execution lease");
+      manager.getPersistence().releaseRunLease(lease);
+    } finally {
+      da.resolve("late result");
+      await promise.catch(() => {});
+      await resume.catch(() => {});
+    }
+    assert.equal(manager.getPersistence().load(runId)?.status, "aborted", "late settlement cannot overwrite state");
+  }),
+);
+
+test(
+  "settled pause retains its lease until a durable paused marker can be saved",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 20, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const persistence = manager.getPersistence();
+    const save = persistence.save.bind(persistence);
+    const deletePersisted = persistence.delete.bind(persistence);
+    let deleteCalls = 0;
+    persistence.save = () => {
+      throw new Error("injected pause save failure");
+    };
+    persistence.delete = () => {
+      deleteCalls++;
+      return false;
+    };
+
+    let contender: WorkflowManager | undefined;
+    try {
+      assert.equal(manager.pause(runId), true);
+      da.resolve("settled result");
+      await promise.catch(() => {});
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      assert.equal(persistence.load(runId)?.status, "running", "both failed pause writes leave the old marker");
+
+      const contenderCalls: string[] = [];
+      contender = new WorkflowManager({
+        cwd,
+        agent: {
+          async run(prompt: string) {
+            contenderCalls.push(prompt);
+            return "resumed";
+          },
+        },
+      });
+      assert.equal(
+        await contender.resume(runId),
+        false,
+        "another manager cannot recover or resume stale running state",
+      );
+      assert.deepEqual(contenderCalls, [], "the contender must not start while the paused marker is not durable");
+      assert.equal(deleteCalls, 0, "a legitimately paused run is retained rather than deleted as cleanup fallback");
+    } finally {
+      persistence.save = save;
+      persistence.delete = deletePersisted;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.equal(persistence.load(runId)?.status, "paused", "cleanup retry eventually saves the paused marker");
+    const resumed = await contender?.resume(runId);
+    assert.equal(resumed, true, "the durably paused run remains normally resumable");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(contender?.getRun(runId)?.status, "completed");
+  }),
+);
+
+test(
+  "settled usage-limit pause retains its lease until its paused marker is durable",
+  withTempCwd(async (cwd) => {
+    let failPausedSave = false;
+    const manager = new WorkflowManager({
+      cwd,
+      cancellationGraceMs: 20,
+      agent: {
+        async run() {
+          failPausedSave = true;
+          throw new WorkflowError("usage limit", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, { recoverable: false });
+        },
+      },
+    });
+    const persistence = manager.getPersistence();
+    const save = persistence.save.bind(persistence);
+    const deletePersisted = persistence.delete.bind(persistence);
+    let deleteCalls = 0;
+    persistence.save = (state) => {
+      if (failPausedSave && state.status === "paused") throw new Error("injected quota pause save failure");
+      save(state);
+    };
+    persistence.delete = () => {
+      deleteCalls++;
+      return false;
+    };
+
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await promise.catch(() => {});
+    assert.equal(persistence.load(runId)?.status, "running", "the failed final pause write leaves the old marker");
+
+    const contender = new WorkflowManager({ cwd, agent: fakeAgent() });
+    assert.equal(await contender.resume(runId), false, "another manager cannot recover a failed quota pause write");
+    assert.equal(deleteCalls, 0, "quota-paused runs are not deleted as a marker-save fallback");
+
+    failPausedSave = false;
+    persistence.save = save;
+    persistence.delete = deletePersisted;
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.equal(persistence.load(runId)?.status, "paused", "retry saves the quota pause marker");
+    assert.equal(await contender.resume(runId), true, "the quota-paused run remains resumable after cleanup");
+  }),
+);
+
+test(
+  "stop on a settled paused run handles lease acquisition failure without mutation",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 20, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(manager.pause(runId), true);
+    da.resolve("settled result");
+    await promise.catch(() => {});
+
+    const persistence = manager.getPersistence();
+    const blocker = persistence.acquireRunLease(runId);
+    assert.ok(blocker, "the settled pause should have released its execution lease");
+    try {
+      assert.equal(manager.stop(runId), false, "stop reports cross-process lease contention cleanly");
+      assert.equal(manager.getRun(runId)?.status, "paused", "failed acquisition does not mutate memory");
+      assert.equal(persistence.load(runId)?.status, "paused", "failed acquisition does not mutate persistence");
+    } finally {
+      persistence.releaseRunLease(blocker);
+    }
+
+    assert.equal(manager.stop(runId), true, "stop succeeds after the competing lease is released");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(persistence.load(runId)?.status, "aborted");
+  }),
+);
+
+test(
+  "settled paused stop retains its acquired lease while abort persistence fails",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 20, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(manager.pause(runId), true);
+    da.resolve("settled result");
+    await promise.catch(() => {});
+
+    const persistence = manager.getPersistence();
+    const save = persistence.save.bind(persistence);
+    const deletePersisted = persistence.delete.bind(persistence);
+    persistence.save = () => {
+      throw new Error("injected abort save failure");
+    };
+    persistence.delete = () => false;
+
+    try {
+      assert.equal(manager.stop(runId), true);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      const contenderCalls: string[] = [];
+      const contender = new WorkflowManager({
+        cwd,
+        agent: {
+          async run(prompt: string) {
+            contenderCalls.push(prompt);
+            return "unsafe resume";
+          },
+        },
+      });
+      assert.equal(
+        await contender.resume(runId),
+        false,
+        "failed abort cleanup remains protected by the acquired lease",
+      );
+      assert.deepEqual(contenderCalls, []);
+      assert.equal(persistence.load(runId)?.status, "paused", "the old durable pause marker remains until retry");
+    } finally {
+      persistence.save = save;
+      persistence.delete = deletePersisted;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.equal(persistence.load(runId)?.status, "aborted", "retry durably marks the stopped run aborted");
+    const releasedLease = persistence.acquireRunLease(runId);
+    assert.ok(releasedLease, "successful retry releases the fail-safe lease");
+    persistence.releaseRunLease(releasedLease);
+  }),
+);
+
+test(
+  "deleteRun on a settled paused run handles lease acquisition failure without mutation",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 20, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(manager.pause(runId), true);
+    da.resolve("settled result");
+    await promise.catch(() => {});
+
+    const persistence = manager.getPersistence();
+    const blocker = persistence.acquireRunLease(runId);
+    assert.ok(blocker, "the settled pause should have released its execution lease");
+    try {
+      assert.equal(manager.deleteRun(runId), false, "delete reports cross-process lease contention cleanly");
+      assert.equal(manager.getRun(runId)?.status, "paused", "failed acquisition keeps the run in memory");
+      assert.equal(persistence.load(runId)?.status, "paused", "failed acquisition keeps the durable paused run");
+    } finally {
+      persistence.releaseRunLease(blocker);
+    }
+
+    assert.equal(manager.deleteRun(runId), true, "delete succeeds after the competing lease is released");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(persistence.load(runId), null);
+  }),
+);
+
+test(
+  "settled paused deleteRun retains its acquired lease while deletion fails",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 20, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(manager.pause(runId), true);
+    da.resolve("settled result");
+    await promise.catch(() => {});
+
+    const persistence = manager.getPersistence();
+    const deletePersisted = persistence.delete.bind(persistence);
+    persistence.delete = () => false;
+
+    try {
+      assert.equal(manager.deleteRun(runId), false, "the injected deletion failure is reported");
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      const contenderCalls: string[] = [];
+      const contender = new WorkflowManager({
+        cwd,
+        agent: {
+          async run(prompt: string) {
+            contenderCalls.push(prompt);
+            return "unsafe resume";
+          },
+        },
+      });
+      assert.equal(await contender.resume(runId), false, "failed deletion remains protected by the acquired lease");
+      assert.deepEqual(contenderCalls, []);
+      assert.equal(
+        persistence.load(runId)?.status,
+        "paused",
+        "the paused state remains protected until deletion retry",
+      );
+    } finally {
+      persistence.delete = deletePersisted;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    assert.equal(persistence.load(runId), null, "retry eventually deletes the paused run");
+    const releasedLease = persistence.acquireRunLease(runId);
+    assert.ok(releasedLease, "successful deletion retry releases the fail-safe lease");
+    persistence.releaseRunLease(releasedLease);
+  }),
+);
+
+test(
+  "settled stop retains the lease when abort-marker save and deletion both fail",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 50, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const persistence = manager.getPersistence();
+    const save = persistence.save.bind(persistence);
+    const deletePersisted = persistence.delete.bind(persistence);
+    persistence.save = () => {
+      throw new Error("injected save failure");
+    };
+    persistence.delete = () => false;
+
+    assert.equal(manager.stop(runId), true);
+    da.resolve("settled result");
+    await promise.catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const contenderCalls: string[] = [];
+    const contender = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string) {
+          contenderCalls.push(prompt);
+          return "unsafe-overlap";
+        },
+      },
+    });
+    const staleStatus = persistence.load(runId)?.status;
+    const resumed = await contender.resume(runId);
+
+    persistence.save = save;
+    persistence.delete = deletePersisted;
+    await new Promise((resolve) => setTimeout(resolve, 70));
+
+    const releasedLease = persistence.acquireRunLease(runId);
+    try {
+      assert.equal(staleStatus, "running", "failed cleanup leaves stale running state protected by the lease");
+      assert.equal(resumed, false, "a second manager cannot resume after the old generation settles unsafely");
+      assert.deepEqual(contenderCalls, [], "the contender must not start a replacement generation");
+      assert.equal(persistence.load(runId)?.status, "aborted");
+      assert.ok(releasedLease, "cleanup retry releases the lease after persisting the aborted marker");
+    } finally {
+      if (releasedLease) persistence.releaseRunLease(releasedLease);
+    }
+  }),
+);
+
+test(
+  "failed abort marker and deletion retain the lease until durable cleanup can retry",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 20, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const persistence = manager.getPersistence();
+    const save = persistence.save.bind(persistence);
+    const deletePersisted = persistence.delete.bind(persistence);
+    persistence.save = () => {
+      throw new Error("injected save failure");
+    };
+    persistence.delete = () => false;
+
+    assert.equal(manager.stop(runId), true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const contenderCalls: string[] = [];
+    const contender = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string) {
+          contenderCalls.push(prompt);
+          return "unsafe-overlap";
+        },
+      },
+    });
+    const staleStatus = persistence.load(runId)?.status;
+    const resumed = await contender.resume(runId);
+
+    persistence.save = save;
+    persistence.delete = deletePersisted;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const releasedLease = persistence.acquireRunLease(runId);
+    try {
+      assert.equal(staleStatus, "running", "failed cleanup must leave the stale marker protected by the lease");
+      assert.equal(resumed, false, "a second manager cannot resume the stale state while cleanup is unsafe");
+      assert.deepEqual(contenderCalls, [], "the contender must not start a concurrent generation");
+      assert.ok(releasedLease, "cleanup retry releases the lease after persisting the aborted marker");
+      assert.equal(persistence.load(runId)?.status, "aborted");
+    } finally {
+      if (releasedLease) persistence.releaseRunLease(releasedLease);
+      da.resolve("late result");
+      await promise.catch(() => {});
+    }
+  }),
+);
+
+test(
+  "unresponsive pause retains the lease when abort-marker save and deletion both fail",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 20, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const persistence = manager.getPersistence();
+    const save = persistence.save.bind(persistence);
+    const deletePersisted = persistence.delete.bind(persistence);
+    persistence.save = () => {
+      throw new Error("injected save failure");
+    };
+    persistence.delete = () => false;
+
+    assert.equal(manager.pause(runId), true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const contenderCalls: string[] = [];
+    const contender = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string) {
+          contenderCalls.push(prompt);
+          return "unsafe-overlap";
+        },
+      },
+    });
+    const staleStatus = persistence.load(runId)?.status;
+    const resumed = await contender.resume(runId);
+
+    persistence.save = save;
+    persistence.delete = deletePersisted;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const releasedLease = persistence.acquireRunLease(runId);
+    try {
+      assert.equal(staleStatus, "running", "failed cleanup must leave stale state protected by the lease");
+      assert.equal(resumed, false, "a second manager cannot resume an unresponsive paused generation");
+      assert.deepEqual(contenderCalls, [], "the contender must not start a concurrent generation");
+      assert.equal(persistence.load(runId)?.status, "aborted");
+      assert.ok(releasedLease, "cleanup retry releases the lease after persisting the aborted marker");
+    } finally {
+      if (releasedLease) persistence.releaseRunLease(releasedLease);
+      da.resolve("late result");
+      await promise.catch(() => {});
+    }
+    assert.equal(persistence.load(runId)?.status, "aborted", "late pause settlement cannot overwrite cleanup");
+  }),
+);
+
+test(
+  "settled deleteRun retains the lease until failed deletion can retry",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 50, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const persistence = manager.getPersistence();
+    const deletePersisted = persistence.delete.bind(persistence);
+    persistence.delete = () => false;
+
+    assert.equal(manager.deleteRun(runId), false, "the injected delete failure is reported");
+    da.resolve("settled result");
+    await promise.catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const contenderCalls: string[] = [];
+    const contender = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string) {
+          contenderCalls.push(prompt);
+          return "unsafe-overlap";
+        },
+      },
+    });
+    const staleStatus = persistence.load(runId)?.status;
+    const resumed = await contender.resume(runId);
+
+    persistence.delete = deletePersisted;
+    await new Promise((resolve) => setTimeout(resolve, 70));
+
+    const releasedLease = persistence.acquireRunLease(runId);
+    try {
+      assert.equal(staleStatus, "running", "failed deletion leaves stale running state protected by the lease");
+      assert.equal(resumed, false, "a second manager cannot recover a deleted run while cleanup is pending");
+      assert.deepEqual(contenderCalls, [], "the contender must not start a replacement generation");
+      assert.equal(persistence.load(runId), null, "cleanup retry eventually deletes the stale state");
+      assert.ok(releasedLease, "successful deletion retry releases the lease");
+    } finally {
+      if (releasedLease) persistence.releaseRunLease(releasedLease);
+    }
+  }),
+);
+
+test(
+  "failed deleteRun cleanup retains the lease until deletion can retry",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 20, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const persistence = manager.getPersistence();
+    const deletePersisted = persistence.delete.bind(persistence);
+    persistence.delete = () => false;
+
+    assert.equal(manager.deleteRun(runId), false, "the injected delete failure is reported");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const contenderCalls: string[] = [];
+    const contender = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string) {
+          contenderCalls.push(prompt);
+          return "unsafe-overlap";
+        },
+      },
+    });
+    const staleStatus = persistence.load(runId)?.status;
+    const resumed = await contender.resume(runId);
+
+    persistence.delete = deletePersisted;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const releasedLease = persistence.acquireRunLease(runId);
+    try {
+      assert.equal(staleStatus, "running", "failed deletion must leave stale state protected by the lease");
+      assert.equal(resumed, false, "a second manager cannot resume while deletion is pending");
+      assert.deepEqual(contenderCalls, [], "the contender must not start a concurrent generation");
+      assert.equal(persistence.load(runId), null, "cleanup retry eventually deletes the stale state");
+      assert.ok(releasedLease, "successful deletion retry releases the lease");
+    } finally {
+      if (releasedLease) persistence.releaseRunLease(releasedLease);
+      da.resolve("late result");
+      await promise.catch(() => {});
+    }
+  }),
+);
+
+test(
+  "stop releases the lease after cancellation grace when an agent ignores abort",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 20, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(manager.stop(runId), true);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    const lease = manager.getPersistence().acquireRunLease(runId);
+    try {
+      assert.ok(lease, "stopped run must not retain a permanent lease");
+    } finally {
+      if (lease) manager.getPersistence().releaseRunLease(lease);
+      da.resolve("late result");
+      await promise.catch(() => {});
+    }
+    assert.equal(manager.getPersistence().load(runId)?.status, "aborted");
+  }),
+);
+
+test(
+  "delete releases the lease after cancellation grace without allowing stale persistence",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, cancellationGraceMs: 20, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(manager.deleteRun(runId), true);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    const lease = manager.getPersistence().acquireRunLease(runId);
+    try {
+      assert.ok(lease, "deleted run must not retain a permanent lease");
+    } finally {
+      if (lease) manager.getPersistence().releaseRunLease(lease);
+      da.resolve("late result");
+      await promise.catch(() => {});
+    }
+    assert.equal(manager.getPersistence().load(runId), null, "late settlement must not resurrect a deleted run");
   }),
 );
 
@@ -790,19 +1466,12 @@ test(
     assert.equal(paused, true);
     assert.equal(manager.getRun(runId)?.status, "paused");
 
-    // Resume — replays journal (empty for single-agent that never completed) and
-    // re-runs the live agent with a fresh (non-aborted) controller.
-    const resumed = await manager.resume(runId);
-    assert.equal(resumed, true, "resume should succeed");
-
-    // The resumed run should be running
-    assert.equal(manager.getRun(runId)?.status, "running", "resumed run should be running");
-
-    // Resolve the deferred agent so the resumed run's agent completes
+    // Resume waits for the paused generation's final write and lease release.
+    const resumePromise = manager.resume(runId);
     da.resolve("resumed-done");
-
-    // The original promise will reject (its controller was aborted). Suppress it.
     await origPromise.catch(() => {});
+    const resumed = await resumePromise;
+    assert.equal(resumed, true, "resume should succeed");
 
     // Wait for the resumed run to complete
     await new Promise((r) => setTimeout(r, 50));
@@ -1156,6 +1825,25 @@ test(
 // ─── getRun tests ──────────────────────────────────────────────────────────────
 
 test(
+  "manager classifies schema-valid null output as done unless error metadata is present",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          return null;
+        },
+      },
+    });
+    const script = `export const meta = { name: 'null-schema', description: 'null schema' }
+return await agent('nullable', { label: 'nullable', schema: {} })`;
+    await manager.runSync(script);
+    const run = manager.listRuns().find((candidate) => candidate.workflowName === "null-schema");
+    assert.equal(run?.agents[0]?.status, "done");
+  }),
+);
+
+test(
   "getRun returns ManagedRun with correct fields for active background run",
   withTempCwd(async (cwd) => {
     const da = deferredAgent();
@@ -1382,14 +2070,14 @@ test(
     await new Promise((resolve) => setTimeout(resolve, 20));
     manager.pause(runId);
 
-    const resumed = await manager.resume(runId);
+    const resumePromise = manager.resume(runId);
+    da.resolve("done");
+    await promise.catch(() => {});
+    const resumed = await resumePromise;
     const persisted = manager.listRuns().find((run) => run.runId === runId);
 
     assert.equal(resumed, true);
     assert.equal(persisted?.status, "running", "listRuns should show running status after resume");
-
-    da.resolve("done");
-    await promise.catch(() => {});
   }),
 );
 
@@ -1408,13 +2096,13 @@ test(
     const { runId, promise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
     manager.pause(runId);
-    await manager.resume(runId);
+    const resumePromise = manager.resume(runId);
+    da.resolve("done");
+    await promise.catch(() => {});
+    await resumePromise;
 
     assert.ok(resumedEvent, "resumed event should fire");
     assert.equal(resumedEvent?.runId, runId);
-
-    da.resolve("done");
-    await promise.catch(() => {});
   }),
 );
 
@@ -1466,13 +2154,11 @@ test(
     assert.equal(manager.pause(runId), true);
     assert.equal(manager.getRun(runId)?.status, "paused", "should be paused after pause");
 
-    const resumed = await manager.resume(runId);
-    assert.equal(resumed, true);
-    assert.equal(manager.getRun(runId)?.status, "running", "should be running after resume");
-
-    // Complete the resumed run
+    const resumePromise = manager.resume(runId);
     da.resolve("resumed-done");
     await origPromise.catch(() => {});
+    const resumed = await resumePromise;
+    assert.equal(resumed, true);
     await new Promise((r) => setTimeout(r, 30));
 
     assert.equal(manager.getRun(runId)?.status, "completed", "should complete after resume finishes");
@@ -1597,16 +2283,15 @@ test(
     assert.equal(manager.pause(runId), true);
     assert.equal(manager.getRun(runId)?.status, "paused");
 
-    // First resume should succeed
-    const firstResume = await manager.resume(runId);
-    assert.equal(firstResume, true, "first resume should succeed");
-
-    // The resumed run is now running; second resume should return false
-    const secondResume = await manager.resume(runId);
-    assert.equal(secondResume, false, "second resume should return false when the resumed run is already running");
-
+    // First resume waits for the old generation to settle.
+    const firstResumePromise = manager.resume(runId);
     da.resolve("done");
     await origPromise.catch(() => {});
+    const firstResume = await firstResumePromise;
+    assert.equal(firstResume, true, "first resume should succeed");
+
+    const secondResume = await manager.resume(runId);
+    assert.equal(secondResume, false, "second resume should return false once a new generation starts");
   }),
 );
 
@@ -1660,8 +2345,11 @@ test(
     });
 
     try {
-      // Resume — executeRun calls runWorkflow which calls the mocked runner
-      const resumed = await manager.resume(runId);
+      // Resume starts only after the paused generation has settled.
+      const resumePromise = manager.resume(runId);
+      da.resolve("done");
+      await origPromise.catch(() => {});
+      const resumed = await resumePromise;
       assert.equal(resumed, true, "resume should schedule the run");
 
       // Wait for the background executed run to process the agent error
@@ -1732,8 +2420,11 @@ test(
     });
 
     try {
-      // Resume — the run will fail because the mocked agent throws
-      const resumed = await manager.resume(runId);
+      // Resume starts only after the paused generation has settled.
+      const resumePromise = manager.resume(runId);
+      da.resolve("done");
+      await origPromise.catch(() => {});
+      const resumed = await resumePromise;
       assert.equal(resumed, true, "resume should schedule the run");
       await new Promise((r) => setTimeout(r, 100));
 
@@ -1774,8 +2465,11 @@ test(
     });
 
     try {
-      // Resume — the run will fail
-      const resumed = await manager.resume(runId);
+      // Resume starts only after the paused generation has settled.
+      const resumePromise = manager.resume(runId);
+      da.resolve("done");
+      await origPromise.catch(() => {});
+      const resumed = await resumePromise;
       assert.equal(resumed, true, "resume should schedule the run");
       await new Promise((r) => setTimeout(r, 100));
 
@@ -1816,8 +2510,11 @@ test(
     });
 
     try {
-      // Resume — the run will fail
-      await manager.resume(runId);
+      // Resume starts only after the paused generation has settled.
+      const resumePromise = manager.resume(runId);
+      da.resolve("done");
+      await origPromise.catch(() => {});
+      await resumePromise;
       await new Promise((r) => setTimeout(r, 100));
 
       // Verify the run is now in failed state

--- a/tests/workflow-parser.test.ts
+++ b/tests/workflow-parser.test.ts
@@ -169,6 +169,15 @@ test("parseWorkflowScript still parses a removed/unknown meta field (e.g. whenTo
   assert.equal(parsed.meta.name, "demo");
 });
 
+test("parseWorkflowScript ignores nondeterministic API names in comments and strings", () => {
+  const parsed = parseWorkflowScript(
+    "export const meta = { name: 'demo', description: 'desc' }\n" +
+      "// Date.now() Math.random() new Date()\n" +
+      "return `Date.now() Math.random() new Date()`",
+  );
+  assert.match(parsed.body, /Date\.now\(\)/);
+});
+
 test("parseWorkflowScript rejects nondeterministic APIs", () => {
   assert.throws(
     () => parseWorkflowScript("export const meta = { name: 'demo', description: 'desc' }\nreturn Date.now()"),

--- a/tests/workflow-routing-telemetry.test.ts
+++ b/tests/workflow-routing-telemetry.test.ts
@@ -1,0 +1,1115 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { Model } from "@earendil-works/pi-ai";
+import type { CreateAgentSessionOptions, ResourceLoader } from "@earendil-works/pi-coding-agent";
+import {
+  type AgentTelemetry,
+  resolveModelAlias,
+  WorkflowAgent,
+  type WorkflowResourceLoaderOptions,
+} from "../src/agent.js";
+import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
+import { saveModelTierConfig } from "../src/model-tier-config.js";
+import type { PersistedRunState } from "../src/run-persistence.js";
+import { type JournalEntry, runWorkflow } from "../src/workflow.js";
+import { WorkflowManager } from "../src/workflow-manager.js";
+import { formatWorkflowReport } from "../src/workflow-report.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+const targetModel = { provider: "mock", id: "target", name: "Target" } as Model<any>;
+const fallbackModel = { provider: "mock", id: "fallback", name: "Fallback" } as Model<any>;
+
+function registry(...models: Model<any>[]) {
+  return {
+    getAll: () => models,
+    getAvailable: () => models,
+    find: (provider: string, id: string) => models.find((model) => model.provider === provider && model.id === id),
+  } as any;
+}
+
+function fakeLoader(
+  skills = ["skill-a"],
+  context = [{ path: "AGENTS.md", content: "project context" }],
+): ResourceLoader {
+  return {
+    getExtensions: () => ({ extensions: [], errors: [], runtime: {} }) as any,
+    getSkills: () =>
+      ({
+        skills: skills.map((name) => ({ name })),
+        diagnostics: [],
+      }) as any,
+    getPrompts: () => ({ prompts: [], diagnostics: [] }),
+    getThemes: () => ({ themes: [], diagnostics: [] }),
+    getAgentsFiles: () => ({ agentsFiles: context }),
+    getSystemPrompt: () => undefined,
+    getAppendSystemPrompt: () => [],
+    extendResources: () => {},
+    reload: async () => {},
+  };
+}
+
+function fakeSessionFactory(captured: CreateAgentSessionOptions[], sessionModel: Model<any> = fallbackModel) {
+  return async (options: CreateAgentSessionOptions) => {
+    captured.push(options);
+    const session = {
+      model: options.model ?? sessionModel,
+      thinkingLevel: options.thinkingLevel ?? "high",
+      systemPrompt: "system prompt",
+      messages: [] as unknown[],
+      prompt: async () => {
+        session.messages.push({ role: "assistant", content: [{ type: "text", text: "done" }] });
+      },
+      abort: async () => {},
+      subscribe: () => () => {},
+      getActiveToolNames: () => ["read", "context_search"],
+      getSessionStats: () => ({
+        tokens: { input: 10, output: 5, cacheRead: 20, cacheWrite: 2, total: 37 },
+        cost: 0.0123,
+      }),
+      dispose: () => {},
+    };
+    return { session, extensionsResult: fakeLoader().getExtensions() } as any;
+  };
+}
+
+test("resolveModelAlias uses exact case-insensitive aliases and leaves concrete/non-aliased specs unchanged", () => {
+  const aliases = { haiku: "openai-codex/gpt-5.6-luna" };
+  assert.equal(resolveModelAlias("haiku", aliases), "openai-codex/gpt-5.6-luna");
+  assert.equal(resolveModelAlias(" HAIKU ", aliases), "openai-codex/gpt-5.6-luna");
+  assert.equal(resolveModelAlias("openai-codex/gpt-5.6-luna", aliases), "openai-codex/gpt-5.6-luna");
+  assert.equal(resolveModelAlias("sonnet", aliases), "sonnet");
+});
+
+test("WorkflowAgent resolves aliases before model parsing and captures exact live telemetry", async () => {
+  const sessions: CreateAgentSessionOptions[] = [];
+  const loaderOptions: WorkflowResourceLoaderOptions[] = [];
+  const telemetry: AgentTelemetry[] = [];
+  const agent = new WorkflowAgent({
+    cwd: "/tmp",
+    modelRegistry: registry(targetModel, fallbackModel),
+    modelAliases: { haiku: "mock/target" },
+    sessionFactory: fakeSessionFactory(sessions),
+    resourceLoaderFactory: (options) => {
+      loaderOptions.push(options);
+      return fakeLoader();
+    },
+  });
+
+  const result = await agent.run("do it", {
+    model: "HAIKU",
+    effort: "medium",
+    onTelemetry: (value) => telemetry.push(value),
+  });
+
+  assert.equal(result, "done");
+  assert.equal(sessions[0].model, targetModel, "alias target must resolve before fuzzy matching the alias name");
+  assert.equal(loaderOptions[0].noSkills, undefined, "default behavior keeps skills enabled");
+  assert.deepEqual(telemetry, [
+    {
+      execution: "live",
+      requestedModelSpec: "HAIKU",
+      resolvedModel: "mock/target",
+      effectiveThinkingLevel: "medium",
+      skillsEnabled: true,
+      loadedSkillCount: 1,
+      activeToolNames: ["read", "context_search"],
+      activeToolCount: 2,
+      systemPromptChars: 13,
+      projectContextFileCount: 1,
+      projectContextChars: 15,
+      usage: { input: 10, output: 5, cacheRead: 20, cacheWrite: 2, total: 37, cost: 0.0123 },
+    },
+  ]);
+});
+
+test("WorkflowAgent strict resolution fails non-recoverably while non-strict mode falls back", async () => {
+  const strictSessions: CreateAgentSessionOptions[] = [];
+  const strictAgent = new WorkflowAgent({
+    cwd: "/tmp",
+    modelRegistry: registry(targetModel),
+    strictModelResolution: true,
+    sessionFactory: fakeSessionFactory(strictSessions),
+    resourceLoaderFactory: () => fakeLoader(),
+  });
+  await assert.rejects(
+    () => strictAgent.run("do it", { model: "missing-symbol" }),
+    (error) =>
+      error instanceof WorkflowError &&
+      error.code === WorkflowErrorCode.SCRIPT_VALIDATION_ERROR &&
+      error.recoverable === false,
+  );
+  await assert.rejects(
+    () => strictAgent.run("do it", { model: "mock/not-configured" }),
+    (error) => error instanceof WorkflowError && error.code === WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+    "strict mode must reject the parser's synthetic custom-model fallback too",
+  );
+  assert.equal(strictSessions.length, 0, "strict failure must happen before session creation");
+
+  const fallbackSessions: CreateAgentSessionOptions[] = [];
+  const fallbackTelemetry: AgentTelemetry[] = [];
+  const fallbackAgent = new WorkflowAgent({
+    cwd: "/tmp",
+    modelRegistry: registry(targetModel),
+    sessionFactory: fakeSessionFactory(fallbackSessions, fallbackModel),
+    resourceLoaderFactory: () => fakeLoader(),
+  });
+  assert.equal(
+    await fallbackAgent.run("do it", {
+      model: "missing-symbol",
+      onTelemetry: (value) => fallbackTelemetry.push(value),
+    }),
+    "done",
+  );
+  assert.equal(fallbackSessions[0].model, undefined, "non-strict fallback leaves the session model unset");
+  assert.equal(fallbackTelemetry[0].requestedModelSpec, "missing-symbol");
+  assert.equal(fallbackTelemetry[0].resolvedModel, "mock/fallback");
+});
+
+test("skills:false creates and reloads a noSkills loader without disabling tools/extensions", async () => {
+  const sessions: CreateAgentSessionOptions[] = [];
+  const loaderOptions: WorkflowResourceLoaderOptions[] = [];
+  let reloads = 0;
+  const loader = fakeLoader([], [{ path: "AGENTS.md", content: "ctx" }]);
+  loader.reload = async () => {
+    reloads++;
+  };
+  const telemetry: AgentTelemetry[] = [];
+  const agent = new WorkflowAgent({
+    cwd: "/tmp",
+    modelRegistry: registry(targetModel),
+    sessionFactory: fakeSessionFactory(sessions, targetModel),
+    resourceLoaderFactory: (options) => {
+      loaderOptions.push(options);
+      return loader;
+    },
+  });
+
+  await agent.run("do it", { skills: false, onTelemetry: (value) => telemetry.push(value) });
+
+  assert.equal(loaderOptions[0].noSkills, true);
+  assert.equal(loaderOptions[0].noExtensions, undefined);
+  assert.equal(loaderOptions[0].noContextFiles, undefined);
+  assert.equal(reloads, 1);
+  assert.equal(sessions[0].resourceLoader, loader);
+  assert.equal(telemetry[0].skillsEnabled, false);
+  assert.equal(telemetry[0].loadedSkillCount, 0);
+  assert.deepEqual(telemetry[0].activeToolNames, ["read", "context_search"]);
+});
+
+test("default skills behavior preserves an explicitly injected resource loader", async () => {
+  const loader = fakeLoader();
+  const sessions: CreateAgentSessionOptions[] = [];
+  let factoryCalls = 0;
+  const agent = new WorkflowAgent({
+    cwd: "/tmp",
+    modelRegistry: registry(targetModel),
+    session: { resourceLoader: loader },
+    sessionFactory: fakeSessionFactory(sessions),
+    resourceLoaderFactory: () => {
+      factoryCalls++;
+      return fakeLoader();
+    },
+  });
+
+  await agent.run("do it", { skills: true });
+  assert.equal(factoryCalls, 0);
+  assert.equal(sessions[0].resourceLoader, loader);
+});
+
+test("skills:false rejects an explicitly injected resource loader instead of claiming enforcement", async () => {
+  const agent = new WorkflowAgent({
+    cwd: "/tmp",
+    modelRegistry: registry(targetModel),
+    session: { resourceLoader: fakeLoader() },
+    sessionFactory: fakeSessionFactory([]),
+  });
+
+  await assert.rejects(
+    () => agent.run("do it", { skills: false }),
+    (error) =>
+      error instanceof WorkflowError &&
+      error.code === WorkflowErrorCode.SCRIPT_VALIDATION_ERROR &&
+      /resourceLoader/.test(error.message),
+  );
+});
+
+test("an unrelated alias change does not invalidate resume while the used alias still replays", async () => {
+  const script = `export const meta = { name: 'alias_resume_unrelated', description: 'routing identity' }
+return await agent('task', { label: 'worker', model: 'haiku' })`;
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+
+  await runWorkflow(script, {
+    agent: runner,
+    modelAliases: { haiku: "mock/one", sonnet: "mock/sonnet" },
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  await runWorkflow(script, {
+    agent: runner,
+    modelAliases: { haiku: "mock/one", sonnet: "mock/changed" },
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+  assert.equal(calls, 1, "unrelated alias changes must not invalidate the used call");
+});
+
+test("an alias target change invalidates resume while unchanged aliases replay", async () => {
+  const script = `export const meta = { name: 'alias_resume', description: 'routing identity' }
+return await agent('task', { label: 'worker', model: 'haiku' })`;
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+
+  await runWorkflow(script, {
+    agent: runner,
+    modelAliases: { haiku: "mock/one" },
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  await runWorkflow(script, {
+    agent: runner,
+    modelAliases: { haiku: "mock/one" },
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+  assert.equal(calls, 1, "unchanged alias configuration replays the journal");
+
+  await runWorkflow(script, {
+    agent: runner,
+    modelAliases: { haiku: "mock/two" },
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+  assert.equal(calls, 2, "changed alias target must force a live rerun");
+});
+
+test("configured tier and implicit medium route changes invalidate replay", async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-route-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      let calls = 0;
+      const runner = {
+        async run() {
+          calls++;
+          return `result-${calls}`;
+        },
+      };
+      for (const [name, options] of [
+        ["explicit-tier", ", { tier: 'small' }"],
+        ["implicit-medium", ""],
+      ] as const) {
+        saveModelTierConfig({ tiers: { small: "mock/small-one", medium: "mock/medium-one" } });
+        const script = `export const meta = { name: '${name}', description: 'route identity' }
+return await agent('constant prompt'${options})`;
+        const journal: JournalEntry[] = [];
+        await runWorkflow(script, {
+          agent: runner,
+          persistLogs: false,
+          onAgentJournal: (entry) => journal.push(entry),
+        });
+        saveModelTierConfig({ tiers: { small: "mock/small-two", medium: "mock/medium-two" } });
+        await runWorkflow(script, {
+          agent: runner,
+          persistLogs: false,
+          resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+        });
+      }
+      assert.equal(calls, 4, "each changed effective tier target must rerun live");
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("untagged agents invalidate replay when the session main model changes without tier config", async () => {
+  const script = `export const meta = { name: 'main-model-route', description: 'main model identity' }
+return await agent('constant prompt')`;
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+
+  await runWorkflow(script, {
+    agent: runner,
+    mainModel: "mock/a",
+    modelTierConfig: null,
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  await runWorkflow(script, {
+    agent: runner,
+    mainModel: "mock/b",
+    modelTierConfig: null,
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+
+  assert.equal(calls, 2, "the changed session default route must rerun the untagged agent");
+});
+
+test("untagged agents invalidate replay when the effective host session model changes", async () => {
+  const script = `export const meta = { name: 'session-model-route', description: 'session model identity' }
+return await agent('constant prompt')`;
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+  const firstModel = { provider: "mock", id: "session-a", name: "Session A" } as Model<any>;
+  const secondModel = { provider: "mock", id: "session-b", name: "Session B" } as Model<any>;
+
+  await runWorkflow(script, {
+    agent: runner,
+    session: { model: firstModel, thinkingLevel: "low" },
+    modelTierConfig: null,
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  await runWorkflow(script, {
+    agent: runner,
+    session: { model: secondModel, thinkingLevel: "low" },
+    modelTierConfig: null,
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+
+  assert.equal(calls, 2, "changing the actual session default model must invalidate replay");
+});
+
+test("untagged replay uses the host session model instead of the mainModel tier fallback", async () => {
+  const script = `export const meta = { name: 'host-session-route', description: 'host session route identity' }
+return await agent('constant prompt')`;
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+  const firstModel = { provider: "mock", id: "session-a", name: "Session A" } as Model<any>;
+  const secondModel = { provider: "mock", id: "session-b", name: "Session B" } as Model<any>;
+
+  await runWorkflow(script, {
+    agent: runner,
+    mainModel: "mock/tier-fallback",
+    session: { model: firstModel },
+    modelTierConfig: null,
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  await runWorkflow(script, {
+    agent: runner,
+    mainModel: "mock/tier-fallback",
+    session: { model: secondModel },
+    modelTierConfig: null,
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+
+  assert.equal(calls, 2, "the changed host session default must rerun an untagged agent");
+});
+
+test("tier fallback replay remains bound to mainModel when the host session model changes", async () => {
+  const script = `export const meta = { name: 'tier-fallback-route', description: 'tier fallback identity' }
+return await agent('constant prompt', { tier: 'custom' })`;
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+  const firstModel = { provider: "mock", id: "session-a", name: "Session A" } as Model<any>;
+  const secondModel = { provider: "mock", id: "session-b", name: "Session B" } as Model<any>;
+  const tierConfig = { tiers: { medium: "mock/medium" } };
+
+  await runWorkflow(script, {
+    agent: runner,
+    mainModel: "mock/tier-fallback",
+    session: { model: firstModel },
+    modelTierConfig: tierConfig,
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  await runWorkflow(script, {
+    agent: runner,
+    mainModel: "mock/tier-fallback",
+    session: { model: secondModel },
+    modelTierConfig: tierConfig,
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+
+  assert.equal(calls, 1, "an unconfigured explicit tier must keep using the stable mainModel fallback");
+});
+
+test("args and inherited thinking, retry, and timeout policy participate in replay identity", async () => {
+  const script = `export const meta = { name: 'policy-hash', description: 'policy identity' }
+return await agent('constant prompt')`;
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `result-${calls}`;
+    },
+  };
+  await runWorkflow(script, {
+    agent: runner,
+    args: { version: 1 },
+    agentRetries: 0,
+    agentTimeoutMs: 100,
+    session: { thinkingLevel: "low" },
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  const replayJournal = new Map(journal.map((entry) => [entry.index, entry]));
+  await runWorkflow(script, {
+    agent: runner,
+    args: { version: 2 },
+    agentRetries: 0,
+    agentTimeoutMs: 100,
+    session: { thinkingLevel: "low" },
+    persistLogs: false,
+    resumeJournal: replayJournal,
+  });
+  await runWorkflow(script, {
+    agent: runner,
+    args: { version: 1 },
+    agentRetries: 1,
+    agentTimeoutMs: 100,
+    session: { thinkingLevel: "low" },
+    persistLogs: false,
+    resumeJournal: replayJournal,
+  });
+  await runWorkflow(script, {
+    agent: runner,
+    args: { version: 1 },
+    agentRetries: 0,
+    agentTimeoutMs: 200,
+    session: { thinkingLevel: "low" },
+    persistLogs: false,
+    resumeJournal: replayJournal,
+  });
+  await runWorkflow(script, {
+    agent: runner,
+    args: { version: 1 },
+    agentRetries: 0,
+    agentTimeoutMs: 100,
+    session: { thinkingLevel: "high" },
+    persistLogs: false,
+    resumeJournal: replayJournal,
+  });
+  assert.equal(calls, 5, "every result-affecting execution identity change must rerun live");
+});
+
+test("WorkflowManager persists live telemetry and replay telemetry from the journal", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-telemetry-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-telemetry-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      let calls = 0;
+      const runner = {
+        async run(_prompt: string, options: any) {
+          calls++;
+          options.onTelemetry?.({
+            execution: "live",
+            requestedModelSpec: options.model,
+            resolvedModel: "mock/target",
+            effectiveThinkingLevel: "high",
+            skillsEnabled: false,
+            loadedSkillCount: 0,
+            activeToolNames: ["read"],
+            activeToolCount: 1,
+            systemPromptChars: 200,
+            projectContextFileCount: 1,
+            projectContextChars: 50,
+            usage: { input: 10, output: 5, cacheRead: 20, cacheWrite: 0, total: 35, cost: 0.01 },
+          });
+          options.onUsage?.({ input: 10, output: 5, cacheRead: 20, cacheWrite: 0, total: 35, cost: 0.01 });
+          return "ok";
+        },
+      };
+      const manager = new WorkflowManager({
+        cwd,
+        modelAliases: { haiku: "mock/target" },
+        agent: runner,
+      });
+      const script = `export const meta = { name: 'telemetry', description: 'persist it' }
+return await agent('task', { label: 'worker', model: 'haiku' })`;
+      await manager.runSync(script);
+      const first = manager.listRuns()[0];
+      assert.equal(first.agents[0].telemetry?.execution, "live");
+      assert.equal(first.agents[0].telemetry?.usage.cacheRead, 20);
+      assert.equal(first.journal?.[0].telemetry?.resolvedModel, "mock/target");
+
+      const replayEvents: AgentTelemetry[] = [];
+      await runWorkflow(script, {
+        cwd,
+        concurrency: 8,
+        agent: runner,
+        modelAliases: { haiku: "mock/target" },
+        persistLogs: false,
+        resumeJournal: new Map((first.journal ?? []).map((entry) => [entry.index, entry])),
+        onAgentEnd: (event) => {
+          if (event.telemetry) replayEvents.push(event.telemetry);
+        },
+      });
+      assert.equal(calls, 1);
+      assert.equal(replayEvents[0].execution, "replay");
+      assert.equal(replayEvents[0].usage?.total, 35, "replay uses persisted exact usage rather than fabricating zero");
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("timeout retries wait for delayed abort settlement and keep exact attempt telemetry isolated", async () => {
+  let attempts = 0;
+  const events: any[] = [];
+  const runner = {
+    run(_prompt: string, options: any) {
+      attempts++;
+      if (attempts === 1) {
+        return new Promise<string>((_resolve, reject) => {
+          options.signal.addEventListener(
+            "abort",
+            () => {
+              setTimeout(() => {
+                const usage = { input: 7, output: 4, cacheRead: 0, cacheWrite: 0, total: 11, cost: 0.001 };
+                options.onUsage?.(usage);
+                options.onTelemetry?.({ execution: "live", resolvedModel: "mock/first", usage });
+                reject(new Error("first attempt aborted"));
+              }, 15);
+            },
+            { once: true },
+          );
+        });
+      }
+      return new Promise<string>((resolve) => {
+        setTimeout(() => {
+          const usage = { input: 13, output: 10, cacheRead: 0, cacheWrite: 0, total: 23, cost: 0.002 };
+          options.onUsage?.(usage);
+          options.onTelemetry?.({ execution: "live", resolvedModel: "mock/second", usage });
+          resolve("ok");
+        }, 30);
+      });
+    },
+  };
+  const script = `export const meta = { name: 'retry-telemetry', description: 'attempt isolation' }
+return await agent('task', { label: 'worker', timeoutMs: 5, retries: 1 })`;
+
+  const result = await runWorkflow(script, {
+    agent: runner,
+    persistLogs: false,
+    onAgentEnd: (event) => events.push(event),
+  });
+
+  assert.equal(attempts, 2);
+  assert.equal(result.tokenUsage.total, 34, "both settled attempts must be accounted exactly once");
+  assert.equal(events[0].telemetry.resolvedModel, "mock/second", "the retry owns final route telemetry");
+  assert.equal(events[0].telemetry.usage.total, 34, "per-agent usage includes both isolated attempts");
+  assert.equal(events[0].telemetry.accountingStatus, "exact");
+  assert.equal(events[0].telemetry.accountingIncompleteAttempts, undefined);
+});
+
+test("timeout retries persist incomplete accounting and ignore callbacks after bounded cleanup grace", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-incomplete-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-incomplete-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      let attempts = 0;
+      const runner = {
+        run(_prompt: string, options: any) {
+          attempts++;
+          if (attempts === 1) {
+            return new Promise<string>((_resolve, reject) => {
+              options.signal.addEventListener(
+                "abort",
+                () => {
+                  setTimeout(() => {
+                    const usage = { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150, cost: 1 };
+                    options.onModelResolved?.("mock/late-display");
+                    options.onUsage?.(usage);
+                    options.onTelemetry?.({ execution: "live", resolvedModel: "mock/late", usage });
+                    reject(new Error("late abort settlement"));
+                  }, 75);
+                },
+                { once: true },
+              );
+            });
+          }
+          options.onModelResolved?.("mock/retry-display");
+          return new Promise<string>((resolve) => {
+            setTimeout(() => {
+              const usage = { input: 13, output: 10, cacheRead: 0, cacheWrite: 0, total: 23, cost: 0.002 };
+              options.onUsage?.(usage);
+              options.onTelemetry?.({ execution: "live", resolvedModel: "mock/retry", usage });
+              resolve("ok");
+            }, 90);
+          });
+        },
+      };
+      const script = `export const meta = { name: 'incomplete-telemetry', description: 'bounded cleanup' }
+return await agent('task', { label: 'worker', timeoutMs: 100, retries: 1 })`;
+      const manager = new WorkflowManager({ cwd, agent: runner });
+
+      await manager.runSync(script);
+      const runId = manager.listRuns()[0].runId;
+      const captured = manager.getRunForReport(runId)?.agents[0].telemetry;
+      assert.equal(captured?.resolvedModel, "mock/retry");
+      assert.equal(manager.getRunForReport(runId)?.agents[0].model, "mock/retry-display");
+      assert.equal(captured?.usage?.total, 23, "late timed-out usage must not be attributed to the retry");
+      assert.equal(captured?.accountingStatus, "incomplete");
+      assert.equal(captured?.accountingIncompleteAttempts, 1);
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      const persisted = manager.getRunForReport(runId);
+      assert.equal(
+        persisted?.agents[0].telemetry?.resolvedModel,
+        "mock/retry",
+        "late callbacks cannot overwrite persisted telemetry",
+      );
+      assert.equal(persisted?.agents[0].telemetry?.usage?.total, 23, "late callbacks cannot change persisted usage");
+
+      assert.ok(persisted);
+      const report = formatWorkflowReport(persisted);
+      assert.match(report, /Usage: partial \(accounting incomplete for 1 agent\)/);
+      assert.match(report, /accounting incomplete \(1 attempt\)/);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("resume identity distinguishes omitted or undefined args from explicit null", async () => {
+  const script = `export const meta = { name: 'args-identity', description: 'args identity' }
+return await agent(args === undefined ? 'undefined' : 'null')`;
+  const journal: JournalEntry[] = [];
+  const prompts: string[] = [];
+  const runner = {
+    async run(prompt: string) {
+      prompts.push(prompt);
+      return prompt;
+    },
+  };
+
+  await runWorkflow(script, {
+    agent: runner,
+    args: undefined,
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  await runWorkflow(script, {
+    agent: runner,
+    args: null,
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+
+  assert.deepEqual(prompts, ["undefined", "null"]);
+});
+
+test("resume hashes the canonical resolved registry route and ignores irrelevant registry additions", async () => {
+  const script = `export const meta = { name: 'registry-route', description: 'registry route' }
+return await agent('task', { model: 'target' })`;
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return `call-${calls}`;
+    },
+  };
+  const alpha = { provider: "mock", id: "target-alpha", name: "Target Alpha" } as Model<any>;
+  const zeta = { provider: "mock", id: "target-zeta", name: "Target Zeta" } as Model<any>;
+  const unrelated = { provider: "other", id: "unrelated", name: "Unrelated" } as Model<any>;
+
+  await runWorkflow(script, {
+    agent: runner,
+    modelRegistry: registry(alpha),
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  const replayJournal = new Map(journal.map((entry) => [entry.index, entry]));
+  await runWorkflow(script, {
+    agent: runner,
+    modelRegistry: registry(alpha, unrelated),
+    persistLogs: false,
+    resumeJournal: replayJournal,
+  });
+  assert.equal(calls, 1, "irrelevant registry entries must not invalidate the route");
+
+  await runWorkflow(script, {
+    agent: runner,
+    modelRegistry: registry(alpha, zeta),
+    persistLogs: false,
+    resumeJournal: replayJournal,
+  });
+  assert.equal(calls, 2, "a fuzzy route resolving to a different registered model must invalidate");
+});
+
+test("exact registered model ids ending in a thinking token are hashed as model ids", async () => {
+  const script = `export const meta = { name: 'colon-route', description: 'colon route' }
+return await agent('task', { model: 'mock/model:high' })`;
+  const journal: JournalEntry[] = [];
+  let calls = 0;
+  const runner = {
+    async run() {
+      calls++;
+      return "ok";
+    },
+  };
+  const exact = { provider: "mock", id: "model:high", name: "Colon Model" } as Model<any>;
+  const base = { provider: "mock", id: "model", name: "Base Model" } as Model<any>;
+
+  await runWorkflow(script, {
+    agent: runner,
+    modelRegistry: registry(exact, base),
+    session: { thinkingLevel: "high" },
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  await runWorkflow(script, {
+    agent: runner,
+    modelRegistry: registry(base),
+    session: { thinkingLevel: "high" },
+    persistLogs: false,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+  });
+  assert.equal(calls, 2, "an exact colon-id route must differ from a base model plus thinking suffix");
+});
+
+test("formatWorkflowReport prefers larger persisted cumulative usage over latest-generation telemetry", () => {
+  const run = {
+    runId: "resumed-cumulative",
+    workflowName: "resumed",
+    script: "",
+    status: "completed",
+    phases: [],
+    logs: [],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    tokenUsage: { input: 12, output: 8, cacheRead: 2, cacheWrite: 1, total: 23, cost: 0.03 },
+    agents: [
+      {
+        id: 1,
+        label: "rerun agent",
+        prompt: "x",
+        status: "done",
+        telemetry: {
+          execution: "live",
+          accountingStatus: "incomplete",
+          accountingIncompleteAttempts: 1,
+          usage: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0, total: 5, cost: 0.005 },
+        },
+      },
+    ],
+  } satisfies PersistedRunState;
+
+  const report = formatWorkflowReport(run);
+  assert.match(
+    report,
+    /Usage: partial \(accounting incomplete for 1 agent\).* input 12 .* output 8 .* total 23 .*\$0\.0300/,
+  );
+  assert.match(report, /accounting incomplete \(1 attempt\)/);
+  assert.doesNotMatch(report.split("\n")[1], /total 5 .*\$0\.0050/);
+});
+
+test("formatWorkflowReport renders aggregate breakdown, replay/live details, tools, and zero cache denominator", () => {
+  const run = {
+    runId: "run-report",
+    workflowName: "report-demo",
+    script: "",
+    status: "completed",
+    phases: ["Work"],
+    logs: [],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    agents: [
+      {
+        id: 1,
+        label: "live agent",
+        phase: "Work",
+        prompt: "x",
+        status: "done",
+        telemetry: {
+          execution: "live",
+          requestedModelSpec: "haiku",
+          resolvedModel: "mock/target",
+          effectiveThinkingLevel: "high",
+          skillsEnabled: false,
+          loadedSkillCount: 0,
+          activeToolNames: ["read", "context_search"],
+          activeToolCount: 2,
+          systemPromptChars: 1200,
+          projectContextFileCount: 2,
+          projectContextChars: 300,
+          usage: { input: 0, output: 5, cacheRead: 0, cacheWrite: 0, total: 5, cost: 0.001 },
+        },
+      },
+      {
+        id: 2,
+        label: "replayed agent",
+        phase: "Work",
+        prompt: "y",
+        status: "done",
+        telemetry: {
+          execution: "replay",
+          requestedModelSpec: "sonnet",
+          resolvedModel: "mock/other",
+          effectiveThinkingLevel: "medium",
+          skillsEnabled: true,
+          loadedSkillCount: 3,
+          activeToolNames: ["read"],
+          activeToolCount: 1,
+          systemPromptChars: 2400,
+          projectContextFileCount: 1,
+          projectContextChars: 100,
+          usage: { input: 10, output: 10, cacheRead: 30, cacheWrite: 2, total: 52, cost: 0.02 },
+        },
+      },
+      { id: 3, label: "legacy agent", phase: "Work", prompt: "z", status: "done" },
+    ],
+  } satisfies PersistedRunState;
+
+  const report = formatWorkflowReport(run);
+  assert.match(
+    report,
+    /Usage: partial \(1 agent missing usage\) .* input 10 .* output 15 .* cache read 30 .* cache write 2 .* total 57 .*\$0\.0210/,
+  );
+  assert.match(report, /live agent .* live .* haiku -> mock\/target .* thinking high .* skills off \(0\)/);
+  assert.match(report, /cache n\/a/, "zero input+cacheRead denominator must not render NaN or Infinity");
+  assert.match(report, /replayed agent .* replay .* sonnet -> mock\/other/);
+  assert.match(report, /tools: read, context_search/);
+  assert.match(report, /legacy agent .* telemetry unavailable/);
+});
+
+test("formatWorkflowReport marks terminal timeout usage as incomplete when usage is missing", () => {
+  const run = {
+    runId: "timeout-run",
+    workflowName: "timeout",
+    script: "",
+    status: "failed",
+    phases: [],
+    logs: [],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    tokenUsage: { input: 4, output: 2, total: 6, cost: 0.01 },
+    agents: [
+      {
+        id: 1,
+        label: "timed out",
+        prompt: "x",
+        status: "error",
+        telemetry: {
+          execution: "live",
+          requestedModelSpec: "haiku",
+          accountingStatus: "incomplete",
+          accountingIncompleteAttempts: 1,
+        },
+      },
+    ],
+  } satisfies PersistedRunState;
+
+  const report = formatWorkflowReport(run);
+  assert.match(report, /Usage: unavailable \(accounting incomplete for 1 agent; 1 agent missing usage\)/);
+  assert.doesNotMatch(report, /input 4 .* output 2/);
+});
+
+test("formatWorkflowReport marks all-usage-missing telemetry as incomplete instead of exact", () => {
+  const run = {
+    runId: "missing-usage-run",
+    workflowName: "missing",
+    script: "",
+    status: "completed",
+    phases: [],
+    logs: [],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    tokenUsage: { input: 4, output: 2, total: 6, cost: 0.01 },
+    agents: [
+      {
+        id: 1,
+        label: "missing usage",
+        prompt: "x",
+        status: "done",
+        telemetry: { execution: "live", accountingStatus: "incomplete" },
+      },
+    ],
+  } satisfies PersistedRunState;
+
+  const report = formatWorkflowReport(run);
+  assert.match(report, /Usage: unavailable \(accounting incomplete for 1 agent; 1 agent missing usage\)/);
+  assert.doesNotMatch(report, /input 4 .* output 2/);
+});
+
+test("manager persists finalized usage when the agent journal save fails", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-journal-usage-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-journal-usage-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const usage = { input: 6, output: 4, cacheRead: 0, cacheWrite: 0, total: 10, cost: 0.01 };
+      const manager = new WorkflowManager({
+        cwd,
+        agent: {
+          async run(_prompt: string, options: any) {
+            options.onUsage?.(usage);
+            options.onTelemetry?.({ execution: "live", usage });
+            return "ok";
+          },
+        },
+      });
+      const persistence = manager.getPersistence();
+      const save = persistence.save.bind(persistence);
+      let saves = 0;
+      persistence.save = (state) => {
+        saves++;
+        if (saves === 2) throw new Error("journal save failed");
+        save(state);
+      };
+
+      await assert.rejects(
+        () =>
+          manager.runSync(`export const meta = { name: 'journal-usage', description: 'usage durability' }
+return await agent('task', { label: 'worker' })`),
+        /journal save failed/,
+      );
+
+      const persisted = manager.listAllRuns()[0];
+      assert.equal(persisted.status, "failed");
+      assert.equal(persisted.tokenUsage?.total, 10);
+      assert.equal(persisted.tokenUsage?.input, 6);
+      assert.equal(persisted.tokenUsage?.output, 4);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("manager persists cumulative usage from recoverable retries", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-retry-usage-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-retry-usage-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      let attempts = 0;
+      const manager = new WorkflowManager({
+        cwd,
+        agent: {
+          async run(_prompt: string, options: any) {
+            attempts++;
+            const usage =
+              attempts === 1
+                ? { input: 7, output: 3, cacheRead: 0, cacheWrite: 0, total: 10, cost: 0.01 }
+                : { input: 3, output: 2, cacheRead: 0, cacheWrite: 0, total: 5, cost: 0.005 };
+            options.onUsage?.(usage);
+            options.onTelemetry?.({ execution: "live", usage });
+            if (attempts === 1) {
+              throw new WorkflowError("retry me", WorkflowErrorCode.AGENT_EMPTY_OUTPUT, { recoverable: true });
+            }
+            return "ok";
+          },
+        },
+      });
+
+      await manager.runSync(
+        `export const meta = { name: 'retry-usage', description: 'retry usage durability' }
+return await agent('task', { label: 'worker' })`,
+        undefined,
+        { agentRetries: 1 },
+      );
+
+      const persisted = manager.listAllRuns()[0];
+      assert.equal(attempts, 2);
+      assert.equal(persisted.tokenUsage?.total, 15);
+      assert.equal(persisted.tokenUsage?.input, 10);
+      assert.equal(persisted.tokenUsage?.output, 5);
+      assert.equal(persisted.agents[0].telemetry?.usage?.total, 15);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("formatWorkflowReport renders legacy telemetry without a literal undefined execution marker", () => {
+  const run = {
+    runId: "legacy-execution-run",
+    workflowName: "legacy-execution",
+    script: "",
+    status: "completed",
+    phases: [],
+    logs: [],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    agents: [
+      {
+        id: 1,
+        label: "old telemetry",
+        prompt: "x",
+        status: "done",
+        telemetry: { requestedModelSpec: "haiku" } as AgentTelemetry,
+      },
+    ],
+  } satisfies PersistedRunState;
+
+  const report = formatWorkflowReport(run);
+  assert.match(report, /old telemetry .* legacy .* requested haiku/);
+  assert.doesNotMatch(report, /undefined/);
+});
+
+test("formatWorkflowReport does not fabricate missing legacy or replay telemetry", () => {
+  const run = {
+    runId: "legacy-run",
+    workflowName: "legacy",
+    script: "",
+    status: "completed",
+    phases: [],
+    logs: [],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    tokenUsage: { input: 4, output: 2, total: 6 },
+    agents: [
+      {
+        id: 1,
+        label: "old replay",
+        prompt: "x",
+        status: "done",
+        telemetry: { execution: "replay", requestedModelSpec: "haiku" },
+      },
+    ],
+  } satisfies PersistedRunState;
+
+  const report = formatWorkflowReport(run);
+  assert.match(report, /cache unavailable/);
+  assert.match(report, /cost unavailable/);
+  assert.match(report, /old replay .* replay .* requested haiku .* telemetry unavailable/);
+  assert.doesNotMatch(report, /system 0|context .*0 chars|\$0\.0000/);
+});

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
@@ -48,6 +51,159 @@ function createDeferred<T = void>(): { promise: Promise<T>; resolve: (value: T |
   });
   return { promise, resolve };
 }
+
+test("a parent-aborted settled attempt persists finalized usage exactly once before cancellation", async () => {
+  const controller = new AbortController();
+  const started = createDeferred<void>();
+  const progress: AgentUsage[] = [];
+  let finalUsageEvents = 0;
+  const run = runWorkflow(
+    `export const meta = { name: 'abort-usage', description: 'abort usage' }
+return await agent('work')`,
+    {
+      persistLogs: false,
+      signal: controller.signal,
+      onTokenUsageProgress: (usage) => progress.push(usage as AgentUsage),
+      onTokenUsage: () => finalUsageEvents++,
+      agent: {
+        async run(_prompt: string, options: { signal?: AbortSignal; onUsage?: (usage: AgentUsage) => void }) {
+          started.resolve();
+          await new Promise<void>((resolve) =>
+            options.signal?.addEventListener("abort", () => resolve(), { once: true }),
+          );
+          options.onUsage?.({ input: 7, output: 4, cacheRead: 0, cacheWrite: 0, total: 11, cost: 0.01 });
+          return "settled-after-abort";
+        },
+      },
+    },
+  );
+
+  await started.promise;
+  controller.abort();
+  await assert.rejects(run, (error: unknown) => {
+    assert.ok(error instanceof WorkflowError);
+    assert.equal(error.code, WorkflowErrorCode.WORKFLOW_ABORTED);
+    return true;
+  });
+  assert.deepEqual(
+    progress.map((usage) => usage.total),
+    [11],
+  );
+  assert.equal(finalUsageEvents, 0, "public usage remains final-success-only");
+});
+
+test("parallel cancellation is operation-scoped, awaits siblings, and permits later workflow work", async () => {
+  let siblingSettled = false;
+  const started = createDeferred<void>();
+  const script = `export const meta = { name: 'parallel-cancel', description: 'parallel cancellation' }
+let caught = ''
+try {
+  await parallel([
+    () => agent('fatal'),
+    () => agent('sibling'),
+  ])
+} catch (error) {
+  caught = error.message
+}
+const after = await agent('after')
+return { caught, after }`;
+
+  const result = await runWorkflow(script, {
+    persistLogs: false,
+    agent: {
+      async run(prompt: string, options: { signal?: AbortSignal }) {
+        if (prompt === "fatal") {
+          await started.promise;
+          throw new WorkflowError("fatal", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, { recoverable: false });
+        }
+        if (prompt === "after") {
+          assert.equal(siblingSettled, true, "parallel must await sibling cleanup before returning");
+          return "continued";
+        }
+        started.resolve();
+        await new Promise<void>((resolve) =>
+          options.signal?.addEventListener("abort", () => resolve(), { once: true }),
+        );
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        siblingSettled = true;
+        throw new Error("cancelled sibling");
+      },
+    },
+  });
+
+  assert.equal(JSON.stringify(result.result), JSON.stringify({ caught: "fatal", after: "continued" }));
+  assert.equal(siblingSettled, true);
+});
+
+test("pipeline cancellation is operation-scoped, awaits siblings, and permits later workflow work", async () => {
+  let siblingSettled = false;
+  const started = createDeferred<void>();
+  const script = `export const meta = { name: 'pipeline-cancel', description: 'pipeline cancellation' }
+let caught = ''
+try {
+  await pipeline(['fatal', 'sibling'], item => agent(item))
+} catch (error) {
+  caught = error.message
+}
+const after = await agent('after')
+return { caught, after }`;
+
+  const result = await runWorkflow(script, {
+    persistLogs: false,
+    agent: {
+      async run(prompt: string, options: { signal?: AbortSignal }) {
+        if (prompt === "fatal") {
+          await started.promise;
+          throw new WorkflowError("fatal", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, { recoverable: false });
+        }
+        if (prompt === "after") {
+          assert.equal(siblingSettled, true, "pipeline must await sibling cleanup before returning");
+          return "continued";
+        }
+        started.resolve();
+        await new Promise<void>((resolve) =>
+          options.signal?.addEventListener("abort", () => resolve(), { once: true }),
+        );
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        siblingSettled = true;
+        throw new Error("cancelled sibling");
+      },
+    },
+  });
+
+  assert.equal(JSON.stringify(result.result), JSON.stringify({ caught: "fatal", after: "continued" }));
+  assert.equal(siblingSettled, true);
+});
+
+test("nested workflow scriptPath rejects symlinks with SCRIPT_VALIDATION_ERROR", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-dw-nested-script-path-"));
+  try {
+    const childPath = join(root, "child.js");
+    writeFileSync(
+      childPath,
+      "export const meta = { name: 'child', description: 'child' }\nreturn await agent('child')",
+    );
+    symlinkSync(childPath, join(root, "child-link.js"));
+    const parent = `export const meta = { name: 'parent', description: 'parent' }
+return await workflow({ scriptPath: 'child-link.js' })`;
+
+    await assert.rejects(
+      runWorkflow(parent, {
+        cwd: root,
+        persistLogs: false,
+        agent: countingAgent().runner,
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof WorkflowError);
+        assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+        assert.match(error.message, /symlink/);
+        return true;
+      },
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("runWorkflow concurrency caps parallel agents", async () => {
   let active = 0;

--- a/tests/workflow-settings.test.ts
+++ b/tests/workflow-settings.test.ts
@@ -242,6 +242,82 @@ describe("workflow settings", () => {
     });
   });
 
+  it("normalizes safe model aliases and strict model resolution", () => {
+    withSettingsPath((settingsPath) => {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          modelAliases: {
+            " HaIkU ": " openai-codex/gpt-5.6-luna ",
+            blank: "   ",
+            "   ": "vendor/model",
+            numeric: 42,
+          },
+          strictModelResolution: true,
+        }),
+        "utf-8",
+      );
+
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {
+        modelAliases: { haiku: "openai-codex/gpt-5.6-luna" },
+        strictModelResolution: true,
+      });
+    });
+  });
+
+  it("rejects unsafe and malformed model alias objects", () => {
+    withSettingsPath((settingsPath) => {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+      writeFileSync(
+        settingsPath,
+        '{"modelAliases":{"safe":"vendor/model","__proto__":"polluted","constructor":"bad","prototype":"bad"}}',
+        "utf-8",
+      );
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { modelAliases: { safe: "vendor/model" } });
+      assert.equal(({} as { polluted?: string }).polluted, undefined);
+
+      for (const modelAliases of [null, [], "haiku", 42]) {
+        writeFileSync(settingsPath, JSON.stringify({ modelAliases }), "utf-8");
+        assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+      }
+    });
+  });
+
+  it("project model aliases replace global aliases using the existing shallow merge", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-alias-settings-"));
+    const cwd = join(dir, "project");
+    const globalPath = join(dir, "global.json");
+    const projectPath = join(dir, "project.json");
+    try {
+      saveWorkflowSettings(
+        { modelAliases: { haiku: "global/haiku", sonnet: "global/sonnet" }, strictModelResolution: false },
+        globalPath,
+      );
+      saveWorkflowSettings(
+        { modelAliases: { haiku: "project/haiku" }, strictModelResolution: true },
+        { cwd, settingsPath: globalPath, projectSettingsPath: projectPath, scope: "project" },
+      );
+
+      assert.deepEqual(loadWorkflowSettings({ cwd, settingsPath: globalPath, projectSettingsPath: projectPath }), {
+        modelAliases: { haiku: "project/haiku" },
+        strictModelResolution: true,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores non-boolean strictModelResolution values", () => {
+    withSettingsPath((settingsPath) => {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+      for (const strictModelResolution of ["true", 1, null]) {
+        writeFileSync(settingsPath, JSON.stringify({ strictModelResolution }), "utf-8");
+        assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+      }
+    });
+  });
+
   it("project persistAgentSessions overrides the global setting", () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-dynamic-workflows-persist-settings-"));
     const cwd = join(dir, "project");

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { closeSync, mkdirSync, mkdtempSync, openSync, renameSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
+import { resolveWorkflowScriptPath } from "../src/workflow.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
 import { backgroundStartedText, createWorkflowTool, modelRoutingGuideline } from "../src/workflow-tool.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
@@ -31,6 +32,169 @@ test("backgroundStartedText tells the user it auto-continues and they can wait",
 });
 
 // ─── createWorkflowTool ────────────────────────────────────────────────────────
+
+test("workflow tool accepts exactly one fresh, cwd-contained scriptPath source", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-dw-tool-"));
+  const outside = mkdtempSync(join(tmpdir(), "pi-dw-tool-outside-"));
+  try {
+    const script = "export const meta = { name: 'path-workflow', description: 'path workflow' }\nreturn args";
+    const scriptPath = join(root, "workflow.js");
+    writeFileSync(scriptPath, script);
+    const captured: Array<{ script: string; args: unknown; cwd?: string }> = [];
+    const manager = {
+      getModelRegistry: () => undefined,
+      startInBackground(source: string, args: unknown, options?: { cwd?: string }) {
+        captured.push({ script: source, args, cwd: options?.cwd });
+        return { runId: "run-path", promise: Promise.resolve({}) };
+      },
+    } as any;
+    const tool = createWorkflowTool({ cwd: root, manager });
+    const execute = tool.execute as any;
+
+    await execute("call", { scriptPath: "workflow.js", args: { fresh: true } }, undefined, undefined, { cwd: root });
+    assert.deepEqual(captured, [{ script, args: { fresh: true }, cwd: root }]);
+    writeFileSync(scriptPath, script.replace("path-workflow", "updated-workflow"));
+    await execute("call", { scriptPath: "workflow.js", args: { fresh: false } }, undefined, undefined, { cwd: root });
+    assert.equal(captured[1]?.script, script.replace("path-workflow", "updated-workflow"));
+
+    const outsidePath = join(outside, "outside.js");
+    writeFileSync(outsidePath, script);
+    const invalid = [
+      [{ script: script, scriptPath: "workflow.js" }, /exactly one/],
+      [{}, /exactly one/],
+      [{ scriptPath: "   " }, /non-empty/],
+      [{ scriptPath: "missing.js" }, /does not exist/],
+      [{ scriptPath: relative(root, outsidePath) }, /escapes workflow cwd/],
+    ] as const;
+    for (const [params, message] of invalid) {
+      await assert.rejects(() => execute("call", params, undefined, undefined, { cwd: root }), message);
+    }
+
+    mkdirSync(join(root, "directory"));
+    await assert.rejects(
+      () => execute("call", { scriptPath: "directory" }, undefined, undefined, { cwd: root }),
+      /must reference a file/,
+    );
+    symlinkSync(outsidePath, join(root, "linked.js"));
+    await assert.rejects(
+      () => execute("call", { scriptPath: "linked.js" }, undefined, undefined, { cwd: root }),
+      /escapes workflow cwd/,
+    );
+    symlinkSync(scriptPath, join(root, "internal-link.js"));
+    await assert.rejects(
+      () => execute("call", { scriptPath: "internal-link.js" }, undefined, undefined, { cwd: root }),
+      /symlink/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
+test("scriptPath rejects deterministic path replacement between validation and open", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-dw-script-race-"));
+  try {
+    const scriptPath = join(root, "workflow.js");
+    const replacementPath = join(root, "replacement.js");
+    const originalPath = join(root, "original.js");
+    writeFileSync(scriptPath, "original");
+    writeFileSync(replacementPath, "replacement");
+
+    assert.throws(
+      () =>
+        (resolveWorkflowScriptPath as any)("workflow.js", root, {
+          openSync(path: string, flags: number) {
+            renameSync(scriptPath, originalPath);
+            renameSync(replacementPath, scriptPath);
+            return openSync(path, flags);
+          },
+        }),
+      (error: unknown) => {
+        assert.ok(error instanceof WorkflowError);
+        assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+        assert.match(error.message, /changed during secure open/);
+        return true;
+      },
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("scriptPath closes its descriptor after a successful secure read", () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-dw-script-close-"));
+  try {
+    writeFileSync(join(root, "workflow.js"), "contents");
+    let closes = 0;
+    const resolved = (resolveWorkflowScriptPath as any)("workflow.js", root, {
+      closeSync(fd: number) {
+        closes++;
+        closeSync(fd);
+      },
+    });
+    assert.equal(resolved.script, "contents");
+    assert.equal(closes, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("workflow tool reports SCRIPT_VALIDATION_ERROR when its cwd was deleted", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-dw-tool-deleted-cwd-"));
+  const manager = {
+    getModelRegistry: () => undefined,
+    startInBackground() {
+      assert.fail("manager must not start for an invalid cwd");
+    },
+  } as any;
+  const execute = createWorkflowTool({ cwd: root, manager }).execute as any;
+  rmSync(root, { recursive: true, force: true });
+
+  await assert.rejects(
+    () => execute("call", { scriptPath: "workflow.js" }, undefined, undefined, { cwd: root }),
+    (error: unknown) => {
+      assert.ok(error instanceof WorkflowError);
+      assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+      assert.match(error.message, /workflow cwd does not exist/);
+      return true;
+    },
+  );
+});
+
+test("workflow tool passes exact scriptPath source and args to foreground manager.runSync", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-dw-tool-foreground-"));
+  try {
+    const script =
+      "export const meta = { name: 'foreground-path', description: 'foreground path' }\n" +
+      "await agent('preserve this source')\n  \n";
+    writeFileSync(join(root, "workflow.js"), script);
+    const args = { unchanged: true, nested: { value: "keep" } };
+    const calls: Array<{ script: string; args: unknown; cwd?: string }> = [];
+    const manager = {
+      getModelRegistry: () => undefined,
+      runSync(source: string, receivedArgs: unknown, options?: { cwd?: string }) {
+        calls.push({ script: source, args: receivedArgs, cwd: options?.cwd });
+        return Promise.resolve({
+          meta: { name: "foreground-path", description: "foreground path" },
+          result: { ok: true },
+          logs: [],
+          phases: [],
+          agentCount: 1,
+          durationMs: 1,
+        });
+      },
+    } as any;
+    const tool = createWorkflowTool({ cwd: root, manager });
+
+    await (tool.execute as any)("call", { scriptPath: "workflow.js", args, background: false }, undefined, undefined, {
+      cwd: root,
+    });
+
+    assert.deepEqual(calls, [{ script, args, cwd: root }]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("createWorkflowTool has correct name and label", () => {
   const tool = createWorkflowTool();
@@ -102,6 +266,210 @@ test("createWorkflowTool schema exposes concurrency and agentRetries", () => {
 
   assert.match(parameters.properties?.concurrency?.description ?? "", /Maximum concurrent agents/i);
   assert.match(parameters.properties?.agentRetries?.description ?? "", /Retry attempts/i);
+});
+
+test("createWorkflowTool schema exposes assistant resume and status controls", () => {
+  const tool = createWorkflowTool();
+  const parameters = tool.parameters as { properties?: Record<string, { description?: string }> };
+
+  assert.match(parameters.properties?.action?.description ?? "", /run.*resume.*status/i);
+  assert.match(parameters.properties?.runId?.description ?? "", /resume.*status/i);
+});
+
+test("workflow tool action arguments enforce run, resume, and status shapes", () => {
+  const tool = createWorkflowTool();
+  const prepare = tool.prepareArguments as (args: unknown) => unknown;
+
+  assert.deepEqual(prepare({ action: "resume", runId: "paused-123", args: { riskAccepted: true } }), {
+    action: "resume",
+    runId: "paused-123",
+    args: { riskAccepted: true },
+  });
+  assert.deepEqual(prepare({ action: "status", runId: "paused-123" }), {
+    action: "status",
+    runId: "paused-123",
+  });
+  assert.throws(
+    () => prepare({ action: "resume", runId: "paused-123", script: "return 1" }),
+    /must not include.*script/i,
+  );
+  assert.throws(() => prepare({ action: "status", runId: "paused-123", args: {} }), /must not include.*args/i);
+  assert.throws(() => prepare({ action: "resume" }), /runId/i);
+  assert.throws(() => prepare({ action: "run", runId: "paused-123", script: "return 1" }), /runId/i);
+});
+
+test("workflow tool resumes a persisted run with an optional args patch", async () => {
+  const calls: unknown[][] = [];
+  const manager = {
+    getModelRegistry: () => undefined,
+    async resume(...args: unknown[]) {
+      calls.push(args);
+      return true;
+    },
+    getRunForReport: () => ({ runId: "paused-123", workflowName: "audit", status: "paused" }),
+  } as any;
+  const tool = createWorkflowTool({ manager });
+
+  const result = await (tool.execute as any)(
+    "call",
+    { action: "resume", runId: "paused-123", args: { riskAccepted: true } },
+    undefined,
+    undefined,
+    {},
+  );
+
+  assert.deepEqual(calls, [["paused-123", { argsPatch: { riskAccepted: true } }]]);
+  assert.match(result.content[0].text, /paused-123.*resumed/i);
+  assert.deepEqual(result.details, { runId: "paused-123", background: true, resumed: true });
+});
+
+test("workflow tool reports why a run cannot be resumed", async () => {
+  const manager = {
+    getModelRegistry: () => undefined,
+    resume: async () => false,
+    getRunForReport: () => ({ runId: "done-123", workflowName: "audit", status: "completed" }),
+  } as any;
+  const tool = createWorkflowTool({ manager });
+
+  await assert.rejects(
+    () => (tool.execute as any)("call", { action: "resume", runId: "done-123" }, undefined, undefined, {}),
+    /not resumable.*completed/i,
+  );
+});
+
+test("workflow tool cold-resumes a persisted manager run end to end", async () => {
+  const root = mkdtempSync(join(tmpdir(), "pi-dw-tool-resume-"));
+  try {
+    const runId = "cold-resume-123";
+    const script = `export const meta = { name: 'cold-resume', description: 'cold resume' }
+return await agent(JSON.stringify(args), { label: 'capture' })`;
+    let prompt = "";
+    const manager = new WorkflowManager({
+      cwd: root,
+      agent: {
+        async run(value: string) {
+          prompt = value;
+          return "ok";
+        },
+      },
+    });
+    const now = new Date().toISOString();
+    manager.getPersistence().save({
+      runId,
+      workflowName: "cold-resume",
+      script,
+      args: { keep: true },
+      status: "paused",
+      phases: [],
+      agents: [],
+      logs: [],
+      startedAt: now,
+      updatedAt: now,
+    });
+    const completed = new Promise<void>((resolve) => {
+      manager.on("complete", (event: { runId: string }) => {
+        if (event.runId === runId) resolve();
+      });
+    });
+    const tool = createWorkflowTool({ cwd: root, manager });
+
+    await (tool.execute as any)("call", { action: "resume", runId, args: { added: 1 } }, undefined, undefined, {
+      cwd: root,
+    });
+    await completed;
+
+    assert.deepEqual(JSON.parse(prompt), { keep: true, added: 1 });
+    const status = await (tool.execute as any)("call", { action: "status", runId }, undefined, undefined, {
+      cwd: root,
+    });
+    assert.equal(status.details.status, "completed");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("workflow tool rejects unsafe resume, status, and edit-resume run IDs before manager access", async () => {
+  let accesses = 0;
+  const manager = {
+    getModelRegistry: () => undefined,
+    getRun: () => {
+      accesses++;
+      return undefined;
+    },
+    getRunForReport: () => {
+      accesses++;
+      return null;
+    },
+    resume: async () => {
+      accesses++;
+      return false;
+    },
+  } as any;
+  const tool = createWorkflowTool({ manager });
+  const execute = tool.execute as any;
+
+  for (const params of [
+    { action: "resume", runId: "../escape" },
+    { action: "status", runId: "a/b" },
+    {
+      script: "export const meta = { name: 'edit', description: 'edit' }\nreturn await agent('x')",
+      resumeFromRunId: "bad\\id",
+    },
+  ]) {
+    await assert.rejects(() => execute("call", params, undefined, undefined, {}), /Invalid workflow run ID/);
+  }
+  assert.equal(accesses, 0);
+});
+
+test("workflow tool status rejects an unknown run ID", async () => {
+  const manager = {
+    getModelRegistry: () => undefined,
+    getRun: () => undefined,
+    getRunForReport: () => null,
+  } as any;
+  const tool = createWorkflowTool({ manager });
+
+  await assert.rejects(
+    () => (tool.execute as any)("call", { action: "status", runId: "missing-123" }, undefined, undefined, {}),
+    /missing-123.*not found/i,
+  );
+});
+
+test("workflow tool reports persisted run status without requiring a script", async () => {
+  const manager = {
+    getModelRegistry: () => undefined,
+    getRunForReport: () => ({
+      runId: "paused-123",
+      workflowName: "audit",
+      status: "paused",
+      currentPhase: "Review",
+      phases: ["Plan", "Review"],
+      agents: [{ status: "done" }, { status: "running" }],
+      startedAt: "2026-07-16T00:00:00.000Z",
+      updatedAt: "2026-07-16T00:01:00.000Z",
+    }),
+  } as any;
+  const tool = createWorkflowTool({ manager });
+
+  const result = await (tool.execute as any)(
+    "call",
+    { action: "status", runId: "paused-123" },
+    undefined,
+    undefined,
+    {},
+  );
+
+  assert.match(result.content[0].text, /audit.*paused/i);
+  assert.deepEqual(result.details, {
+    runId: "paused-123",
+    workflowName: "audit",
+    status: "paused",
+    currentPhase: "Review",
+    phases: ["Plan", "Review"],
+    agentCount: 2,
+    startedAt: "2026-07-16T00:00:00.000Z",
+    updatedAt: "2026-07-16T00:01:00.000Z",
+  });
 });
 
 test("createWorkflowTool promptGuidelines mention retry and concurrency controls", () => {
@@ -271,11 +639,11 @@ function withToolTempCwd(fn: (cwd: string) => Promise<void>) {
   };
 }
 
-test("workflowToolSchema exposes resumeFromRunId as optional; script stays required", () => {
+test("workflowToolSchema exposes resumeFromRunId while action controls keep source fields optional", () => {
   const tool = createWorkflowTool();
   const schema = tool.parameters as { properties: Record<string, unknown>; required?: string[] };
   assert.ok(schema.properties.resumeFromRunId, "resumeFromRunId should be a schema property");
-  assert.ok((schema.required ?? []).includes("script"), "script stays required");
+  assert.ok(!(schema.required ?? []).includes("script"), "resume and status actions do not require a script");
   assert.ok(!(schema.required ?? []).includes("resumeFromRunId"), "resumeFromRunId is optional");
 });
 

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -24,6 +24,20 @@ function fakeManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
         resultPreview: "found 2",
         tokens: 100,
         model: "fast-llm/model",
+        telemetry: {
+          execution: "live",
+          requestedModelSpec: "haiku",
+          resolvedModel: "fast-llm/model",
+          effectiveThinkingLevel: "high",
+          skillsEnabled: false,
+          loadedSkillCount: 0,
+          activeToolNames: ["read", "context_search"],
+          activeToolCount: 2,
+          systemPromptChars: 1234,
+          projectContextFileCount: 2,
+          projectContextChars: 456,
+          usage: { input: 50, output: 20, cacheRead: 30, cacheWrite: 0, total: 100, cost: 0.01 },
+        },
       },
       {
         id: 2,
@@ -464,6 +478,14 @@ test("renderNavigator shows agent detail view", () => {
   assert.match(text, /Status:/);
   assert.match(text, /Model:/);
   assert.match(text, /model/); // shortModel strips provider prefix
+  assert.match(text, /Routing:.*haiku -> fast-llm\/model/);
+  assert.match(text, /Thinking:.*high/);
+  assert.match(text, /Skills:.*off \(0 loaded\)/);
+  assert.match(text, /Tools:.*2/);
+  assert.match(text, /Prompt chars:.*1,234/);
+  assert.match(text, /Context:.*2 files.*456 chars/);
+  assert.match(text, /Usage:.*input 50.*cache read 30.*\$0\.0100/);
+  assert.match(text, /Tool names:.*read, context_search/);
   assert.match(text, /j\/k scroll/); // detail view footer
 });
 


### PR DESCRIPTION
## Summary
- add AI Code Flow compatibility, top-level workflow paths, routing telemetry, and assistant-facing run/resume/status controls
- preserve upstream edit-and-resume and auto-resume behavior while making cold resume retain cwd, limits, budget, telemetry, and safe args semantics
- harden replay identity, script-path containment/TOCTOU handling, shared-store isolation, sibling cancellation, and cross-process lease lifecycle
- add deterministic atomic-child telemetry and comprehensive persistence/resume regression coverage

## Validation
- 1,039 tests passed across 63 suites
- TypeScript build passed
- Biome check passed
- `git diff --check` passed

## Linked PRs
- AI Code Flow response integration: https://github.com/trycourier/aicodeflow/pull/52
- Reviewer convergence/calibration protocol: https://github.com/Gabrielgvl/pi-review/pull/1
