### PR TITLE
feat: authorize keyword triggering instead of forcing it (addresses #88, #89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Run a workflow to audit every route under src/routes/ for missing auth checks.
 
 Pi writes and starts the workflow in the background. A live panel tracks progress while you keep working, and the final result is delivered back into the conversation automatically.
 
-Keyword triggering is on by default: use the bounded word **workflow** or **workflows** in a message to force workflow mode, or run `/workflows run <prompt>` explicitly. Identifier-like text and paths such as `myworkflow`, `workflow_name`, and `src/workflow-editor.ts` do not trigger. You can change the keyword with `/workflows-trigger set pi-workflow` or disable it with `/workflows-trigger off`.
+Keyword triggering is on by default: use the bounded word **workflow** or **workflows** in a message to arm workflow mode — the assistant then handles a request by fanning it out across agents, but still answers plainly if you're only asking *about* workflows (the trigger authorizes the tool, it doesn't force it). Or run `/workflows run <prompt>` explicitly. Identifier-like text and paths such as `myworkflow`, `workflow_name`, and `src/workflow-editor.ts` do not trigger. You can change the keyword with `/workflows-trigger set pi-workflow` or disable it with `/workflows-trigger off`.
 
 ## How it works
 
@@ -114,7 +114,7 @@ Pi can manage background runs directly with the `workflow_control` tool instead 
 | Command | Purpose |
 | --- | --- |
 | `/workflows` | Open the interactive run navigator |
