### PR TITLE
fix: support pi >= 0.80.8 ModelRuntime API (removed AuthStorage/ModelRegistry.create)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -699,9 +699,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
-      "integrity": "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
+      "integrity": "sha512-Moe/H8c87yacDGK9dPbWphZNjVsrb3nTrIHycOQJAkFEnY9PYxOOd74+ny44kATfPU9Dm7aTHefar3pZF+UKUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -732,16 +732,16 @@
       "license": "MIT"
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
-      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.10.tgz",
+      "integrity": "sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.6",
-        "@earendil-works/pi-ai": "^0.80.6",
-        "@earendil-works/pi-tui": "^0.80.6",
+        "@earendil-works/pi-agent-core": "^0.80.10",
+        "@earendil-works/pi-ai": "^0.80.10",
+        "@earendil-works/pi-tui": "^0.80.10",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1231,12 +1231,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.10",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1246,8 +1246,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1264,15 +1264,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2705,9 +2705,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.6",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
-      "integrity": "sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==",
+      "version": "0.80.10",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.10.tgz",
+      "integrity": "sha512-c2JO29PbhKPEQ6fgHQKAl0WhwuFqzWfzspMmP+8B5tpDuP+0mvarRbKKg8gq4b+pQx/QX+6aVS4ko7deoyjQjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "acorn": "^8.16.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.80.6",
+    "@earendil-works/pi-coding-agent": ">=0.80.8",
     "@earendil-works/pi-tui": ">=0.80.6",
     "typebox": "*"
   },

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -3,12 +3,12 @@ import { unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AssistantMessage, Model, TextContent } from "@earendil-works/pi-ai";
 import {
-  AuthStorage,
   type CreateAgentSessionOptions,
   createAgentSession,
   createCodingTools,
   getAgentDir,
   ModelRegistry,
+  ModelRuntime,
   SessionManager,
   SettingsManager,
   type ToolDefinition,
@@ -205,7 +205,7 @@ export interface WorkflowAgentOptions {
   cwd?: string;
   /** Extra tools available to the subagent in addition to the structured output tool. */
   tools?: ToolDefinition[];
-  /** Override any createAgentSession option (model, authStorage, resourceLoader, etc.). */
+  /** Override any createAgentSession option (model, modelRuntime, resourceLoader, etc.). */
   session?: Partial<CreateAgentSessionOptions>;
   /** Extra system guidance prepended to every subagent task. */
   instructions?: string;
@@ -233,22 +233,79 @@ export interface WorkflowAgentOptions {
   persistAgentSessions?: boolean;
 }
 
+// pi >= 0.80.8: ModelRegistry is a sync facade over an async-created ModelRuntime
+// (AuthStorage/ModelRegistry.create are gone). The disk-backed fallback is built
+// lazily; sync callers see [] until it resolves and real specs on later reads.
+let fallbackRuntimePromise: Promise<ModelRuntime> | undefined;
+let fallbackRegistry: ModelRegistry | undefined;
+
+function ensureFallbackRegistry(): Promise<ModelRegistry> {
+  if (!fallbackRuntimePromise) {
+    const dir = getAgentDir();
+    // Same auth.json/models.json createAgentSession uses by default, so a model
+    // resolved here carries valid credentials.
+    fallbackRuntimePromise = (async () => {
+      const runtime = await ModelRuntime.create({
+        authPath: join(dir, "auth.json"),
+        modelsPath: join(dir, "models.json"),
+      });
+      // Warm the availability snapshot so the facade's sync getAvailable() is
+      // populated immediately after this promise resolves.
+      await runtime.getAvailable().catch(() => {});
+      return runtime;
+    })();
+    // Don't cache a rejection: a transient failure (e.g. auth.json lock) would
+    // otherwise wedge the fallback for the rest of the process.
+    fallbackRuntimePromise.catch(() => {
+      fallbackRuntimePromise = undefined;
+    });
+  }
+  return fallbackRuntimePromise.then((runtime) => {
+    fallbackRegistry ??= new ModelRegistry(runtime);
+    return fallbackRegistry;
+  });
+}
+
+let warnedNoRuntime = false;
+
+/**
+ * The ModelRuntime behind a registry facade. pi's ModelRegistry does not expose
+ * its runtime publicly, so reach into the private field (stable since 0.80.8);
+ * subagent sessions need it to share the host session's exact catalog and auth
+ * (createAgentSession takes modelRuntime, not a registry, since 0.80.8).
+ *
+ * Exported so the test suite can pin this pi-internals contract: the cast means
+ * neither tsc nor mock-based tests would notice pi renaming the field, and the
+ * runtime consequence is silent (subagents fall back to a default runtime and
+ * extension-registered providers vanish from routing).
+ */
+export function runtimeOf(registry: ModelRegistry): ModelRuntime | undefined {
+  const runtime = (registry as unknown as { runtime?: ModelRuntime }).runtime;
+  if (!runtime && !warnedNoRuntime) {
+    warnedNoRuntime = true;
+    console.warn(
+      "[workflow] ModelRegistry no longer carries a private `runtime` field (pi internals changed); subagents fall back to a default-built runtime and may miss extension-registered providers",
+    );
+  }
+  return runtime;
+}
+
 /**
  * List the user's currently available models (those with auth configured) with
  * the minimal fields tier ranking needs: canonical spec, output price, and
  * context window. This is the single place the SDK `Model` is projected into
  * the SDK-agnostic `RankableModel`. Best-effort: returns [] if the registry
- * can't be built.
+ * can't be built (or while the disk-backed fallback is still initializing).
  */
 export function listAvailableModels(registry?: ModelRegistry): RankableModel[] {
   try {
-    const modelRegistry =
-      registry ??
-      (() => {
-        const dir = getAgentDir();
-        const auth = AuthStorage.create(join(dir, "auth.json"));
-        return ModelRegistry.create(auth, join(dir, "models.json"));
-      })();
+    const modelRegistry = registry ?? fallbackRegistry;
+    if (!modelRegistry) {
+      // Kick off the async fallback build; this call reports [] and later
+      // calls (e.g. the tool's lazy promptGuidelines re-reads) see real specs.
+      void ensureFallbackRegistry().catch(() => {});
+      return [];
+    }
     return modelRegistry.getAvailable().map((model) => ({
       spec: canonicalModelSpec(model),
       costOutput: model.cost?.output,
@@ -436,9 +493,10 @@ export class WorkflowAgent {
   /**
    * Resolve the registry for a run: an explicit per-run registry wins, then the
    * constructor's shared registry, then a lazily-built disk registry (shared
-   * across calls once built).
+   * across calls once built). Async because pi >= 0.80.8 builds registries from
+   * an async-created ModelRuntime.
    */
-  private getRegistry(perRunRegistry?: ModelRegistry): ModelRegistry {
+  private async getRegistry(perRunRegistry?: ModelRegistry): Promise<ModelRegistry> {
     if (perRunRegistry) {
       return perRunRegistry;
     }
@@ -446,11 +504,7 @@ export class WorkflowAgent {
       return this.sharedRegistry;
     }
     if (!this.registry) {
-      const dir = getAgentDir();
-      // Same agentDir/auth files createAgentSession uses by default, so a model
-      // resolved here carries valid credentials.
-      const auth = AuthStorage.create(join(dir, "auth.json"));
-      this.registry = ModelRegistry.create(auth, join(dir, "models.json"));
+      this.registry = await ensureFallbackRegistry();
     }
     return this.registry;
   }
@@ -518,18 +572,22 @@ export class WorkflowAgent {
       customTools.push(createStructuredOutputTool({ schema: options.schema, capture }) as unknown as ToolDefinition);
     }
 
+    // Per-run modelRegistry wins over the constructor's shared registry, then
+    // the lazily-built disk fallback. Used for tier diagnostics, model
+    // resolution, and the subagent session's runtime below.
+    const modelRegistry = await this.getRegistry(options.modelRegistry);
+
     // Resolve the model spec (explicit model > tier > session default). This
     // composes with phase-based routing in workflow.ts, which only supplies
     // options.model when a phase pattern matches — so an explicit model wins.
     const modelSpec = resolveAgentModelSpec(options, this.mainModel, loadModelTierConfig, () =>
-      warnTierUnconfiguredOnce(this.mainModel, this.getRegistry(options.modelRegistry)),
+      warnTierUnconfiguredOnce(this.mainModel, modelRegistry),
     );
 
     // Resolve a requested model spec to a Model object. Specs use Pi CLI-style
     // parsing, including an optional :thinking suffix such as gpt-5.5:xhigh.
     // A given-but-unresolved spec falls back to the session default (with a
     // warning) rather than failing.
-    const modelRegistry = this.getRegistry(options.modelRegistry);
     let resolvedModel: Model<any> | undefined;
     let resolvedThinkingLevel: CreateAgentSessionOptions["thinkingLevel"] | undefined;
     if (modelSpec) {
@@ -546,6 +604,9 @@ export class WorkflowAgent {
     }
 
     const agentDir = getAgentDir();
+    // The runtime behind the resolved registry, handed to the subagent session
+    // below so it shares the host session's exact catalog and auth.
+    const modelRuntime = runtimeOf(modelRegistry);
     // Key persisted sessions by the runner's project cwd (this.cwd), NOT the
     // per-call runCwd: agents working in short-lived git worktrees should still
     // group under the project's session dir instead of scattering across
@@ -561,11 +622,10 @@ export class WorkflowAgent {
       // not have valid auth, causing silent empty responses.
       settingsManager: SettingsManager.create(this.cwd, agentDir),
       customTools,
-      // Per-run modelRegistry wins over the constructor's shared registry
-      // (see getRegistry() precedence above).
-      ...(options.modelRegistry || this.sharedRegistry
-        ? { modelRegistry: options.modelRegistry ?? this.sharedRegistry }
-        : {}),
+      // Share the resolved registry's ModelRuntime (catalog + auth, including
+      // extension-registered providers) with the subagent session. pi >= 0.80.8
+      // takes modelRuntime here; the old modelRegistry option is gone.
+      ...(modelRuntime ? { modelRuntime } : {}),
       ...this.sessionOptions,
       // Per-call model/thinking wins over any sessionOptions defaults.
       ...(resolvedModel ? { model: resolvedModel } : {}),

--- a/src/workflows-models-command.ts
+++ b/src/workflows-models-command.ts
@@ -48,9 +48,13 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
 
       // Load the saved config, or build an in-memory default spread across the
       // available models. If the model registry is empty, fall back to the
-      // current Pi model so the tiers are still usable.
+      // current Pi model so the tiers are still usable. Pass the host session's
+      // registry explicitly: since pi 0.80.8 the no-registry fallback inside
+      // listAvailableModels() initializes asynchronously and reports [] on the
+      // first call, which would rank defaults from an empty model list.
       const currentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
-      let config = loadModelTierConfig() ?? buildDefaultTierConfig(currentModel, listAvailableModels());
+      let config =
+        loadModelTierConfig() ?? buildDefaultTierConfig(currentModel, listAvailableModels(ctx.modelRegistry));
       let dirty = false;
 
       const ensureFresh = (cfg: typeof config) => {
@@ -94,7 +98,7 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
             "This will reset tiers from your available model list. Continue?",
           );
           if (confirmed) {
-            ensureFresh(buildDefaultTierConfig(currentModel, listAvailableModels()));
+            ensureFresh(buildDefaultTierConfig(currentModel, listAvailableModels(ctx.modelRegistry)));
             ctx.ui.notify("Tiers reset to defaults. Use 'Save and exit' to persist.", "info");
           }
         }

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -180,7 +180,7 @@ test("WorkflowAgent constructor accepts all option shapes without throwing", () 
   }
 });
 
-test("WorkflowAgent reuses an injected ModelRegistry instead of building its own", () => {
+test("WorkflowAgent reuses an injected ModelRegistry instead of building its own", async () => {
   const mockModel = { provider: "mock", id: "shared" } as any;
   const registry = {
     find: (provider: string, id: string) => (provider === "mock" && id === "shared" ? mockModel : undefined),
@@ -189,17 +189,20 @@ test("WorkflowAgent reuses an injected ModelRegistry instead of building its own
   } as any;
 
   const agent = new WorkflowAgent({ cwd: "/tmp", modelRegistry: registry });
-  const resolved = resolveModelSpecWithThinking("mock/shared", (agent as any).getRegistry());
+  const resolvedRegistry = await (agent as any).getRegistry();
+  assert.equal(resolvedRegistry, registry, "should hand back the injected registry");
+  const resolved = resolveModelSpecWithThinking("mock/shared", resolvedRegistry);
   assert.equal(resolved.model, mockModel, "should resolve via the injected registry");
 });
 
-test("WorkflowAgent falls back to building a disk registry when no registry is injected", () => {
+test("WorkflowAgent falls back to building a disk registry when no registry is injected", async () => {
   const agent = new WorkflowAgent({ cwd: "/tmp" });
-  // Should not throw; getRegistry() lazily builds a ModelRegistry.
-  assert.doesNotThrow(() => (agent as any).getRegistry());
+  // Should not reject; getRegistry() lazily builds a ModelRegistry from disk
+  // (async since pi 0.80.8: registries wrap an async-created ModelRuntime).
+  await assert.doesNotReject(() => (agent as any).getRegistry());
 });
 
-test("WorkflowAgent.resolveModel resolves via a per-run registry when the constructor got none", () => {
+test("WorkflowAgent.resolveModel resolves via a per-run registry when the constructor got none", async () => {
   // Regression test for the per-run `modelRegistry` AgentRunOptions field: a
   // model present only in a registry passed to run() (not the constructor)
   // must still resolve.
@@ -211,11 +214,14 @@ test("WorkflowAgent.resolveModel resolves via a per-run registry when the constr
   } as any;
 
   const agent = new WorkflowAgent({ cwd: "/tmp" });
-  const resolved = resolveModelSpecWithThinking("router/per-run-only", (agent as any).getRegistry(perRunRegistry));
+  const resolved = resolveModelSpecWithThinking(
+    "router/per-run-only",
+    await (agent as any).getRegistry(perRunRegistry),
+  );
   assert.equal(resolved.model, perRunModel, "should resolve via the per-run registry, not a disk registry");
 });
 
-test("WorkflowAgent.resolveModel: per-run registry takes precedence over the constructor's shared registry", () => {
+test("WorkflowAgent.resolveModel: per-run registry takes precedence over the constructor's shared registry", async () => {
   const constructorModel = { provider: "ctor", id: "shared" } as any;
   const constructorRegistry = {
     find: (provider: string, id: string) => (provider === "ctor" && id === "shared" ? constructorModel : undefined),
@@ -232,23 +238,23 @@ test("WorkflowAgent.resolveModel: per-run registry takes precedence over the con
 
   const agent = new WorkflowAgent({ cwd: "/tmp", modelRegistry: constructorRegistry });
   // The per-run registry, not the constructor's, is consulted when both are set.
-  const resolved = resolveModelSpecWithThinking("run/override", (agent as any).getRegistry(perRunRegistry));
+  const resolved = resolveModelSpecWithThinking("run/override", await (agent as any).getRegistry(perRunRegistry));
   assert.equal(resolved.model, perRunModel, "per-run registry should win over the constructor's shared registry");
   // And the constructor registry is still used when no per-run registry is given.
-  const fallback = resolveModelSpecWithThinking("ctor/shared", (agent as any).getRegistry());
+  const fallback = resolveModelSpecWithThinking("ctor/shared", await (agent as any).getRegistry());
   assert.equal(fallback.model, constructorModel, "constructor registry should still apply without a per-run override");
 });
 
-test("WorkflowAgent.getRegistry: per-run registry wins, then constructor's shared registry, then disk", () => {
+test("WorkflowAgent.getRegistry: per-run registry wins, then constructor's shared registry, then disk", async () => {
   const constructorRegistry = { getAvailable: () => [], find: () => undefined, getAll: () => [] } as any;
   const perRunRegistry = { getAvailable: () => [], find: () => undefined, getAll: () => [] } as any;
 
   const agent = new WorkflowAgent({ cwd: "/tmp", modelRegistry: constructorRegistry });
-  assert.equal((agent as any).getRegistry(perRunRegistry), perRunRegistry);
-  assert.equal((agent as any).getRegistry(), constructorRegistry);
+  assert.equal(await (agent as any).getRegistry(perRunRegistry), perRunRegistry);
+  assert.equal(await (agent as any).getRegistry(), constructorRegistry);
 
   const bareAgent = new WorkflowAgent({ cwd: "/tmp" });
-  assert.doesNotThrow(() => (bareAgent as any).getRegistry());
+  await assert.doesNotReject(() => (bareAgent as any).getRegistry());
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/model-runtime-routing.test.ts
+++ b/tests/model-runtime-routing.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Guards the pi >= 0.80.8 subagent routing contract end-to-end.
+ *
+ * WorkflowAgent shares the HOST session's model catalog with each subagent by
+ * reaching through the ModelRegistry facade's PRIVATE `runtime` field (see
+ * runtimeOf in src/agent.ts) and passing that ModelRuntime to
+ * createAgentSession. That access is cast through `unknown`, so a pi upgrade
+ * renaming the field breaks routing SILENTLY: tsc stays green, mock-based
+ * tests stay green, and subagents just fall back to a default-built runtime in
+ * which extension-registered providers (e.g. ollama) do not exist.
+ *
+ * These tests are the loud tripwire: they use the real installed pi classes,
+ * and the end-to-end test gives the subagent NO session.modelRuntime override,
+ * so the scripted faux provider is reachable ONLY via runtimeOf(). If pi
+ * renames the internals, this file fails and the fix is to update runtimeOf().
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
+import { runtimeOf, WorkflowAgent } from "../src/agent.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+test("runtimeOf reaches the ModelRuntime behind pi's real ModelRegistry facade (pi-internals contract)", async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-runtimeof-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const runtime = await ModelRuntime.create({ authPath: join(home, "auth.json"), modelsPath: null });
+      const registry = new ModelRegistry(runtime);
+      assert.equal(
+        runtimeOf(registry),
+        runtime,
+        "ModelRegistry's private `runtime` field no longer exposes its ModelRuntime — pi internals changed; update runtimeOf() in src/agent.ts",
+      );
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("runtimeOf degrades to undefined (no throw) on a registry without a runtime field", () => {
+  const mock = { getAvailable: () => [], find: () => undefined, getAll: () => [] } as unknown as ModelRegistry;
+  assert.equal(runtimeOf(mock), undefined);
+});
+
+test("a shared host ModelRegistry routes subagents to extension-registered providers (no session override)", async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-routing-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-routing-cwd-"));
+  const core = createFauxCore({
+    provider: "fauxtest",
+    models: [{ id: "faux-model", name: "Faux Model", contextWindow: 128000, maxTokens: 4096 }],
+  });
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const runtime = await ModelRuntime.create({ authPath: join(home, "auth.json"), modelsPath: null });
+      runtime.registerProvider("fauxtest", {
+        name: "Faux Test",
+        // Required by custom-model validation; never dialed — streamSimple intercepts.
+        baseUrl: "http://127.0.0.1:9/faux",
+        apiKey: "faux-dummy-key-not-used",
+        api: core.api,
+        streamSimple: core.streamSimple as never,
+        models: core.models.map((m) => ({
+          id: m.id,
+          name: m.name ?? m.id,
+          reasoning: false,
+          input: ["text"] as ("text" | "image")[],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: m.contextWindow ?? 128000,
+          maxTokens: m.maxTokens ?? 4096,
+        })),
+      });
+      // The extension's exact wiring (extensions/workflow.ts session_start →
+      // manager.setModelRegistry → WorkflowAgentOptions.modelRegistry): the
+      // host registry facade is shared, and there is NO session.modelRuntime
+      // override — the subagent can only reach "fauxtest" via runtimeOf().
+      const registry = new ModelRegistry(runtime);
+      core.setResponses([fauxAssistantMessage("routed-through-extension-provider", { stopReason: "stop" })]);
+      const agent = new WorkflowAgent({ cwd, modelRegistry: registry });
+      const text = await agent.run("do the task", { label: "routing probe", model: "fauxtest/faux-model" });
+      assert.ok(
+        typeof text === "string" && text.includes("routed-through-extension-provider"),
+        `subagent did not stream through the extension-registered provider (got: ${String(text).slice(0, 120)})`,
+      );
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/tests/usage-limit-integration.test.ts
+++ b/tests/usage-limit-integration.test.ts
@@ -3,19 +3,27 @@
  *
  * Every other test injects a fake agent runner; this one drives the REAL
  * `WorkflowAgent.run` → `createAgentSession` path and uses the pi SDK's built-in
- * FAUX provider to end a turn in a "usage limit reached" error (stopReason
+ * faux stream to end a turn in a "usage limit reached" error (stopReason
  * "error" + errorMessage), exactly as a real provider buries a quota exhaustion.
  * It is the contract guard for the load-bearing SDK assumption behind the fix:
  * a usage limit surfaces as an error-status assistant message, not a thrown error.
  * No network call is made and NO provider quota is consumed.
+ *
+ * pi >= 0.80.8: sessions stream through a ModelRuntime, and a builtin provider
+ * with no overlays bypasses the compat api registry entirely — so the old
+ * registerFauxProvider() global-registry hook is invisible to the session.
+ * Instead, register the faux core as an extension provider on an explicit
+ * ModelRuntime (its streamSimple is closure-scripted, no registry involved)
+ * and hand that runtime to the subagent session.
  */
 
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { WorkflowAgent } from "../src/agent.js";
 import { WorkflowErrorCode } from "../src/errors.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
@@ -24,69 +32,68 @@ import { withFakeHomeAsync } from "./helpers/fake-home.js";
 const USAGE_LIMIT_MSG = "Codex usage limit reached (plus plan). Resets in ~3h.";
 
 /**
- * Load the faux provider from the SAME pi-ai instance that pi-coding-agent's
- * createAgentSession dispatches through. pi-coding-agent ships its own nested
- * pi-ai copy; registering on a different instance would be invisible to the
- * session ("No API provider registered"). Prefer the nested copy when present,
- * else fall back to the bare specifier — which, when npm has deduped to a single
- * copy, resolves to that same shared instance. Robust to both layouts.
- */
-async function loadFaux(): Promise<typeof import("@earendil-works/pi-ai/compat")> {
-  const nested = fileURLToPath(
-    new URL(
-      "../node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/compat.js",
-      import.meta.url,
-    ),
-  );
-  const entry = existsSync(nested) ? pathToFileURL(nested).href : "@earendil-works/pi-ai/compat";
-  return import(entry) as Promise<typeof import("@earendil-works/pi-ai/compat")>;
-}
-
-/**
- * Run `fn` with an isolated HOME and a dummy provider key so hasConfiguredAuth()
- * passes via env — no real credentials are touched, and the faux api means the
- * key is never actually used. A faux "deepseek" provider is registered/torn down
- * around `fn`; `setResponses` queues the scripted turns.
+ * Run `fn` with an isolated HOME and a scripted faux provider registered on a
+ * test-scoped ModelRuntime — no real credentials are touched and no network
+ * call can happen; `setResponses` queues the scripted turns.
  */
 async function withFauxSession(
   fn: (ctx: {
     cwd: string;
     model: unknown;
+    modelRuntime: ModelRuntime;
     setResponses: (msgs: unknown[]) => void;
     fauxAssistantMessage: typeof import("@earendil-works/pi-ai").fauxAssistantMessage;
   }) => Promise<void>,
 ): Promise<void> {
-  const { registerFauxProvider, fauxAssistantMessage } = await loadFaux();
   const home = mkdtempSync(join(tmpdir(), "pi-dw-i26-home-"));
   const cwd = mkdtempSync(join(tmpdir(), "pi-dw-i26-cwd-"));
-  const prevKey = process.env.DEEPSEEK_API_KEY;
-  process.env.DEEPSEEK_API_KEY = "faux-dummy-key-not-used";
-  const faux = registerFauxProvider({
-    provider: "deepseek",
-    models: [{ id: "faux-deepseek", name: "Faux DeepSeek", contextWindow: 128000, maxTokens: 4096 }],
+  const core = createFauxCore({
+    provider: "fauxtest",
+    models: [{ id: "faux-model", name: "Faux Model", contextWindow: 128000, maxTokens: 4096 }],
   });
   try {
-    await withFakeHomeAsync(home, () =>
-      fn({
+    await withFakeHomeAsync(home, async () => {
+      // Created inside the fake home so every default path stays isolated.
+      const modelRuntime = await ModelRuntime.create({
+        authPath: join(home, "auth.json"),
+        modelsPath: null,
+      });
+      modelRuntime.registerProvider("fauxtest", {
+        name: "Faux Test",
+        // Required by custom-model validation; never dialed — streamSimple intercepts.
+        baseUrl: "http://127.0.0.1:9/faux",
+        apiKey: "faux-dummy-key-not-used",
+        api: core.api,
+        streamSimple: core.streamSimple as never,
+        models: core.models.map((m) => ({
+          id: m.id,
+          name: m.name ?? m.id,
+          reasoning: false,
+          input: ["text"] as ("text" | "image")[],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: m.contextWindow ?? 128000,
+          maxTokens: m.maxTokens ?? 4096,
+        })),
+      });
+      const model = modelRuntime.getModel("fauxtest", "faux-model") ?? core.getModel();
+      await fn({
         cwd,
-        model: faux.getModel(),
-        setResponses: (msgs) => faux.setResponses(msgs as never),
+        model,
+        modelRuntime,
+        setResponses: (msgs) => core.setResponses(msgs as never),
         fauxAssistantMessage,
-      }),
-    );
+      });
+    });
   } finally {
-    faux.unregister();
-    if (prevKey === undefined) delete process.env.DEEPSEEK_API_KEY;
-    else process.env.DEEPSEEK_API_KEY = prevKey;
     rmSync(home, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });
   }
 }
 
 test("a real subagent session that hits a usage limit surfaces PROVIDER_USAGE_LIMIT (not SCHEMA_NONCOMPLIANCE/EMPTY)", () =>
-  withFauxSession(async ({ cwd, model, setResponses, fauxAssistantMessage }) => {
+  withFauxSession(async ({ cwd, model, modelRuntime, setResponses, fauxAssistantMessage }) => {
     setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: USAGE_LIMIT_MSG })]);
-    const agent = new WorkflowAgent({ cwd, session: { model: model as never } });
+    const agent = new WorkflowAgent({ cwd, session: { model: model as never, modelRuntime } });
     await assert.rejects(
       () => agent.run("do the task", { label: "probe" }),
       (err: unknown) => {
@@ -101,16 +108,16 @@ test("a real subagent session that hits a usage limit surfaces PROVIDER_USAGE_LI
   }));
 
 test("a successful real turn whose text merely mentions 'rate limit' is NOT misclassified", () =>
-  withFauxSession(async ({ cwd, model, setResponses, fauxAssistantMessage }) => {
+  withFauxSession(async ({ cwd, model, modelRuntime, setResponses, fauxAssistantMessage }) => {
     setResponses([fauxAssistantMessage("Done. I handled the rate limit gracefully.", { stopReason: "stop" })]);
-    const agent = new WorkflowAgent({ cwd, session: { model: model as never } });
+    const agent = new WorkflowAgent({ cwd, session: { model: model as never, modelRuntime } });
     const text = await agent.run("do the task", { label: "ok" });
     assert.ok(typeof text === "string" && text.includes("Done."), `expected normal text, got ${String(text)}`);
   }));
 
 test("through the manager: a usage limit pauses the run (not fails) and resume replays the journal", () =>
-  withFauxSession(async ({ cwd, model, setResponses, fauxAssistantMessage }) => {
-    const managerAgent = new WorkflowAgent({ cwd, session: { model: model as never } });
+  withFauxSession(async ({ cwd, model, modelRuntime, setResponses, fauxAssistantMessage }) => {
+    const managerAgent = new WorkflowAgent({ cwd, session: { model: model as never, modelRuntime } });
     const manager = new WorkflowManager({ cwd, agent: managerAgent });
     const pausedReasons: Array<string | undefined> = [];
     manager.on("paused", (e: { reason?: string }) => pausedReasons.push(e.reason));

--- a/tests/workflows-models-command.test.ts
+++ b/tests/workflows-models-command.test.ts
@@ -10,7 +10,11 @@
  */
 
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it, mock } from "node:test";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 async function loadCommand() {
   const mod = await import("../src/workflows-models-command.js");
@@ -176,6 +180,70 @@ describe("workflows-models-command", () => {
       const result = await editSingleTier(ctx as never, tiers, "small");
       assert.ok(result, "should return updated tiers");
       assert.equal(result.small, "openai/gpt-4.1-mini");
+    });
+  });
+
+  describe("default tier config on first use (pi >= 0.80.8 regression)", () => {
+    it("builds defaults from ctx.modelRegistry, not the empty async disk fallback", async () => {
+      // Since pi 0.80.8 the no-registry fallback inside listAvailableModels()
+      // initializes asynchronously and reports [] on the FIRST call. If the
+      // command handler builds its default tier config without passing the host
+      // session's registry, a first-ever /workflows-models open ranks tiers
+      // from an empty model list (every tier => ""). Drive the real handler
+      // with a stub registry and assert the first menu shows tiers ranked from
+      // that registry.
+      const { registerWorkflowModelsCommand } = await loadCommand();
+      let handler: ((args: unknown, ctx: unknown) => Promise<void>) | undefined;
+      const mockPi = {
+        registerCommand: mock.fn(
+          (_name: string, opts: { handler?: (args: unknown, ctx: unknown) => Promise<void> }) => {
+            handler = opts.handler;
+          },
+        ),
+      };
+      registerWorkflowModelsCommand(mockPi as never);
+      assert.ok(handler, "handler should be registered");
+
+      const cheap = {
+        provider: "mockvendor",
+        id: "cheap-model",
+        cost: { input: 0, output: 1, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 100000,
+      };
+      const registry = { getAvailable: () => [cheap], getAll: () => [cheap], find: () => cheap };
+      const selectCalls: string[][] = [];
+      const ctx = {
+        waitForIdle: async () => {},
+        model: undefined,
+        modelRegistry: registry,
+        ui: {
+          select: mock.fn(async (_title: string, options: string[]) => {
+            selectCalls.push(options);
+            return "Exit"; // leave the menu immediately, nothing saved
+          }),
+          notify: mock.fn(),
+          confirm: mock.fn(async () => false),
+          custom: mock.fn(async () => null),
+        },
+      };
+
+      // Fresh fake home: no saved model-tiers.json, so the handler must build
+      // an in-memory default config.
+      const home = mkdtempSync(join(tmpdir(), "pi-dw-wmc-home-"));
+      try {
+        await withFakeHomeAsync(home, () =>
+          (handler as (args: unknown, ctx: unknown) => Promise<void>)(undefined, ctx),
+        );
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+      }
+
+      assert.ok(selectCalls.length >= 1, "the tier menu should have been shown");
+      const menu = selectCalls[0].join("\n");
+      assert.ok(
+        menu.includes("mockvendor/cheap-model"),
+        `default tiers must rank from the host registry's models; menu was:\n${menu}`,
+      );
     });
   });
 });


### PR DESCRIPTION
## What broke

pi 0.80.8 shipped breaking SDK changes ([CHANGELOG](https://github.com/earendil-works/pi/blob/main/CHANGELOG.md#0808---2026-07-16)):

- `AuthStorage` is no longer exported from `@earendil-works/pi-coding-agent` (only `readStoredCredential` remains).
- `ModelRegistry.create(auth, modelsPath)` is gone — `ModelRegistry` is now a synchronous facade constructed from an async-created `ModelRuntime`.
- `CreateAgentSessionOptions.modelRegistry` was replaced by `modelRuntime`.

Because pi loads extensions via jiti (missing named imports become `undefined` instead of a load error), the package still _loads_ on 0.80.8+, but degrades silently:

1. **Disk-fallback registry paths throw at runtime** — `AuthStorage.create(...)` is `undefined.create(...)` (`listAvailableModels()` with no registry, `WorkflowAgent.getRegistry()` with no shared registry).
2. **Subagents lose the host session's catalog** — `createAgentSession` silently ignores the removed `modelRegistry` option, so every subagent gets a default-built runtime. Models from extension-registered providers (e.g. an ollama extension) resolve at spec time but are unreachable at stream time.
3. **The usage-limit integration tests fail** — `registerFauxProvider()` registers into the compat api registry, but a `ModelRuntime` session with an un-overlaid builtin provider never consults that registry (`recomposeProvider` uses the builtin untouched), so the faux turns are never served and the tests die on real connection errors after ~14s of retries.

The repo's own `npm test` currently only stays green because `package-lock.json` pins `@earendil-works/pi-coding-agent@0.80.6`; a fresh `npm update` to latest breaks the build on `import { AuthStorage }`.

## The fix

- **`src/agent.ts`**
  - Disk fallback is now a lazily-created shared `ModelRuntime` (`ModelRuntime.create({authPath, modelsPath})`) wrapped in a `ModelRegistry` facade; the availability snapshot is warmed once so the facade's sync `getAvailable()` is populated. A rejected create is not cached (transient failures don't wedge the process). Sync callers (`listAvailableModels`) report `[]` while it initializes — same best-effort contract as before, and the workflow tool's lazy `promptGuidelines` re-reads pick up real specs on the next read.
  - `getRegistry()` is now async (registries wrap an async-created runtime); `run()` resolves the registry once and uses it for tier diagnostics, model resolution, and the session.
  - `run()` passes the registry's underlying `ModelRuntime` to `createAgentSession` (replacing the removed `modelRegistry` option), so subagents share the host session's exact catalog and auth again. `ModelRegistry` doesn't expose its runtime publicly, so this reaches the private `runtime` field via an exported `runtimeOf()` helper that warns once and degrades to the previous (default-runtime) behavior if pi ever renames the field.
- **`tests/usage-limit-integration.test.ts`** — rewritten for the `ModelRuntime` dispatch path: the faux core (`createFauxCore`) is registered as an extension provider (`registerProvider` with `api` + `streamSimple`) on an explicit test-scoped `ModelRuntime` handed to the session. Faux state is closure-scoped, so no global registry or module-instance concerns; tests now run in milliseconds instead of retrying real connections.
- **`tests/model-runtime-routing.test.ts`** (new) — pins the private-field contract against the real installed pi, plus an end-to-end test where a subagent reaches an extension-registered provider **only** via `runtimeOf()` (no `session.modelRuntime` override). If a future pi renames the internals, these fail loudly instead of tsc/mock tests staying green while routing silently degrades.
- **`tests/agent.test.ts`** — updated to the async `getRegistry()` contract.
- **`package.json` / `package-lock.json`** — peer dependency bumped to `@earendil-works/pi-coding-agent >= 0.80.8` (`ModelRuntime` doesn't exist earlier) and the lockfile refreshed to 0.80.10. If you'd rather keep supporting 0.80.6/0.80.7, `runtimeOf`/the fallback could feature-detect `ModelRuntime` vs `AuthStorage` — happy to amend, but given pi's release cadence a minimum-version bump seemed cleaner.

## Verification

- `npm test` (biome + tsc build + unit tests) green against pi **0.80.10**: 904/904.
- Per CONTRIBUTING, verified end-to-end against real pi 0.80.10 subagent sessions (real `createAgentSession` → real provider): plain `agent()`, tier routing (`small`/`big` resolving to different real models), and `schema` structured output all work; results and token accounting come back correctly.
