### PR TITLE
feat(workflow): add cwd-aware runtime controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,33 @@ Pi writes and starts the workflow in the background. A live panel tracks progres
 
 Keyword triggering is on by default: use the bounded word **workflow** or **workflows** in a message to force workflow mode, or run `/workflows run <prompt>` explicitly. Identifier-like text and paths such as `myworkflow`, `workflow_name`, and `src/workflow-editor.ts` do not trigger. You can change the keyword with `/workflows-trigger set pi-workflow` or disable it with `/workflows-trigger off`.
 
+## Assistant `workflow` tool API
+
+The original run shape remains valid: omitting `action` is exactly the same as `action: "run"`. Flat control actions let an assistant recover a run without asking the user to type a slash command.
+
+| Action | Required | Optional | Rejected |
+| --- | --- | --- | --- |
+| omitted / `"run"` | `script` | `cwd`, `args`, `background`, `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, `tokenBudget` | `runId` |
+| `"status"` | — | `cwd`, `runId` | script and all execution options |
+| `"resume"` | `runId` | `cwd` | script and all execution options |
+| `"stop"` | `runId` | `cwd` | script and all execution options |
+
+```json
+{ "action": "status", "cwd": "/workspace/project", "runId": "audit-abc123" }
+```
+
+`cwd` may be any existing host-accessible directory. The runtime checks that it exists and is a directory, canonicalizes it with `realpath`, and uses that canonical value for both execution and its isolated persistence namespace. It never calls global `process.chdir()`. Host permission callbacks remain responsible for access policy; there is no extension-owned approved-root allowlist.
+
+`status` with a run ID returns one redacted metadata record. Without an ID it returns at most 20 recent records from that cwd namespace, including persisted runs from other sessions for recovery. Status omits scripts, arguments, agent prompts/history, logs, journal values, and workflow results, and never scans another cwd namespace.
+
+`resume` acquires the persisted run lease before reloading state, replays the journaled prefix once, and restores the captured effective limits, concurrency, retries, timeout, and token budget. The original session remains provenance; the requesting live session becomes the delivery target. `stop` requires the active lease owner or atomically acquires the lease for a persisted paused run. It does not call a model.
+
+New run files include canonical `cwd`/`projectKey`, `originSessionId`/`deliverySessionId`, `executionOptions`, and a bounded deterministic `terminalSnapshot` for completed, failed, or explicitly aborted runs. Host-loss recovery is nonterminal (`paused` with `pauseReason: "host_lost"`) and deliberately has no terminal snapshot. Legacy JSON remains readable with canonical namespace identity, legacy `sessionId` provenance, and deterministic historical execution defaults.
+
+Runtime consumers can import `WorkflowToolAction`, `WorkflowToolInput`, `WorkflowRunMetadata`, `PersistedExecutionOptions`, `TerminalSnapshot`, `WorkflowManagerRegistry`, `canonicalWorkflowCwd`, and the related manager/persistence option types from the package root.
+
+If another Pi extension has already installed a custom editor component, pi-dynamic-workflows leaves it in place and keeps the submit-time workflow trigger active. In that compatibility mode, the animated keyword highlight and Backspace one-shot disarm affordance are skipped because the existing editor remains responsible for rendering and input handling; use `/workflows-trigger off` or `/workflows-trigger set <word>` when you need to discuss workflow/workflows without auto-triggering, including in future sessions. Editor composition is load-order dependent: whichever extension installs a visual editor last owns the editor surface, while pi-dynamic-workflows still keeps its submit-time hook registered.
+
 ## How it works
 
 ![A prompt becomes deterministic orchestration, parallel routed agents, verification, and one result](https://raw.githubusercontent.com/QuintinShaw/pi-dynamic-workflows/main/assets/readme/workflow.png)

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -15,11 +15,12 @@ import {
   saveWorkflowSettingsForCwd,
   UsageLimitScheduler,
   WorkflowManager,
+  WorkflowManagerRegistry,
 } from "../src/index.js";
 
 export default function extension(pi: ExtensionAPI) {
-  // Single manager/storage shared by the workflow tool and the /workflows command,
-  // so background runs started by the tool are reachable from the command.
+  // Preserve one default manager/storage for the slash command and TUI. The
+  // registry adds one shared manager per explicit canonical cwd for tool controls.
   const cwd = process.cwd();
   const storage = createWorkflowStorage(cwd);
   const settings = loadWorkflowSettings({ cwd });
@@ -31,17 +32,46 @@ export default function extension(pi: ExtensionAPI) {
     defaultAgentRetries: settings.defaultAgentRetries,
     persistAgentSessions: settings.persistAgentSessions,
   });
+  let deliveryReady = false;
+  const usageLimitSchedulers = new Map<WorkflowManager, UsageLimitScheduler>();
+  const ensureUsageLimitScheduler = (registeredManager: WorkflowManager) => {
+    if (!usageLimitSchedulers.has(registeredManager)) {
+      usageLimitSchedulers.set(registeredManager, new UsageLimitScheduler(registeredManager));
+    }
+  };
+  const managerRegistry = new WorkflowManagerRegistry({
+    defaultCwd: cwd,
+    defaultManager: manager,
+    createManager: (managerCwd) => {
+      const managerStorage = createWorkflowStorage(managerCwd);
+      const managerSettings = loadWorkflowSettings({ cwd: managerCwd });
+      return new WorkflowManager({
+        cwd: managerCwd,
+        loadSavedWorkflow: (name) => managerStorage.load(name)?.script,
+        defaultAgentTimeoutMs: managerSettings.defaultAgentTimeoutMs ?? null,
+        concurrency: managerSettings.defaultConcurrency,
+        defaultAgentRetries: managerSettings.defaultAgentRetries,
+        persistAgentSessions: managerSettings.persistAgentSessions,
+      });
+    },
+    onCreate: (createdManager, managerCwd) => {
+      ensureUsageLimitScheduler(createdManager);
+      if (deliveryReady) {
+        installResultDelivery(pi, createdManager, {
+          loadSettings: () => loadWorkflowSettings({ cwd: managerCwd }),
+          getActiveSessionId: () => createdManager.getSessionId(),
+        });
+      }
+    },
+  });
 
-  const workflowTool = createWorkflowTool({ cwd, manager, storage });
+  const workflowTool = createWorkflowTool({ cwd, managerRegistry, storage });
   pi.registerTool(workflowTool);
-  // Auto-resume runs that paused on a provider usage limit once the quota is
-  // likely refilled. Standalone: only consumes the manager's public surface, so
-  // it stays decoupled from manager/persistence internals. Its constructor also
-  // re-arms any run that was already paused-on-usage_limit before this process
-  // started (cold start), so restarting pi doesn't strand a paused run.
-  const usageLimitScheduler = new UsageLimitScheduler(manager);
+  // Auto-resume runs that pause on provider usage limits in every canonical-cwd
+  // manager. Constructors also re-arm persisted usage_limit pauses after restart.
   pi.on("session_shutdown", () => {
-    usageLimitScheduler.dispose();
+    for (const scheduler of usageLimitSchedulers.values()) scheduler.dispose();
+    usageLimitSchedulers.clear();
   });
   // Standing /effort opt-in (off|high|ultra): auto-arms a workflow for substantive
   // messages, like CC's ultracode. Shared with the editor's input hook below and
@@ -60,13 +90,13 @@ export default function extension(pi: ExtensionAPI) {
   pi.on("session_start", (_event: unknown, ctx: ExtensionContext) => {
     // Tell the manager the session's main model so "explore" agents auto-tier
     // down to a lighter same-family sibling (e.g. Claude → Haiku).
-    manager.setMainModel(ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined);
+    managerRegistry.setMainModel(ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined);
     // Share the host session's model registry so tier/phase routing resolves
     // extension-registered providers (e.g. ollama-cloud) consistently. Set it
     // before activating the tool: the tool's promptGuidelines read the
     // manager's registry lazily, so tool-registry refreshes from here on
     // advertise the shared registry's models.
-    manager.setModelRegistry(ctx.modelRegistry);
+    managerRegistry.setModelRegistry(ctx.modelRegistry);
     const active = pi.getActiveTools();
     if (!active.includes(workflowTool.name)) {
       pi.setActiveTools([...active, workflowTool.name]);
@@ -75,14 +105,20 @@ export default function extension(pi: ExtensionAPI) {
     // sessions, but the navigator/task panel show only the current session's runs.
     // Switching back to a previous session re-shows that session's runs.
     try {
-      manager.setSessionId(ctx.sessionManager?.getSessionId());
+      managerRegistry.setSessionId(ctx.sessionManager?.getSessionId());
     } catch {
       // sessionManager may be unavailable in some contexts — fall back to global history.
     }
     // Deliver a background run's result into the conversation when it finishes.
     // The live settings loader lets `deliveredResultMaxChars` take effect without
     // a restart.
-    installResultDelivery(pi, manager, { loadSettings: () => loadWorkflowSettings({ cwd }) });
+    deliveryReady = true;
+    managerRegistry.forEach((registeredManager, managerCwd) => {
+      installResultDelivery(pi, registeredManager, {
+        loadSettings: () => loadWorkflowSettings({ cwd: managerCwd }),
+        getActiveSessionId: () => registeredManager.getSessionId(),
+      });
+    });
     // Live "workflows running" panel below the input (focus + enter to open).
     // Pass a live settings loader so /workflows-progress (compact|detailed) takes
     // effect without a restart.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintinshaw/pi-dynamic-workflows",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintinshaw/pi-dynamic-workflows",
-      "version": "2.14.1",
+      "version": "2.15.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintinshaw/pi-dynamic-workflows",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "Claude-Code-style dynamic workflows for Pi — fan a task out across 100s of subagents with real model routing, token/cost accounting, resume, git-worktree isolation, an interactive /workflows TUI, and a real /deep-research.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,8 +66,23 @@ export {
   saveModelTierConfig,
   sortedTierNames,
 } from "./model-tier-config.js";
-export type { PersistedRunState, RunPersistence, RunStatus } from "./run-persistence.js";
-export { createRunPersistence, generateRunId } from "./run-persistence.js";
+export type {
+  PersistedExecutionOptions,
+  PersistedRunState,
+  RunLease,
+  RunPersistence,
+  RunStatus,
+  TerminalRunStatus,
+  TerminalSnapshot,
+} from "./run-persistence.js";
+export {
+  assertSafeRunId,
+  createRunPersistence,
+  createTerminalSnapshot,
+  generateRunId,
+  isSafeRunId,
+  LEGACY_EXECUTION_OPTIONS,
+} from "./run-persistence.js";
 export {
   parseCommandArgs,
   registerAllSavedWorkflows,
@@ -110,10 +125,17 @@ export {
   WorkflowEditor,
   type WorkflowModeState,
 } from "./workflow-editor.js";
-export type { ManagedRun, WorkflowManagerOptions } from "./workflow-manager.js";
-export { WorkflowManager } from "./workflow-manager.js";
+export type {
+  ExecOptions,
+  ManagedRun,
+  WorkflowManagerOptions,
+  WorkflowManagerRegistryOptions,
+  WorkflowRunMetadata,
+} from "./workflow-manager.js";
+export { WorkflowManager, WorkflowManagerRegistry } from "./workflow-manager.js";
 export type { WorkflowProjectPaths } from "./workflow-paths.js";
 export {
+  canonicalWorkflowCwd,
   WORKFLOW_HOME_RELATIVE_DIR,
   WORKFLOW_PROJECTS_SUBDIR,
   workflowHomeDir,
@@ -131,7 +153,7 @@ export {
   saveWorkflowSettings,
   saveWorkflowSettingsForCwd,
 } from "./workflow-settings.js";
-export type { WorkflowToolInput, WorkflowToolOptions } from "./workflow-tool.js";
+export type { WorkflowToolAction, WorkflowToolInput, WorkflowToolOptions } from "./workflow-tool.js";
 export { backgroundStartedText, createWorkflowTool } from "./workflow-tool.js";
 export {
   keyToAction,

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -6,10 +6,51 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSyn
 import { join } from "node:path";
 import type { AgentUsage } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
+import { MAX_AGENTS_PER_RUN } from "./config.js";
 import type { WorkflowErrorCode } from "./errors.js";
-import { workflowProjectPaths } from "./workflow-paths.js";
+import { canonicalWorkflowCwd, workflowProjectKey, workflowProjectPaths } from "./workflow-paths.js";
 
 export type RunStatus = "pending" | "running" | "paused" | "completed" | "failed" | "aborted";
+export type TerminalRunStatus = Extract<RunStatus, "completed" | "failed" | "aborted">;
+
+export interface PersistedExecutionOptions {
+  maxAgents: number;
+  concurrency: number;
+  agentRetries: number;
+  agentTimeoutMs: number | null;
+  tokenBudget: number | null;
+}
+
+export const LEGACY_EXECUTION_OPTIONS: Readonly<PersistedExecutionOptions> = Object.freeze({
+  maxAgents: MAX_AGENTS_PER_RUN,
+  concurrency: 8,
+  agentRetries: 0,
+  agentTimeoutMs: null,
+  tokenBudget: null,
+});
+
+export interface TerminalSnapshot {
+  version: 1;
+  outcome: TerminalRunStatus;
+  terminalAt: string;
+  runId: string;
+  workflowName: string;
+  currentPhase?: string;
+  agents: {
+    total: number;
+    done: number;
+    error: number;
+    skipped: number;
+  };
+  journalEntries: number;
+  tokenUsage?: PersistedRunState["tokenUsage"];
+  resultEvidence?: string;
+  error?: {
+    code?: WorkflowErrorCode;
+    message: string;
+  };
+  reason?: "stopped" | "aborted";
+}
 
 export interface PersistedAgentState {
   id: number;
@@ -33,13 +74,25 @@ export interface PersistedAgentState {
 }
 
 export interface PersistedRunState {
+  /** Version 2 is the projected/validated format; absent means legacy v1 input. */
+  version?: 2;
   runId: string;
+  /** Canonical execution cwd. Missing in legacy files and filled from the selected namespace on read. */
+  cwd?: string;
+  /** Stable project namespace derived from canonical cwd. */
+  projectKey?: string;
   workflowName: string;
   script: string;
   args?: unknown;
   /** The pi session this run belongs to. Runs persist on disk across sessions but
    * the navigator shows only the current session's runs (undefined = legacy/global). */
   sessionId?: string;
+  /** Immutable session provenance for new runs; falls back to legacy sessionId on read. */
+  originSessionId?: string;
+  /** Live session that requested the latest resume and should receive delivery. */
+  deliverySessionId?: string;
+  /** Effective runtime options. Legacy files receive deterministic historical defaults. */
+  executionOptions?: PersistedExecutionOptions;
   status: RunStatus;
   /** Why a paused run is paused (e.g. "usage_limit" when a provider quota was hit). */
   pauseReason?: string;
@@ -63,7 +116,7 @@ export interface PersistedRunState {
     cacheWrite?: number;
   };
   /** Cached agent results for resume, keyed by deterministic call index. */
-  journal?: Array<{ index: number; hash: string; result: unknown }>;
+  journal?: Array<{ index: number; hash: string; result: unknown; storeDelta?: Record<string, unknown> }>;
   /**
    * Opt-out of auto-resume for this run (default true, i.e. eligible unless
    * explicitly set to false via ExecOptions.autoResume). Set once at run start
@@ -76,6 +129,8 @@ export interface PersistedRunState {
    * auto-resume attempt has been recorded yet.
    */
   autoResumeAttempts?: number;
+  /** Bounded deterministic terminal evidence. Paused runs never carry this field. */
+  terminalSnapshot?: TerminalSnapshot;
 }
 
 export interface RunPersistence {
@@ -92,6 +147,8 @@ export interface RunPersistence {
    * live process owns the run; stale/corrupt lock files are removed and retried.
    */
   acquireRunLease(runId: string): RunLease | null;
+  /** Check that a lease is still owned by its exact token. */
+  ownsRunLease(lease: RunLease): boolean;
   /** Release a lease previously returned by acquireRunLease(). */
   releaseRunLease(lease: RunLease): void;
   /** Get runs directory path. */
@@ -101,6 +158,14 @@ export interface RunPersistence {
 export interface RunLease {
   runId: string;
   token: string;
+}
+
+export function isSafeRunId(runId: string): boolean {
+  return runId.length > 0 && runId.length <= 256 && runId !== "." && runId !== ".." && /^[a-zA-Z0-9._-]+$/.test(runId);
+}
+
+export function assertSafeRunId(runId: string): void {
+  if (!isSafeRunId(runId)) throw new Error("Workflow runId must be a non-empty path-safe identifier");
 }
 
 interface LockFile {
@@ -125,6 +190,88 @@ export type FsLayer = {
   writeFileSync: typeof writeFileSync;
 };
 
+const TERMINAL_EVIDENCE_MAX_CHARS = 4096;
+const TERMINAL_STRING_MAX_CHARS = 512;
+const TERMINAL_ERROR_MAX_CHARS = 1024;
+const TERMINAL_COLLECTION_MAX_ITEMS = 20;
+const TERMINAL_MAX_DEPTH = 4;
+
+export function createTerminalSnapshot(
+  state: PersistedRunState,
+  options: {
+    terminalAt?: string;
+    result?: unknown;
+    error?: { code?: WorkflowErrorCode; message: string };
+    reason?: "stopped" | "aborted";
+  } = {},
+): TerminalSnapshot | undefined {
+  if (state.terminalSnapshot) return state.terminalSnapshot;
+  if (state.status !== "completed" && state.status !== "failed" && state.status !== "aborted") return undefined;
+
+  const result = options.result !== undefined ? options.result : state.result;
+  const resultEvidence = result === undefined ? undefined : boundedTerminalEvidence(result);
+  const error = options.error
+    ? {
+        code: options.error.code,
+        message: options.error.message.slice(0, TERMINAL_ERROR_MAX_CHARS),
+      }
+    : undefined;
+  return {
+    version: 1,
+    outcome: state.status,
+    terminalAt: options.terminalAt ?? state.completedAt ?? state.updatedAt ?? state.startedAt,
+    runId: state.runId,
+    workflowName: state.workflowName.slice(0, 256),
+    currentPhase: state.currentPhase?.slice(0, 256),
+    agents: {
+      total: state.agents.length,
+      done: state.agents.filter((agent) => agent.status === "done").length,
+      error: state.agents.filter((agent) => agent.status === "error").length,
+      skipped: state.agents.filter((agent) => agent.status === "skipped").length,
+    },
+    journalEntries: state.journal?.length ?? 0,
+    tokenUsage: state.tokenUsage ? { ...state.tokenUsage } : undefined,
+    resultEvidence,
+    error,
+    reason: state.status === "aborted" ? (options.reason ?? "aborted") : undefined,
+  };
+}
+
+function boundedTerminalEvidence(value: unknown): string {
+  const seen = new WeakSet<object>();
+  const visit = (current: unknown, depth: number): unknown => {
+    if (typeof current === "string") {
+      return current.length > TERMINAL_STRING_MAX_CHARS ? `${current.slice(0, TERMINAL_STRING_MAX_CHARS)}…` : current;
+    }
+    if (current === null || typeof current === "number" || typeof current === "boolean") return current;
+    if (typeof current === "bigint") return current.toString();
+    if (typeof current === "undefined") return "[undefined]";
+    if (typeof current === "function" || typeof current === "symbol") return `[${typeof current}]`;
+    if (depth >= TERMINAL_MAX_DEPTH) return "[max-depth]";
+    if (seen.has(current as object)) return "[circular]";
+    seen.add(current as object);
+    if (Array.isArray(current)) {
+      const items = current.slice(0, TERMINAL_COLLECTION_MAX_ITEMS).map((item) => visit(item, depth + 1));
+      if (current.length > TERMINAL_COLLECTION_MAX_ITEMS) items.push(`[+${current.length - items.length} items]`);
+      return items;
+    }
+    const record = current as Record<string, unknown>;
+    const keys = Object.keys(record).sort();
+    const result: Record<string, unknown> = {};
+    for (const key of keys.slice(0, TERMINAL_COLLECTION_MAX_ITEMS)) {
+      result[key.slice(0, 128)] = visit(record[key], depth + 1);
+    }
+    if (keys.length > TERMINAL_COLLECTION_MAX_ITEMS) {
+      result.__truncatedKeys = keys.length - TERMINAL_COLLECTION_MAX_ITEMS;
+    }
+    return result;
+  };
+  const serialized = JSON.stringify(visit(value, 0));
+  return serialized.length > TERMINAL_EVIDENCE_MAX_CHARS
+    ? `${serialized.slice(0, TERMINAL_EVIDENCE_MAX_CHARS - 1)}…`
+    : serialized;
+}
+
 export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>): RunPersistence {
   const _existsSync = fsOverride?.existsSync ?? existsSync;
   const _mkdirSync = fsOverride?.mkdirSync ?? mkdirSync;
@@ -134,7 +281,9 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
   const _unlinkSync = fsOverride?.unlinkSync ?? unlinkSync;
   const _writeFileSync = fsOverride?.writeFileSync ?? writeFileSync;
 
-  const paths = workflowProjectPaths(cwd);
+  const canonicalCwd = canonicalWorkflowCwd(cwd);
+  const paths = workflowProjectPaths(canonicalCwd);
+  const projectKey = workflowProjectKey(canonicalCwd);
   const runsDir = paths.runsDir;
   const legacyRunsDir = paths.legacyRunsDir;
 
@@ -151,6 +300,246 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
   const primaryLockPath = (runId: string) => lockPath(runsDir, runId);
   const legacyLockPath = (runId: string) => lockPath(legacyRunsDir, runId);
   const candidateRunPaths = (runId: string) => [primaryRunPath(runId), legacyRunPath(runId)];
+  const record = (value: unknown, field: string): Record<string, unknown> => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`Invalid ${field}`);
+    return value as Record<string, unknown>;
+  };
+  const string = (value: unknown, field: string, max = 20_000): string => {
+    if (typeof value !== "string" || value.length > max) throw new Error(`Invalid ${field}`);
+    return value;
+  };
+  const optionalString = (value: unknown, field: string, max = 20_000): string | undefined =>
+    value === undefined ? undefined : string(value, field, max);
+  const number = (value: unknown, field: string, integer = false): number => {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || (integer && !Number.isInteger(value))) {
+      throw new Error(`Invalid ${field}`);
+    }
+    return value;
+  };
+  const optionalNumber = (value: unknown, field: string, integer = false): number | undefined =>
+    value === undefined ? undefined : number(value, field, integer);
+  const stringArray = (value: unknown, field: string, legacy: boolean, maxItems: number): string[] => {
+    if (value === undefined && legacy) return [];
+    if (!Array.isArray(value) || value.length > maxItems) throw new Error(`Invalid ${field}`);
+    return value.map((item, index) => string(item, `${field}[${index}]`, 4096));
+  };
+  const tokenUsage = (value: unknown, field: string): PersistedRunState["tokenUsage"] | undefined => {
+    if (value === undefined) return undefined;
+    const usage = record(value, field);
+    const cost = optionalNumber(usage.cost, `${field}.cost`);
+    const cacheRead = optionalNumber(usage.cacheRead, `${field}.cacheRead`);
+    const cacheWrite = optionalNumber(usage.cacheWrite, `${field}.cacheWrite`);
+    return {
+      input: number(usage.input, `${field}.input`),
+      output: number(usage.output, `${field}.output`),
+      total: number(usage.total, `${field}.total`),
+      ...(cost === undefined ? {} : { cost }),
+      ...(cacheRead === undefined ? {} : { cacheRead }),
+      ...(cacheWrite === undefined ? {} : { cacheWrite }),
+    };
+  };
+  const agentUsage = (value: unknown, field: string): AgentUsage | undefined => {
+    if (value === undefined) return undefined;
+    const usage = record(value, field);
+    return {
+      input: number(usage.input, `${field}.input`),
+      output: number(usage.output, `${field}.output`),
+      total: number(usage.total, `${field}.total`),
+      cost: number(usage.cost, `${field}.cost`),
+      cacheRead: number(usage.cacheRead, `${field}.cacheRead`),
+      cacheWrite: number(usage.cacheWrite, `${field}.cacheWrite`),
+    };
+  };
+  const normalizeExecutionOptions = (value: unknown, legacy: boolean): PersistedExecutionOptions => {
+    if (value === undefined && legacy) return { ...LEGACY_EXECUTION_OPTIONS };
+    const options = record(value, "executionOptions");
+    const intInRange = (key: string, min: number, max: number): number => {
+      const parsed = number(options[key], `executionOptions.${key}`, true);
+      if (parsed < min || parsed > max) throw new Error(`Invalid executionOptions.${key}`);
+      return parsed;
+    };
+    const nullablePositive = (key: string): number | null => {
+      const candidate = options[key];
+      if (candidate === null) return null;
+      const parsed = number(candidate, `executionOptions.${key}`);
+      if (parsed <= 0) throw new Error(`Invalid executionOptions.${key}`);
+      return parsed;
+    };
+    return {
+      maxAgents: intInRange("maxAgents", 1, MAX_AGENTS_PER_RUN),
+      concurrency: intInRange("concurrency", 1, 16),
+      agentRetries: intInRange("agentRetries", 0, 3),
+      agentTimeoutMs: nullablePositive("agentTimeoutMs"),
+      tokenBudget: nullablePositive("tokenBudget"),
+    };
+  };
+  const normalizeHistory = (value: unknown, field: string): AgentHistoryEntry[] | undefined => {
+    if (value === undefined) return undefined;
+    if (!Array.isArray(value) || value.length > 40) throw new Error(`Invalid ${field}`);
+    return value.map((item, index) => {
+      const entry = record(item, `${field}[${index}]`);
+      if (!["user", "assistant", "tool"].includes(entry.role as string)) throw new Error(`Invalid ${field}.role`);
+      if (!["text", "toolCall", "toolResult", "error"].includes(entry.kind as string))
+        throw new Error(`Invalid ${field}.kind`);
+      return {
+        role: entry.role as AgentHistoryEntry["role"],
+        kind: entry.kind as AgentHistoryEntry["kind"],
+        text: string(entry.text, `${field}.text`, 2000),
+        toolName: optionalString(entry.toolName, `${field}.toolName`, 256),
+        isError:
+          entry.isError === undefined || typeof entry.isError === "boolean"
+            ? entry.isError
+            : (() => {
+                throw new Error(`Invalid ${field}.isError`);
+              })(),
+        timestamp: optionalNumber(entry.timestamp, `${field}.timestamp`),
+      };
+    });
+  };
+  const normalizeAgents = (value: unknown, legacy: boolean): PersistedAgentState[] => {
+    if (value === undefined && legacy) return [];
+    if (!Array.isArray(value) || value.length > MAX_AGENTS_PER_RUN) throw new Error("Invalid agents");
+    return value.map((item, index) => {
+      const agent = record(item, `agents[${index}]`);
+      if (!["queued", "running", "done", "error", "skipped"].includes(agent.status as string))
+        throw new Error(`Invalid agents[${index}].status`);
+      return {
+        id: number(agent.id, `agents[${index}].id`, true),
+        label: string(agent.label, `agents[${index}].label`, 512),
+        phase: optionalString(agent.phase, `agents[${index}].phase`, 512),
+        prompt: string(agent.prompt, `agents[${index}].prompt`, 1_000_000),
+        status: agent.status as PersistedAgentState["status"],
+        result: agent.result,
+        error: optionalString(agent.error, `agents[${index}].error`, 20_000),
+        errorCode: optionalString(agent.errorCode, `agents[${index}].errorCode`, 128) as WorkflowErrorCode | undefined,
+        recoverable:
+          agent.recoverable === undefined || typeof agent.recoverable === "boolean"
+            ? agent.recoverable
+            : (() => {
+                throw new Error(`Invalid agents[${index}].recoverable`);
+              })(),
+        history: normalizeHistory(agent.history, `agents[${index}].history`),
+        startedAt: optionalString(agent.startedAt, `agents[${index}].startedAt`, 64),
+        endedAt: optionalString(agent.endedAt, `agents[${index}].endedAt`, 64),
+        tokens: optionalNumber(agent.tokens, `agents[${index}].tokens`),
+        tokenUsage: agentUsage(agent.tokenUsage, `agents[${index}].tokenUsage`),
+        model: optionalString(agent.model, `agents[${index}].model`, 512),
+      };
+    });
+  };
+  const normalizeJournal = (value: unknown, legacy: boolean): PersistedRunState["journal"] => {
+    if (value === undefined) return legacy ? [] : undefined;
+    if (!Array.isArray(value) || value.length > MAX_AGENTS_PER_RUN) throw new Error("Invalid journal");
+    return value.map((item, index) => {
+      const entry = record(item, `journal[${index}]`);
+      const storeDelta =
+        entry.storeDelta === undefined ? undefined : { ...record(entry.storeDelta, `journal[${index}].storeDelta`) };
+      return {
+        index: number(entry.index, `journal[${index}].index`, true),
+        hash: string(entry.hash, `journal[${index}].hash`, 512),
+        result: entry.result,
+        ...(storeDelta === undefined ? {} : { storeDelta }),
+      };
+    });
+  };
+  const normalizeTerminalSnapshot = (value: unknown): TerminalSnapshot | undefined => {
+    if (value === undefined) return undefined;
+    const snapshot = record(value, "terminalSnapshot");
+    if (snapshot.version !== 1 || !["completed", "failed", "aborted"].includes(snapshot.outcome as string))
+      throw new Error("Invalid terminalSnapshot");
+    const counts = record(snapshot.agents, "terminalSnapshot.agents");
+    const error = snapshot.error === undefined ? undefined : record(snapshot.error, "terminalSnapshot.error");
+    return {
+      version: 1,
+      outcome: snapshot.outcome as TerminalRunStatus,
+      terminalAt: string(snapshot.terminalAt, "terminalSnapshot.terminalAt", 64),
+      runId: string(snapshot.runId, "terminalSnapshot.runId", 256),
+      workflowName: string(snapshot.workflowName, "terminalSnapshot.workflowName", 256),
+      currentPhase: optionalString(snapshot.currentPhase, "terminalSnapshot.currentPhase", 256),
+      agents: {
+        total: number(counts.total, "terminalSnapshot.agents.total", true),
+        done: number(counts.done, "terminalSnapshot.agents.done", true),
+        error: number(counts.error, "terminalSnapshot.agents.error", true),
+        skipped: number(counts.skipped, "terminalSnapshot.agents.skipped", true),
+      },
+      journalEntries: number(snapshot.journalEntries, "terminalSnapshot.journalEntries", true),
+      tokenUsage: tokenUsage(snapshot.tokenUsage, "terminalSnapshot.tokenUsage"),
+      resultEvidence: optionalString(snapshot.resultEvidence, "terminalSnapshot.resultEvidence", 4096),
+      error: error
+        ? {
+            code: optionalString(error.code, "terminalSnapshot.error.code", 128) as WorkflowErrorCode | undefined,
+            message: string(error.message, "terminalSnapshot.error.message", 1024),
+          }
+        : undefined,
+      reason:
+        snapshot.reason === undefined || snapshot.reason === "stopped" || snapshot.reason === "aborted"
+          ? (snapshot.reason as TerminalSnapshot["reason"])
+          : (() => {
+              throw new Error("Invalid terminalSnapshot.reason");
+            })(),
+    };
+  };
+  const normalizeState = (input: unknown, expectedRunId?: string): PersistedRunState => {
+    const state = record(input, "persisted workflow record");
+    if (state.version !== undefined && state.version !== 2) throw new Error("Unsupported persisted workflow version");
+    const legacy = state.version === undefined;
+    if (!isSafeRunId(state.runId as string) || (expectedRunId !== undefined && state.runId !== expectedRunId)) {
+      throw new Error("Persisted workflow runId mismatch");
+    }
+    if (!["pending", "running", "paused", "completed", "failed", "aborted"].includes(state.status as string))
+      throw new Error("Invalid persisted workflow status");
+    if (
+      !legacy &&
+      (typeof state.script !== "string" || typeof state.startedAt !== "string" || typeof state.updatedAt !== "string")
+    )
+      throw new Error("Invalid version 2 persisted workflow fields");
+    const phases = stringArray(state.phases, "phases", legacy, 1000);
+    const currentPhase = optionalString(state.currentPhase, "currentPhase", 4096);
+    if (currentPhase !== undefined && !phases.includes(currentPhase)) throw new Error("Invalid currentPhase");
+    const normalized: PersistedRunState = {
+      version: 2,
+      runId: state.runId as string,
+      cwd: canonicalCwd,
+      projectKey,
+      workflowName: string(state.workflowName, "workflowName", 4096),
+      script: state.script === undefined && legacy ? "" : string(state.script, "script", 10_000_000),
+      args: state.args,
+      sessionId: optionalString(state.sessionId, "sessionId", 512),
+      originSessionId: optionalString(state.originSessionId ?? state.sessionId, "originSessionId", 512),
+      deliverySessionId: optionalString(state.deliverySessionId ?? state.sessionId, "deliverySessionId", 512),
+      executionOptions: normalizeExecutionOptions(state.executionOptions, legacy),
+      status: state.status as RunStatus,
+      pauseReason: optionalString(state.pauseReason, "pauseReason", 512),
+      resetHint: optionalString(state.resetHint, "resetHint", 512),
+      phases,
+      currentPhase,
+      agents: normalizeAgents(state.agents, legacy),
+      logs: stringArray(state.logs, "logs", legacy, 10_000),
+      result: state.result,
+      startedAt:
+        state.startedAt === undefined && legacy ? new Date(0).toISOString() : string(state.startedAt, "startedAt", 64),
+      updatedAt:
+        state.updatedAt === undefined && legacy ? new Date(0).toISOString() : string(state.updatedAt, "updatedAt", 64),
+      completedAt: optionalString(state.completedAt, "completedAt", 64),
+      durationMs: optionalNumber(state.durationMs, "durationMs"),
+      tokenUsage: tokenUsage(state.tokenUsage, "tokenUsage"),
+      journal: normalizeJournal(state.journal, legacy),
+      autoResume:
+        state.autoResume === undefined || typeof state.autoResume === "boolean"
+          ? state.autoResume
+          : (() => {
+              throw new Error("Invalid autoResume");
+            })(),
+      autoResumeAttempts: optionalNumber(state.autoResumeAttempts, "autoResumeAttempts", true),
+      terminalSnapshot: normalizeTerminalSnapshot(state.terminalSnapshot),
+    };
+    if (normalized.terminalSnapshot?.runId !== undefined && normalized.terminalSnapshot.runId !== normalized.runId)
+      throw new Error("Persisted terminalSnapshot runId mismatch");
+    if (normalized.terminalSnapshot && normalized.terminalSnapshot.outcome !== normalized.status)
+      throw new Error("Persisted terminalSnapshot outcome mismatch");
+    normalized.terminalSnapshot = createTerminalSnapshot(normalized);
+    return normalized;
+  };
 
   const pidIsAlive = (pid: number): boolean => {
     if (!Number.isInteger(pid) || pid <= 0) return false;
@@ -187,10 +576,15 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
 
   return {
     save(state: PersistedRunState) {
+      assertSafeRunId(state.runId);
       ensureDir();
-      state.updatedAt = new Date().toISOString();
+      const savedAt = new Date().toISOString();
+      const normalized = normalizeState(state);
+      state.updatedAt = savedAt;
+      normalized.updatedAt = savedAt;
+      state.terminalSnapshot ??= normalized.terminalSnapshot;
       const path = primaryRunPath(state.runId);
-      const json = JSON.stringify(state, null, 2);
+      const json = JSON.stringify(normalized, null, 2);
       // Atomic write: a crash mid-write can't corrupt the live file (tmp+rename is
       // atomic on the same filesystem). A .bak from the previous good save is the
       // recovery fallback if the primary is somehow truncated.
@@ -204,12 +598,13 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     },
 
     load(runId: string): PersistedRunState | null {
+      if (!isSafeRunId(runId)) return null;
       // Try the primary, then the .bak — so a corrupt primary doesn't lose the run.
       for (const path of candidateRunPaths(runId)) {
         for (const candidate of [path, `${path}.bak`]) {
           try {
             if (!_existsSync(candidate)) continue;
-            return JSON.parse(_readFileSync(candidate, "utf-8")) as PersistedRunState;
+            return normalizeState(JSON.parse(_readFileSync(candidate, "utf-8")), runId);
           } catch {
             // corrupt candidate -> fall through to the next candidate
           }
@@ -226,7 +621,8 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
           const files = _readdirSync(dir).filter((f) => f.endsWith(".json"));
           for (const file of files) {
             try {
-              const state = JSON.parse(_readFileSync(join(dir, file), "utf-8")) as PersistedRunState;
+              const expectedRunId = file.slice(0, -".json".length);
+              const state = normalizeState(JSON.parse(_readFileSync(join(dir, file), "utf-8")), expectedRunId);
               if (!byRunId.has(state.runId)) byRunId.set(state.runId, state);
             } catch {
               // Skip corrupted files
@@ -240,6 +636,7 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     },
 
     delete(runId: string): boolean {
+      if (!isSafeRunId(runId)) return false;
       let deleted = false;
       try {
         for (const path of candidateRunPaths(runId)) {
@@ -268,6 +665,7 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     },
 
     acquireRunLease(runId: string): RunLease | null {
+      if (!isSafeRunId(runId)) return null;
       ensureDir();
       const path = primaryRunPath(runId);
       const lock = primaryLockPath(runId);
@@ -288,20 +686,49 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
           const code = (err as { code?: string }).code;
           if (code !== "EEXIST") throw err;
           const existing = readLock(runId);
-          if (existing && existing.runPath === path && pidIsAlive(existing.pid)) {
+          if (existing && existing.runPath === path && pidIsAlive(existing.pid)) return null;
+
+          // Atomically move the exact stale candidate out of the lock pathname.
+          // Never unlink by pathname after inspection: another owner could replace
+          // the file between the stale read and unlink. A contender racing this
+          // rename either wins the pathname or makes the rename fail; both cases
+          // leave its lease untouched and make this acquisition return null.
+          const quarantine = `${lock}.stale-${token}`;
+          try {
+            _renameSync(lock, quarantine);
+          } catch {
             return null;
           }
           try {
-            _unlinkSync(lock);
-          } catch {
-            return null;
+            const moved = readLockAt(quarantine);
+            if (existing?.token && moved?.token !== existing.token) {
+              try {
+                _renameSync(quarantine, lock);
+              } catch {
+                // A new owner already claimed the path; do not disturb it.
+              }
+              return null;
+            }
+          } finally {
+            try {
+              if (_existsSync(quarantine)) _unlinkSync(quarantine);
+            } catch {
+              // Quarantine cleanup is best-effort and cannot affect lock ownership.
+            }
           }
         }
       }
       return null;
     },
 
+    ownsRunLease(lease: RunLease): boolean {
+      if (!isSafeRunId(lease.runId)) return false;
+      const existing = readLock(lease.runId);
+      return existing?.token === lease.token;
+    },
+
     releaseRunLease(lease: RunLease): void {
+      if (!isSafeRunId(lease.runId)) return;
       try {
         const existing = readLock(lease.runId);
         if (existing?.token === lease.token) _unlinkSync(primaryLockPath(lease.runId));

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -151,19 +151,36 @@ function deliveredMaxChars(opts: { loadSettings?: () => WorkflowSettings }): num
 export function installResultDelivery(
   pi: ExtensionAPI,
   manager: WorkflowManager,
-  opts: { loadSettings?: () => WorkflowSettings } = {},
+  opts: { loadSettings?: () => WorkflowSettings; getActiveSessionId?: () => string | undefined } = {},
 ): void {
+  type PendingDelivery = { sessionId: string; content: string };
+  type DeliveryHolder = {
+    pi: ExtensionAPI;
+    getActiveSessionId?: () => string | undefined;
+    pending: PendingDelivery[];
+  };
   // Mutable holder on manager so shared across re-calls (e.g. session_start after /reload).
-  const m = manager as unknown as { __deliveryInstalled?: boolean; __holder?: { pi: ExtensionAPI } };
+  const m = manager as unknown as { __deliveryInstalled?: boolean; __holder?: DeliveryHolder };
+  const flushPending = () => {
+    const holder = m.__holder;
+    const active = holder?.getActiveSessionId?.();
+    if (!holder || !active) return;
+    const ready = holder.pending.filter((item) => item.sessionId === active);
+    holder.pending = holder.pending.filter((item) => item.sessionId !== active);
+    for (const item of ready) deliver(item.content);
+  };
   if (m.__deliveryInstalled) {
-    // Refresh pi reference only — listeners stay registered.
-    if (m.__holder) m.__holder.pi = pi;
+    if (m.__holder) {
+      m.__holder.pi = pi;
+      m.__holder.getActiveSessionId = opts.getActiveSessionId;
+    }
+    flushPending();
     return;
   }
   m.__deliveryInstalled = true;
-  m.__holder = { pi };
+  m.__holder = { pi, getActiveSessionId: opts.getActiveSessionId, pending: [] };
 
-  const deliver = (content: string) => {
+  function deliver(content: string) {
     try {
       const ret = m.__holder?.pi.sendMessage(
         { customType: "workflow-result", content, display: true },
@@ -176,6 +193,17 @@ export function installResultDelivery(
     } catch {
       // Synchronous failure (e.g. stale ctx) — result still visible via /workflows.
     }
+  }
+
+  const deliverToRunSession = (run: ManagedRun, content: string) => {
+    const target = run.deliverySessionId;
+    const getActive = m.__holder?.getActiveSessionId;
+    if (!target || !getActive) {
+      deliver(content);
+      return;
+    }
+    if (getActive() === target) deliver(content);
+    else m.__holder?.pending.push({ sessionId: target, content });
   };
 
   manager.on("complete", ({ runId }: { runId: string }) => {
@@ -183,12 +211,16 @@ export function installResultDelivery(
     // Only background/resumed runs are delivered: a foreground (sync) run already
     // returns its result inline as the tool result, so re-delivering would dup it.
     if (run?.background) {
-      deliver(deliverText(run, { resultPath: persistedResultPath(manager, runId), maxChars: deliveredMaxChars(opts) }));
+      deliverToRunSession(
+        run,
+        deliverText(run, { resultPath: persistedResultPath(manager, runId), maxChars: deliveredMaxChars(opts) }),
+      );
     }
   });
   manager.on("error", ({ runId, error }: { runId: string; error?: { message?: string } }) => {
-    if (!manager.getRun(runId)?.background) return;
-    deliver(`✗ Background workflow ${runId} failed: ${error?.message ?? "unknown error"}`);
+    const run = manager.getRun(runId);
+    if (!run?.background || run.status === "paused" || run.status === "aborted") return;
+    deliverToRunSession(run, `✗ Background workflow ${runId} failed: ${error?.message ?? "unknown error"}`);
   });
   // A provider usage/quota limit checkpoints the run as paused (not failed): tell the
   // user it is resumable once their budget refills, rather than letting it look dead.
@@ -211,7 +243,10 @@ export function installResultDelivery(
       if (!manager.getRun(runId)?.background) return;
       const when = resetHint ? ` (${resetHint})` : "";
       const cause = error?.message ?? "provider usage limit reached";
-      deliver(
+      const run = manager.getRun(runId);
+      if (!run) return;
+      deliverToRunSession(
+        run,
         `⏸ Background workflow ${runId} paused: ${cause}${when}. ` +
           `Completed steps are saved — run /workflows resume ${runId} once your usage limit resets.`,
       );

--- a/src/usage-limit-scheduler.ts
+++ b/src/usage-limit-scheduler.ts
@@ -17,13 +17,14 @@
  */
 
 import type { PersistedRunState, RunPersistence, RunStatus } from "./run-persistence.js";
+import type { AutomaticResumeOptions } from "./workflow-manager.js";
 
 /** Narrow surface this scheduler depends on — satisfied by WorkflowManager. */
 export interface SchedulableWorkflowManager {
   on(event: string, listener: (...args: any[]) => void): unknown;
   off(event: string, listener: (...args: any[]) => void): unknown;
   listAllRuns(): PersistedRunState[];
-  resume(runId: string): Promise<boolean>;
+  resume(runId: string, options: AutomaticResumeOptions): Promise<boolean>;
   getPersistence(): RunPersistence;
 }
 
@@ -298,7 +299,7 @@ export class UsageLimitScheduler {
 
     let resumed = false;
     try {
-      resumed = await this.manager.resume(runId);
+      resumed = await this.manager.resume(runId, { intent: "automatic" });
     } catch (err) {
       this.diagnostic(`[usage-limit-scheduler] ${runId}: resume() threw`, err);
       resumed = false;

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -5,17 +5,23 @@
 import { EventEmitter } from "node:events";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { WorkflowAgent } from "./agent.js";
+import { MAX_AGENTS_PER_RUN } from "./config.js";
 import { preview, type WorkflowSnapshot } from "./display.js";
 import { WorkflowError, WorkflowErrorCode } from "./errors.js";
 import {
   createRunPersistence,
+  createTerminalSnapshot,
   generateRunId,
+  LEGACY_EXECUTION_OPTIONS,
+  type PersistedExecutionOptions,
   type PersistedRunState,
   type RunLease,
   type RunPersistence,
   type RunStatus,
+  type TerminalSnapshot,
 } from "./run-persistence.js";
 import { type JournalEntry, parseWorkflowScript, runWorkflow, type WorkflowRunResult } from "./workflow.js";
+import { canonicalWorkflowCwd, workflowProjectKey } from "./workflow-paths.js";
 
 export interface ManagedRun {
   runId: string;
@@ -30,8 +36,19 @@ export interface ManagedRun {
   args?: unknown;
   /** Accumulated agent results for resume (deterministic call index -> result). */
   journal: JournalEntry[];
+  /** Canonical execution options captured once and reused verbatim on resume. */
+  executionOptions: PersistedExecutionOptions;
+  /** Immutable session provenance. */
+  originSessionId?: string;
+  /** Session that requested the current execution and receives background delivery. */
+  deliverySessionId?: string;
+  /** Created once for a terminal transition and reused by later persistence writes. */
+  terminalSnapshot?: TerminalSnapshot;
+  terminalAt?: string;
   /** Cross-process execution lease for this run, when it is actively executing. */
   lease?: RunLease;
+  /** Settlement of this exact execution generation; replacements await it. */
+  settlement?: Promise<unknown>;
   /**
    * True when the run was started in the background (or resumed) and the caller is
    * not awaiting its result inline. Only background runs deliver their result back
@@ -74,6 +91,55 @@ export interface ExecOptions {
    * it too. See usage-limit-scheduler.ts.
    */
   autoResume?: boolean;
+}
+
+export interface ExplicitResumeOptions {
+  /** Explicit callers retarget delivery to the manager/session requesting the resume. */
+  intent?: "explicit";
+  script?: string;
+  args?: unknown;
+}
+
+export interface AutomaticResumeOptions {
+  /** Automatic recovery preserves the run's existing delivery target. */
+  intent: "automatic";
+}
+
+export type ResumeOptions = ExplicitResumeOptions | AutomaticResumeOptions;
+
+export interface WorkflowRunMetadata {
+  runId: string;
+  workflowName: string;
+  status: RunStatus;
+  cwd: string;
+  projectKey: string;
+  startedAt: string;
+  updatedAt: string;
+  completedAt?: string;
+  durationMs?: number;
+  currentPhase?: string;
+  phases: string[];
+  pauseReason?: string;
+  agents: {
+    total: number;
+    queued: number;
+    running: number;
+    done: number;
+    error: number;
+    skipped: number;
+  };
+  journalEntries: number;
+  tokenUsage?: PersistedRunState["tokenUsage"];
+  terminal?: {
+    version: 1;
+    outcome: TerminalSnapshot["outcome"];
+    terminalAt: string;
+    agents: TerminalSnapshot["agents"];
+    journalEntries: number;
+    hasResultEvidence: boolean;
+    errorCode?: WorkflowErrorCode;
+    reason?: TerminalSnapshot["reason"];
+  };
 }
 
 export interface WorkflowManagerOptions {
@@ -123,7 +189,7 @@ export class WorkflowManager extends EventEmitter {
 
   constructor(options: WorkflowManagerOptions = {}) {
     super();
-    this.cwd = options.cwd ?? process.cwd();
+    this.cwd = canonicalWorkflowCwd(options.cwd ?? process.cwd());
     this.concurrency = options.concurrency ?? 8;
     this.loadSavedWorkflow = options.loadSavedWorkflow;
     this.agent = options.agent;
@@ -143,6 +209,10 @@ export class WorkflowManager extends EventEmitter {
     this.sessionId = id;
   }
 
+  getSessionId(): string | undefined {
+    return this.sessionId;
+  }
+
   /**
    * On startup, any persisted run still marked "running" belongs to a process
    * that died mid-run (this fresh manager has it nowhere in memory). Reconcile it
@@ -156,7 +226,7 @@ export class WorkflowManager extends EventEmitter {
           const lease = this.persistence.acquireRunLease(p.runId);
           if (!lease) continue;
           try {
-            this.persistence.save({ ...p, status: "paused" });
+            this.persistence.save({ ...p, status: "paused", pauseReason: "host_lost", terminalSnapshot: undefined });
           } finally {
             this.persistence.releaseRunLease(lease);
           }
@@ -226,6 +296,9 @@ export class WorkflowManager extends EventEmitter {
       script,
       args,
       journal: [],
+      executionOptions: this.resolveExecutionOptions(exec),
+      originSessionId: this.sessionId,
+      deliverySessionId: this.sessionId,
       background: true,
       lease,
       autoResume: exec.autoResume,
@@ -234,21 +307,7 @@ export class WorkflowManager extends EventEmitter {
     this.runs.set(runId, managed);
 
     try {
-      // Persist initial state
-      this.persistence.save({
-        runId,
-        workflowName: parsed.meta.name,
-        script,
-        args,
-        sessionId: this.sessionId,
-        status: "running",
-        phases: managed.snapshot.phases,
-        agents: [],
-        logs: [],
-        startedAt: managed.startedAt.toISOString(),
-        updatedAt: managed.startedAt.toISOString(),
-        autoResume: managed.autoResume,
-      });
+      this.persistRun(managed);
     } catch (err) {
       this.releaseRunLease(managed);
       this.runs.delete(runId);
@@ -261,6 +320,7 @@ export class WorkflowManager extends EventEmitter {
     // already records status/event/persist, but the promise still rejects.
     // The original promise is returned so callers can await it in try/catch.
     const promise = this.executeRun(managed, script, args, exec);
+    managed.settlement = promise;
     promise.catch(() => {});
 
     return { runId, promise };
@@ -273,7 +333,7 @@ export class WorkflowManager extends EventEmitter {
    * a caller (e.g. the workflow tool) drive its own inline display.
    */
   async runSync(script: string, args?: unknown, exec: ExecOptions = {}): Promise<WorkflowRunResult> {
-    const managed = this.createManaged(script, args);
+    const managed = this.createManaged(script, args, exec);
     const lease = this.persistence.acquireRunLease(managed.runId);
     if (!lease) throw new Error(`Could not acquire workflow run lease for ${managed.runId}`);
     managed.lease = lease;
@@ -286,7 +346,7 @@ export class WorkflowManager extends EventEmitter {
   }
 
   /** Build a fresh managed run with an empty snapshot. */
-  private createManaged(script: string, args?: unknown): ManagedRun {
+  private createManaged(script: string, args?: unknown, exec: ExecOptions = {}): ManagedRun {
     const parsed = parseWorkflowScript(script);
     const slug = parsed.meta.name
       ? parsed.meta.name
@@ -315,7 +375,20 @@ export class WorkflowManager extends EventEmitter {
       script,
       args,
       journal: [],
+      executionOptions: this.resolveExecutionOptions(exec),
+      originSessionId: this.sessionId,
+      deliverySessionId: this.sessionId,
       background: false,
+    };
+  }
+
+  private resolveExecutionOptions(exec: ExecOptions): PersistedExecutionOptions {
+    return {
+      maxAgents: exec.maxAgents ?? MAX_AGENTS_PER_RUN,
+      concurrency: exec.concurrency ?? this.concurrency,
+      agentRetries: exec.agentRetries ?? this.defaultAgentRetries,
+      agentTimeoutMs: exec.agentTimeoutMs !== undefined ? exec.agentTimeoutMs : this.defaultAgentTimeoutMs,
+      tokenBudget: exec.tokenBudget ?? null,
     };
   }
 
@@ -325,21 +398,22 @@ export class WorkflowManager extends EventEmitter {
     args?: unknown,
     exec: ExecOptions = {},
   ): Promise<WorkflowRunResult> {
+    const { resumeJournal, externalSignal, onProgress, confirm } = exec;
     const {
-      resumeJournal,
       maxAgents,
-      agentTimeoutMs,
-      externalSignal,
-      onProgress,
+      agentTimeoutMs: resolvedAgentTimeoutMs,
       tokenBudget,
-      concurrency,
-      agentRetries,
-      confirm,
-    } = exec;
-    const resolvedAgentTimeoutMs = agentTimeoutMs !== undefined ? agentTimeoutMs : this.defaultAgentTimeoutMs;
-    const resolvedConcurrency = concurrency ?? this.concurrency;
-    const resolvedAgentRetries = agentRetries ?? this.defaultAgentRetries;
-    const progress = () => onProgress?.(managed.snapshot);
+      concurrency: resolvedConcurrency,
+      agentRetries: resolvedAgentRetries,
+    } = managed.executionOptions;
+    const ownsGeneration = () =>
+      this.runs.get(managed.runId) === managed &&
+      managed.status === "running" &&
+      !!managed.lease &&
+      this.persistence.ownsRunLease(managed.lease);
+    const progress = () => {
+      if (ownsGeneration()) onProgress?.(managed.snapshot);
+    };
     // Let a host abort (e.g. Esc during a blocking tool call) cancel this run.
     if (externalSignal) {
       if (externalSignal.aborted) managed.controller.abort();
@@ -363,23 +437,30 @@ export class WorkflowManager extends EventEmitter {
         agentRetries: resolvedAgentRetries,
         maxAgents,
         agentTimeoutMs: resolvedAgentTimeoutMs,
+        // Keep the original ceiling and seed the fresh runtime with persisted
+        // cumulative accounting. Replay costs zero; only new work consumes more.
         tokenBudget,
+        initialTokenUsage: managed.snapshot.tokenUsage,
+        initialTokenSpend: managed.snapshot.tokenUsage?.total ?? 0,
         confirm,
         loadSavedWorkflow: this.loadSavedWorkflow,
         resumeJournal,
         resumeFromRunId: resumeJournal ? managed.runId : undefined,
         onAgentJournal: (entry) => {
+          if (!ownsGeneration()) return;
           // Append (crash-safe-ish): keep the latest entry per index, then persist.
           managed.journal = managed.journal.filter((e) => e.index !== entry.index);
           managed.journal.push(entry);
           this.persistRun(managed);
         },
         onLog: (message) => {
+          if (!ownsGeneration()) return;
           managed.snapshot.logs.push(message);
           this.emit("log", { runId: managed.runId, message });
           progress();
         },
         onPhase: (title) => {
+          if (!ownsGeneration()) return;
           managed.snapshot.currentPhase = title;
           if (!managed.snapshot.phases.includes(title)) {
             managed.snapshot.phases.push(title);
@@ -388,6 +469,7 @@ export class WorkflowManager extends EventEmitter {
           progress();
         },
         onAgentStart: (event) => {
+          if (!ownsGeneration()) return;
           managed.snapshot.agents.push({
             id: managed.snapshot.agents.length + 1,
             label: event.label,
@@ -400,6 +482,7 @@ export class WorkflowManager extends EventEmitter {
           progress();
         },
         onAgentEnd: (event) => {
+          if (!ownsGeneration()) return;
           const agent = [...managed.snapshot.agents]
             .reverse()
             .find((a) => a.label === event.label && a.status === "running");
@@ -410,13 +493,32 @@ export class WorkflowManager extends EventEmitter {
             agent.errorCode = event.errorCode;
             agent.recoverable = event.recoverable;
             agent.tokens = event.tokens;
-            if (event.tokenUsage) agent.tokenUsage = event.tokenUsage;
+            if (event.tokenUsage) {
+              agent.tokenUsage = event.tokenUsage;
+              const prior = managed.snapshot.tokenUsage ?? {
+                input: 0,
+                output: 0,
+                total: 0,
+                cost: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+              };
+              managed.snapshot.tokenUsage = {
+                input: prior.input + event.tokenUsage.input,
+                output: prior.output + event.tokenUsage.output,
+                total: prior.total + event.tokenUsage.total,
+                cost: (prior.cost ?? 0) + (event.tokenUsage.cost ?? 0),
+                cacheRead: (prior.cacheRead ?? 0) + (event.tokenUsage.cacheRead ?? 0),
+                cacheWrite: (prior.cacheWrite ?? 0) + (event.tokenUsage.cacheWrite ?? 0),
+              };
+            }
             if (event.model) agent.model = event.model;
           }
           this.emit("agentEnd", { runId: managed.runId, ...event });
           progress();
         },
         onAgentHistory: (event) => {
+          if (!ownsGeneration()) return;
           const agent = [...managed.snapshot.agents]
             .reverse()
             .find((a) => a.label === event.label && a.status === "running");
@@ -427,14 +529,35 @@ export class WorkflowManager extends EventEmitter {
           progress();
         },
         onTokenUsage: (usage) => {
-          managed.snapshot.tokenUsage = usage;
+          // Usage may arrive while an intentionally paused generation is
+          // settling. Accept it while this generation still owns the lease even
+          // though status is no longer "running", and persist immediately.
+          if (
+            this.runs.get(managed.runId) !== managed ||
+            !managed.lease ||
+            !this.persistence.ownsRunLease(managed.lease)
+          )
+            return;
+          const persistedBase = managed.snapshot.tokenUsage;
+          if (!persistedBase || usage.total >= persistedBase.total) managed.snapshot.tokenUsage = { ...usage };
           this.emit("tokenUsage", { runId: managed.runId, usage });
+          this.persistRun(managed);
           progress();
         },
       });
 
+      // The public/control-plane run ID is the persisted manager ID. Keep the
+      // runtime's legacy internal run-* identifier for subagent session names.
+      result.runId = managed.runId;
+      if (managed.status !== "running" || !managed.lease || !this.persistence.ownsRunLease(managed.lease)) {
+        throw new WorkflowError("Workflow execution no longer owns its run lease", WorkflowErrorCode.WORKFLOW_ABORTED, {
+          recoverable: true,
+        });
+      }
       managed.status = "completed";
       managed.result = result;
+      managed.terminalAt ??= new Date().toISOString();
+      this.ensureTerminalSnapshot(managed);
       this.emit("complete", { runId: managed.runId, result });
 
       // Persist final state
@@ -468,6 +591,13 @@ export class WorkflowManager extends EventEmitter {
         managed.status = "failed";
       }
       managed.error = workflowError;
+      if (managed.status === "failed" || managed.status === "aborted") {
+        managed.terminalAt ??= new Date().toISOString();
+        this.ensureTerminalSnapshot(managed, {
+          error: { code: workflowError.code, message: workflowError.message },
+          reason: managed.status === "aborted" ? "aborted" : undefined,
+        });
+      }
       if (usageLimitPaused) {
         this.emit("paused", {
           runId: managed.runId,
@@ -475,13 +605,17 @@ export class WorkflowManager extends EventEmitter {
           error: workflowError,
           resetHint: workflowError.resetHint,
         });
-      } else {
+      } else if (!managed.controller.signal.aborted) {
         this.emit("error", { runId: managed.runId, error: workflowError });
       }
 
-      // Persist final state
-      this.persistRun(managed);
-      this.releaseRunLease(managed);
+      // pause()/stop() persist their transition before releasing the lease. Their
+      // aborted execution may settle later; never let that stale catch overwrite a
+      // resumed owner that acquired the lease in the meantime.
+      if (managed.lease && this.persistence.ownsRunLease(managed.lease)) {
+        this.persistRun(managed);
+        this.releaseRunLease(managed);
+      }
 
       throw workflowError;
     }
@@ -493,56 +627,79 @@ export class WorkflowManager extends EventEmitter {
     managed.lease = undefined;
   }
 
+  private toPersistedState(managed: ManagedRun): PersistedRunState {
+    return {
+      runId: managed.runId,
+      cwd: this.cwd,
+      projectKey: workflowProjectKey(this.cwd),
+      workflowName: managed.snapshot.name,
+      // Persist the real script + journal so the run can be resumed. Runs live
+      // in workflow run storage — protect via directory permissions, not blanking.
+      script: managed.script,
+      args: managed.args,
+      sessionId: managed.originSessionId,
+      originSessionId: managed.originSessionId,
+      deliverySessionId: managed.deliverySessionId,
+      executionOptions: { ...managed.executionOptions },
+      journal: managed.journal,
+      status: managed.status,
+      // Fixed at run start and retained across manual and automatic resumes.
+      autoResume: managed.autoResume,
+      // Why a usage-limit pause happened, so the navigator / a future cold start
+      // can show it and (eventually) re-arm resume after the budget refills.
+      pauseReason:
+        managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
+          ? "usage_limit"
+          : undefined,
+      resetHint:
+        managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
+          ? managed.error.resetHint
+          : undefined,
+      phases: managed.snapshot.phases,
+      currentPhase: managed.snapshot.currentPhase,
+      agents: managed.snapshot.agents.map((agent) => ({
+        ...agent,
+        startedAt: managed.startedAt.toISOString(),
+        endedAt: managed.terminalAt ?? new Date().toISOString(),
+      })),
+      logs: managed.snapshot.logs,
+      result: managed.result?.result,
+      tokenUsage: managed.snapshot.tokenUsage
+        ? {
+            input: managed.snapshot.tokenUsage.input,
+            output: managed.snapshot.tokenUsage.output,
+            total: managed.snapshot.tokenUsage.total,
+            cost: managed.snapshot.tokenUsage.cost,
+            cacheRead: managed.snapshot.tokenUsage.cacheRead,
+            cacheWrite: managed.snapshot.tokenUsage.cacheWrite,
+          }
+        : undefined,
+      startedAt: managed.startedAt.toISOString(),
+      updatedAt: managed.terminalAt ?? new Date().toISOString(),
+      completedAt: managed.status === "completed" ? managed.terminalAt : undefined,
+      durationMs: managed.result?.durationMs,
+      terminalSnapshot: managed.terminalSnapshot,
+    };
+  }
+
+  private ensureTerminalSnapshot(
+    managed: ManagedRun,
+    options: {
+      error?: { code?: WorkflowErrorCode; message: string };
+      reason?: "stopped" | "aborted";
+    } = {},
+  ): void {
+    if (managed.terminalSnapshot) return;
+    managed.terminalSnapshot = createTerminalSnapshot(this.toPersistedState(managed), {
+      terminalAt: managed.terminalAt,
+      result: managed.result?.result,
+      ...options,
+    });
+  }
+
   private persistRun(managed: ManagedRun) {
     try {
-      this.persistence.save({
-        runId: managed.runId,
-        workflowName: managed.snapshot.name,
-        // Persist the real script + journal so the run can be resumed. Runs live
-        // in workflow run storage — protect via directory permissions, not blanking.
-        script: managed.script,
-        args: managed.args,
-        sessionId: this.sessionId,
-        journal: managed.journal,
-        status: managed.status,
-        // Persisted every write (not just at pause) so a stale read during the
-        // "paused" event race (see UsageLimitScheduler) is still correct — this
-        // is fixed at run-start and doesn't change over the run's lifetime.
-        autoResume: managed.autoResume,
-        // Why a usage-limit pause happened, so the navigator / a future cold start
-        // can show it and (eventually) re-arm resume after the budget refills.
-        pauseReason:
-          managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
-            ? "usage_limit"
-            : undefined,
-        resetHint:
-          managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
-            ? managed.error.resetHint
-            : undefined,
-        phases: managed.snapshot.phases,
-        currentPhase: managed.snapshot.currentPhase,
-        agents: managed.snapshot.agents.map((a) => ({
-          ...a,
-          startedAt: managed.startedAt.toISOString(),
-          endedAt: new Date().toISOString(),
-        })),
-        logs: managed.snapshot.logs,
-        result: managed.result?.result,
-        tokenUsage: managed.snapshot.tokenUsage
-          ? {
-              input: managed.snapshot.tokenUsage.input,
-              output: managed.snapshot.tokenUsage.output,
-              total: managed.snapshot.tokenUsage.total,
-              cost: managed.snapshot.tokenUsage.cost,
-              cacheRead: managed.snapshot.tokenUsage.cacheRead,
-              cacheWrite: managed.snapshot.tokenUsage.cacheWrite,
-            }
-          : undefined,
-        startedAt: managed.startedAt.toISOString(),
-        updatedAt: new Date().toISOString(),
-        completedAt: managed.status === "completed" ? new Date().toISOString() : undefined,
-        durationMs: managed.result?.durationMs,
-      });
+      this.persistence.save(this.toPersistedState(managed));
     } catch (err) {
       // Persistence is best-effort: the run is still healthy in memory.
       // Log so an operator debugging state-loss has a lead, but never crash
@@ -556,13 +713,16 @@ export class WorkflowManager extends EventEmitter {
    */
   pause(runId: string): boolean {
     const managed = this.runs.get(runId);
-    if (managed?.status !== "running") return false;
+    if (managed?.status !== "running" || !managed.lease || !this.persistence.ownsRunLease(managed.lease)) {
+      return false;
+    }
 
     managed.controller.abort();
     managed.status = "paused";
     this.emit("paused", { runId });
     this.persistRun(managed);
-    this.releaseRunLease(managed);
+    // Keep the lease until executeRun settles. Its callbacks are fenced by this
+    // generation's status and lease, and resume awaits settlement before takeover.
     return true;
   }
 
@@ -576,25 +736,44 @@ export class WorkflowManager extends EventEmitter {
    * from cache, while the first changed or newly inserted call — and everything
    * after it — re-runs live. When `opts.script` is omitted, resume behaves
    * exactly as before and uses the persisted script (auto-resume, TUI resume);
-   * this keeps the existing single-arg `resume(runId)` callers (e.g. the
-   * UsageLimitScheduler) unchanged. `opts.args` overrides the persisted args
-   * only when provided; otherwise the persisted args are kept.
+   * this keeps existing v2.14 single-arg and edited-script callers explicit by
+   * default. Automatic recovery must pass `{ intent: "automatic" }`, which
+   * preserves the persisted delivery session rather than targeting whichever
+   * session happens to be active when the timer fires.
    */
-  async resume(runId: string, opts?: { script?: string; args?: unknown }): Promise<boolean> {
+  async resume(runId: string, opts: ResumeOptions = { intent: "explicit" }): Promise<boolean> {
     // Guard: refuse to resume a run that is already running, or one that was
     // intentionally aborted (pause/stop/Esc). Paused and failed runs can restart.
     const active = this.runs.get(runId);
     if (active?.status === "running") return false;
     if (active?.status === "aborted") return false;
+    if (active?.settlement) {
+      try {
+        await active.settlement;
+      } catch {
+        // Expected for paused/failed generations; settlement is the fence.
+      }
+      if (this.runs.get(runId)?.status === "aborted") return false;
+    }
 
-    const persisted = this.persistence.load(runId);
-    if (!persisted?.script || persisted.status === "completed" || persisted.status === "aborted") return false;
     const lease = this.persistence.acquireRunLease(runId);
     if (!lease) return false;
+    const persisted = this.persistence.load(runId);
+    if (
+      !persisted?.script ||
+      persisted.status === "running" ||
+      persisted.status === "completed" ||
+      persisted.status === "aborted"
+    ) {
+      this.persistence.releaseRunLease(lease);
+      return false;
+    }
 
-    // Use the edited script when supplied, else the persisted one (backward-compat).
-    const script = opts?.script ?? persisted.script;
-    const args = opts?.args !== undefined ? opts.args : persisted.args;
+    // Edited script/args are an explicit-resume feature. Automatic recovery
+    // deliberately has no fields with which to mutate the persisted execution.
+    const explicit = opts.intent !== "automatic" ? opts : undefined;
+    const script = explicit?.script ?? persisted.script;
+    const args = explicit?.args !== undefined ? explicit.args : persisted.args;
 
     const controller = new AbortController();
     const managed: ManagedRun = {
@@ -609,14 +788,19 @@ export class WorkflowManager extends EventEmitter {
         runningCount: 0,
         doneCount: 0,
         errorCount: 0,
+        tokenUsage: persisted.tokenUsage ? { ...persisted.tokenUsage } : undefined,
       },
       controller,
-      startedAt: new Date(),
+      startedAt: validDate(persisted.startedAt),
       // The (possibly edited) script + args become the run's own — persistRun()
-      // writes them below, so a later resume of this run sees the edited script.
+      // writes them below, so a later resume sees the edited input.
       script,
       args,
       journal: persisted.journal ?? [],
+      executionOptions: { ...(persisted.executionOptions ?? LEGACY_EXECUTION_OPTIONS) },
+      originSessionId: persisted.originSessionId ?? persisted.sessionId,
+      deliverySessionId:
+        opts.intent === "automatic" ? persisted.deliverySessionId : (this.sessionId ?? persisted.deliverySessionId),
       background: true,
       lease,
       // Carry the original opt-out forward across resumes; it's fixed at
@@ -631,7 +815,9 @@ export class WorkflowManager extends EventEmitter {
     const resumeJournal = new Map((persisted.journal ?? []).map((e) => [e.index, e] as const));
     this.emit("resumed", { runId });
     // Run in the background; executeRun records status/errors on the managed run.
-    void this.executeRun(managed, script, args, { resumeJournal }).catch(() => {});
+    const settlement = this.executeRun(managed, script, args, { resumeJournal });
+    managed.settlement = settlement;
+    void settlement.catch(() => {});
     return true;
   }
 
@@ -640,14 +826,56 @@ export class WorkflowManager extends EventEmitter {
    */
   stop(runId: string): boolean {
     const managed = this.runs.get(runId);
-    if (!managed || (managed.status !== "running" && managed.status !== "paused")) return false;
+    if (managed?.status === "paused" && managed.lease && this.persistence.ownsRunLease(managed.lease)) {
+      managed.status = "aborted";
+      managed.terminalAt ??= new Date().toISOString();
+      this.ensureTerminalSnapshot(managed, { reason: "stopped" });
+      this.emit("stopped", { runId });
+      this.persistRun(managed);
+      // executeRun still owns this lease until its abort settles.
+      return true;
+    }
+    if (managed?.status === "running") {
+      if (!managed.lease || !this.persistence.ownsRunLease(managed.lease)) return false;
+      managed.controller.abort();
+      managed.status = "aborted";
+      managed.terminalAt ??= new Date().toISOString();
+      this.ensureTerminalSnapshot(managed, { reason: "stopped" });
+      this.emit("stopped", { runId });
+      this.persistRun(managed);
+      this.releaseRunLease(managed);
+      return true;
+    }
 
-    managed.controller.abort();
-    managed.status = "aborted";
-    this.emit("stopped", { runId });
-    this.persistRun(managed);
-    this.releaseRunLease(managed);
-    return true;
+    const lease = this.persistence.acquireRunLease(runId);
+    if (!lease) return false;
+    try {
+      const persisted = this.persistence.load(runId);
+      if (persisted?.status !== "paused") return false;
+      const terminalAt = new Date().toISOString();
+      const stopped: PersistedRunState = {
+        ...persisted,
+        status: "aborted",
+        pauseReason: undefined,
+        resetHint: undefined,
+        updatedAt: terminalAt,
+        deliverySessionId: persisted.deliverySessionId,
+        terminalSnapshot: undefined,
+      };
+      stopped.terminalSnapshot = createTerminalSnapshot(stopped, { terminalAt, reason: "stopped" });
+      this.persistence.save(stopped);
+      if (managed) {
+        managed.controller.abort();
+        managed.status = "aborted";
+        managed.deliverySessionId = stopped.deliverySessionId;
+        managed.terminalAt = terminalAt;
+        managed.terminalSnapshot = stopped.terminalSnapshot;
+      }
+      this.emit("stopped", { runId });
+      return true;
+    } finally {
+      this.persistence.releaseRunLease(lease);
+    }
   }
 
   /**
@@ -667,12 +895,94 @@ export class WorkflowManager extends EventEmitter {
    */
   listRuns(): PersistedRunState[] {
     const all = this.persistence.list();
-    return this.sessionId ? all.filter((r) => r.sessionId === this.sessionId) : all;
+    return this.sessionId
+      ? all.filter(
+          (run) =>
+            (run.originSessionId ?? run.sessionId) === this.sessionId || run.deliverySessionId === this.sessionId,
+        )
+      : all;
   }
 
   /** All persisted runs regardless of session (used by cross-session recovery). */
   listAllRuns(): PersistedRunState[] {
     return this.persistence.list();
+  }
+
+  /** Canonical namespace owned by this manager. */
+  getCwd(): string {
+    return this.cwd;
+  }
+
+  /** Bounded cross-session status for assistant recovery in this cwd namespace. */
+  listRunMetadata(limit = 20): WorkflowRunMetadata[] {
+    const boundedLimit = Math.max(1, Math.min(50, Math.floor(limit)));
+    return this.listAllRuns()
+      .slice(0, boundedLimit)
+      .map((run) => this.toRunMetadata(run));
+  }
+
+  /** Redacted status for one run in this cwd namespace, regardless of origin session. */
+  getRunMetadata(runId: string): WorkflowRunMetadata | null {
+    const run = this.persistence.load(runId);
+    return run ? this.toRunMetadata(run) : null;
+  }
+
+  private toRunMetadata(run: PersistedRunState): WorkflowRunMetadata {
+    const live = this.runs.get(run.runId);
+    const agents = live?.snapshot.agents ?? run.agents;
+    const count = (status: PersistedRunState["agents"][number]["status"]) =>
+      agents.filter((agent) => agent.status === status).length;
+    const terminal = run.terminalSnapshot
+      ? {
+          version: 1 as const,
+          outcome: run.terminalSnapshot.outcome,
+          terminalAt: run.terminalSnapshot.terminalAt.slice(0, 64),
+          agents: {
+            total: run.terminalSnapshot.agents.total,
+            done: run.terminalSnapshot.agents.done,
+            error: run.terminalSnapshot.agents.error,
+            skipped: run.terminalSnapshot.agents.skipped,
+          },
+          journalEntries: run.terminalSnapshot.journalEntries,
+          hasResultEvidence: run.terminalSnapshot.resultEvidence !== undefined,
+          errorCode: run.terminalSnapshot.error?.code,
+          reason: run.terminalSnapshot.reason,
+        }
+      : undefined;
+    return {
+      runId: run.runId.slice(0, 256),
+      workflowName: run.workflowName.slice(0, 256),
+      status: live?.status ?? run.status,
+      cwd: this.cwd,
+      projectKey: workflowProjectKey(this.cwd),
+      startedAt: run.startedAt.slice(0, 64),
+      updatedAt: run.updatedAt.slice(0, 64),
+      completedAt: run.completedAt?.slice(0, 64),
+      durationMs: run.durationMs,
+      currentPhase: (live?.snapshot.currentPhase ?? run.currentPhase)?.slice(0, 256),
+      phases: (live?.snapshot.phases ?? run.phases).slice(0, 20).map((phase) => phase.slice(0, 256)),
+      pauseReason: run.pauseReason === "usage_limit" || run.pauseReason === "host_lost" ? run.pauseReason : undefined,
+      agents: {
+        total: agents.length,
+        queued: count("queued"),
+        running: count("running"),
+        done: count("done"),
+        error: count("error"),
+        skipped: count("skipped"),
+      },
+      journalEntries: run.journal?.length ?? 0,
+      tokenUsage: run.tokenUsage
+        ? {
+            input: run.tokenUsage.input,
+            output: run.tokenUsage.output,
+            total: run.tokenUsage.total,
+            ...(run.tokenUsage.cost === undefined ? {} : { cost: run.tokenUsage.cost }),
+            ...(run.tokenUsage.cacheRead === undefined ? {} : { cacheRead: run.tokenUsage.cacheRead }),
+            ...(run.tokenUsage.cacheWrite === undefined ? {} : { cacheWrite: run.tokenUsage.cacheWrite }),
+          }
+        : undefined,
+      terminal,
+    };
   }
 
   /**
@@ -697,5 +1007,94 @@ export class WorkflowManager extends EventEmitter {
    */
   getPersistence(): RunPersistence {
     return this.persistence;
+  }
+}
+
+function validDate(value: string | undefined): Date {
+  const parsed = value ? new Date(value) : new Date(0);
+  return Number.isNaN(parsed.getTime()) ? new Date(0) : parsed;
+}
+
+export interface WorkflowManagerRegistryOptions {
+  defaultCwd?: string;
+  defaultManager?: WorkflowManager;
+  createManager?: (canonicalCwd: string) => WorkflowManager;
+  /** Called exactly once for each canonical manager, including a seeded default. */
+  onCreate?: (manager: WorkflowManager, canonicalCwd: string) => void;
+}
+
+/** Extension-owned manager registry. One manager (and one event/delivery surface) per canonical cwd. */
+export class WorkflowManagerRegistry {
+  private readonly managers = new Map<string, WorkflowManager>();
+  private readonly defaultCwd?: string;
+  private readonly createManager: (canonicalCwd: string) => WorkflowManager;
+  private readonly onCreate?: (manager: WorkflowManager, canonicalCwd: string) => void;
+  private sessionId?: string;
+  private sessionConfigured = false;
+  private mainModel?: string;
+  private mainModelConfigured = false;
+  private modelRegistry?: ModelRegistry;
+
+  constructor(options: WorkflowManagerRegistryOptions = {}) {
+    this.defaultCwd = options.defaultCwd ? canonicalWorkflowCwd(options.defaultCwd) : undefined;
+    this.createManager = options.createManager ?? ((cwd) => new WorkflowManager({ cwd }));
+    this.onCreate = options.onCreate;
+    if (options.defaultManager) {
+      const cwd = this.defaultCwd ?? options.defaultManager.getCwd();
+      this.add(cwd, options.defaultManager);
+    }
+  }
+
+  get size(): number {
+    return this.managers.size;
+  }
+
+  get(cwd?: string): WorkflowManager {
+    const canonicalCwd = canonicalWorkflowCwd(cwd ?? this.defaultCwd ?? process.cwd());
+    const existing = this.managers.get(canonicalCwd);
+    if (existing) return existing;
+    return this.add(canonicalCwd, this.createManager(canonicalCwd));
+  }
+
+  forEach(callback: (manager: WorkflowManager, canonicalCwd: string) => void): void {
+    for (const [cwd, manager] of this.managers) callback(manager, cwd);
+  }
+
+  setSessionId(sessionId: string | undefined): void {
+    this.sessionConfigured = true;
+    this.sessionId = sessionId;
+    this.forEach((manager) => {
+      manager.setSessionId(sessionId);
+    });
+  }
+
+  setMainModel(model: string | undefined): void {
+    this.mainModelConfigured = true;
+    this.mainModel = model;
+    this.forEach((manager) => {
+      manager.setMainModel(model);
+    });
+  }
+
+  setModelRegistry(registry: ModelRegistry): void {
+    this.modelRegistry = registry;
+    this.forEach((manager) => {
+      manager.setModelRegistry(registry);
+    });
+  }
+
+  private add(cwd: string, manager: WorkflowManager): WorkflowManager {
+    const canonicalCwd = canonicalWorkflowCwd(cwd);
+    const existing = this.managers.get(canonicalCwd);
+    if (existing) return existing;
+    if (manager.getCwd() !== canonicalCwd) {
+      throw new Error(`Workflow manager cwd mismatch: expected ${canonicalCwd}, received ${manager.getCwd()}`);
+    }
+    if (this.sessionConfigured) manager.setSessionId(this.sessionId);
+    if (this.mainModelConfigured) manager.setMainModel(this.mainModel);
+    if (this.modelRegistry) manager.setModelRegistry(this.modelRegistry);
+    this.managers.set(canonicalCwd, manager);
+    this.onCreate?.(manager, canonicalCwd);
+    return manager;
   }
 }

--- a/src/workflow-paths.ts
+++ b/src/workflow-paths.ts
@@ -7,6 +7,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import { WORKFLOW_RUNS_DIR, WORKFLOW_SAVED_DIR } from "./config.js";
@@ -32,15 +33,38 @@ export function workflowUserSavedDir(): string {
   return join(workflowHomeDir(), "saved");
 }
 
+export function canonicalWorkflowCwd(cwd: string): string {
+  const requested = resolve(cwd);
+  let canonical: string;
+  try {
+    canonical = realpathSync(requested);
+  } catch {
+    throw new Error(`Workflow cwd does not exist or is not accessible: ${requested}`);
+  }
+  if (!statSync(canonical).isDirectory()) {
+    throw new Error(`Workflow cwd is not a directory: ${canonical}`);
+  }
+  return canonical;
+}
+
+function workflowNamespacePath(cwd: string): string {
+  const requested = resolve(cwd);
+  // Keep the long-standing path-helper behavior for settings/saved-workflow
+  // callers that compute a future project path. Execution and run persistence
+  // call canonicalWorkflowCwd first and therefore still fail closed.
+  return existsSync(requested) ? canonicalWorkflowCwd(requested) : requested;
+}
+
 export function workflowProjectKey(cwd: string): string {
-  const projectPath = resolve(cwd);
+  const projectPath = workflowNamespacePath(cwd);
   const slug = sanitizePathSegment(basename(projectPath) || "project");
   const hash = createHash("sha256").update(projectPath).digest("hex").slice(0, 12);
   return `${slug}-${hash}`;
 }
 
 export function workflowProjectPaths(cwd: string): WorkflowProjectPaths {
-  const key = workflowProjectKey(cwd);
+  const projectPath = workflowNamespacePath(cwd);
+  const key = workflowProjectKey(projectPath);
   const rootDir = join(workflowHomeDir(), WORKFLOW_PROJECTS_SUBDIR, key);
   return {
     key,
@@ -48,8 +72,8 @@ export function workflowProjectPaths(cwd: string): WorkflowProjectPaths {
     runsDir: join(rootDir, "runs"),
     savedDir: join(rootDir, "saved"),
     settingsPath: join(rootDir, "settings.json"),
-    legacyRunsDir: resolve(cwd, WORKFLOW_RUNS_DIR),
-    legacySavedDir: resolve(cwd, WORKFLOW_SAVED_DIR),
+    legacyRunsDir: resolve(projectPath, WORKFLOW_RUNS_DIR),
+    legacySavedDir: resolve(projectPath, WORKFLOW_SAVED_DIR),
   };
 }
 

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -14,8 +14,10 @@ import {
   type WorkflowSnapshot,
 } from "./display.js";
 import { WorkflowError, WorkflowErrorCode } from "./errors.js";
+import { isSafeRunId } from "./run-persistence.js";
 import { parseWorkflowScript, type WorkflowRunResult } from "./workflow.js";
-import { WorkflowManager } from "./workflow-manager.js";
+import { WorkflowManager, WorkflowManagerRegistry } from "./workflow-manager.js";
+import { canonicalWorkflowCwd } from "./workflow-paths.js";
 import { createWorkflowStorage, type WorkflowStorage } from "./workflow-saved.js";
 import { loadWorkflowSettings } from "./workflow-settings.js";
 
@@ -58,14 +60,28 @@ export function agentTypeGuideline(cwd: string = process.cwd()): string | undefi
 }
 
 const workflowToolSchema = Type.Object({
-  script: Type.String({
-    description: [
-      "Required raw JavaScript workflow script, with no Markdown fences.",
-      "First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }",
-      "Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, and budget. The workflow must call agent() at least once.",
-      "parallel() requires functions, not promises: await parallel(items.map(item => () => agent(...))).",
-    ].join(" "),
-  }),
+  action: Type.Optional(
+    Type.Union([Type.Literal("run"), Type.Literal("status"), Type.Literal("resume"), Type.Literal("stop")], {
+      description: "Control action. Omit for the backward-compatible legacy run behavior.",
+    }),
+  ),
+  cwd: Type.Optional(
+    Type.String({
+      description:
+        "Existing host-accessible directory used for execution and the persistence namespace. Canonicalized with realpath.",
+    }),
+  ),
+  runId: Type.Optional(Type.String({ description: "Run ID for status, resume, or stop. Forbidden for run actions." })),
+  script: Type.Optional(
+    Type.String({
+      description: [
+        "Required for run actions: raw JavaScript workflow script, with no Markdown fences.",
+        "First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }",
+        "Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, and budget. The workflow must call agent() at least once.",
+        "parallel() requires functions, not promises: await parallel(items.map(item => () => agent(...))).",
+      ].join(" "),
+    }),
+  ),
   args: Type.Optional(
     Type.Any({ description: "Optional JSON value exposed to the workflow script as global `args`." }),
   ),
@@ -115,8 +131,13 @@ const workflowToolSchema = Type.Object({
   ),
 });
 
+export type WorkflowToolAction = "run" | "status" | "resume" | "stop";
+
 export type WorkflowToolInput = {
-  script: string;
+  action?: WorkflowToolAction;
+  cwd?: string;
+  runId?: string;
+  script?: string;
   args?: unknown;
   background?: boolean;
   maxAgents?: number;
@@ -130,8 +151,10 @@ export type WorkflowToolInput = {
 export interface WorkflowToolOptions {
   cwd?: string;
   concurrency?: number;
-  /** Shared manager so background runs are reachable from the `/workflows` command. */
+  /** Shared manager so default-cwd background runs are reachable from the `/workflows` command. */
   manager?: WorkflowManager;
+  /** Canonical-cwd manager registry used by extension hosts for multi-project control actions. */
+  managerRegistry?: WorkflowManagerRegistry;
   /** Shared saved-workflow storage. */
   storage?: WorkflowStorage;
   /** Default per-agent timeout for runs created by this tool. null means no hard timeout. */
@@ -143,28 +166,38 @@ export interface WorkflowToolOptions {
 }
 
 export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefinition<typeof workflowToolSchema, any> {
-  const storage = options.storage ?? createWorkflowStorage(options.cwd ?? process.cwd());
-  const cwd = options.cwd ?? process.cwd();
-  const defaults = resolveWorkflowToolDefaults(options, cwd);
-  const manager =
-    options.manager ??
-    new WorkflowManager({
-      cwd: options.cwd,
+  const cwd = canonicalWorkflowCwd(options.cwd ?? process.cwd());
+  const storage = options.storage ?? createWorkflowStorage(cwd);
+  const createManager = (managerCwd: string) => {
+    const managerStorage = managerCwd === cwd ? storage : createWorkflowStorage(managerCwd);
+    const defaults = resolveWorkflowToolDefaults(options, managerCwd);
+    return new WorkflowManager({
+      cwd: managerCwd,
       concurrency: defaults.concurrency,
-      loadSavedWorkflow: (name: string) => storage.load(name)?.script,
+      loadSavedWorkflow: (name: string) => managerStorage.load(name)?.script,
       defaultAgentTimeoutMs: defaults.agentTimeoutMs,
       defaultAgentRetries: defaults.agentRetries,
     });
+  };
+  const managerRegistry =
+    options.managerRegistry ??
+    new WorkflowManagerRegistry({
+      defaultCwd: cwd,
+      defaultManager: options.manager,
+      createManager,
+    });
+  // Ensure the default-cwd manager exists even before the first tool call.
+  managerRegistry.get(cwd);
 
   return defineTool({
     name: "workflow",
     label: "Workflow",
     description: [
-      "Execute a deterministic JavaScript workflow that orchestrates multiple subagents with agent(), parallel(), and pipeline().",
-      "script is required raw JavaScript. It must start with export const meta = { name, description, phases? } and must call agent() at least once.",
+      "Run or control deterministic JavaScript workflows that orchestrate multiple subagents.",
+      "Omit action (or use action='run') with a script to start a run; use status, resume, or stop with the documented control fields.",
     ].join(" "),
     promptSnippet:
-      "Run a deterministic JavaScript workflow. Required script header: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }.",
+      "Run or control a deterministic JavaScript workflow. Run scripts require: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }.",
     // Lazy accessor: the SDK re-reads definition.promptGuidelines on every
     // tool-registry refresh, so changes to the agentType registry are reflected.
     get promptGuidelines() {
@@ -200,7 +233,57 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       return normalizeWorkflowToolArgs(args);
     },
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
-      const script = normalizeWorkflowScript(params.script);
+      const action = params.action ?? "run";
+      const selectedCwd = canonicalWorkflowCwd(params.cwd ?? cwd);
+      const manager = managerRegistry.get(selectedCwd);
+
+      if (action === "status") {
+        if (params.runId) {
+          const run = manager.getRunMetadata(params.runId);
+          if (!run) throw new Error(`No workflow run "${params.runId}" in cwd namespace ${selectedCwd}`);
+          return {
+            content: [{ type: "text", text: JSON.stringify(run, null, 2) }],
+            details: { action, cwd: selectedCwd, run },
+          };
+        }
+        const runs = manager.listRunMetadata();
+        return {
+          content: [{ type: "text", text: JSON.stringify(runs, null, 2) }],
+          details: { action, cwd: selectedCwd, runs },
+        };
+      }
+
+      if (action === "resume") {
+        const resumed = await manager.resume(params.runId as string);
+        return {
+          content: [
+            {
+              type: "text",
+              text: resumed
+                ? `Workflow ${params.runId} resumed in ${selectedCwd}.`
+                : `Workflow ${params.runId} could not be resumed in ${selectedCwd}.`,
+            },
+          ],
+          details: { action, cwd: selectedCwd, runId: params.runId, resumed },
+        };
+      }
+
+      if (action === "stop") {
+        const stopped = manager.stop(params.runId as string);
+        return {
+          content: [
+            {
+              type: "text",
+              text: stopped
+                ? `Workflow ${params.runId} stopped in ${selectedCwd}.`
+                : `Workflow ${params.runId} could not be stopped in ${selectedCwd}.`,
+            },
+          ],
+          details: { action, cwd: selectedCwd, runId: params.runId, stopped },
+        };
+      }
+
+      const script = normalizeWorkflowScript(params.script as string);
       const parsed = parseWorkflowScript(script);
 
       // Iteration / cached-prefix reuse: resume a prior run with THIS (edited)
@@ -245,7 +328,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
         });
         return {
           content: [{ type: "text", text: backgroundStartedText(parsed.meta.name, runId) }],
-          details: { runId, background: true },
+          details: { action: "run", cwd: selectedCwd, runId, background: true },
         };
       }
 
@@ -326,6 +409,8 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
           result: result.result,
           durationMs: result.durationMs,
           tokenUsage: result.tokenUsage,
+          action: "run",
+          cwd: selectedCwd,
           runId: result.runId,
         },
       };
@@ -441,11 +526,85 @@ export function resumeFailureText(manager: WorkflowManager, runId: string): stri
   return `Cannot resume workflow run "${runId}": it is not currently resumable (it may be busy under another process). Try again shortly, or start a new run.`;
 }
 
+const WORKFLOW_TOOL_FIELDS = new Set([
+  "action",
+  "cwd",
+  "runId",
+  "script",
+  "args",
+  "background",
+  "maxAgents",
+  "concurrency",
+  "agentRetries",
+  "agentTimeoutMs",
+  "tokenBudget",
+  "resumeFromRunId",
+]);
+const RUN_ONLY_FIELDS = [
+  "script",
+  "args",
+  "background",
+  "maxAgents",
+  "concurrency",
+  "agentRetries",
+  "agentTimeoutMs",
+  "tokenBudget",
+  "resumeFromRunId",
+] as const;
+
 function normalizeWorkflowToolArgs(args: unknown): WorkflowToolInput {
-  if (!args || typeof args !== "object") throw new Error("workflow requires an object argument with a script string");
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    throw new Error("workflow requires an object argument");
+  }
   const value = args as Record<string, unknown>;
-  if (typeof value.script !== "string") throw new Error("workflow requires `script` to be a string");
-  return { ...value, script: normalizeWorkflowScript(value.script) } as WorkflowToolInput;
+  const unknown = Object.keys(value).find((field) => !WORKFLOW_TOOL_FIELDS.has(field));
+  if (unknown) throw new Error(`workflow received unknown field \`${unknown}\``);
+
+  const rawAction = value.action;
+  if (
+    rawAction !== undefined &&
+    rawAction !== "run" &&
+    rawAction !== "status" &&
+    rawAction !== "resume" &&
+    rawAction !== "stop"
+  ) {
+    throw new Error("workflow `action` must be run, status, resume, or stop");
+  }
+  const action = (rawAction ?? "run") as WorkflowToolAction;
+  if (value.cwd !== undefined && typeof value.cwd !== "string") {
+    throw new Error("workflow `cwd` must be a string");
+  }
+  if (value.runId !== undefined && (typeof value.runId !== "string" || !isSafeRunId(value.runId.trim()))) {
+    throw new Error("workflow `runId` must be a non-empty path-safe identifier");
+  }
+  if (
+    value.resumeFromRunId !== undefined &&
+    (typeof value.resumeFromRunId !== "string" || !isSafeRunId(value.resumeFromRunId.trim()))
+  ) {
+    throw new Error("workflow `resumeFromRunId` must be a non-empty path-safe identifier");
+  }
+
+  if (action === "run") {
+    if (typeof value.script !== "string") {
+      throw new Error("workflow run: `script` is required and must be a string");
+    }
+    if (Object.hasOwn(value, "runId")) throw new Error("workflow run does not accept `runId`");
+  } else {
+    const forbidden = RUN_ONLY_FIELDS.find((field) => Object.hasOwn(value, field));
+    if (forbidden) throw new Error(`workflow ${action} does not accept \`${forbidden}\``);
+    if ((action === "resume" || action === "stop") && value.runId === undefined) {
+      throw new Error(`workflow ${action} requires \`runId\``);
+    }
+  }
+
+  return {
+    ...value,
+    ...(value.action === undefined ? {} : { action }),
+    ...(typeof value.cwd === "string" ? { cwd: canonicalWorkflowCwd(value.cwd) } : {}),
+    ...(typeof value.runId === "string" ? { runId: value.runId.trim() } : {}),
+    ...(typeof value.resumeFromRunId === "string" ? { resumeFromRunId: value.resumeFromRunId.trim() } : {}),
+    ...(typeof value.script === "string" ? { script: normalizeWorkflowScript(value.script) } : {}),
+  } as WorkflowToolInput;
 }
 
 function normalizeWorkflowScript(script: string): string {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -78,6 +78,10 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   /** Retry attempts after a recoverable agent failure. Default 0. */
   agentRetries?: number;
   tokenBudget?: number | null;
+  /** Persisted cumulative usage from earlier generations of this run. */
+  initialTokenUsage?: Partial<SharedRuntime["tokenUsage"]>;
+  /** Persisted cumulative budget spend; defaults to initialTokenUsage.total. */
+  initialTokenSpend?: number;
   signal?: AbortSignal;
   /** Maximum number of agents allowed in this run. Default: 1000 */
   maxAgents?: number;
@@ -301,11 +305,19 @@ export async function runWorkflow<T = unknown>(
     options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2),
   );
   // Global caps + budget are shared with any nested workflow() so they hold across nesting.
