### PR TITLE
fix: /deep-research crashes when the query planner returns null (#86)

### DIFF
--- a/src/deep-research.ts
+++ b/src/deep-research.ts
@@ -39,7 +39,12 @@ const plan = await agent(
   '\\n\\nProduce ' + angles + ' diverse, specific search queries that together cover the question from different angles.',
   { label: 'plan queries', schema: { type: 'object', properties: { queries: { type: 'array', items: { type: 'string' } } }, required: ['queries'] } }
 )
-const queries = (plan.queries || []).slice(0, angles)
+// The planner agent() can return null (e.g. a subagent that died on a terminal
+// provider error) or omit a usable queries array. Mirror the null-tolerance the
+// Gather phase uses below and fall back to the original question as a single
+// query so research still proceeds (degraded) instead of crashing on plan.queries.
+const planned = plan && Array.isArray(plan.queries) ? plan.queries.filter((q) => typeof q === 'string' && q.trim().length > 0) : []
+const queries = (planned.length > 0 ? planned : [question]).slice(0, angles)
 
 phase('Gather')
 const gathered = await parallel(queries.map((q, i) => () =>

--- a/tests/builtin-workflows.test.ts
+++ b/tests/builtin-workflows.test.ts
@@ -4,7 +4,7 @@ import { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } f
 import { generateCodeReviewWorkflow } from "../src/code-review.js";
 import { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "../src/deep-research.js";
 import { createWebTools } from "../src/web-tools.js";
-import { parseWorkflowScript } from "../src/workflow.js";
+import { parseWorkflowScript, runWorkflow } from "../src/workflow.js";
 
 // ─── Deep Research ──────────────────────────────────────────────────────────────
 
@@ -24,6 +24,45 @@ test("generateDeepResearchWorkflow uses configurable angles and minSupport", () 
   const body = generateDeepResearchWorkflow();
   assert.match(body, /args\.angles/);
   assert.match(body, /args\.minSupport/);
+});
+
+test("generateDeepResearchWorkflow guards the planner result before reading queries (#86)", () => {
+  const body = generateDeepResearchWorkflow();
+  assert.match(body, /Array\.isArray\(plan\.queries\)/);
+  assert.match(body, /\[question\]/); // falls back to the question when the planner yields nothing
+});
+
+test("deep_research tolerates a null query planner and falls back to the question (#86)", async () => {
+  // Regression for #86: the planner agent() can return null (e.g. a subagent that
+  // died on a terminal provider error). The Queries phase must not crash on
+  // plan.queries — it should fall back to the original question so research proceeds.
+  const gatherPrompts: string[] = [];
+  const runner = {
+    async run(prompt: string) {
+      if (prompt.includes("planning web research")) return null; // planner "failed"
+      if (prompt.includes("Research this query")) {
+        gatherPrompts.push(prompt);
+        return { sources: [] };
+      }
+      return null; // verify/report are already null-tolerant downstream
+    },
+  };
+  // Would reject (crash) before the fix; must resolve now.
+  const result = await runWorkflow(generateDeepResearchWorkflow(), {
+    agent: runner as never,
+    persistLogs: false,
+    args: { question: "What is WebGPU?", angles: 3 },
+  });
+  assert.ok(gatherPrompts.length >= 1, "Gather should still run using the fallback query");
+  assert.ok(
+    gatherPrompts.some((p) => p.includes("What is WebGPU?")),
+    "the fallback query should be the original question",
+  );
+  // Value-compare (not deepEqual): the script runs in a vm realm, so its arrays
+  // have the realm's Array prototype and fail a strict reference-equal check.
+  const queries = (result.result as { queries?: string[] })?.queries;
+  assert.equal(queries?.length, 1, "a null planner should fall back to exactly one query");
+  assert.equal(queries?.[0], "What is WebGPU?", "the fallback query should be the original question");
 });
 
 // ─── Adversarial Review ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #86.

## Bug
`/deep-research <question>` crashed immediately with `TypeError: Cannot read properties of null (reading 'queries')`, before any run was even registered.

## Root cause
The workflow's `agent()` returns `null` when a subagent dies on a terminal provider error (documented behavior). The **Queries** phase read the planner result directly:
```js
const queries = (plan.queries || []).slice(0, angles)   // plan can be null → crash
```
Every *other* phase already null-tolerates its agent result — Gather (`gathered.filter(Boolean).flatMap((g) => (g && g.sources) || [])`), Verify/Report (`(verdict && verdict.supported) || []`). The Queries phase was the one gap.

## Fix
Mirror the other phases: when the planner yields no usable queries (null result, or no string queries), fall back to the original question as a single query so research still proceeds (degraded) instead of crashing.
```js
const planned = plan && Array.isArray(plan.queries) ? plan.queries.filter((q) => typeof q === 'string' && q.trim().length > 0) : []
const queries = (planned.length > 0 ? planned : [question]).slice(0, angles)
```

## Tests
- static guard check (the script validates `plan.queries` and has a `[question]` fallback);
- a real `runWorkflow` execution with a planner that returns `null`, asserting it does **not** throw and that Gather runs with the fallback question.

901 unit tests pass; tsc + biome clean.