-| `/workflows run <prompt>` | Force a workflow even when keyword triggering is off |
+| `/workflows run <prompt>` | Arm workflow mode for a prompt even when keyword triggering is off |
 | `/workflows status <id>` | Watch a run and print its result when complete |
 | `/workflows pause\|resume\|stop\|rm <id>` | Control a run |
 | `/workflows save <name>` | Save the latest script as a reusable command |

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export type {
 } from "./workflow-control-tool.js";
 export { createWorkflowControlTool } from "./workflow-control-tool.js";
 export {
-  buildForcedWorkflowPrompt,
+  buildArmedWorkflowPrompt,
   colorizeWorkflow,
   endsWithTrigger,
   hasTrigger,

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,9 @@ export type {
 } from "./workflow-control-tool.js";
 export { createWorkflowControlTool } from "./workflow-control-tool.js";
 export {
+  type ArmReason,
   buildArmedWorkflowPrompt,
+  buildForcedWorkflowPrompt,
   colorizeWorkflow,
   endsWithTrigger,
   hasTrigger,

--- a/src/workflow-commands.ts
+++ b/src/workflow-commands.ts
@@ -15,7 +15,7 @@ import {
 import { type EffortState, effortDirective } from "./effort-command.js";
 import type { PersistedRunState } from "./run-persistence.js";
 import { registerSavedWorkflow } from "./saved-commands.js";
-import { buildArmedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "./workflow-editor.js";
+import { buildForcedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "./workflow-editor.js";
 import type { WorkflowManager } from "./workflow-manager.js";
 import type { WorkflowStorage } from "./workflow-saved.js";
 import { openWorkflowNavigator } from "./workflow-ui.js";
@@ -164,7 +164,10 @@ export function registerWorkflowCommands(
 
           const effort = opts.effort;
           const extra = effort && effort.level !== "off" ? effortDirective(effort.level) : undefined;
-          const armed = buildArmedWorkflowPrompt(prompt, extra);
+          // `/workflows run` is an explicit, maximal-intent command — use the
+          // forcing directive (no "if it's a question just answer" escape),
+          // distinct from the heuristic keyword/effort arming.
+          const armed = buildForcedWorkflowPrompt(prompt, extra);
           ctx.ui.notify(`Running workflow: ${prompt.slice(0, 60)}${prompt.length > 60 ? "…" : ""}`, "info");
           try {
             await pi.sendMessage(

--- a/src/workflow-commands.ts
+++ b/src/workflow-commands.ts
@@ -15,7 +15,7 @@ import {
 import { type EffortState, effortDirective } from "./effort-command.js";
 import type { PersistedRunState } from "./run-persistence.js";
 import { registerSavedWorkflow } from "./saved-commands.js";
-import { buildForcedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "./workflow-editor.js";
+import { buildArmedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "./workflow-editor.js";
 import type { WorkflowManager } from "./workflow-manager.js";
 import type { WorkflowStorage } from "./workflow-saved.js";
 import { openWorkflowNavigator } from "./workflow-ui.js";
@@ -164,11 +164,11 @@ export function registerWorkflowCommands(
 
           const effort = opts.effort;
           const extra = effort && effort.level !== "off" ? effortDirective(effort.level) : undefined;
-          const forced = buildForcedWorkflowPrompt(prompt, extra);
-          ctx.ui.notify(`Forcing workflow: ${prompt.slice(0, 60)}${prompt.length > 60 ? "…" : ""}`, "info");
+          const armed = buildArmedWorkflowPrompt(prompt, extra);
+          ctx.ui.notify(`Running workflow: ${prompt.slice(0, 60)}${prompt.length > 60 ? "…" : ""}`, "info");
           try {
             await pi.sendMessage(
-              { customType: "workflow-run", content: forced, display: true },
+              { customType: "workflow-run", content: armed, display: true },
               { triggerTurn: true, deliverAs: "followUp" },
             );
           } catch {

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -31,6 +31,7 @@ import {
   type WorkflowSettings,
   type WorkflowSettingsStore,
 } from "./workflow-settings.js";
+import { workflowHowToGuidelines } from "./workflow-tool.js";
 
 // A keyword trigger is a configured literal term. All trigger words use token
 // boundaries so slash commands, paths, and identifier-like text stay untouched.
@@ -384,28 +385,48 @@ export class WorkflowEditor extends CustomEditor {
 }
 
 /**
- * The directive appended to a submitted message when workflows mode is armed.
+ * The directive appended to a submitted message when workflows mode is ARMED
+ * (via the keyword trigger, standing `/effort`, or `/workflows run`).
+ *
+ * This authorizes — it does not force. Arming is a confirmed opt-in signal that
+ * lifts the always-on "do not call the tool" gate for THIS message; the model
+ * still decides whether the message is actually a request to do work (→ call the
+ * `workflow` tool) or just talk about workflows (→ answer directly). The old
+ * "You MUST / the ONLY acceptable action / Do NOT answer directly" forcing text
+ * caused two bugs: it over-triggered on messages that merely mention workflows
+ * (#88), and — by commanding the model to emit nothing but one `workflow` call
+ * and not talk — it produced a bare background run that ends the turn and leaves
+ * the user at an idle prompt (#89). Letting the model handle the request in a
+ * normal turn restores the inline/interactive path.
+ *
+ * The how-to mechanics for writing a workflow script are appended here (only on
+ * an armed turn) so the model has them at the moment of use without paying for
+ * them in the always-on prompt (#65).
+ *
  * `extraDirective` (e.g. an effort-tier nudge) is appended when present.
  */
-export function buildForcedWorkflowPrompt(text: string, extraDirective?: string): string {
+/**
+ * Appended to the effort-path directive: standing `/effort` arms on every
+ * substantive message, so the model must be told it can decline the workflow on
+ * a conversational or trivial turn (mirrors "solo only on conversational turns").
+ */
+export const EFFORT_CONVERSATIONAL_ESCAPE =
+  "This turn was armed by standing effort mode, not by an explicit workflow request: if it is conversational or trivial, skip the workflow and just respond directly.";
+
+export function buildArmedWorkflowPrompt(text: string, extraDirective?: string): string {
   const lines = [
     text,
     "",
     "---",
-    "[workflows mode is ON for this message]",
-    "You MUST handle this request by calling the tool named exactly `workflow` (Pi's",
-    "deterministic JavaScript workflow-orchestration tool from pi-dynamic-workflows).",
-    "Write a workflow script that fans the task out across subagents via",
-    "agent()/parallel()/pipeline().",
-    "",
-    "The ONLY acceptable action is a `workflow` tool call. Do NOT instead:",
-    "- answer directly or in prose,",
-    "- call the `subagent` tool yourself,",
-    "- use any skill or command (e.g. pi-subagents, /code-review, deep-research),",
-    '- or interpret the word "workflow/workflows" loosely as some other parallel/audit approach.',
-    "Even for a small task, wrap it in a minimal `workflow` call with at least one agent().",
+    "[workflows mode armed — the trigger word you typed counts as explicit opt-in to",
+    "multi-agent orchestration. If this message is a request to do work, handle it by",
+    "calling the `workflow` tool: write a script that fans the task out across subagents",
+    "via agent()/parallel()/pipeline(). If it's a question ABOUT workflows, this repo, or",
+    "the tool itself, just answer it directly — the opt-in does not force a workflow, and",
+    "you should stay conversational and interactive rather than emitting a bare tool call.]",
   ];
   if (extraDirective) lines.push("", extraDirective);
+  lines.push("", "If you do call `workflow`, follow this guidance:", ...workflowHowToGuidelines().map((g) => `- ${g}`));
   return lines.join("\n");
 }
 
@@ -603,10 +624,17 @@ export function installWorkflowEditor(
         pi.setActiveTools?.(current);
       }
     } catch {
-      // Tool restriction is best-effort; the directive still forces the workflow.
+      // Tool restriction is best-effort; the armed directive still authorizes the workflow.
     }
-    const extra = byEffort && effort ? effortDirective(effort.level) : undefined;
-    return { action: "transform", text: buildForcedWorkflowPrompt(event.text, extra) } as const;
+    // Effort path: the trigger word was NOT typed — this arms on ANY substantive
+    // message while standing effort is on. So the directive must let the model
+    // skip the workflow entirely on conversational/trivial turns, not just on
+    // questions about workflows.
+    const extra =
+      byEffort && effort
+        ? [effortDirective(effort.level), EFFORT_CONVERSATIONAL_ESCAPE].filter(Boolean).join(" ")
+        : undefined;
+    return { action: "transform", text: buildArmedWorkflowPrompt(event.text, extra) } as const;
   });
 
   // Restore the user's full tool set once the forced turn completes.

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -31,7 +31,6 @@ import {
   type WorkflowSettings,
   type WorkflowSettingsStore,
 } from "./workflow-settings.js";
-import { workflowHowToGuidelines } from "./workflow-tool.js";
 
 // A keyword trigger is a configured literal term. All trigger words use token
 // boundaries so slash commands, paths, and identifier-like text stay untouched.
@@ -385,8 +384,41 @@ export class WorkflowEditor extends CustomEditor {
 }
 
 /**
- * The directive appended to a submitted message when workflows mode is ARMED
- * (via the keyword trigger, standing `/effort`, or `/workflows run`).
+ * Why a turn was armed. This is stated truthfully in the banner so the model
+ * isn't told "the trigger word you typed" on a path where no word was typed:
+ *  - "keyword": the user typed the configured workflow trigger word.
+ *  - "effort": standing `/effort` armed this turn (no workflow word was typed).
+ */
+export type ArmReason = "keyword" | "effort";
+
+/**
+ * Appended to the effort-path directive: standing `/effort` arms on every
+ * substantive message, so the model must be told it can decline the workflow on
+ * a conversational or trivial turn (mirrors "solo only on conversational turns").
+ */
+export const EFFORT_CONVERSATIONAL_ESCAPE =
+  "This turn was armed by standing effort mode, not by an explicit workflow request: if it is conversational or trivial, skip the workflow and just respond directly.";
+
+/** The one-line, truthful "why armed" clause for each heuristic arming path. */
+function armReasonClause(reason: ArmReason): string {
+  return reason === "keyword"
+    ? "you typed the workflow trigger word, which counts as an explicit opt-in to multi-agent orchestration"
+    : "standing effort mode armed this turn (you did not explicitly ask for a workflow)";
+}
+
+/**
+ * The #89 reassurance shared by every arming banner: a background run ENDING the
+ * turn is expected, not a stall — the result auto-delivers back — so the model
+ * shouldn't feel it must stay and block, nor avoid the tool to stay interactive.
+ * Names when `background:false` is the right call (user waiting inline).
+ */
+const BACKGROUND_DELIVERY_REASSURANCE =
+  "If you do call `workflow`, it runs in the background by default: this turn will end and the result is delivered back into the conversation automatically when it finishes — that's expected, not a stall, so you do not need to stay and block. Only pass background:false if the user is waiting for the result inline in this same turn.";
+
+/**
+ * The directive appended to a submitted message when workflows mode is ARMED by a
+ * HEURISTIC path — the keyword trigger or standing `/effort`. (The explicit
+ * `/workflows run` command uses {@link buildForcedWorkflowPrompt} instead.)
  *
  * This authorizes — it does not force. Arming is a confirmed opt-in signal that
  * lifts the always-on "do not call the tool" gate for THIS message; the model
@@ -396,37 +428,62 @@ export class WorkflowEditor extends CustomEditor {
  * caused two bugs: it over-triggered on messages that merely mention workflows
  * (#88), and — by commanding the model to emit nothing but one `workflow` call
  * and not talk — it produced a bare background run that ends the turn and leaves
- * the user at an idle prompt (#89). Letting the model handle the request in a
- * normal turn restores the inline/interactive path.
+ * the user at an idle prompt (#89).
  *
- * The how-to mechanics for writing a workflow script are appended here (only on
- * an armed turn) so the model has them at the moment of use without paying for
- * them in the always-on prompt (#65).
+ * The banner therefore (1) LEADS with the decision boundary (question/trivial →
+ * answer directly; a real decomposable request → call `workflow`) rather than
+ * leading with "call the tool"; (2) states the truthful opt-in `reason` for THIS
+ * path (no "the word you typed" on the effort path, where none was); and (3)
+ * carries the #89 background/deliver-back reassurance so an ending turn reads as
+ * expected. The how-to mechanics are NOT here — they live in the tool's static
+ * `description` (see createWorkflowTool), visible whenever the model looks at the
+ * tool, so they aren't re-injected per armed turn (#65).
  *
- * `extraDirective` (e.g. an effort-tier nudge) is appended when present.
+ * `extraDirective` (e.g. an effort-tier nudge + EFFORT_CONVERSATIONAL_ESCAPE) is
+ * appended when present.
  */
-/**
- * Appended to the effort-path directive: standing `/effort` arms on every
- * substantive message, so the model must be told it can decline the workflow on
- * a conversational or trivial turn (mirrors "solo only on conversational turns").
- */
-export const EFFORT_CONVERSATIONAL_ESCAPE =
-  "This turn was armed by standing effort mode, not by an explicit workflow request: if it is conversational or trivial, skip the workflow and just respond directly.";
-
-export function buildArmedWorkflowPrompt(text: string, extraDirective?: string): string {
+export function buildArmedWorkflowPrompt(
+  text: string,
+  opts: { reason?: ArmReason; extraDirective?: string } = {},
+): string {
+  const reason = opts.reason ?? "keyword";
   const lines = [
     text,
     "",
     "---",
-    "[workflows mode armed — the trigger word you typed counts as explicit opt-in to",
-    "multi-agent orchestration. If this message is a request to do work, handle it by",
-    "calling the `workflow` tool: write a script that fans the task out across subagents",
-    "via agent()/parallel()/pipeline(). If it's a question ABOUT workflows, this repo, or",
-    "the tool itself, just answer it directly — the opt-in does not force a workflow, and",
-    "you should stay conversational and interactive rather than emitting a bare tool call.]",
+    "[workflows mode armed. Decide first: if this message is a question, a trivial task, or",
+    "just talk (about workflows, this repo, or the tool itself), answer it directly and stay",
+    "conversational — arming authorizes the tool, it does not force it. If it is a real,",
+    "decomposable request to do work, handle it by calling the `workflow` tool: write a script",
+    "that fans the task out across subagents via agent()/parallel()/pipeline().",
+    `Why this turn is armed: ${armReasonClause(reason)}.`,
+    BACKGROUND_DELIVERY_REASSURANCE + "]",
+  ];
+  if (opts.extraDirective) lines.push("", opts.extraDirective);
+  return lines.join("\n");
+}
+
+/**
+ * The directive for the explicit `/workflows run <prompt>` command. Unlike the
+ * heuristic {@link buildArmedWorkflowPrompt}, `/workflows run` is a maximal-intent
+ * command — the user typed a command whose whole purpose is to execute a workflow
+ * now — so it does NOT get the "if it's a question, just answer" escape. It still
+ * avoids the old MUST/ONLY forcing language (which caused #88/#89) and still
+ * carries the #89 background/deliver-back reassurance so an ending turn reads as
+ * expected. `extraDirective` (e.g. a standing effort-tier nudge) is appended.
+ */
+export function buildForcedWorkflowPrompt(text: string, extraDirective?: string): string {
+  const lines = [
+    text,
+    "",
+    "---",
+    "[/workflows run — you ran an explicit command to execute a workflow for this request.",
+    "Call the `workflow` tool now: write a script that fans this task out across subagents",
+    "via agent()/parallel()/pipeline(). (This is a direct command, not a heuristic guess, so",
+    "do not answer in prose instead of running the workflow.)",
+    BACKGROUND_DELIVERY_REASSURANCE + "]",
   ];
   if (extraDirective) lines.push("", extraDirective);
-  lines.push("", "If you do call `workflow`, follow this guidance:", ...workflowHowToGuidelines().map((g) => `- ${g}`));
   return lines.join("\n");
 }
 
@@ -627,14 +684,19 @@ export function installWorkflowEditor(
       // Tool restriction is best-effort; the armed directive still authorizes the workflow.
     }
     // Effort path: the trigger word was NOT typed — this arms on ANY substantive
-    // message while standing effort is on. So the directive must let the model
+    // message while standing effort is on. So the directive must (a) state the
+    // truthful "effort" reason (not "the word you typed"), and (b) let the model
     // skip the workflow entirely on conversational/trivial turns, not just on
     // questions about workflows.
     const extra =
       byEffort && effort
         ? [effortDirective(effort.level), EFFORT_CONVERSATIONAL_ESCAPE].filter(Boolean).join(" ")
         : undefined;
-    return { action: "transform", text: buildArmedWorkflowPrompt(event.text, extra) } as const;
+    const reason: ArmReason = byEffort ? "effort" : "keyword";
+    return {
+      action: "transform",
+      text: buildArmedWorkflowPrompt(event.text, { reason, extraDirective: extra }),
+    } as const;
   });
 
   // Restore the user's full tool set once the forced turn completes.

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -61,18 +61,37 @@ export function agentTypeGuideline(cwd: string = process.cwd()): string | undefi
  * The single ALWAYS-ON guideline rendered into the system prompt every turn.
  * It is a pure gate: it tells the model when the tool is in scope and, crucially,
  * that it should NOT reach for the tool otherwise. The how-to mechanics live in
- * {@link workflowHowToGuidelines}, injected only on an armed turn.
+ * {@link workflowHowToGuidelines} and are folded into the tool's static
+ * `description` (see {@link createWorkflowTool}), not into this always-on line.
+ *
+ * The line is balanced on purpose: a task-shape positive ("this is the kind of
+ * work the tool is for") so the model recognizes a good fit even when the user
+ * phrases it off-keyword, PLUS the explicit-opt-in gate and the "do not call it
+ * otherwise" negative so it doesn't self-trigger (#88). The "offer with a rough
+ * cost" keeps a non-forcing path open for a task that fits but wasn't opted into.
  */
 export const WORKFLOW_GATE_GUIDELINE =
-  "The `workflow` tool runs multi-agent orchestration (fan-out across subagents). ONLY call it when the user explicitly opts in — via the workflow trigger word, `/workflows run`, or their own words (e.g. 'run a workflow', 'fan this out', '并行审一遍'). For any other task — even one that would clearly benefit — do not call it; you may briefly offer it (with a rough cost) as an option instead.";
+  "The `workflow` tool runs multi-agent orchestration — it fans decomposable work out across subagents, and fits tasks shaped like: repo-wide inspection, independent parallel research/checks, multi-perspective review, or fan-out/fan-in synthesis. ONLY call it when the user explicitly opts in — via the workflow trigger word, `/workflows run`, or their own words (e.g. 'run a workflow', 'fan this out', '并行审一遍'). For any other task — even one that would clearly benefit — do not call it; you may briefly offer it (with a rough cost) as an option instead.";
 
 /**
- * The how-to guidance for actually WRITING a workflow script. This is NOT
- * always-on: it is injected into the message only on an armed turn (keyword
- * trigger, `/effort`, or `/workflows run`), where the model may genuinely be
- * about to call the tool. Keeping it off the always-on prompt shrinks the
- * per-turn budget (#65) and removes the self-priming pressure (#88), while still
- * giving the model the full mechanics at the exact moment it needs them.
+ * The how-to guidance for actually WRITING a workflow script. These lines are
+ * folded into the tool's static `description` (see {@link createWorkflowTool}),
+ * NOT into the always-on `promptGuidelines` and NOT re-injected into the armed
+ * turn's message.
+ *
+ * A tool description is the right home for this "manual": it is visible to the
+ * model whenever it considers or calls the tool — regardless of which path armed
+ * the turn, and even on the natural-language opt-ins that the gate line blesses
+ * but that never trip the literal keyword arm — and it is a static, prefix-
+ * cacheable part of the tool definition rather than per-turn behavioral priming.
+ * That fixes both the "armed off-keyword ⇒ no mechanics ⇒ lower-quality script"
+ * gap and the ~1.4KB-per-armed-turn re-injection (worse for `/effort` users).
+ *
+ * Keeping it out of `promptGuidelines` still shrinks the always-on prompt (#88
+ * self-priming) — this array is the how-to only, never the always-on gate. Note
+ * the description now carries this weight in the tool DEFINITION budget; trimming
+ * the how-to text itself is a separate concern (#65 / contract-concision work),
+ * not this change's job.
  */
 export function workflowHowToGuidelines(cwd: string = process.cwd()): string[] {
   return [
@@ -204,10 +223,21 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
   return defineTool({
     name: "workflow",
     label: "Workflow",
+    // The how-to "manual" lives here, in the static tool description, so the
+    // model has the mechanics whenever it considers/calls the tool — on every
+    // arming path AND on off-keyword natural-language opt-ins that never trip the
+    // literal keyword arm. This is a cacheable part of the tool definition, not
+    // per-turn priming (that's why it's here and not appended to the armed
+    // message; see workflowHowToGuidelines / buildArmedWorkflowPrompt). It grows
+    // the tool-DEFINITION budget; trimming the how-to itself is separate work
+    // (#65 / contract-concision), not this change's job.
     description: [
       "Execute a deterministic JavaScript workflow that orchestrates multiple subagents with agent(), parallel(), and pipeline().",
       "script is required raw JavaScript. It must start with export const meta = { name, description, phases? } and must call agent() at least once.",
-    ].join(" "),
+      "",
+      "How to write the script:",
+      ...workflowHowToGuidelines(cwd).map((g) => `- ${g}`),
+    ].join("\n"),
     promptSnippet:
       "Run a deterministic JavaScript workflow. Required script header: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }.",
     // Lazy accessor: the SDK re-reads definition.promptGuidelines on every
@@ -215,9 +245,10 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
     // prompt every turn), so it is deliberately a single gate line — see #65
     // (always-on prompt budget) and #88 (self-priming: a wall of "For workflow, …"
     // how-to text nudges the model toward the tool even when it wasn't asked for).
-    // The ~20 how-to lines that used to live here are injected only on an ARMED
-    // turn (see workflowHowToGuidelines / buildArmedWorkflowPrompt), so the model
-    // still has them at the moment it actually writes a workflow.
+    // The ~20 how-to lines that used to live here now live in the tool's static
+    // `description` (see above / workflowHowToGuidelines), so the model has the
+    // mechanics whenever it looks at the tool — without paying the always-on cost
+    // or the per-armed-turn re-injection.
     get promptGuidelines() {
       return [WORKFLOW_GATE_GUIDELINE];
     },

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -231,6 +231,13 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
     // message; see workflowHowToGuidelines / buildArmedWorkflowPrompt). It grows
     // the tool-DEFINITION budget; trimming the how-to itself is separate work
     // (#65 / contract-concision), not this change's job.
+    //
+    // CAVEAT: the off-keyword natural-language path only sees this description if
+    // the host keeps the `workflow` tool in its default active tool set. The
+    // arming paths add the tool on arm (installWorkflowEditor's setActiveTools),
+    // but a bare natural-language opt-in with no arm relies on the tool already
+    // being active in the host's config — keep `workflow` default-active so the
+    // gate line's "fan this out" promise (mechanics available) holds.
     description: [
       "Execute a deterministic JavaScript workflow that orchestrates multiple subagents with agent(), parallel(), and pipeline().",
       "script is required raw JavaScript. It must start with export const meta = { name, description, phases? } and must call agent() at least once.",

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -57,6 +57,51 @@ export function agentTypeGuideline(cwd: string = process.cwd()): string | undefi
   return `For workflow, opts.agentType routes an agent to a named definition that binds its tools, model, and role prompt. Available agentTypes: ${list}. An explicit opts.model still overrides the definition's model.`;
 }
 
+/**
+ * The single ALWAYS-ON guideline rendered into the system prompt every turn.
+ * It is a pure gate: it tells the model when the tool is in scope and, crucially,
+ * that it should NOT reach for the tool otherwise. The how-to mechanics live in
+ * {@link workflowHowToGuidelines}, injected only on an armed turn.
+ */
+export const WORKFLOW_GATE_GUIDELINE =
+  "The `workflow` tool runs multi-agent orchestration (fan-out across subagents). ONLY call it when the user explicitly opts in — via the workflow trigger word, `/workflows run`, or their own words (e.g. 'run a workflow', 'fan this out', '并行审一遍'). For any other task — even one that would clearly benefit — do not call it; you may briefly offer it (with a rough cost) as an option instead.";
+
+/**
+ * The how-to guidance for actually WRITING a workflow script. This is NOT
+ * always-on: it is injected into the message only on an armed turn (keyword
+ * trigger, `/effort`, or `/workflows run`), where the model may genuinely be
+ * about to call the tool. Keeping it off the always-on prompt shrinks the
+ * per-turn budget (#65) and removes the self-priming pressure (#88), while still
+ * giving the model the full mechanics at the exact moment it needs them.
+ */
+export function workflowHowToGuidelines(cwd: string = process.cwd()): string[] {
+  return [
+    "For workflow, always pass one raw JavaScript string in the required script parameter; do not include Markdown fences or prose around the script.",
+    "For workflow, the script's first statement must be `export const meta = { name: 'short_snake_case', description: 'non-empty human description', phases: [{ title: 'Phase name' }] }`; meta.name and meta.description are required non-empty strings.",
+    "For workflow, write plain JavaScript after the meta export. Do not use TypeScript syntax, imports, require(), fs, Date.now(), Math.random(), or new Date().",
+    "For workflow, available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), args, cwd, process.cwd(), and budget. Every workflow must call agent() at least once; do not use workflow only to declare phases or return a static object.",
+    "For workflow, prefer the built-in quality helpers when they fit (each is built on agent()/parallel() and returns plain data): verify(item, {reviewers, threshold, lens}) for adversarial fact-checking; judgePanel(attempts, {judges, rubric}) to score N candidates and return the best; loopUntilDry({round, key, consecutiveEmpty}) to keep finding until rounds stop yielding new items; completenessCheck(args, results) as a final 'what's missing' critic.",
+    "For workflow, when meta.phases declares more than one phase, call phase('Exact Title') at the start of each phase's work (or set opts.phase on each agent) so every agent groups under the correct phase; never declare a phase you don't switch into — a declared phase with no agents shows as 0/0 and any agent you forgot to move stays in the previous phase.",
+    "For workflow, do not set tokenBudget or agentTimeoutMs unless the user explicitly asks to cap spend or time; the defaults are unbounded.",
+    "For workflow, to bound spend: pass tokenBudget for a hard run-wide cap; carve a per-phase ceiling with phase('Name', {budget: N}) (that phase throws at its sub-budget without touching the run total — wrap its work in try/catch so later phases proceed); use retry(thunk, {attempts, until}) for bounded retry, and gate(thunk, validator, {attempts}) when a validator's feedback should steer the next attempt. To degrade gracefully, branch on budget.remaining() to skip optional rounds or choose a lighter tier.",
+    "For workflow, prefer it for decomposable work: repository inspection, independent research/checks, multi-perspective review, or fan-out/fan-in synthesis. Do not use it for a single quick file read/edit or when ordinary tools are enough.",
+    "For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.",
+    "For workflow, pipeline(items, ...stages) runs each item through stages sequentially, while different items may run concurrently. Each stage receives (previousValue, originalItem, index).",
+    "For workflow, every agent() call should include a unique short label option, 2-5 words, such as { label: 'repo inventory' } or { label: 'source modules' }; unique labels make live status and error reporting readable.",
+    "For workflow, use low concurrency and agentRetries for unstable provider/transport fan-out runs; retries apply only to recoverable agent failures and still require explicit null handling after exhaustion.",
+    "For workflow, failed agent(), parallel(), or pipeline() branches return null and log the failure unless the workflow is aborted. Check for nulls before synthesizing conclusions.",
+    "For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.",
+    "For workflow, the default quality shape for fan-out work is finder -> verify -> merge: run one agent per angle or work-unit (in parallel), pass each candidate finding through verify() and drop the unconfirmed, then a single synthesis agent that de-duplicates, ranks by confidence/severity, and caps the output. If nothing survives verification, return an empty result and say so rather than padding.",
+    "For workflow, give each subagent a substantive, self-contained task: do not spawn an agent just to read one file or run one command, and do not use one agent only to check on another. Prefer fewer, higher-level agents over many trivial micro-tasks.",
+    "For workflow, if agent() needs machine-readable output, pass a plain JSON Schema via opts.schema; agent() will return the validated object. Use JSON Schema syntax, not TypeScript or TypeBox constructors.",
+    modelRoutingGuideline(),
+    agentTypeGuideline(cwd),
+    "For workflow, do not assume the parent assistant has repository code context inside subagents; include enough task context and relevant paths in each agent prompt.",
+    "For workflow, runs are background by default: the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when the run finishes. Pass background: false only when you must use the result inline in this same turn (it will block).",
+    "For workflow, you may call `await workflow('saved-name', argsObject)` to run a saved workflow inline and use its result; nesting is one level deep only, and the global 16-concurrent / 1000-total caps hold across the nesting.",
+  ].filter((g): g is string => typeof g === "string" && g.length > 0);
+}
+
 const workflowToolSchema = Type.Object({
   script: Type.String({
     description: [
@@ -166,34 +211,15 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
     promptSnippet:
       "Run a deterministic JavaScript workflow. Required script header: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }.",
     // Lazy accessor: the SDK re-reads definition.promptGuidelines on every
-    // tool-registry refresh, so changes to the agentType registry are reflected.
+    // tool-registry refresh. This is ALWAYS-ON weight (rendered into the system
+    // prompt every turn), so it is deliberately a single gate line — see #65
+    // (always-on prompt budget) and #88 (self-priming: a wall of "For workflow, …"
+    // how-to text nudges the model toward the tool even when it wasn't asked for).
+    // The ~20 how-to lines that used to live here are injected only on an ARMED
+    // turn (see workflowHowToGuidelines / buildArmedWorkflowPrompt), so the model
+    // still has them at the moment it actually writes a workflow.
     get promptGuidelines() {
-      return [
-        "Use workflow only when the user explicitly asks for a workflow, workflows, fan-out, or multi-agent orchestration.",
-        "For workflow, always pass one raw JavaScript string in the required script parameter; do not include Markdown fences or prose around the script.",
-        "For workflow, the script's first statement must be `export const meta = { name: 'short_snake_case', description: 'non-empty human description', phases: [{ title: 'Phase name' }] }`; meta.name and meta.description are required non-empty strings.",
-        "For workflow, write plain JavaScript after the meta export. Do not use TypeScript syntax, imports, require(), fs, Date.now(), Math.random(), or new Date().",
-        "For workflow, available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), args, cwd, process.cwd(), and budget. Every workflow must call agent() at least once; do not use workflow only to declare phases or return a static object.",
-        "For workflow, prefer the built-in quality helpers when they fit (each is built on agent()/parallel() and returns plain data): verify(item, {reviewers, threshold, lens}) for adversarial fact-checking; judgePanel(attempts, {judges, rubric}) to score N candidates and return the best; loopUntilDry({round, key, consecutiveEmpty}) to keep finding until rounds stop yielding new items; completenessCheck(args, results) as a final 'what's missing' critic.",
-        "For workflow, when meta.phases declares more than one phase, call phase('Exact Title') at the start of each phase's work (or set opts.phase on each agent) so every agent groups under the correct phase; never declare a phase you don't switch into — a declared phase with no agents shows as 0/0 and any agent you forgot to move stays in the previous phase.",
-        "For workflow, do not set tokenBudget or agentTimeoutMs unless the user explicitly asks to cap spend or time; the defaults are unbounded.",
-        "For workflow, to bound spend: pass tokenBudget for a hard run-wide cap; carve a per-phase ceiling with phase('Name', {budget: N}) (that phase throws at its sub-budget without touching the run total — wrap its work in try/catch so later phases proceed); use retry(thunk, {attempts, until}) for bounded retry, and gate(thunk, validator, {attempts}) when a validator's feedback should steer the next attempt. To degrade gracefully, branch on budget.remaining() to skip optional rounds or choose a lighter tier.",
-        "For workflow, prefer it for decomposable work: repository inspection, independent research/checks, multi-perspective review, or fan-out/fan-in synthesis. Do not use it for a single quick file read/edit or when ordinary tools are enough.",
-        "For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.",
-        "For workflow, pipeline(items, ...stages) runs each item through stages sequentially, while different items may run concurrently. Each stage receives (previousValue, originalItem, index).",
-        "For workflow, every agent() call should include a unique short label option, 2-5 words, such as { label: 'repo inventory' } or { label: 'source modules' }; unique labels make live status and error reporting readable.",
-        "For workflow, use low concurrency and agentRetries for unstable provider/transport fan-out runs; retries apply only to recoverable agent failures and still require explicit null handling after exhaustion.",
-        "For workflow, failed agent(), parallel(), or pipeline() branches return null and log the failure unless the workflow is aborted. Check for nulls before synthesizing conclusions.",
-        "For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.",
-        "For workflow, the default quality shape for fan-out work is finder -> verify -> merge: run one agent per angle or work-unit (in parallel), pass each candidate finding through verify() and drop the unconfirmed, then a single synthesis agent that de-duplicates, ranks by confidence/severity, and caps the output. If nothing survives verification, return an empty result and say so rather than padding.",
-        "For workflow, give each subagent a substantive, self-contained task: do not spawn an agent just to read one file or run one command, and do not use one agent only to check on another. Prefer fewer, higher-level agents over many trivial micro-tasks.",
-        "For workflow, if agent() needs machine-readable output, pass a plain JSON Schema via opts.schema; agent() will return the validated object. Use JSON Schema syntax, not TypeScript or TypeBox constructors.",
-        modelRoutingGuideline(),
-        agentTypeGuideline(),
-        "For workflow, do not assume the parent assistant has repository code context inside subagents; include enough task context and relevant paths in each agent prompt.",
-        "For workflow, runs are background by default: the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when the run finishes. Pass background: false only when you must use the result inline in this same turn (it will block).",
-        "For workflow, you may call `await workflow('saved-name', argsObject)` to run a saved workflow inline and use its result; nesting is one level deep only, and the global 16-concurrent / 1000-total caps hold across the nesting.",
-      ].filter((g): g is string => typeof g === "string" && g.length > 0);
+      return [WORKFLOW_GATE_GUIDELINE];
     },
     parameters: workflowToolSchema,
     prepareArguments(args) {

--- a/tests/effort-command.test.ts
+++ b/tests/effort-command.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createEffortState, effortDirective, isSubstantive, registerEffortCommand } from "../src/effort-command.js";
-import { buildForcedWorkflowPrompt } from "../src/workflow-editor.js";
+import { buildArmedWorkflowPrompt } from "../src/workflow-editor.js";
 
 test("effortDirective returns a tier nudge for high/ultra, nothing for off", () => {
   assert.equal(effortDirective("off"), undefined);
@@ -16,11 +16,11 @@ test("isSubstantive accepts real requests, rejects terse text and slash commands
   assert.equal(isSubstantive("    "), false);
 });
 
-test("buildForcedWorkflowPrompt appends the extra directive only when provided", () => {
-  const base = buildForcedWorkflowPrompt("do X");
+test("buildArmedWorkflowPrompt appends the extra directive only when provided", () => {
+  const base = buildArmedWorkflowPrompt("do X");
   assert.ok(!/ULTRA/.test(base), "no directive by default");
   assert.ok(base.startsWith("do X"));
-  const ultra = buildForcedWorkflowPrompt("do X", effortDirective("ultra"));
+  const ultra = buildArmedWorkflowPrompt("do X", effortDirective("ultra"));
   assert.match(ultra, /ULTRA/, "ultra directive appended");
   assert.ok(ultra.startsWith("do X"));
 });

--- a/tests/effort-command.test.ts
+++ b/tests/effort-command.test.ts
@@ -20,7 +20,7 @@ test("buildArmedWorkflowPrompt appends the extra directive only when provided", 
   const base = buildArmedWorkflowPrompt("do X");
   assert.ok(!/ULTRA/.test(base), "no directive by default");
   assert.ok(base.startsWith("do X"));
-  const ultra = buildArmedWorkflowPrompt("do X", effortDirective("ultra"));
+  const ultra = buildArmedWorkflowPrompt("do X", { reason: "effort", extraDirective: effortDirective("ultra") });
   assert.match(ultra, /ULTRA/, "ultra directive appended");
   assert.ok(ultra.startsWith("do X"));
 });

--- a/tests/workflow-commands.test.ts
+++ b/tests/workflow-commands.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { createEffortState, effortDirective } from "../src/effort-command.js";
 import { registerWorkflowCommands } from "../src/workflow-commands.js";
-import { buildArmedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "../src/workflow-editor.js";
+import { buildForcedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "../src/workflow-editor.js";
 import type { WorkflowManager } from "../src/workflow-manager.js";
 
 type Handler = (args: string, ctx: any) => Promise<void>;
@@ -108,7 +108,10 @@ test("/workflows run <prompt> sends a forced workflow follow-up turn", async () 
   await h.run("run audit auth boundaries");
   assert.equal(h.sent.length, 1);
   assert.equal(h.sent[0].customType, "workflow-run");
-  assert.equal(h.sent[0].content, buildArmedWorkflowPrompt("audit auth boundaries"));
+  // #P5: /workflows run is an explicit command → forcing directive (no question-escape).
+  assert.equal(h.sent[0].content, buildForcedWorkflowPrompt("audit auth boundaries"));
+  assert.doesNotMatch(h.sent[0].content ?? "", /answer it directly and stay/i, "no question-answer escape");
+  assert.match(h.sent[0].content ?? "", /Call the `workflow` tool now/i, "forces the tool call");
   assert.equal(h.sent[0].options?.triggerTurn, true);
   assert.equal(h.sent[0].options?.deliverAs, "followUp");
   assert.deepEqual(h.activeTools, [WORKFLOW_TOOL_NAME], "does not duplicate an already-active workflow tool");
@@ -130,7 +133,7 @@ test("/workflows run adds the workflow tool when absent and does not depend on t
   const h = harness({}, {}, ["bash", "read"]);
   await h.run("run summarize the auth module");
   assert.deepEqual(h.activeTools, ["bash", "read", WORKFLOW_TOOL_NAME]);
-  assert.equal(h.sent[0].content, buildArmedWorkflowPrompt("summarize the auth module"));
+  assert.equal(h.sent[0].content, buildForcedWorkflowPrompt("summarize the auth module"));
 });
 
 test("/workflows run carries standing effort directives", async () => {
@@ -138,7 +141,7 @@ test("/workflows run carries standing effort directives", async () => {
   effort.level = "ultra";
   const h = harness({}, { effort });
   await h.run("run do X");
-  assert.equal(h.sent[0].content, buildArmedWorkflowPrompt("do X", effortDirective("ultra")));
+  assert.equal(h.sent[0].content, buildForcedWorkflowPrompt("do X", effortDirective("ultra")));
 });
 
 test("/workflows stop <id> calls manager.stop", async () => {

--- a/tests/workflow-commands.test.ts
+++ b/tests/workflow-commands.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { createEffortState, effortDirective } from "../src/effort-command.js";
 import { registerWorkflowCommands } from "../src/workflow-commands.js";
-import { buildForcedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "../src/workflow-editor.js";
+import { buildArmedWorkflowPrompt, WORKFLOW_TOOL_NAME } from "../src/workflow-editor.js";
 import type { WorkflowManager } from "../src/workflow-manager.js";
 
 type Handler = (args: string, ctx: any) => Promise<void>;
@@ -108,7 +108,7 @@ test("/workflows run <prompt> sends a forced workflow follow-up turn", async () 
   await h.run("run audit auth boundaries");
   assert.equal(h.sent.length, 1);
   assert.equal(h.sent[0].customType, "workflow-run");
-  assert.equal(h.sent[0].content, buildForcedWorkflowPrompt("audit auth boundaries"));
+  assert.equal(h.sent[0].content, buildArmedWorkflowPrompt("audit auth boundaries"));
   assert.equal(h.sent[0].options?.triggerTurn, true);
   assert.equal(h.sent[0].options?.deliverAs, "followUp");
   assert.deepEqual(h.activeTools, [WORKFLOW_TOOL_NAME], "does not duplicate an already-active workflow tool");
@@ -130,7 +130,7 @@ test("/workflows run adds the workflow tool when absent and does not depend on t
   const h = harness({}, {}, ["bash", "read"]);
   await h.run("run summarize the auth module");
   assert.deepEqual(h.activeTools, ["bash", "read", WORKFLOW_TOOL_NAME]);
-  assert.equal(h.sent[0].content, buildForcedWorkflowPrompt("summarize the auth module"));
+  assert.equal(h.sent[0].content, buildArmedWorkflowPrompt("summarize the auth module"));
 });
 
 test("/workflows run carries standing effort directives", async () => {
@@ -138,7 +138,7 @@ test("/workflows run carries standing effort directives", async () => {
   effort.level = "ultra";
   const h = harness({}, { effort });
   await h.run("run do X");
-  assert.equal(h.sent[0].content, buildForcedWorkflowPrompt("do X", effortDirective("ultra")));
+  assert.equal(h.sent[0].content, buildArmedWorkflowPrompt("do X", effortDirective("ultra")));
 });
 
 test("/workflows stop <id> calls manager.stop", async () => {

--- a/tests/workflow-editor.test.ts
+++ b/tests/workflow-editor.test.ts
@@ -364,23 +364,38 @@ describe("colorizeWorkflow", () => {
   });
 });
 
-describe("buildForcedWorkflowPrompt", () => {
+describe("buildArmedWorkflowPrompt", () => {
   it("includes the original text", async () => {
-    const { buildForcedWorkflowPrompt } = await load();
-    const result = buildForcedWorkflowPrompt("hello world");
+    const { buildArmedWorkflowPrompt } = await load();
+    const result = buildArmedWorkflowPrompt("hello world");
     assert.ok(result.startsWith("hello world"), "should start with hello world");
   });
 
-  it("includes the directive", async () => {
-    const { buildForcedWorkflowPrompt } = await load();
-    const result = buildForcedWorkflowPrompt("test");
-    assert.ok(result.includes("tool named exactly `workflow`"), "should contain tool named exactly `workflow");
-    assert.ok(result.includes("MUST"), "should contain MUST");
+  it("arms (authorizes) rather than forces — no MUST/ONLY/'Do NOT answer' language", async () => {
+    const { buildArmedWorkflowPrompt } = await load();
+    const result = buildArmedWorkflowPrompt("test");
+    assert.ok(result.includes("workflows mode armed"), "should announce armed mode");
+    assert.ok(result.includes("`workflow` tool"), "should still name the workflow tool");
+    assert.ok(!/\bMUST\b/.test(result), "must not force with MUST");
+    assert.ok(!/ONLY acceptable/i.test(result), "must not force with 'ONLY acceptable'");
+    assert.ok(!/Do NOT (instead|answer)/i.test(result), "must not forbid answering directly");
+    assert.ok(
+      result.includes("answer it directly") || result.includes("does not force"),
+      "should permit answering a question directly",
+    );
+  });
+
+  it("carries the how-to guidance for writing a workflow when armed", async () => {
+    const { buildArmedWorkflowPrompt } = await load();
+    const result = buildArmedWorkflowPrompt("test");
+    assert.ok(result.includes("If you do call `workflow`, follow this guidance:"), "should introduce the how-to");
+    assert.ok(result.includes("export const meta = {"), "should carry the meta-header how-to line");
+    assert.ok(result.includes("parallel() takes functions, not promises"), "should carry a mechanics how-to line");
   });
 
   it("is a multi-line string", async () => {
-    const { buildForcedWorkflowPrompt } = await load();
-    const result = buildForcedWorkflowPrompt("test");
+    const { buildArmedWorkflowPrompt } = await load();
+    const result = buildArmedWorkflowPrompt("test");
     assert.ok(result.includes("\n"), "should contain \n");
     assert.ok(result.includes("---"), "should contain ---");
   });
@@ -1194,7 +1209,7 @@ describe("installWorkflowEditor", () => {
 
     assert.deepEqual(result, {
       action: "transform",
-      text: mod.buildForcedWorkflowPrompt(text),
+      text: mod.buildArmedWorkflowPrompt(text),
     });
   });
 
@@ -1232,10 +1247,20 @@ describe("installWorkflowEditor", () => {
     assert.ok(inputHandler, "input handler should be registered");
     const result = inputHandler({ source: "interactive", text });
 
+    // The effort path arms on ANY substantive message, so its directive also
+    // carries the conversational-escape (skip the workflow on trivial turns).
+    const effortExtra = [effortDirective("high"), mod.EFFORT_CONVERSATIONAL_ESCAPE].filter(Boolean).join(" ");
     assert.deepEqual(result, {
       action: "transform",
-      text: mod.buildForcedWorkflowPrompt(text, effortDirective("high")),
+      text: mod.buildArmedWorkflowPrompt(text, effortExtra),
     });
+    const transformed = (result as { text: string }).text;
+    assert.match(
+      transformed,
+      /skip the workflow and just respond directly/,
+      "effort path allows skipping the workflow",
+    );
+    assert.ok(!/\bMUST\b/.test(transformed), "effort path must not force with MUST");
     assert.ok(tools.includes(mod.WORKFLOW_TOOL_NAME), "effort mode should still add the workflow tool");
   });
 

--- a/tests/workflow-editor.test.ts
+++ b/tests/workflow-editor.test.ts
@@ -222,6 +222,57 @@ describe("hasTrigger", () => {
   });
 });
 
+// Regression corpus (#88): the lexical arm must not fire on identifiers, paths,
+// URLs, or hyphen/camelCase compounds that merely embed the letters "workflow".
+// Two layers matter, so we test both (as the redesign intends):
+//  (1) hasTrigger — the LEXICAL arm. It fires ONLY on the bounded standalone word.
+//  (2) the armed DIRECTIVE — for the one case that legitimately IS the bare word in
+//      a sentence ("the workflow tool is slow"), the lexical arm does fire, but the
+//      banner LEADS with "if it's just talk about the tool, answer directly", so the
+//      model is not pushed into a workflow. That layered behavior is the whole point.
+describe("trigger regression corpus (#88 boundaries)", () => {
+  const NON_ARMING = [
+    "https://github.com/x/pi-dynamic-workflows", // URL: preceded by "-", inside a path
+    "see github.com/x/pi-dynamic-workflows for docs",
+    "the workflowRunner class handles this", // camelCase compound
+    "add my-workflow-helper to the plugin list", // hyphen compound
+    "open src/workflow-editor.ts and fix the bug", // file path
+    "/workflows list", // slash command
+  ];
+
+  it("does NOT lexically arm on identifiers, paths, URLs, or compounds", async () => {
+    const { hasTrigger } = await load();
+    for (const text of NON_ARMING) {
+      assert.equal(hasTrigger(text), false, `${text} must NOT arm`);
+    }
+  });
+
+  const ARMING = [
+    "run a workflow to audit the repo",
+    "workflow: audit the auth module",
+    "帮我跑一个 workflow 审计整个仓库", // CJK context, space-delimited literal word
+  ];
+
+  it("lexically arms on the bounded standalone word (incl. CJK context)", async () => {
+    const { hasTrigger } = await load();
+    for (const text of ARMING) {
+      assert.equal(hasTrigger(text), true, `${text} should arm`);
+    }
+  });
+
+  it("natural English 'the workflow tool is slow' arms lexically but the banner routes it to a direct answer", async () => {
+    const { hasTrigger, buildArmedWorkflowPrompt } = await load();
+    // Honest: the bare word IS a standalone token here, so the lexical arm fires.
+    assert.equal(hasTrigger("the workflow tool is slow"), true);
+    // But the armed banner leads with the decision boundary, so a "talk about the
+    // tool" turn is answered directly rather than forced into a workflow.
+    const armed = buildArmedWorkflowPrompt("the workflow tool is slow", { reason: "keyword" });
+    assert.match(armed, /answer it directly and stay/i);
+    assert.match(armed, /arming authorizes the tool, it does not force it/i);
+    assert.ok(!/\bMUST\b/.test(armed));
+  });
+});
+
 describe("endsWithTrigger", () => {
   it('returns true when text ends with "workflow"', async () => {
     const { endsWithTrigger } = await load();
@@ -385,12 +436,59 @@ describe("buildArmedWorkflowPrompt", () => {
     );
   });
 
-  it("carries the how-to guidance for writing a workflow when armed", async () => {
+  it("leads with the decision boundary, not with 'call the tool' (#P3)", async () => {
     const { buildArmedWorkflowPrompt } = await load();
     const result = buildArmedWorkflowPrompt("test");
-    assert.ok(result.includes("If you do call `workflow`, follow this guidance:"), "should introduce the how-to");
-    assert.ok(result.includes("export const meta = {"), "should carry the meta-header how-to line");
-    assert.ok(result.includes("parallel() takes functions, not promises"), "should carry a mechanics how-to line");
+    const bannerStart = result.indexOf("[workflows mode armed");
+    assert.ok(bannerStart >= 0, "should have the armed banner");
+    const decideIdx = result.indexOf("Decide first");
+    const callToolIdx = result.indexOf("calling the `workflow` tool");
+    assert.ok(decideIdx >= 0, "should state the decision boundary");
+    assert.ok(callToolIdx >= 0, "should still tell it how to call the tool");
+    assert.ok(decideIdx < callToolIdx, "the decision boundary must come BEFORE the call-the-tool instruction");
+  });
+
+  it("carries the #89 background/deliver-back reassurance (no idle-at-prompt worry)", async () => {
+    const { buildArmedWorkflowPrompt } = await load();
+    const result = buildArmedWorkflowPrompt("test");
+    assert.match(result, /runs in the background by default/i);
+    assert.match(result, /delivered back into the conversation automatically/i);
+    assert.match(result, /that's expected, not a stall/i);
+    assert.match(result, /pass background:false if the user is waiting for the result inline/i);
+  });
+
+  it("states the truthful opt-in reason per path (keyword vs effort) (#P3)", async () => {
+    const { buildArmedWorkflowPrompt } = await load();
+    const keyword = buildArmedWorkflowPrompt("test", { reason: "keyword" });
+    assert.match(keyword, /you typed the workflow trigger word/i);
+    assert.doesNotMatch(keyword, /standing effort mode/i);
+
+    const effort = buildArmedWorkflowPrompt("test", { reason: "effort" });
+    assert.match(effort, /standing effort mode armed this turn/i);
+    assert.match(effort, /you did not explicitly ask for a workflow/i);
+    // The effort path must NOT falsely claim the user typed the trigger word.
+    assert.doesNotMatch(effort, /you typed the workflow trigger word/i);
+  });
+
+  it("defaults the reason to keyword when none is given", async () => {
+    const { buildArmedWorkflowPrompt } = await load();
+    assert.equal(buildArmedWorkflowPrompt("test"), buildArmedWorkflowPrompt("test", { reason: "keyword" }));
+  });
+
+  it("does NOT carry the how-to mechanics — those live in the tool description now (#P2)", async () => {
+    const { buildArmedWorkflowPrompt } = await load();
+    const result = buildArmedWorkflowPrompt("test");
+    assert.ok(!result.includes("export const meta = {"), "meta how-to must not be in the armed message");
+    assert.ok(!result.includes("parallel() takes functions"), "mechanics how-to must not be in the armed message");
+    assert.ok(!result.includes("follow this guidance"), "no how-to preamble in the armed message");
+  });
+
+  it("appends the extra directive only when provided", async () => {
+    const { buildArmedWorkflowPrompt } = await load();
+    const base = buildArmedWorkflowPrompt("do X", { reason: "effort" });
+    const withExtra = buildArmedWorkflowPrompt("do X", { reason: "effort", extraDirective: "SENTINEL-DIRECTIVE" });
+    assert.ok(!base.includes("SENTINEL-DIRECTIVE"));
+    assert.ok(withExtra.includes("SENTINEL-DIRECTIVE"));
   });
 
   it("is a multi-line string", async () => {
@@ -398,6 +496,40 @@ describe("buildArmedWorkflowPrompt", () => {
     const result = buildArmedWorkflowPrompt("test");
     assert.ok(result.includes("\n"), "should contain \n");
     assert.ok(result.includes("---"), "should contain ---");
+  });
+});
+
+describe("buildForcedWorkflowPrompt (/workflows run)", () => {
+  it("forces — no 'if it's a question just answer' escape (#P5)", async () => {
+    const { buildForcedWorkflowPrompt } = await load();
+    const result = buildForcedWorkflowPrompt("audit the repo");
+    assert.ok(result.startsWith("audit the repo"), "starts with the original prompt");
+    assert.match(result, /\/workflows run/, "identifies the explicit command");
+    assert.match(result, /Call the `workflow` tool now/i, "tells the model to run the workflow");
+    // The forcing directive must NOT offer the question-answer escape the armed banner has.
+    assert.doesNotMatch(result, /just talk \(about workflows/i);
+    assert.doesNotMatch(result, /answer it directly and stay/i);
+    assert.match(result, /do not answer in prose instead of running the workflow/i);
+  });
+
+  it("still carries the #89 background/deliver-back reassurance", async () => {
+    const { buildForcedWorkflowPrompt } = await load();
+    const result = buildForcedWorkflowPrompt("audit the repo");
+    assert.match(result, /runs in the background by default/i);
+    assert.match(result, /delivered back into the conversation automatically/i);
+  });
+
+  it("does NOT reintroduce the MUST/ONLY forcing language that caused #88/#89", async () => {
+    const { buildForcedWorkflowPrompt } = await load();
+    const result = buildForcedWorkflowPrompt("audit the repo");
+    assert.ok(!/\bMUST\b/.test(result), "no MUST");
+    assert.ok(!/ONLY acceptable/i.test(result), "no 'ONLY acceptable'");
+  });
+
+  it("appends the extra directive when provided", async () => {
+    const { buildForcedWorkflowPrompt } = await load();
+    assert.ok(!buildForcedWorkflowPrompt("do X").includes("SENTINEL"));
+    assert.ok(buildForcedWorkflowPrompt("do X", "SENTINEL").includes("SENTINEL"));
   });
 });
 
@@ -1248,11 +1380,12 @@ describe("installWorkflowEditor", () => {
     const result = inputHandler({ source: "interactive", text });
 
     // The effort path arms on ANY substantive message, so its directive also
-    // carries the conversational-escape (skip the workflow on trivial turns).
+    // carries the conversational-escape (skip the workflow on trivial turns) and
+    // states the truthful "effort" opt-in reason (not "the word you typed").
     const effortExtra = [effortDirective("high"), mod.EFFORT_CONVERSATIONAL_ESCAPE].filter(Boolean).join(" ");
     assert.deepEqual(result, {
       action: "transform",
-      text: mod.buildArmedWorkflowPrompt(text, effortExtra),
+      text: mod.buildArmedWorkflowPrompt(text, { reason: "effort", extraDirective: effortExtra }),
     });
     const transformed = (result as { text: string }).text;
     assert.match(
@@ -1260,6 +1393,7 @@ describe("installWorkflowEditor", () => {
       /skip the workflow and just respond directly/,
       "effort path allows skipping the workflow",
     );
+    assert.match(transformed, /standing effort mode armed this turn/i, "effort path states the truthful reason");
     assert.ok(!/\bMUST\b/.test(transformed), "effort path must not force with MUST");
     assert.ok(tools.includes(mod.WORKFLOW_TOOL_NAME), "effort mode should still add the workflow tool");
   });

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -14,11 +14,12 @@ import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 // Exact post-change measurements: ratchet only after reviewing a new accepted form.
 // The prompt baseline intentionally uses an empty agentType registry so user configuration cannot alter it.
-// Ratcheted for the resumeFromRunId (edited-script resume / cached-prefix reuse) tool surface:
-// one new optional schema param on the tool DEFINITION only. The always-on rendered
-// prompt is intentionally unchanged — discoverability comes from the tool-def
-// description plus the per-result revise hint, not an always-on guideline line.
-const RENDERED_PROMPT_BUDGET_BYTES = 6_500;
+// Ratcheted DOWN from 6_500 to 650 by the authorize-keyword-trigger change (#65/#88):
+// the ~20 always-on "For workflow, …" how-to lines were removed from the always-on
+// prompt (measured 6_500 -> 599 bytes) and are now injected only on an ARMED turn
+// (see workflowHowToGuidelines / buildArmedWorkflowPrompt). The always-on surface is
+// now a single opt-in gate line, which cuts self-priming pressure toward the tool.
+const RENDERED_PROMPT_BUDGET_BYTES = 650;
 const TOOL_DEFINITION_BUDGET_BYTES = 2_529;
 
 test("rendered workflow prompt contribution stays within its accepted size", async () => {

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -14,13 +14,26 @@ import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 // Exact post-change measurements: ratchet only after reviewing a new accepted form.
 // The prompt baseline intentionally uses an empty agentType registry so user configuration cannot alter it.
-// Ratcheted DOWN from 6_500 to 650 by the authorize-keyword-trigger change (#65/#88):
-// the ~20 always-on "For workflow, …" how-to lines were removed from the always-on
-// prompt (measured 6_500 -> 599 bytes) and are now injected only on an ARMED turn
-// (see workflowHowToGuidelines / buildArmedWorkflowPrompt). The always-on surface is
-// now a single opt-in gate line, which cuts self-priming pressure toward the tool.
-const RENDERED_PROMPT_BUDGET_BYTES = 650;
-const TOOL_DEFINITION_BUDGET_BYTES = 2_529;
+//
+// ALWAYS-ON prompt (promptSnippet line + the single gate line): the authorize-
+// keyword-trigger change took this DOWN from ~6_500 bytes (the ~20 "For workflow, …"
+// how-to lines used to render every turn) to a single opt-in gate line. This PR then
+// added concise task-shape positives to the gate line (#P4: balance the strong
+// "do not call it" negative so the model still recognizes a good fit off-keyword),
+// nudging the rendered always-on surface up to ~766 bytes — still an order of
+// magnitude below the old always-on cost, and still self-priming-safe (no how-to here).
+const RENDERED_PROMPT_BUDGET_BYTES = 800;
+// TOOL DEFINITION (name + description + parameters): this GREW on purpose. The how-to
+// mechanics moved OUT of the always-on prompt and the per-armed-turn message and INTO
+// the tool's static `description` (see createWorkflowTool / workflowHowToGuidelines),
+// where the model sees them whenever it looks at the tool — on every arming path and on
+// off-keyword natural-language opt-ins — as a cacheable part of the tool definition
+// rather than per-turn priming. So the definition went from ~2_529 to ~8_770 bytes.
+// This is a MOVE, not new weight: it removed ~6.1KB re-injected on EACH armed turn
+// (the armed message dropped from ~6_765 to ~905 bytes). Trimming the how-to text
+// itself to shrink this definition is a SEPARATE concern (#65 / contract-concision
+// work), not this PR's job — this PR does not claim a token saving on the definition.
+const TOOL_DEFINITION_BUDGET_BYTES = 8_800;
 
 test("rendered workflow prompt contribution stays within its accepted size", async () => {
   await withRenderedWorkflow(async ({ systemPrompt, promptLines }) => {
@@ -51,6 +64,19 @@ test("provider-visible workflow tool definition stays within its accepted size",
       actualBytes <= TOOL_DEFINITION_BUDGET_BYTES,
       `Workflow tool definition is ${actualBytes} bytes; budget is ${TOOL_DEFINITION_BUDGET_BYTES} (parameters: ${parameterBytes} bytes).\n${definitionJson}`,
     );
+  });
+});
+
+test("the how-to mechanics live in the tool DESCRIPTION, not the always-on prompt", async () => {
+  await withRenderedWorkflow(async ({ systemPrompt, wrappedWorkflow }) => {
+    // The description is where the manual now lives (the model sees it whenever it
+    // looks at the tool, on any arming path).
+    assert.match(wrappedWorkflow.description, /How to write the script:/);
+    assert.match(wrappedWorkflow.description, /export const meta = \{/);
+    assert.match(wrappedWorkflow.description, /parallel\(\) takes functions, not promises/);
+
+    // ...and NOT re-rendered into the always-on system prompt every turn.
+    assert.doesNotMatch(systemPrompt, /parallel\(\) takes functions, not promises/);
   });
 });
 

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -92,6 +92,38 @@ test("workflowHowToGuidelines carries the full how-to for an armed turn", () => 
   assert.ok(guidelines.length > 5, "should have several how-to guidelines");
 });
 
+// #P4 (R3): the always-on gate must OFFER rather than FORCE, and must include
+// task-shape positives so it doesn't lean toward under-triggering off-keyword.
+test("WORKFLOW_GATE_GUIDELINE offers (not forces) and carries task-shape positives", () => {
+  const gate = WORKFLOW_GATE_GUIDELINE;
+  // Offer-with-cost, not force.
+  assert.match(gate, /you may briefly offer it \(with a rough cost\)/i, "keeps the non-forcing offer");
+  assert.ok(!/\bMUST\b/.test(gate), "the gate must not force with MUST");
+  // Keeps the explicit-opt-in gate + the negative.
+  assert.match(gate, /ONLY call it when the user explicitly opts in/i);
+  assert.match(gate, /even one that would clearly benefit — do not call it/i);
+  // Task-shape positives (#P4).
+  assert.match(gate, /repo-wide inspection/i);
+  assert.match(gate, /independent parallel research\/checks/i);
+  assert.match(gate, /multi-perspective review/i);
+  assert.match(gate, /fan-out\/fan-in synthesis/i);
+});
+
+// #P2: the how-to mechanics now live in the tool's static description (visible
+// whenever the model looks at the tool), NOT in the always-on prompt.
+test("createWorkflowTool folds the how-to into the tool description", () => {
+  const tool = createWorkflowTool();
+  assert.match(tool.description, /How to write the script:/);
+  assert.match(tool.description, /export const meta = \{/, "meta how-to should be in the description");
+  assert.match(
+    tool.description,
+    /parallel\(\) takes functions, not promises/,
+    "mechanics how-to should be in the description",
+  );
+  // And it must NOT have leaked back into the always-on gate.
+  assert.doesNotMatch(tool.promptGuidelines.join(" "), /export const meta = \{/);
+});
+
 test("workflowHowToGuidelines routes normal work through tiers and reserves exact models for user requests", () => {
   const all = workflowHowToGuidelines().join(" ");
 

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -6,7 +6,13 @@ import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
-import { backgroundStartedText, createWorkflowTool, modelRoutingGuideline } from "../src/workflow-tool.js";
+import {
+  backgroundStartedText,
+  createWorkflowTool,
+  modelRoutingGuideline,
+  WORKFLOW_GATE_GUIDELINE,
+  workflowHowToGuidelines,
+} from "../src/workflow-tool.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 /** Minimal fake ModelRegistry, matching the shape the PR's existing tests use. */
@@ -66,24 +72,36 @@ test("createWorkflowTool has promptSnippet", () => {
   assert.ok(tool.promptSnippet.includes("workflow"), "should contain workflow");
 });
 
-test("createWorkflowTool has promptGuidelines array", () => {
+test("createWorkflowTool always-on promptGuidelines is only the single gate line", () => {
   const tool = createWorkflowTool();
   assert.ok(Array.isArray(tool.promptGuidelines), "tool.promptGuidelines should be an array");
-  assert.ok(tool.promptGuidelines.length > 5, "should have several guidelines");
+  // #65 / #88: the always-on prompt is a single opt-in gate; the ~20 how-to lines
+  // are NOT always-on — they live in workflowHowToGuidelines (armed-turn only).
+  assert.equal(tool.promptGuidelines.length, 1, "always-on guidelines should be a single gate line");
+  assert.equal(tool.promptGuidelines[0], WORKFLOW_GATE_GUIDELINE);
+  assert.match(tool.promptGuidelines[0], /ONLY call it when the user explicitly opts in/);
+  // The how-to mechanics must NOT be always-on.
+  const all = tool.promptGuidelines.join(" ");
+  assert.doesNotMatch(all, /export const meta = \{/, "meta how-to must not be always-on");
+  assert.doesNotMatch(all, /parallel\(\) takes functions/, "parallel how-to must not be always-on");
 });
 
-test("createWorkflowTool routes normal work through tiers and reserves exact models for user requests", () => {
-  const tool = createWorkflowTool();
-  const all = tool.promptGuidelines.join(" ");
+test("workflowHowToGuidelines carries the full how-to for an armed turn", () => {
+  const guidelines = workflowHowToGuidelines();
+  assert.ok(Array.isArray(guidelines), "workflowHowToGuidelines should be an array");
+  assert.ok(guidelines.length > 5, "should have several how-to guidelines");
+});
+
+test("workflowHowToGuidelines routes normal work through tiers and reserves exact models for user requests", () => {
+  const all = workflowHowToGuidelines().join(" ");
 
   assert.match(all, /opts\.tier/);
   assert.match(all, /small.+medium.+big/s);
   assert.match(all, /opts\.model only when the user names/i);
 });
 
-test("createWorkflowTool promptGuidelines keep budget and timeout unbounded by default", () => {
-  const tool = createWorkflowTool();
-  const all = tool.promptGuidelines.join(" ");
+test("workflowHowToGuidelines keep budget and timeout unbounded by default", () => {
+  const all = workflowHowToGuidelines().join(" ");
   assert.match(all, /do not set tokenBudget or agentTimeoutMs/i);
   assert.match(all, /defaults are unbounded/i);
 });
@@ -104,9 +122,8 @@ test("createWorkflowTool schema exposes concurrency and agentRetries", () => {
   assert.match(parameters.properties?.agentRetries?.description ?? "", /Retry attempts/i);
 });
 
-test("createWorkflowTool promptGuidelines mention retry and concurrency controls", () => {
-  const tool = createWorkflowTool();
-  const all = tool.promptGuidelines.join(" ");
+test("workflowHowToGuidelines mention retry and concurrency controls", () => {
+  const all = workflowHowToGuidelines().join(" ");
 
   assert.match(all, /low concurrency/i);
   assert.match(all, /agentRetries/i);

--- a/tests/workflow-tools-available.test.ts
+++ b/tests/workflow-tools-available.test.ts
@@ -19,7 +19,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, mock } from "node:test";
 import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
-import { buildForcedWorkflowPrompt, WORKFLOW_TOOL_NAME, type WorkflowModeState } from "../src/workflow-editor.js";
+import { buildArmedWorkflowPrompt, WORKFLOW_TOOL_NAME, type WorkflowModeState } from "../src/workflow-editor.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 // ---------------------------------------------------------------------------
@@ -112,7 +112,7 @@ describe("installWorkflowEditor - tool availability", () => {
     // Verify transform result
     assert.deepEqual(result, {
       action: "transform",
-      text: buildForcedWorkflowPrompt("przetestuj to workflow zadanie"),
+      text: buildArmedWorkflowPrompt("przetestuj to workflow zadanie"),
     });
 
     // Verify getActiveTools was called


### PR DESCRIPTION
Reframes keyword/effort triggering from **force** to **authorize** — the trigger arms the `workflow` tool and lets the model decide, instead of rewriting the message into "You MUST / the ONLY acceptable action / Do NOT answer". Addresses #88 (over-triggering) and #89 (triggered runs going idle), and cuts self-priming (contributes to #65).

## What it does
- **Authorize, not force.** `buildArmedWorkflowPrompt` leads with the decision boundary (a question / trivial task / just talk → answer directly; a real decomposable request → call `workflow`) and states the true opt-in reason per path (keyword vs standing-effort — no longer falsely claiming "you typed the trigger word" on the effort path). No MUST/ONLY/Do-NOT-answer.
- **#89 fixed at the root.** A shared `BACKGROUND_DELIVERY_REASSURANCE` clause on all arm paths tells the model a background run legitimately ends the turn and its result auto-delivers back — "expected, not a stall" — and to use `background:false` only when the user is waiting inline. The idle was the model being told to emit one bare background call with no signal that turn-end is normal; this closes it.
- **How-to moved to the tool `description`** (a static, cacheable part of the tool definition), removed from the armed message — so the mechanics are available on every path that calls the tool, including natural-language opt-ins ("fan this out") that don't trip the literal keyword, instead of only on keyword-armed turns.
- **Always-on prompt = one gate line** (task-shape positives + explicit-opt-in gate + "even a beneficial task, don't call it — offer it with a rough cost").
- **`/workflows run` stays a force** (explicit command → distinct `buildForcedWorkflowPrompt`, no question-escape) but without the old hostile language.
- **Kept:** keyword triggering default-ON (under authorize semantics its worst case is a single armed-turn directive), the #79 boundary regex, rainbow highlight, Backspace-to-disarm.

## Honest sizing (a *move*, not a saving)
- Always-on prompt: ~6500 → ~766 B (now just the gate line).
- Tool definition: ~2529 → ~8770 B (how-to moved in — a cacheable, once-per-definition cost, replacing ~6.1 KB that was re-injected on *every* armed turn).
- Per-armed-turn message: ~6765 → ~905 B.

Trimming the how-to text itself is separate work (#65 / contract concision), not this change — no token saving on the definition is claimed.

## Tests
Trigger regression corpus (negatives: URLs, camelCase, hyphens, filenames, `/workflows list`; positives: `run a workflow to…`, `workflow:`, a CJK phrasing) at the lexical + directive layers; how-to-lives-in-description assertions; #89 reassurance present on all paths; decision-first ordering; per-path truthful reason; `/workflows run` forces without hostile language. **929 tests pass; tsc + biome clean.**

Addresses #88 and #89; reduces self-priming toward #65.