+  const initialUsage = options.initialTokenUsage;
   const shared: SharedRuntime = options.sharedRuntime ?? {
     limiter: createLimiter(concurrency),
     agentCount: 0,
-    spent: 0,
-    tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
+    spent: options.initialTokenSpend ?? initialUsage?.total ?? 0,
+    tokenUsage: {
+      input: initialUsage?.input ?? 0,
+      output: initialUsage?.output ?? 0,
+      total: initialUsage?.total ?? 0,
+      cost: initialUsage?.cost ?? 0,
+      cacheRead: initialUsage?.cacheRead ?? 0,
+      cacheWrite: initialUsage?.cacheWrite ?? 0,
+    },
     depth: 0,
   };
   const limiter = shared.limiter;
@@ -356,36 +368,7 @@ export async function runWorkflow<T = unknown>(
       );
     }
 
-    if (budget.total !== null && budget.remaining() <= 0) {
-      throw new WorkflowError("workflow token budget exhausted", WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED, {
-        recoverable: false,
-      });
-    }
-
     const assignedPhase = agentOptions.phase ?? state.currentPhase;
-
-    // Per-phase soft sub-budget gate: a noisy phase can exhaust its own ceiling
-    // without touching the run's overall budget. Soft (spent accrues post-agent),
-    // warns once at ~80%, throws at 100%. Scripts can try/catch around a phase's
-    // work so later phases still proceed.
-    if (assignedPhase) {
-      const pb = state.phaseBudgets.get(assignedPhase);
-      if (pb) {
-        const phaseSpent = shared.spent - pb.startSpent;
-        if (phaseSpent >= pb.budget) {
-          throw new WorkflowError(
-            `phase "${assignedPhase}" token sub-budget exhausted (${pb.budget})`,
-            WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED,
-            { recoverable: false },
-          );
-        }
-        if (!pb.warned && phaseSpent >= pb.budget * 0.8) {
-          pb.warned = true;
-          log(`phase "${assignedPhase}" at ${Math.round((phaseSpent / pb.budget) * 100)}% of its token sub-budget`);
-        }
-      }
-    }
-
     const requestedLabel = agentOptions.label?.trim();
 
     // Resolve a named agentType to its bound definition (tools/model/prompt).
@@ -448,6 +431,36 @@ export async function runWorkflow<T = unknown>(
     // A genuine miss (no journal entry, or the hash changed) marks where the
     // unchanged prefix ends; this call and every later one then run live.
     if (!hashMatches || cachedEmptyOutput) state.firstMiss = Math.min(state.firstMiss, callIndex);
+
+    // Replay is free and must happen before budget gates: a fully cached run can
+    // finish at zero remaining budget, while the first genuinely fresh call is blocked.
+    if (budget.total !== null && budget.remaining() <= 0) {
+      throw new WorkflowError("workflow token budget exhausted", WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED, {
+        recoverable: false,
+      });
+    }
+
+    // Per-phase soft sub-budget gate: a noisy phase can exhaust its own ceiling
+    // without touching the run's overall budget. Soft (spent accrues post-agent),
+    // warns once at ~80%, throws at 100%. Scripts can try/catch around a phase's
+    // work so later phases still proceed.
+    if (assignedPhase) {
+      const pb = state.phaseBudgets.get(assignedPhase);
+      if (pb) {
+        const phaseSpent = shared.spent - pb.startSpent;
+        if (phaseSpent >= pb.budget) {
+          throw new WorkflowError(
+            `phase "${assignedPhase}" token sub-budget exhausted (${pb.budget})`,
+            WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED,
+            { recoverable: false },
+          );
+        }
+        if (!pb.warned && phaseSpent >= pb.budget * 0.8) {
+          pb.warned = true;
+          log(`phase "${assignedPhase}" at ${Math.round((phaseSpent / pb.budget) * 100)}% of its token sub-budget`);
+        }
+      }
+    }
 
     return limiter(async () => {
       const timeout = agentOptions.timeoutMs !== undefined ? agentOptions.timeoutMs : agentTimeoutMs;
@@ -557,13 +570,26 @@ export async function runWorkflow<T = unknown>(
             });
             return result;
           } catch (error) {
-            if (options.signal?.aborted) throw error;
+            if (options.signal?.aborted) {
+              // Providers can report usage before the agent promise settles. A
+              // deliberate pause/abort must checkpoint that spend without
+              // fabricating an agent failure event, or resume can spend it again.
+              if (usage) {
+                recordTokens(null);
+                options.onTokenUsage?.(shared.tokenUsage);
+              }
+              throw error;
+            }
 
             const workflowError = wrapError(error, { agentLabel: label });
             logger.error(`agent ${label} attempt ${attempt}/${maxAttempts} failed: ${workflowError.message}`);
             const tokens = recordTokens(null);
 
             if (workflowError.recoverable && attempt < maxAttempts) {
+              // This attempt consumed provider tokens even though it will retry.
+              // Checkpoint cumulative spend now; otherwise a later pause/resume
+              // can incorrectly reclaim the failed attempt's budget.
+              options.onTokenUsage?.(shared.tokenUsage);
               log(
                 `agent "${label}" attempt ${attempt}/${maxAttempts} failed: ${workflowError.code} ${workflowError.message}; retrying`,
               );

--- a/tests/run-persistence.test.ts
+++ b/tests/run-persistence.test.ts
@@ -1,5 +1,14 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -748,6 +757,217 @@ test(
 
     assert.equal(rp.load("legacy-live")?.status, "running");
     assert.equal(existsSync(join(workflowProjectPaths(cwd).runsDir, "legacy-live.json")), false);
+  }),
+);
+
+test(
+  "terminal snapshots remain idempotent across repeated saves",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    const state: PersistedRunState = {
+      runId: "terminal-idempotent",
+      workflowName: "terminal",
+      script: "export const meta = { name: 'terminal', description: 'terminal' }",
+      status: "completed",
+      phases: [],
+      agents: [],
+      logs: [],
+      result: { ok: true },
+      startedAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-02T00:00:00.000Z",
+    };
+
+    rp.save(state);
+    const first = rp.load(state.runId)?.terminalSnapshot;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    rp.save(state);
+    assert.deepEqual(rp.load(state.runId)?.terminalSnapshot, first);
+  }),
+);
+
+test(
+  "legacy run JSON receives deterministic cwd, provenance, execution-option, and terminal fallbacks",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    const runsDir = workflowProjectPaths(cwd).runsDir;
+    mkdirSync(runsDir, { recursive: true });
+    writeFileSync(
+      join(runsDir, "legacy-defaults.json"),
+      JSON.stringify({
+        runId: "legacy-defaults",
+        workflowName: "legacy",
+        script: "export const meta = { name: 'legacy', description: 'legacy' }",
+        sessionId: "legacy-session",
+        status: "completed",
+        phases: [],
+        agents: [],
+        logs: [],
+        result: { ok: true },
+        startedAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-02T00:00:00.000Z",
+      }),
+      "utf-8",
+    );
+
+    const loaded = rp.load("legacy-defaults");
+    assert.equal(loaded?.cwd, cwd);
+    assert.equal(loaded?.projectKey, workflowProjectPaths(cwd).key);
+    assert.equal(loaded?.originSessionId, "legacy-session");
+    assert.equal(loaded?.deliverySessionId, "legacy-session");
+    assert.deepEqual(loaded?.executionOptions, {
+      maxAgents: 1000,
+      concurrency: 8,
+      agentRetries: 0,
+      agentTimeoutMs: null,
+      tokenBudget: null,
+    });
+    assert.equal(loaded?.terminalSnapshot?.outcome, "completed");
+    assert.equal(loaded?.terminalSnapshot?.terminalAt, "2024-01-02T00:00:00.000Z");
+  }),
+);
+
+test(
+  "stale-lock takeover cannot unlink a concurrently replaced live lease",
+  withTempCwd(async (cwd) => {
+    const runsDir = workflowProjectPaths(cwd).runsDir;
+    mkdirSync(runsDir, { recursive: true });
+    const lock = join(runsDir, "takeover-race.lock");
+    writeFileSync(
+      lock,
+      JSON.stringify({
+        runId: "takeover-race",
+        runPath: join(runsDir, "takeover-race.json"),
+        pid: 2147483647,
+        startedAt: "2024-01-01T00:00:00.000Z",
+        token: "stale-token",
+      }),
+    );
+
+    let raced = false;
+    const liveToken = "live-contender";
+    const rp = createRunPersistence(cwd, {
+      renameSync(source, destination) {
+        if (!raced && source === lock) {
+          raced = true;
+          renameSync(source, destination);
+          writeFileSync(
+            lock,
+            JSON.stringify({
+              runId: "takeover-race",
+              runPath: join(runsDir, "takeover-race.json"),
+              pid: process.pid,
+              startedAt: "2026-01-01T00:00:00.000Z",
+              token: liveToken,
+            }),
+          );
+          const error = new Error("destination already claimed") as NodeJS.ErrnoException;
+          error.code = "EEXIST";
+          throw error;
+        }
+        renameSync(source, destination);
+      },
+      unlinkSync(path) {
+        if (path === lock) {
+          // Model the old read-stale/unlink race: a live contender replaces the
+          // stale file after it was inspected but before the unlink occurs.
+          writeFileSync(
+            lock,
+            JSON.stringify({
+              runId: "takeover-race",
+              runPath: join(runsDir, "takeover-race.json"),
+              pid: process.pid,
+              startedAt: "2026-01-01T00:00:00.000Z",
+              token: liveToken,
+            }),
+          );
+        }
+        unlinkSync(path);
+      },
+    });
+
+    assert.equal(rp.acquireRunLease("takeover-race"), null, "the live replacement remains the owner");
+    const owner = JSON.parse(readFileSync(lock, "utf-8")) as { token: string };
+    assert.equal(owner.token, liveToken);
+  }),
+);
+
+test(
+  "versioned decoder deeply projects known fields and rejects malformed nested state",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    const runsDir = workflowProjectPaths(cwd).runsDir;
+    mkdirSync(runsDir, { recursive: true });
+    const base = {
+      version: 2,
+      runId: "decoded",
+      workflowName: "decoded",
+      script: "export const meta = { name: 'decoded', description: 'decoded' }",
+      status: "completed",
+      phases: ["phase"],
+      currentPhase: "phase",
+      agents: [
+        {
+          id: 1,
+          label: "agent",
+          prompt: "prompt",
+          status: "done",
+          tokenUsage: { input: 1, output: 2, total: 3, cost: 4, cacheRead: 5, cacheWrite: 6, secret: "DROP" },
+          history: [{ role: "assistant", kind: "text", text: "safe", secret: "DROP" }],
+          secret: "DROP",
+        },
+      ],
+      logs: ["safe"],
+      journal: [{ index: 0, hash: "hash", result: { kept: true }, secret: "DROP" }],
+      tokenUsage: { input: 1, output: 2, total: 3, secret: "DROP" },
+      startedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      executionOptions: { maxAgents: 10, concurrency: 2, agentRetries: 1, agentTimeoutMs: null, tokenBudget: 100 },
+      terminalSnapshot: {
+        version: 1,
+        outcome: "completed",
+        terminalAt: "2026-01-01T00:00:00.000Z",
+        runId: "decoded",
+        workflowName: "decoded",
+        agents: { total: 1, done: 1, error: 0, skipped: 0, secret: `DROP${"x".repeat(100_000)}` },
+        journalEntries: 1,
+        error: { message: "safe", secret: "DROP" },
+        secret: "DROP",
+      },
+      TOP_SECRET_EXTRA: "must not survive projection",
+    };
+    writeFileSync(join(runsDir, "decoded.json"), JSON.stringify(base));
+    writeFileSync(join(runsDir, "mismatch.json"), JSON.stringify({ ...base, runId: "different" }));
+    writeFileSync(join(runsDir, "future.json"), JSON.stringify({ ...base, version: 999, runId: "future" }));
+    const malformed = [
+      { agents: ["bad"] },
+      { agents: [{ ...base.agents[0], history: ["bad"] }] },
+      { logs: ["safe", { secret: "bad" }] },
+      { phases: ["safe", ["bad"]] },
+      { journal: [{ index: "0", hash: "hash", result: null }] },
+      { tokenUsage: { input: 1, output: -1, total: 0 } },
+      { executionOptions: { ...base.executionOptions, tokenBudget: -1 } },
+      { executionOptions: { ...base.executionOptions, tokenBudget: "100" } },
+      { executionOptions: { ...base.executionOptions, concurrency: 99 } },
+    ];
+    malformed.forEach((patch, index) => {
+      const runId = `malformed-${index}`;
+      writeFileSync(
+        join(runsDir, `${runId}.json`),
+        JSON.stringify({ ...base, ...patch, runId, terminalSnapshot: undefined }),
+      );
+      assert.equal(rp.load(runId), null);
+    });
+
+    const decoded = rp.load("decoded") as (PersistedRunState & { TOP_SECRET_EXTRA?: string }) | null;
+    assert.equal(decoded?.TOP_SECRET_EXTRA, undefined);
+    assert.equal(JSON.stringify(decoded).includes("DROP"), false);
+    assert.deepEqual(decoded?.executionOptions, base.executionOptions);
+    assert.equal(rp.load("mismatch"), null);
+    assert.equal(rp.load("future"), null);
+    assert.deepEqual(
+      rp.list().map((run) => run.runId),
+      ["decoded"],
+    );
   }),
 );
 

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -417,6 +417,45 @@ describe("installResultDelivery", () => {
     assert.equal(calls1.length, 0, "pi1 should not be used after refresh");
     assert.equal(calls2.length, 1, "pi2 should receive the delivery");
   });
+
+  it("queues pause, completion, and failure delivery until the exact target session becomes active", () => {
+    const pi = createMockPi();
+    let activeSessionId = "session-2";
+    const run = makeRun({ deliverySessionId: "session-1" });
+    const manager = createMockManager(run);
+    const options = { getActiveSessionId: () => activeSessionId };
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager, options);
+    manager.emit("paused", { runId: "test-run-1", reason: "usage_limit", error: { message: "usage limit" } });
+    manager.emit("complete", { runId: "test-run-1" });
+    manager.emit("error", { runId: "test-run-1", error: { message: "failure" } });
+    assert.equal(pi._calls.length, 0, "another active session must not receive any run delivery");
+
+    activeSessionId = "session-1";
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager, options);
+    assert.equal(pi._calls.length, 3, "the target session receives every queued lifecycle message on activation");
+    assert.ok(pi._calls[0].content.includes("paused"));
+    assert.ok(pi._calls[1].content.includes("Background workflow"));
+    assert.ok(pi._calls[2].content.includes("failed"));
+
+    activeSessionId = "session-2";
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager, options);
+    assert.equal(pi._calls.length, 3, "delivery is flushed exactly once and never leaks back into session 2");
+  });
+
+  it("does not deliver an error event for intentionally paused or stopped runs", () => {
+    const pi = createMockPi();
+    const paused = makeRun({ status: "paused" });
+    const manager = createMockManager(paused);
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+
+    manager.emit("error", { runId: "test-run-1", error: { message: "workflow aborted" } });
+    assert.equal(pi._calls.length, 0);
+
+    Object.assign(paused, { status: "aborted" });
+    manager.emit("error", { runId: "test-run-1", error: { message: "workflow aborted" } });
+    assert.equal(pi._calls.length, 0);
+  });
 });
 
 // ─── installTaskPanel ─────────────────────────────────────────────────────────

--- a/tests/usage-limit-scheduler.test.ts
+++ b/tests/usage-limit-scheduler.test.ts
@@ -8,6 +8,7 @@ import {
   type SchedulableWorkflowManager,
   UsageLimitScheduler,
 } from "../src/usage-limit-scheduler.js";
+import type { AutomaticResumeOptions } from "../src/workflow-manager.js";
 
 // ---- test doubles -----------------------------------------------------------
 
@@ -77,14 +78,14 @@ class FakePersistence {
 
 class FakeManager extends EventEmitter implements SchedulableWorkflowManager {
   readonly persistence = new FakePersistence();
-  resumeImpl: (runId: string) => Promise<boolean> = async () => false;
+  resumeImpl: (runId: string, options: AutomaticResumeOptions) => Promise<boolean> = async () => false;
 
   listAllRuns(): PersistedRunState[] {
     return this.persistence.list();
   }
 
-  resume(runId: string): Promise<boolean> {
-    return this.resumeImpl(runId);
+  resume(runId: string, options: AutomaticResumeOptions): Promise<boolean> {
+    return this.resumeImpl(runId, options);
   }
 
   getPersistence(): RunPersistence {
@@ -178,9 +179,9 @@ test("live pause: arms a timer that calls manager.resume() on fire", async () =>
   const manager = new FakeManager();
   manager.persistence.seed(makeRun({ resetHint: "resets in 10m" }));
   const clock = createFakeClock();
-  const resumedRunIds: string[] = [];
-  manager.resumeImpl = async (runId) => {
-    resumedRunIds.push(runId);
+  const resumeCalls: Array<{ runId: string; options: AutomaticResumeOptions }> = [];
+  manager.resumeImpl = async (runId, options) => {
+    resumeCalls.push({ runId, options });
     return true;
   };
 
@@ -198,7 +199,11 @@ test("live pause: arms a timer that calls manager.resume() on fire", async () =>
   clock.fireAll();
   await flush();
 
-  assert.deepEqual(resumedRunIds, ["run-1"], "resume() was called when the timer fired");
+  assert.deepEqual(
+    resumeCalls,
+    [{ runId: "run-1", options: { intent: "automatic" } }],
+    "scheduler marks resume intent as automatic",
+  );
   scheduler.dispose();
 });
 

--- a/tests/workflow-control-runtime.test.ts
+++ b/tests/workflow-control-runtime.test.ts
@@ -1,0 +1,612 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { AgentUsage } from "../src/agent.js";
+import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
+import { createRunPersistence, type PersistedRunState } from "../src/run-persistence.js";
+import { WorkflowManager, WorkflowManagerRegistry } from "../src/workflow-manager.js";
+import { workflowProjectKey } from "../src/workflow-paths.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+const script = `export const meta = { name: 'control_runtime', description: 'runtime controls' }
+const value = await agent('work', { label: 'worker' })
+return { value, cwd, processCwd: process.cwd() }`;
+
+function fakeAgent(result: unknown = "ok") {
+  return {
+    async run() {
+      return result;
+    },
+  };
+}
+
+function deferredAgent() {
+  let resolve!: (value: unknown) => void;
+  const promise = new Promise<unknown>((done) => {
+    resolve = done;
+  });
+  return {
+    resolve,
+    runner: {
+      async run() {
+        return promise;
+      },
+    },
+  };
+}
+
+function withTempProjects(fn: (first: string, second: string) => Promise<void>) {
+  return async () => {
+    const first = mkdtempSync(join(tmpdir(), "pi-dw-controls-a-"));
+    const second = mkdtempSync(join(tmpdir(), "pi-dw-controls-b-"));
+    const home = mkdtempSync(join(tmpdir(), "pi-dw-controls-home-"));
+    try {
+      await withFakeHomeAsync(home, () => fn(first, second));
+    } finally {
+      rmSync(first, { recursive: true, force: true });
+      rmSync(second, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+    }
+  };
+}
+
+function persisted(runId: string, status: PersistedRunState["status"] = "paused"): PersistedRunState {
+  return {
+    runId,
+    workflowName: "control_runtime",
+    script,
+    status,
+    phases: ["Work"],
+    agents: [],
+    logs: [],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+test(
+  "WorkflowManagerRegistry keys managers by canonical cwd and initializes each manager once",
+  withTempProjects(async (cwd) => {
+    const link = `${cwd}-link`;
+    symlinkSync(cwd, link, "dir");
+    const created: string[] = [];
+    const initialized: string[] = [];
+    const registry = new WorkflowManagerRegistry({
+      createManager(canonicalCwd) {
+        created.push(canonicalCwd);
+        return new WorkflowManager({ cwd: canonicalCwd, agent: fakeAgent() });
+      },
+      onCreate(_manager, canonicalCwd) {
+        initialized.push(canonicalCwd);
+      },
+    });
+
+    try {
+      const direct = registry.get(cwd);
+      const throughLink = registry.get(link);
+      assert.equal(direct, throughLink);
+      assert.deepEqual(created, [cwd]);
+      assert.deepEqual(initialized, [cwd], "delivery/listener initialization runs once per canonical manager");
+      assert.equal(registry.size, 1);
+    } finally {
+      rmSync(link, { force: true });
+    }
+  }),
+);
+
+test(
+  "manager uses canonical cwd without changing the host process cwd",
+  withTempProjects(async (cwd) => {
+    const hostCwd = process.cwd();
+    const manager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    const result = await manager.runSync(script);
+
+    assert.equal(process.cwd(), hostCwd);
+    const output = result.result as { value: string; cwd: string; processCwd: string };
+    assert.equal(output.value, "ok");
+    assert.equal(output.cwd, cwd);
+    assert.equal(output.processCwd, cwd);
+  }),
+);
+
+test(
+  "new runs persist canonical project identity, exact effective options, provenance, and terminal evidence",
+  withTempProjects(async (cwd) => {
+    const manager = new WorkflowManager({
+      cwd,
+      sessionId: "origin-session",
+      concurrency: 7,
+      defaultAgentRetries: 2,
+      defaultAgentTimeoutMs: 1234,
+      agent: fakeAgent({ report: "x".repeat(10_000) }),
+    });
+
+    const { runId, promise } = manager.startInBackground(
+      script,
+      { secret: "persisted-for-resume" },
+      {
+        maxAgents: 9,
+        concurrency: 3,
+        agentRetries: 1,
+        agentTimeoutMs: 99,
+        tokenBudget: 12345,
+      },
+    );
+    await promise;
+
+    const state = manager.getPersistence().load(runId);
+    assert.equal(state?.cwd, cwd);
+    assert.equal(state?.projectKey, workflowProjectKey(cwd));
+    assert.deepEqual(state?.executionOptions, {
+      maxAgents: 9,
+      concurrency: 3,
+      agentRetries: 1,
+      agentTimeoutMs: 99,
+      tokenBudget: 12345,
+    });
+    assert.equal(state?.sessionId, "origin-session");
+    assert.equal(state?.originSessionId, "origin-session");
+    assert.equal(state?.deliverySessionId, "origin-session");
+    assert.equal(state?.terminalSnapshot?.outcome, "completed");
+    assert.ok((state?.terminalSnapshot?.resultEvidence?.length ?? 0) <= 4096);
+    assert.equal(state?.terminalSnapshot?.agents.total, 1);
+
+    const firstSnapshot = state?.terminalSnapshot;
+    assert.equal(manager.stop(runId), false);
+    assert.deepEqual(manager.getPersistence().load(runId)?.terminalSnapshot, firstSnapshot);
+  }),
+);
+
+test(
+  "failed and explicitly stopped runs persist deterministic terminal snapshots",
+  withTempProjects(async (cwd) => {
+    const failing = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          throw new WorkflowError("private failure detail", WorkflowErrorCode.UNKNOWN, { recoverable: false });
+        },
+      },
+    });
+    failing.on("error", () => {});
+    const failed = failing.startInBackground(script);
+    await failed.promise.catch(() => {});
+    const failedState = failing.getPersistence().load(failed.runId);
+    assert.equal(failedState?.terminalSnapshot?.outcome, "failed");
+    assert.equal(failedState?.terminalSnapshot?.error?.code, WorkflowErrorCode.UNKNOWN);
+
+    const pausedId = "persisted-paused-stop";
+    const coldPaused = persisted(pausedId);
+    coldPaused.deliverySessionId = "session-a";
+    failing.getPersistence().save(coldPaused);
+    assert.equal(failing.stop(pausedId), true, "a cold persisted paused run can be stopped");
+    const stopped = failing.getPersistence().load(pausedId);
+    assert.equal(stopped?.status, "aborted");
+    assert.equal(stopped?.deliverySessionId, "session-a", "cold stop must not retarget delivery");
+    assert.equal(stopped?.terminalSnapshot?.outcome, "aborted");
+    assert.equal(stopped?.terminalSnapshot?.reason, "stopped");
+  }),
+);
+
+test(
+  "host-loss reconciliation pauses with host_lost and never creates terminal evidence",
+  withTempProjects(async (cwd) => {
+    const persistence = createRunPersistence(cwd);
+    persistence.save(persisted("host-lost", "running"));
+
+    new WorkflowManager({ cwd });
+
+    const recovered = persistence.load("host-lost");
+    assert.equal(recovered?.status, "paused");
+    assert.equal(recovered?.pauseReason, "host_lost");
+    assert.equal(recovered?.terminalSnapshot, undefined);
+  }),
+);
+
+test(
+  "resume restores persisted options once and preserves origin while targeting the requesting session",
+  withTempProjects(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, sessionId: "requesting-session", agent: da.runner });
+    const run = persisted("resume-options");
+    run.sessionId = "original-session";
+    run.originSessionId = "original-session";
+    run.deliverySessionId = "original-session";
+    run.executionOptions = {
+      maxAgents: 11,
+      concurrency: 2,
+      agentRetries: 3,
+      agentTimeoutMs: 777,
+      tokenBudget: 4567,
+    };
+    run.journal = [{ index: 99, hash: "not-replayed", result: "kept" }];
+    manager.getPersistence().save(run);
+
+    assert.equal(await manager.resume(run.runId), true);
+    assert.equal(await manager.resume(run.runId), false, "the same live run cannot resume twice");
+    assert.deepEqual(manager.getRun(run.runId)?.executionOptions, run.executionOptions);
+
+    const running = manager.getPersistence().load(run.runId);
+    assert.equal(running?.originSessionId, "original-session");
+    assert.equal(running?.sessionId, "original-session");
+    assert.equal(running?.deliverySessionId, "requesting-session");
+    assert.deepEqual(running?.executionOptions, run.executionOptions);
+
+    assert.equal(manager.stop(run.runId), true);
+    da.resolve("done");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }),
+);
+
+test(
+  "automatic resume preserves session A while explicit resume retargets to requesting session B",
+  withTempProjects(async (cwd) => {
+    const automaticAgent = deferredAgent();
+    const managerB = new WorkflowManager({ cwd, sessionId: "session-b", agent: automaticAgent.runner });
+    const automaticRun = persisted("automatic-resume");
+    automaticRun.sessionId = "session-a";
+    automaticRun.originSessionId = "session-a";
+    automaticRun.deliverySessionId = "session-a";
+    managerB.getPersistence().save(automaticRun);
+
+    assert.equal(await managerB.resume(automaticRun.runId, { intent: "automatic" }), true);
+    assert.equal(managerB.getPersistence().load(automaticRun.runId)?.deliverySessionId, "session-a");
+    assert.equal(managerB.stop(automaticRun.runId), true);
+    automaticAgent.resolve("done");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const explicitAgent = deferredAgent();
+    const explicitManagerB = new WorkflowManager({ cwd, sessionId: "session-b", agent: explicitAgent.runner });
+    const explicitRun = persisted("explicit-resume");
+    explicitRun.sessionId = "session-a";
+    explicitRun.originSessionId = "session-a";
+    explicitRun.deliverySessionId = "session-a";
+    explicitManagerB.getPersistence().save(explicitRun);
+
+    assert.equal(await explicitManagerB.resume(explicitRun.runId), true);
+    assert.equal(explicitManagerB.getPersistence().load(explicitRun.runId)?.deliverySessionId, "session-b");
+    assert.equal(explicitManagerB.stop(explicitRun.runId), true);
+    explicitAgent.resolve("done");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }),
+);
+
+test(
+  "a manager cannot stop a live run whose lease belongs to another manager",
+  withTempProjects(async (cwd) => {
+    const da = deferredAgent();
+    const owner = new WorkflowManager({ cwd, agent: da.runner });
+    owner.on("error", () => {});
+    const active = owner.startInBackground(script);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const contender = new WorkflowManager({ cwd, agent: fakeAgent() });
+    assert.equal(contender.stop(active.runId), false);
+    assert.equal(owner.getRun(active.runId)?.status, "running");
+    assert.equal(owner.stop(active.runId), true);
+
+    da.resolve("done");
+    await active.promise.catch(() => {});
+  }),
+);
+
+test(
+  "pause waits for the old generation to settle before resume starts a replacement",
+  withTempProjects(async (cwd) => {
+    const pending: Array<(value: unknown) => void> = [];
+    let calls = 0;
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          calls++;
+          return new Promise((resolve) => pending.push(resolve));
+        },
+      },
+    });
+    const first = manager.startInBackground(script);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(calls, 1);
+    assert.equal(manager.pause(first.runId), true);
+
+    let resumed = false;
+    const resume = manager.resume(first.runId).then((value) => {
+      resumed = value;
+      return value;
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(calls, 1, "the replacement cannot overlap the paused generation");
+    assert.equal(resumed, false, "resume is still waiting for lease settlement");
+
+    pending.shift()?.("old-finished");
+    await first.promise.catch(() => {});
+    assert.equal(await resume, true);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(calls, 2);
+    pending.shift()?.("resumed-finished");
+    await new Promise<void>((resolve) => manager.once("complete", () => resolve()));
+    assert.equal(manager.getPersistence().load(first.runId)?.status, "completed");
+  }),
+);
+
+test(
+  "pause followed by stop stays aborted after the old generation settles and emits no failure",
+  withTempProjects(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, agent: da.runner });
+    let errors = 0;
+    manager.on("error", () => errors++);
+    const first = manager.startInBackground(script);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(manager.pause(first.runId), true);
+    assert.equal(manager.stop(first.runId), true);
+    da.resolve("late-result");
+    await first.promise.catch(() => {});
+
+    assert.equal(errors, 0);
+    assert.equal(manager.getRun(first.runId)?.status, "aborted");
+    assert.equal(manager.getPersistence().load(first.runId)?.status, "aborted");
+    assert.equal(manager.getPersistence().load(first.runId)?.terminalSnapshot?.reason, "stopped");
+  }),
+);
+
+test(
+  "pause after onUsage persists spend before agent settlement without emitting failure",
+  withTempProjects(async (cwd) => {
+    let resolveUsageReported!: () => void;
+    const usageReported = new Promise<void>((resolve) => {
+      resolveUsageReported = resolve;
+    });
+    let calls = 0;
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(_prompt: string, options?: { onUsage?: (value: AgentUsage) => void; signal?: AbortSignal }) {
+          calls++;
+          options?.onUsage?.({ input: 100, output: 0, total: 100, cacheRead: 0, cacheWrite: 0, cost: 0 });
+          resolveUsageReported();
+          await new Promise<void>((_resolve, reject) => {
+            options?.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+          });
+          return "unreachable";
+        },
+      },
+    });
+    let errors = 0;
+    manager.on("error", () => errors++);
+    manager.on("paused", () => {});
+
+    const first = manager.startInBackground(script, undefined, { tokenBudget: 100 });
+    await usageReported;
+    assert.equal(manager.pause(first.runId), true);
+    await first.promise.catch(() => {});
+
+    const paused = manager.getPersistence().load(first.runId);
+    assert.equal(paused?.status, "paused");
+    assert.equal(paused?.tokenUsage?.total, 100);
+    assert.equal(errors, 0);
+
+    const failed = new Promise<void>((resolve) => manager.once("error", () => resolve()));
+    assert.equal(await manager.resume(first.runId), true);
+    await failed;
+    assert.equal(calls, 1, "resume cannot start fresh work after the persisted spend exhausted the budget");
+    assert.equal(manager.getPersistence().load(first.runId)?.tokenUsage?.total, 100);
+  }),
+);
+
+test(
+  "resumes preserve cumulative token usage and hard-budget spending without charging replay",
+  withTempProjects(async (cwd) => {
+    const budgetScript = `export const meta = { name: 'resume_budget', description: 'resume budget' }
+const first = await agent('first', { label: 'first' })
+const second = await agent('second', { label: 'second' })
+const third = await agent('third', { label: 'third' })
+return { first, second, third }`;
+    const prompts: string[] = [];
+    let secondAttempts = 0;
+    const usage = (total: number): AgentUsage => ({
+      input: total,
+      output: 0,
+      total,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+    });
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string, options?: { onUsage?: (value: AgentUsage) => void }) {
+          prompts.push(prompt);
+          if (prompt === "first") {
+            options?.onUsage?.(usage(70));
+            return "first-result";
+          }
+          if (prompt === "second" && secondAttempts++ === 0) {
+            options?.onUsage?.(usage(1));
+            throw new WorkflowError("quota", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, {
+              recoverable: false,
+            });
+          }
+          if (prompt === "second") {
+            options?.onUsage?.(usage(29));
+            return "second-result";
+          }
+          throw new Error("third must be blocked by the cumulative budget");
+        },
+      },
+    });
+    manager.on("paused", () => {});
+    manager.on("error", () => {});
+
+    const first = manager.startInBackground(budgetScript, undefined, { tokenBudget: 100 });
+    await first.promise.catch(() => {});
+    assert.equal(manager.getPersistence().load(first.runId)?.status, "paused");
+    assert.equal(manager.getPersistence().load(first.runId)?.tokenUsage?.total, 71);
+
+    const failed = new Promise<void>((resolve) => manager.once("error", () => resolve()));
+    assert.equal(await manager.resume(first.runId), true);
+    await failed;
+    assert.equal(manager.getPersistence().load(first.runId)?.status, "failed");
+    assert.equal(manager.getPersistence().load(first.runId)?.tokenUsage?.total, 100);
+    assert.deepEqual(prompts, ["first", "second", "second"], "the first call replays for zero tokens");
+
+    const failedAgain = new Promise<void>((resolve) => manager.once("error", () => resolve()));
+    assert.equal(await manager.resume(first.runId), true);
+    await failedAgain;
+    assert.equal(manager.getPersistence().load(first.runId)?.tokenUsage?.total, 100);
+    assert.deepEqual(prompts, ["first", "second", "second"], "repeated replay cannot reset or add spending");
+  }),
+);
+
+test(
+  "persisted manager resume replays shared-store journal deltas before live agents",
+  withTempProjects(async (cwd) => {
+    const storeScript = `export const meta = { name: 'store_resume', description: 'store resume' }
+await agent('put', { label: 'put' })
+const value = await agent('read', { label: 'read' })
+return { value }`;
+    let quotaActive = true;
+    const prompts: string[] = [];
+    const agent = {
+      async run(
+        prompt: string,
+        options?: {
+          systemTools?: Array<{ name: string; execute: (id: string, params: unknown) => Promise<unknown> }>;
+        },
+      ) {
+        prompts.push(prompt);
+        if (prompt === "put") {
+          await options?.systemTools
+            ?.find((tool) => tool.name === "store_put")
+            ?.execute("", {
+              key: "persisted-key",
+              value: "persisted-value",
+            });
+          return "stored";
+        }
+        if (quotaActive) {
+          quotaActive = false;
+          throw new WorkflowError("quota", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, { recoverable: false });
+        }
+        const result = (await options?.systemTools
+          ?.find((tool) => tool.name === "store_get")
+          ?.execute("", { key: "persisted-key" })) as { details?: { value?: unknown } };
+        return result.details?.value;
+      },
+    };
+
+    const original = new WorkflowManager({ cwd, sessionId: "origin", agent });
+    original.on("paused", () => {});
+    const first = original.startInBackground(storeScript);
+    await first.promise.catch(() => {});
+    const paused = original.getPersistence().load(first.runId);
+    assert.equal(paused?.status, "paused");
+    assert.deepEqual(paused?.journal?.[0]?.storeDelta, { "persisted-key": "persisted-value" });
+
+    const resumed = new WorkflowManager({ cwd, sessionId: "requester", agent });
+    const completed = new Promise<void>((resolve) => resumed.once("complete", () => resolve()));
+    assert.equal(await resumed.resume(first.runId), true);
+    await completed;
+    assert.equal((resumed.getRun(first.runId)?.result?.result as { value?: unknown })?.value, "persisted-value");
+    assert.deepEqual(prompts, ["put", "read", "read"], "the store-writing agent is replayed, not rerun");
+  }),
+);
+
+test(
+  "recoverable retry spend is persisted before a later usage-limit resume",
+  withTempProjects(async (cwd) => {
+    const retryScript = `export const meta = { name: 'retry_budget', description: 'retry budget' }
+const first = await agent('retry', { label: 'retry' })
+const second = await agent('pause', { label: 'pause' })
+const third = await agent('fresh', { label: 'fresh' })
+return { first, second, third }`;
+    const prompts: string[] = [];
+    let retryAttempts = 0;
+    let pauseAttempts = 0;
+    const usage = (total: number): AgentUsage => ({
+      input: total,
+      output: 0,
+      total,
+      cacheRead: 0,
+      cacheWrite: 0,
+      cost: 0,
+    });
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string, options?: { onUsage?: (value: AgentUsage) => void }) {
+          prompts.push(prompt);
+          if (prompt === "retry" && retryAttempts++ === 0) {
+            options?.onUsage?.(usage(40));
+            throw new Error("transient failure");
+          }
+          if (prompt === "retry") {
+            options?.onUsage?.(usage(30));
+            return "retry-result";
+          }
+          if (prompt === "pause" && pauseAttempts++ === 0) {
+            options?.onUsage?.(usage(1));
+            throw new WorkflowError("quota", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, { recoverable: false });
+          }
+          if (prompt === "pause") {
+            options?.onUsage?.(usage(29));
+            return "pause-result";
+          }
+          throw new Error("fresh work must be blocked by cumulative spend");
+        },
+      },
+    });
+    manager.on("paused", () => {});
+    manager.on("error", () => {});
+
+    const first = manager.startInBackground(retryScript, undefined, { tokenBudget: 100, agentRetries: 1 });
+    await first.promise.catch(() => {});
+    assert.equal(manager.getPersistence().load(first.runId)?.status, "paused");
+    assert.equal(manager.getPersistence().load(first.runId)?.tokenUsage?.total, 71);
+
+    const failed = new Promise<void>((resolve) => manager.once("error", () => resolve()));
+    assert.equal(await manager.resume(first.runId), true);
+    await failed;
+    assert.equal(manager.getPersistence().load(first.runId)?.status, "failed");
+    assert.equal(manager.getPersistence().load(first.runId)?.tokenUsage?.total, 100);
+    assert.deepEqual(prompts, ["retry", "retry", "pause", "pause"]);
+  }),
+);
+
+test(
+  "status metadata is cross-session, bounded, and excludes persisted scripts, args, prompts, logs, and results",
+  withTempProjects(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, sessionId: "current" });
+    for (let i = 0; i < 25; i++) {
+      const run = persisted(`run-${i}`, "completed");
+      run.sessionId = i % 2 ? "other" : "current";
+      run.script = "TOP_SECRET_SCRIPT";
+      run.args = { secret: "TOP_SECRET_ARGS" };
+      run.logs = ["TOP_SECRET_LOG"];
+      run.result = { secret: "TOP_SECRET_RESULT" };
+      run.agents = [{ id: 1, label: "worker", prompt: "TOP_SECRET_PROMPT", status: "done" }];
+      manager.getPersistence().save(run);
+    }
+
+    const metadata = manager.listRunMetadata(10);
+    assert.equal(metadata.length, 10);
+    assert.ok(
+      metadata.some((run) => Number(run.runId.split("-")[1]) % 2 === 1),
+      "cross-session recovery runs are included",
+    );
+    const serialized = JSON.stringify(metadata);
+    for (const secret of [
+      "TOP_SECRET_SCRIPT",
+      "TOP_SECRET_ARGS",
+      "TOP_SECRET_LOG",
+      "TOP_SECRET_RESULT",
+      "TOP_SECRET_PROMPT",
+    ]) {
+      assert.doesNotMatch(serialized, new RegExp(secret));
+    }
+    assert.equal(manager.getRunMetadata("run-1")?.runId, "run-1");
+  }),
+);

--- a/tests/workflow-manager-abort.test.ts
+++ b/tests/workflow-manager-abort.test.ts
@@ -106,7 +106,7 @@ test(
       assert.ok((err as WorkflowError).recoverable, "abort error should be recoverable");
     }
 
-    assert.equal(errorEmitted, true, "manager should emit 'error' event on abort");
+    assert.equal(errorEmitted, false, "intentional external abort should not emit a failure event");
   }),
 );
 
@@ -338,42 +338,38 @@ test(
 test(
   "resume full cycle: pause then resume then complete",
   withTempCwd(async (cwd) => {
-    const da = deferredAgent();
-    const manager = new WorkflowManager({ cwd, agent: da.runner });
+    const pending: Array<(value: unknown) => void> = [];
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          return new Promise((resolve) => pending.push(resolve));
+        },
+      },
+    });
     manager.on("error", () => {});
 
     const { runId, promise: origPromise } = manager.startInBackground(oneAgentScript);
-    await new Promise((r) => setTimeout(r, 20));
+    await new Promise((r) => setImmediate(r));
 
-    // Pause while the deferred agent is in-flight
-    const paused = manager.pause(runId);
-    assert.equal(paused, true);
+    assert.equal(manager.pause(runId), true);
     assert.equal(manager.getRun(runId)?.status, "paused");
 
-    // Resume — replays journal (empty for single-agent that never completed) and
-    // re-runs the live agent with a fresh (non-aborted) controller.
-    const resumed = await manager.resume(runId);
-    assert.equal(resumed, true, "resume should succeed");
-
-    // The resumed run should be running
+    // Resume must wait for the paused generation to settle before acquiring its lease.
+    const resumePromise = manager.resume(runId);
+    pending.shift()?.("paused-generation-done");
+    await origPromise.catch(() => {});
+    assert.equal(await resumePromise, true, "resume should succeed after settlement");
     assert.equal(manager.getRun(runId)?.status, "running", "resumed run should be running");
 
-    // Resolve the deferred agent so the resumed run's agent completes
-    da.resolve("resumed-done");
-
-    // The original promise will reject (its controller was aborted). Suppress it.
-    await origPromise.catch(() => {});
-
-    // Wait for the resumed run to complete
-    await new Promise((r) => setTimeout(r, 50));
+    const completed = new Promise<void>((resolve) => manager.once("complete", () => resolve()));
+    pending.shift()?.("resumed-done");
+    await completed;
 
     const finalRun = manager.getRun(runId);
     assert.equal(finalRun?.status, "completed", "resumed run should complete successfully");
     assert.equal(finalRun?.result?.result?.a, "resumed-done", "resumed run should have the agent result");
-
-    // The run should also appear in listRuns as completed
-    const persisted = manager.listRuns().find((r) => r.runId === runId);
-    assert.equal(persisted?.status, "completed");
+    assert.equal(manager.listRuns().find((r) => r.runId === runId)?.status, "completed");
   }),
 );
 
@@ -658,7 +654,7 @@ test(
 );
 
 test(
-  "manager emits 'resumed' and 'error' events",
+  "manager emits 'resumed' and suppresses failure events for intentional aborts",
   withTempCwd(async (cwd) => {
     const _ac = new AbortController();
     const da = deferredAgent();
@@ -674,13 +670,13 @@ test(
     const { runId, promise: origPromise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
     manager.pause(runId);
-    await manager.resume(runId);
+    const resumePromise = manager.resume(runId);
+    da.resolve("done");
+    await origPromise.catch(() => {});
+    assert.equal(await resumePromise, true);
 
     assert.ok(resumedEvent, "resumed event should fire on resume");
     assert.equal(resumedEvent?.runId, runId);
-
-    da.resolve("done");
-    await origPromise.catch(() => {});
 
     // Now test error event on abort
     let capturedError: { runId: string; error: WorkflowError } | null = null;
@@ -704,8 +700,6 @@ test(
       /* expected */
     }
 
-    assert.ok(capturedError, "error event should fire on abort");
-    assert.ok(capturedError?.error instanceof WorkflowError, "error should be instance of WorkflowError");
-    assert.equal(capturedError?.error.code, WorkflowErrorCode.WORKFLOW_ABORTED);
+    assert.equal(capturedError, null, "intentional external abort should not emit a failure event");
   }),
 );

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -81,6 +81,18 @@ function withTempCwd(fn: (cwd: string) => Promise<void>) {
   };
 }
 
+async function resumeAfterSettlement(
+  manager: WorkflowManager,
+  runId: string,
+  original: Promise<unknown>,
+  settleOriginal: () => void,
+): Promise<boolean> {
+  const resumed = manager.resume(runId);
+  settleOriginal();
+  await original.catch(() => {});
+  return resumed;
+}
+
 test(
   "runSync registers the run so /workflows (listRuns) can see it",
   withTempCwd(async (cwd) => {
@@ -546,7 +558,7 @@ test(
       assert.ok((err as WorkflowError).recoverable, "abort error should be recoverable");
     }
 
-    assert.equal(errorEmitted, true, "manager should emit 'error' event on abort");
+    assert.equal(errorEmitted, false, "intentional external abort should not emit a failure event");
   }),
 );
 
@@ -790,19 +802,9 @@ test(
     assert.equal(paused, true);
     assert.equal(manager.getRun(runId)?.status, "paused");
 
-    // Resume — replays journal (empty for single-agent that never completed) and
-    // re-runs the live agent with a fresh (non-aborted) controller.
-    const resumed = await manager.resume(runId);
+    // Resume waits for the paused generation to settle before acquiring its lease.
+    const resumed = await resumeAfterSettlement(manager, runId, origPromise, () => da.resolve("resumed-done"));
     assert.equal(resumed, true, "resume should succeed");
-
-    // The resumed run should be running
-    assert.equal(manager.getRun(runId)?.status, "running", "resumed run should be running");
-
-    // Resolve the deferred agent so the resumed run's agent completes
-    da.resolve("resumed-done");
-
-    // The original promise will reject (its controller was aborted). Suppress it.
-    await origPromise.catch(() => {});
 
     // Wait for the resumed run to complete
     await new Promise((r) => setTimeout(r, 50));
@@ -849,8 +851,11 @@ return { a, b }`;
       const persisted = manager.listRuns().find((r) => r.runId === runId);
       assert.ok(persisted?.journal && persisted.journal.length >= 1, "journal should have at least one entry");
 
-      // Resume
-      const resumed = await manager.resume(runId);
+      // The original generation already has a resolved in-flight promise; wait for
+      // that settlement before the replacement acquires the lease.
+      const resumePromise = manager.resume(runId);
+      await origPromise.catch(() => {});
+      const resumed = await resumePromise;
       assert.equal(resumed, true);
 
       // Wait for resumed run to complete (agent 1 replayed from journal, agent 2 live)
@@ -1382,14 +1387,11 @@ test(
     await new Promise((resolve) => setTimeout(resolve, 20));
     manager.pause(runId);
 
-    const resumed = await manager.resume(runId);
+    const resumed = await resumeAfterSettlement(manager, runId, promise, () => da.resolve("done"));
     const persisted = manager.listRuns().find((run) => run.runId === runId);
 
     assert.equal(resumed, true);
     assert.equal(persisted?.status, "running", "listRuns should show running status after resume");
-
-    da.resolve("done");
-    await promise.catch(() => {});
   }),
 );
 
@@ -1408,18 +1410,15 @@ test(
     const { runId, promise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
     manager.pause(runId);
-    await manager.resume(runId);
+    assert.equal(await resumeAfterSettlement(manager, runId, promise, () => da.resolve("done")), true);
 
     assert.ok(resumedEvent, "resumed event should fire");
     assert.equal(resumedEvent?.runId, runId);
-
-    da.resolve("done");
-    await promise.catch(() => {});
   }),
 );
 
 test(
-  "manager emits 'error' event on abort with WorkflowError",
+  "manager suppresses 'error' events for intentional external abort",
   withTempCwd(async (cwd) => {
     const ac = new AbortController();
     const da = deferredAgent();
@@ -1443,9 +1442,7 @@ test(
       /* expected */
     }
 
-    assert.ok(capturedError, "error event should fire on abort");
-    assert.ok(capturedError?.error instanceof WorkflowError, "error should be instance of WorkflowError");
-    assert.equal(capturedError?.error.code, WorkflowErrorCode.WORKFLOW_ABORTED);
+    assert.equal(capturedError, null, "intentional external abort should not emit a failure event");
   }),
 );
 
@@ -1466,13 +1463,8 @@ test(
     assert.equal(manager.pause(runId), true);
     assert.equal(manager.getRun(runId)?.status, "paused", "should be paused after pause");
 
-    const resumed = await manager.resume(runId);
+    const resumed = await resumeAfterSettlement(manager, runId, origPromise, () => da.resolve("resumed-done"));
     assert.equal(resumed, true);
-    assert.equal(manager.getRun(runId)?.status, "running", "should be running after resume");
-
-    // Complete the resumed run
-    da.resolve("resumed-done");
-    await origPromise.catch(() => {});
     await new Promise((r) => setTimeout(r, 30));
 
     assert.equal(manager.getRun(runId)?.status, "completed", "should complete after resume finishes");
@@ -1597,16 +1589,13 @@ test(
     assert.equal(manager.pause(runId), true);
     assert.equal(manager.getRun(runId)?.status, "paused");
 
-    // First resume should succeed
-    const firstResume = await manager.resume(runId);
+    // First resume waits for the paused generation to settle, then succeeds.
+    const firstResume = await resumeAfterSettlement(manager, runId, origPromise, () => da.resolve("done"));
     assert.equal(firstResume, true, "first resume should succeed");
 
     // The resumed run is now running; second resume should return false
     const secondResume = await manager.resume(runId);
     assert.equal(secondResume, false, "second resume should return false when the resumed run is already running");
-
-    da.resolve("done");
-    await origPromise.catch(() => {});
   }),
 );
 
@@ -1660,8 +1649,8 @@ test(
     });
 
     try {
-      // Resume — executeRun calls runWorkflow which calls the mocked runner
-      const resumed = await manager.resume(runId);
+      // The mocked runner is used only after the paused generation settles.
+      const resumed = await resumeAfterSettlement(manager, runId, origPromise, () => da.resolve("old-done"));
       assert.equal(resumed, true, "resume should schedule the run");
 
       // Wait for the background executed run to process the agent error
@@ -1676,10 +1665,7 @@ test(
         "error code should be AGENT_EXECUTION_ERROR",
       );
     } finally {
-      // Resolve the original deferred promise so the first executeRun settles
       da.runner.run = async (_prompt: string) => "done";
-      da.resolve("done");
-      await origPromise.catch(() => {});
     }
   }),
 );
@@ -1732,8 +1718,8 @@ test(
     });
 
     try {
-      // Resume — the run will fail because the mocked agent throws
-      const resumed = await manager.resume(runId);
+      // Resume after the paused generation settles; the mocked agent then fails.
+      const resumed = await resumeAfterSettlement(manager, runId, origPromise, () => da.resolve("old-done"));
       assert.equal(resumed, true, "resume should schedule the run");
       await new Promise((r) => setTimeout(r, 100));
 
@@ -1748,8 +1734,6 @@ test(
       assert.equal(manager.getRun(runId)?.status, "failed", "status should remain failed after rejected pause");
     } finally {
       da.runner.run = async (_prompt: string) => "done";
-      da.resolve("done");
-      await origPromise.catch(() => {});
     }
   }),
 );
@@ -1774,8 +1758,8 @@ test(
     });
 
     try {
-      // Resume — the run will fail
-      const resumed = await manager.resume(runId);
+      // Resume after the paused generation settles; the mocked agent then fails.
+      const resumed = await resumeAfterSettlement(manager, runId, origPromise, () => da.resolve("old-done"));
       assert.equal(resumed, true, "resume should schedule the run");
       await new Promise((r) => setTimeout(r, 100));
 
@@ -1790,8 +1774,6 @@ test(
       assert.equal(manager.getRun(runId)?.status, "failed", "status should remain failed after rejected stop");
     } finally {
       da.runner.run = async (_prompt: string) => "done";
-      da.resolve("done");
-      await origPromise.catch(() => {});
     }
   }),
 );
@@ -1816,8 +1798,8 @@ test(
     });
 
     try {
-      // Resume — the run will fail
-      await manager.resume(runId);
+      // Resume after the paused generation settles; the mocked agent then fails.
+      await resumeAfterSettlement(manager, runId, origPromise, () => da.resolve("old-done"));
       await new Promise((r) => setTimeout(r, 100));
 
       // Verify the run is now in failed state
@@ -1825,10 +1807,8 @@ test(
       assert.equal(failedRun?.status, "failed", "run should be in failed state");
       assert.ok(failedRun?.error instanceof WorkflowError, "error should be a WorkflowError");
     } finally {
-      // Restore the runner so the resumed run's agent call succeeds
+      // Restore the runner so the next resume succeeds.
       da.runner.run = async (_prompt: string) => "done";
-      da.resolve("done");
-      await origPromise.catch(() => {});
     }
 
     // Resume the failed run — resume() allows failed status

--- a/tests/workflow-paths.test.ts
+++ b/tests/workflow-paths.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join, normalize } from "node:path";
 import { describe, it } from "node:test";
 import {
+  canonicalWorkflowCwd,
   WORKFLOW_HOME_RELATIVE_DIR,
   WORKFLOW_PROJECTS_SUBDIR,
   workflowHomeDir,
@@ -38,6 +39,29 @@ describe("workflow paths", () => {
       assert.equal(key, workflowProjectKey(cwd));
       assert.match(key, /^[a-z0-9._-]+-[a-f0-9]{12}$/);
       assert.ok(key.startsWith(basename(cwd).toLowerCase()));
+    });
+  });
+
+  it("canonicalizes symlinked cwd values before deriving a namespace", () => {
+    withIsolatedHome((_home, cwd) => {
+      const link = `${cwd}-link`;
+      try {
+        symlinkSync(cwd, link, "dir");
+        assert.equal(canonicalWorkflowCwd(link), cwd);
+        assert.equal(workflowProjectKey(link), workflowProjectKey(cwd));
+        assert.equal(workflowProjectPaths(link).rootDir, workflowProjectPaths(cwd).rootDir);
+      } finally {
+        rmSync(link, { force: true });
+      }
+    });
+  });
+
+  it("rejects missing paths and regular files as workflow cwd values", () => {
+    withIsolatedHome((_home, cwd) => {
+      const file = join(cwd, "not-a-directory.txt");
+      writeFileSync(file, "x");
+      assert.throws(() => canonicalWorkflowCwd(join(cwd, "missing")), /does not exist/i);
+      assert.throws(() => canonicalWorkflowCwd(file), /not a directory/i);
     });
   });
 

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -14,12 +14,11 @@ import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 // Exact post-change measurements: ratchet only after reviewing a new accepted form.
 // The prompt baseline intentionally uses an empty agentType registry so user configuration cannot alter it.
-// Ratcheted for the resumeFromRunId (edited-script resume / cached-prefix reuse) tool surface:
-// one new optional schema param on the tool DEFINITION only. The always-on rendered
-// prompt is intentionally unchanged — discoverability comes from the tool-def
-// description plus the per-result revise hint, not an always-on guideline line.
-const RENDERED_PROMPT_BUDGET_BYTES = 6_500;
-const TOOL_DEFINITION_BUDGET_BYTES = 2_529;
+// Ratcheted for the additive run/status/resume/stop controls plus the existing
+// resumeFromRunId edited-script surface. The always-on rendered prompt remains
+// unchanged; control discoverability comes from the tool definition.
+const RENDERED_PROMPT_BUDGET_BYTES = 6_520;
+const TOOL_DEFINITION_BUDGET_BYTES = 3_000;
 
 test("rendered workflow prompt contribution stays within its accepted size", async () => {
   await withRenderedWorkflow(async ({ systemPrompt, promptLines }) => {

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -513,6 +513,75 @@ return { a, second }`;
   assert.equal(result.result.second, "blocked");
 });
 
+test("resume accounting is cumulative and cached replay completes at zero remaining budget", async () => {
+  const script = `export const meta = { name: 'resume_budget', description: 'budget' }
+const value = await agent('cached', { label: 'cached' })
+return { value, total: budget.total, spent: budget.spent(), remaining: budget.remaining() }`;
+  const journal: JournalEntry[] = [];
+  const first = await runWorkflow<{
+    value: unknown;
+    total: number;
+    spent: number;
+    remaining: number;
+  }>(script, {
+    agent: fakeAgent({ input: 60, output: 40, total: 100, cost: 0.25 }),
+    tokenBudget: 100,
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  assert.equal(first.result.value, "ok");
+  assert.equal(first.result.total, 100);
+  assert.equal(first.result.spent, 100);
+  assert.equal(first.result.remaining, 0);
+
+  let liveCalls = 0;
+  const resumed = await runWorkflow<typeof first.result>(script, {
+    agent: {
+      async run() {
+        liveCalls++;
+        return "must-not-run";
+      },
+    },
+    tokenBudget: 100,
+    initialTokenUsage: first.tokenUsage,
+    initialTokenSpend: first.tokenUsage?.total,
+    resumeJournal: new Map(journal.map((entry) => [entry.index, entry])),
+    persistLogs: false,
+  });
+
+  assert.equal(liveCalls, 0);
+  assert.equal(resumed.result.value, "ok");
+  assert.equal(resumed.result.total, 100);
+  assert.equal(resumed.result.spent, 100);
+  assert.equal(resumed.result.remaining, 0);
+  assert.deepEqual(resumed.tokenUsage, first.tokenUsage, "replay adds zero and result usage stays cumulative");
+});
+
+test("resume blocks fresh work when cumulative spend has exhausted the original budget", async () => {
+  const script = `export const meta = { name: 'resume_fresh', description: 'budget' }
+await agent('fresh', { label: 'fresh' })
+return true`;
+  let liveCalls = 0;
+  await assert.rejects(
+    () =>
+      runWorkflow(script, {
+        agent: {
+          async run() {
+            liveCalls++;
+            return "must-not-run";
+          },
+        },
+        tokenBudget: 100,
+        initialTokenUsage: { input: 100, output: 0, total: 100, cost: 0 },
+        initialTokenSpend: 100,
+        resumeJournal: new Map(),
+        persistLogs: false,
+      }),
+    /budget exhausted/i,
+  );
+  assert.equal(liveCalls, 0);
+});
+
 test("token budget exhaustion inside parallel() halts (non-recoverable, not swallowed)", async () => {
   // A warm-up agent spends the whole budget (soft gate: spent accrues after it
   // finishes); the agent() inside parallel() then hits the gate and must

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
-import { WorkflowManager } from "../src/workflow-manager.js";
+import { WorkflowManager, WorkflowManagerRegistry } from "../src/workflow-manager.js";
 import { backgroundStartedText, createWorkflowTool, modelRoutingGuideline } from "../src/workflow-tool.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
@@ -203,6 +203,185 @@ test("createWorkflowTool prepareArguments strips javascript fences", () => {
   }
 });
 
+test("createWorkflowTool exposes optional action, cwd, and runId without requiring script in the schema", () => {
+  const tool = createWorkflowTool();
+  const parameters = tool.parameters as {
+    properties?: Record<string, { anyOf?: unknown[] }>;
+    required?: string[];
+  };
+
+  assert.ok(parameters.properties?.action);
+  assert.ok(parameters.properties?.cwd);
+  assert.ok(parameters.properties?.runId);
+  assert.equal(parameters.required?.includes("script") ?? false, false);
+});
+
+test("createWorkflowTool prepareArguments keeps omitted action as a legacy run", () => {
+  const tool = createWorkflowTool();
+  const prepare = tool.prepareArguments as (args: unknown) => { action?: string; script: string };
+  const result = prepare({ script: " const x = 1 " });
+
+  assert.equal(result.action, undefined);
+  assert.equal(result.script, "const x = 1");
+});
+
+test("createWorkflowTool prepareArguments validates action-specific field combinations strictly", () => {
+  const tool = createWorkflowTool();
+  const prepare = tool.prepareArguments as (args: unknown) => unknown;
+
+  assert.throws(() => prepare({ action: "run" }), /script.*required/i);
+  assert.throws(() => prepare({ action: "status", script: "return 1" }), /status.*script/i);
+  assert.throws(() => prepare({ action: "status", background: true }), /status.*background/i);
+  assert.throws(() => prepare({ action: "resume" }), /resume.*runId/i);
+  assert.throws(() => prepare({ action: "resume", runId: "r1", args: {} }), /resume.*args/i);
+  assert.throws(() => prepare({ action: "resume", runId: "r1", resumeFromRunId: "r0" }), /resume.*resumeFromRunId/i);
+  assert.throws(() => prepare({ action: "stop" }), /stop.*runId/i);
+  assert.throws(() => prepare({ action: "stop", runId: "r1", tokenBudget: 10 }), /stop.*tokenBudget/i);
+  assert.throws(() => prepare({ action: "invalid", runId: "r1" }), /action/i);
+  assert.throws(() => prepare({ action: "status", runId: "../other-project" }), /path-safe/i);
+  assert.throws(() => prepare({ script: "return 1", runId: "r1" }), /runId/i);
+  assert.throws(() => prepare({ script: "return 1", resumeFromRunId: "../other-project" }), /path-safe/i);
+});
+
+test("createWorkflowTool canonicalizes an explicit cwd during argument preparation", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-tool-cwd-"));
+  const link = `${cwd}-link`;
+  try {
+    symlinkSync(cwd, link, "dir");
+    const tool = createWorkflowTool({ cwd });
+    const prepare = tool.prepareArguments as (args: unknown) => { action: string; cwd: string; runId: string };
+    const result = prepare({ action: "status", cwd: link, runId: "r1" });
+    assert.equal(result.cwd, cwd);
+  } finally {
+    rmSync(link, { force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test("createWorkflowTool routes run/status/resume/stop through the canonical cwd manager", async () => {
+  const first = mkdtempSync(join(tmpdir(), "pi-dw-tool-first-"));
+  const second = mkdtempSync(join(tmpdir(), "pi-dw-tool-second-"));
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-tool-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const registry = new WorkflowManagerRegistry({
+        createManager(cwd) {
+          return new WorkflowManager({
+            cwd,
+            agent: {
+              async run() {
+                return "ok";
+              },
+            },
+          });
+        },
+      });
+      const tool = createWorkflowTool({ cwd: first, managerRegistry: registry });
+      const execute = tool.execute as (...args: any[]) => Promise<any>;
+      const runResult = await execute(
+        "call-run",
+        {
+          action: "run",
+          cwd: second,
+          script: `export const meta = { name: 'tool_actions', description: 'tool actions' }
+const value = await agent('work', { label: 'worker' })
+return { value, cwd }`,
+          background: false,
+        },
+        undefined,
+        () => {},
+        {},
+      );
+      const runId = runResult.details.runId as string;
+      assert.equal(runResult.details.result.cwd, second);
+      assert.equal(registry.get(first).listAllRuns().length, 0, "default cwd namespace remains untouched");
+
+      const statusResult = await execute(
+        "call-status",
+        { action: "status", cwd: second, runId },
+        undefined,
+        () => {},
+        {},
+      );
+      assert.equal(statusResult.details.run.runId, runId);
+      assert.equal(statusResult.details.run.cwd, second);
+      assert.equal("script" in statusResult.details.run, false);
+      assert.equal("args" in statusResult.details.run, false);
+
+      registry.get(first).getPersistence().save({
+        runId: "foreign-namespace",
+        workflowName: "foreign",
+        script: "secret foreign script",
+        status: "completed",
+        phases: [],
+        agents: [],
+        logs: [],
+        startedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+      const listResult = await execute("call-status-list", { action: "status", cwd: second }, undefined, () => {}, {});
+      assert.ok(listResult.details.runs.length <= 20);
+      assert.equal(
+        listResult.details.runs.some((run: { runId: string }) => run.runId === "foreign-namespace"),
+        false,
+        "status never scans another cwd namespace",
+      );
+
+      const pausedId = "tool-paused";
+      registry
+        .get(second)
+        .getPersistence()
+        .save({
+          runId: pausedId,
+          workflowName: "tool_actions",
+          script: `export const meta = { name: 'tool_actions', description: 'tool actions' }
+return await agent('work', { label: 'worker' })`,
+          status: "paused",
+          phases: [],
+          agents: [],
+          logs: [],
+          startedAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        });
+      const resumeResult = await execute(
+        "call-resume",
+        { action: "resume", cwd: second, runId: pausedId },
+        undefined,
+        () => {},
+        {},
+      );
+      assert.equal(resumeResult.details.resumed, true);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      const stopId = "tool-stop";
+      registry.get(second).getPersistence().save({
+        runId: stopId,
+        workflowName: "tool_actions",
+        script: "",
+        status: "paused",
+        phases: [],
+        agents: [],
+        logs: [],
+        startedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      });
+      const stopResult = await execute(
+        "call-stop",
+        { action: "stop", cwd: second, runId: stopId },
+        undefined,
+        () => {},
+        {},
+      );
+      assert.equal(stopResult.details.stopped, true);
+      assert.equal(registry.get(second).getPersistence().load(stopId)?.status, "aborted");
+    });
+  } finally {
+    rmSync(first, { recursive: true, force: true });
+    rmSync(second, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
 test("createWorkflowTool prepareArguments passes through args", () => {
   const tool = createWorkflowTool();
   if (tool.prepareArguments) {
@@ -271,11 +450,11 @@ function withToolTempCwd(fn: (cwd: string) => Promise<void>) {
   };
 }
 
-test("workflowToolSchema exposes resumeFromRunId as optional; script stays required", () => {
+test("workflowToolSchema exposes resumeFromRunId while control actions keep script optional", () => {
   const tool = createWorkflowTool();
   const schema = tool.parameters as { properties: Record<string, unknown>; required?: string[] };
   assert.ok(schema.properties.resumeFromRunId, "resumeFromRunId should be a schema property");
-  assert.ok((schema.required ?? []).includes("script"), "script stays required");
+  assert.ok(!(schema.required ?? []).includes("script"), "control actions do not require script at schema level");
   assert.ok(!(schema.required ?? []).includes("resumeFromRunId"), "resumeFromRunId is optional");
 });
 


### PR DESCRIPTION
## Summary
- add assistant-facing workflow actions for run, status, resume, and stop
- isolate managers and persisted runs by canonical realpath cwd
- add lease-safe pause/resume/stop recovery, exact-session delivery, and bounded terminal snapshots
- preserve v2.14 edited-script resume and automatic usage-limit recovery
- validate persisted state deeply and preserve cumulative token budgets across retries/resumes
- bump package version to 2.15.0

## Validation
- npm test (931 passed)
- npm run check
- npm run build

## Compatibility
This is additive over v2.14.1. Existing run calls and resumeFromRunId edited-script resume remain supported.