### PR TITLE
fix: cancel queued agents when a fan-out breaches the agent cap

### DIFF
--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash } from "node:crypto";
 import vm from "node:vm";
 import type { Node } from "acorn";
@@ -19,6 +20,27 @@ import { createWorkflowLogger } from "./logger.js";
 import { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.js";
 import { createAgentStoreTools, SharedStore } from "./shared-store.js";
 import { createWorktree, removeWorktree, type Worktree } from "./worktree.js";
+
+/**
+ * Batch-scoped cancellation for a single parallel()/pipeline() fan-out. When a
+ * fan-out's agent() calls reserve past maxAgents, the breaching call throws and
+ * the whole fan-out rejects — but agents already reserved and queued behind the
+ * limiter would otherwise keep draining and spending. parallel()/pipeline()
+ * establish a fresh store per call via fanoutScope.run(); agent() captures the
+ * nearest enclosing store synchronously (before suspending on the limiter) so a
+ * still-queued agent can bail once ITS OWN fan-out breaches, without touching
+ * sibling fan-outs running concurrently or an enclosing fan-out when this one is
+ * nested inside it (each nesting level gets its own store via ALS scoping).
+ *
+ * Scope note: cancellation is bounded PER breaching fan-out, not run-global — a
+ * deliberate tradeoff. Deep-sixing the earlier run-global flag was required
+ * because it wrongly cancelled an innocent, independently-caught sibling batch.
+ * The consequence: if one fan-out breaches while an unrelated in-cap sibling or
+ * a nested inner fan-out is mid-flight, that other batch is NOT cancelled and
+ * finishes its already-reserved agents (still capped at maxAgents total). Only
+ * the breaching fan-out's own queue is short-circuited.
+ */
+const fanoutScope = new AsyncLocalStorage<{ cancelled: boolean }>();
 
 export interface WorkflowMetaPhase {
   title: string;
@@ -338,6 +360,13 @@ export async function runWorkflow<T = unknown>(
     remaining: () => (options.tokenBudget == null ? Infinity : Math.max(0, options.tokenBudget - shared.spent)),
   });
 
+  const agentLimitError = () =>
+    new WorkflowError(
+      `Agent limit exceeded (${maxAgents}). Use maxAgents option to increase the limit.`,
+      WorkflowErrorCode.AGENT_LIMIT_EXCEEDED,
+      { recoverable: false },
+    );
+
   const throwIfAborted = () => {
     if (options.signal?.aborted) {
       throw new WorkflowError("workflow aborted", WorkflowErrorCode.WORKFLOW_ABORTED, { recoverable: true });
@@ -347,13 +376,19 @@ export async function runWorkflow<T = unknown>(
   const agent = async (prompt: string, agentOptions: AgentOptions = {}) => {
     throwIfAborted();
 
-    // Check agent limit
+    // Capture the enclosing parallel()/pipeline() fan-out's cancellation batch
+    // (if any) synchronously, while the ALS context of the caller is still
+    // active — i.e. before suspending on the limiter below. The limiter body
+    // closes over this so a still-queued agent can bail once its OWN fan-out
+    // breaches the cap, without affecting sibling or outer fan-outs.
+    const batch = fanoutScope.getStore();
+
+    // Check agent limit. A fan-out that overshoots the cap has already reserved
+    // and queued up to `maxAgents` agents; the breaching call throws here, and
+    // parallel()/pipeline() mark their own batch cancelled so the already-queued
+    // agents short-circuit before their real API call (see the limiter body).
     if (shared.agentCount >= maxAgents) {
-      throw new WorkflowError(
-        `Agent limit exceeded (${maxAgents}). Use maxAgents option to increase the limit.`,
-        WorkflowErrorCode.AGENT_LIMIT_EXCEEDED,
-        { recoverable: false },
-      );
+      throw agentLimitError();
     }
 
     if (budget.total !== null && budget.remaining() <= 0) {
@@ -492,6 +527,10 @@ export async function runWorkflow<T = unknown>(
           usage = undefined;
           try {
             throwIfAborted();
+            // This agent's own fan-out already breached maxAgents while this
+            // call sat queued behind the limiter; bail before spending on the
+            // real API call instead of draining the whole reserved queue.
+            if (batch?.cancelled) throw agentLimitError();
 
             // Run agent with timeout
             const result = await withTimeout(
@@ -606,21 +645,35 @@ export async function runWorkflow<T = unknown>(
     if (thunks.some((thunk) => typeof thunk !== "function")) {
       throw new TypeError("parallel() expects an array of functions, not promises. Wrap each call: () => agent(...)");
     }
-    return Promise.all(
-      thunks.map(async (thunk, index) => {
-        try {
-          return await thunk();
-        } catch (error) {
-          if (options.signal?.aborted) throw error;
-          const workflowError = wrapError(error);
-          // Non-recoverable failures (token budget / agent limit exhausted) must
-          // halt the whole run, exactly like a directly-awaited agent() — not be
-          // swallowed into a null in the result array.
-          if (!workflowError.recoverable) throw workflowError;
-          log(`parallel[${index}] failed: ${workflowError.message}`);
-          return null;
-        }
-      }),
+    // Batch-scoped cancellation: agent() calls made (directly or transitively)
+    // from these thunks see this store via fanoutScope.getStore(). A breach in
+    // THIS fan-out flips `cancelled` so its own still-queued agents bail, without
+    // touching a sibling fan-out running concurrently or an enclosing one.
+    const batch = { cancelled: false };
+    return fanoutScope.run(batch, () =>
+      Promise.all(
+        thunks.map(async (thunk, index) => {
+          try {
+            return await thunk();
+          } catch (error) {
+            if (options.signal?.aborted) throw error;
+            const workflowError = wrapError(error);
+            // Non-recoverable failures (token budget / agent limit exhausted) must
+            // halt the whole run, exactly like a directly-awaited agent() — not be
+            // swallowed into a null in the result array.
+            if (!workflowError.recoverable) {
+              // Only a breached agent cap cancels the rest of this batch; the
+              // token budget stays a soft gate by design (in-flight agents may
+              // finish past it), and other non-recoverable errors don't imply
+              // the rest of the batch is doomed.
+              if (workflowError.code === WorkflowErrorCode.AGENT_LIMIT_EXCEEDED) batch.cancelled = true;
+              throw workflowError;
+            }
+            log(`parallel[${index}] failed: ${workflowError.message}`);
+            return null;
+          }
+        }),
+      ),
     );
   };
 
@@ -633,25 +686,32 @@ export async function runWorkflow<T = unknown>(
     if (stages.some((stage) => typeof stage !== "function")) {
       throw new TypeError("pipeline() stages must be functions: pipeline(items, item => ..., result => ...)");
     }
-    return Promise.all(
-      items.map(async (item, index) => {
-        let value: unknown = item;
-        for (const stage of stages) {
-          try {
-            throwIfAborted();
-            value = await stage(value, item, index);
-            throwIfAborted();
-          } catch (error) {
-            if (options.signal?.aborted) throw error;
-            const workflowError = wrapError(error);
-            // Non-recoverable failures halt the whole run (see parallel()).
-            if (!workflowError.recoverable) throw workflowError;
-            log(`pipeline[${index}] failed: ${workflowError.message}`);
-            return null;
+    // Batch-scoped cancellation — see parallel() for the rationale.
+    const batch = { cancelled: false };
+    return fanoutScope.run(batch, () =>
+      Promise.all(
+        items.map(async (item, index) => {
+          let value: unknown = item;
+          for (const stage of stages) {
+            try {
+              throwIfAborted();
+              value = await stage(value, item, index);
+              throwIfAborted();
+            } catch (error) {
+              if (options.signal?.aborted) throw error;
+              const workflowError = wrapError(error);
+              // Non-recoverable failures halt the whole run (see parallel()).
+              if (!workflowError.recoverable) {
+                if (workflowError.code === WorkflowErrorCode.AGENT_LIMIT_EXCEEDED) batch.cancelled = true;
+                throw workflowError;
+              }
+              log(`pipeline[${index}] failed: ${workflowError.message}`);
+              return null;
+            }
           }
-        }
-        return value;
-      }),
+          return value;
+        }),
+      ),
     );
   };
 
@@ -849,11 +909,7 @@ export async function runWorkflow<T = unknown>(
     throwIfAborted();
     if (typeof promptText !== "string") throw new TypeError("checkpoint(promptText, options?) needs a prompt string");
     if (shared.agentCount >= maxAgents) {
-      throw new WorkflowError(
-        `Agent limit exceeded (${maxAgents}). Use maxAgents option to increase the limit.`,
-        WorkflowErrorCode.AGENT_LIMIT_EXCEEDED,
-        { recoverable: false },
-      );
+      throw agentLimitError();
     }
     const callIndex = state.callSeq++;
     const callHash = hashCheckpoint(promptText, checkpointOptions);

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -584,6 +584,100 @@ return xs`;
   );
 });
 
+test("a fan-out past maxAgents cancels queued agents instead of draining the reserved queue", async () => {
+  // A parallel() overshoot reserves and queues up to maxAgents agents behind the
+  // limiter. Before the fix, every reserved agent ran its real API call (spending)
+  // even though the fan-out had already rejected; now the breach short-circuits the
+  // still-queued agents so at most ~concurrency of them execute.
+  const fanout = 100;
+  const maxAgents = 50;
+  const concurrency = 4;
+  const calls = { count: 0 };
+  let release!: () => void;
+  const gate = new Promise<void>((r) => {
+    release = r;
+  });
+  const runner = {
+    async run(prompt: string) {
+      calls.count++;
+      await gate; // stay in-flight/queued while the limit breach propagates
+      return `ran:${prompt}`;
+    },
+  };
+  const script = `export const meta = { name: 'c4', description: 'fanout cancel' }
+const xs = await parallel(Array.from({ length: ${fanout} }, (_, i) => () => agent('x' + i, { label: 'a' + i })))
+return xs`;
+  const run = runWorkflow(script, { agent: runner, maxAgents, concurrency, persistLogs: false });
+  await assert.rejects(run, /limit/i);
+  release();
+  await new Promise((r) => setTimeout(r, 50)); // let any queued agents drain
+  // Deterministically exactly `concurrency`: the limiter runs the first
+  // `concurrency` submissions' bodies synchronously during the reservation
+  // pass (each immediately calls runner.run() and then suspends on `gate`);
+  // every submission after that suspends on the limiter's internal queue
+  // before it ever reaches runner.run(), and the batch is cancelled (via
+  // fanoutScope) before any of them get their turn.
+  assert.equal(calls.count, concurrency);
+});
+
+test("sibling parallel() batches are isolated: one breaching maxAgents does not cancel the other", async () => {
+  // Two independent parallel() fan-outs run CONCURRENTLY inside the same run
+  // (sharing one shared.agentCount / maxAgents), each isolated via its own
+  // .then(ok, err). Batch A (3 agents) never breaches; batch B (40 agents)
+  // does. Before batch-scoped cancellation, a run-global "limitReached" flag
+  // would wrongly cancel A's still-queued agents too, purely because B (an
+  // unrelated fan-out) breached the shared cap — that's the regression this
+  // guards against.
+  const maxAgents = 10;
+  const concurrency = 2;
+  const runner = {
+    async run(prompt: string) {
+      await new Promise((r) => setTimeout(r, 5));
+      return `ran:${prompt}`;
+    },
+  };
+  const script = `export const meta = { name: 'sib', description: 'sibling isolation' }
+const batchA = parallel(Array.from({ length: 3 }, (_, i) => () => agent('a' + i, { label: 'a' + i })))
+  .then((r) => ({ ok: true, r }), (e) => ({ ok: false, code: e && e.code }))
+const batchB = parallel(Array.from({ length: 40 }, (_, i) => () => agent('b' + i, { label: 'b' + i })))
+  .then((r) => ({ ok: true, r }), (e) => ({ ok: false, code: e && e.code }))
+const [a, b] = await Promise.all([batchA, batchB])
+return { a, b }`;
+  const res = await runWorkflow<{
+    a: { ok: boolean; r?: unknown[] };
+    b: { ok: boolean; code?: string };
+  }>(script, { agent: runner, maxAgents, concurrency, persistLogs: false });
+
+  assert.equal(res.result.a.ok, true, "batch A (never breaches) must resolve, not be cancelled by sibling B");
+  assert.equal(res.result.a.r?.length, 3);
+  assert.ok((res.result.a.r as unknown[]).every((r) => typeof r === "string" && r.startsWith("ran:")));
+
+  assert.equal(res.result.b.ok, false, "batch B (breaches maxAgents) must reject");
+  assert.equal(res.result.b.code, WorkflowErrorCode.AGENT_LIMIT_EXCEEDED);
+});
+
+test("a breach in a nested parallel() doesn't corrupt the outer batch's state", async () => {
+  // Outer parallel() of two thunks; one thunk runs an inner parallel() that
+  // breaches a low maxAgents. The breach should propagate as a rejection of
+  // the whole run (agent limit is non-recoverable) without throwing anything
+  // unexpected (e.g. an ALS/ordering bug corrupting shared.agentCount).
+  const runner = {
+    async run(prompt: string) {
+      return `ran:${prompt}`;
+    },
+  };
+  const script = `export const meta = { name: 'nest', description: 'nested fanout' }
+const xs = await parallel([
+  () => agent('outer-1', { label: 'outer-1' }),
+  () => parallel(Array.from({ length: 5 }, (_, i) => () => agent('inner' + i, { label: 'inner' + i }))),
+])
+return xs`;
+  await assert.rejects(
+    () => runWorkflow(script, { agent: runner, maxAgents: 2, concurrency: 2, persistLogs: false }),
+    /limit/i,
+  );
+});
+
 // ─── Additional edge case tests ─────────────────────────────────────────────────
 
 test("runWorkflow returns meta, logs, phases, and duration", async () => {


### PR DESCRIPTION
## Problem

A `parallel()` / `pipeline()` fan-out larger than `maxAgents` wastes real agent spend. Because the agent-slot reservation is synchronous (gate check + `agentCount++` with no `await` between), one synchronous pass over the fan-out reserves and queues agents up to the cap; only the overshooting call throws `AGENT_LIMIT_EXCEEDED`. `Promise.all` rejects at that point — but the agents already reserved keep draining through the limiter and running their **real API calls** (spending tokens), even though the fan-out has already failed.

Reproduced deterministically (agents gated so they stay queued while the breach propagates):

| maxAgents | concurrency | fan-out | agents actually executed |
|-----------|-------------|---------|--------------------------|
| 50        | 4           | 100     | **50** (before) → **4** (after) |

So a doomed fan-out could burn up to `maxAgents` agents' worth of tokens when only `~concurrency` were ever going to run before the abort. This matters most for cost-conscious users who set a *low* `maxAgents` as a budget guardrail — exceeding it still spent up to the cap.

## Fix — batch-scoped cancellation

Scope the cancellation to the **breaching fan-out** using an `AsyncLocalStorage` store (`fanoutScope`):

- `parallel()` / `pipeline()` each wrap their `Promise.all(...)` in `fanoutScope.run({ cancelled: false }, …)`, establishing a fresh store per call. In their catch, they set `batch.cancelled = true` **only** when the non-recoverable error's code is `AGENT_LIMIT_EXCEEDED`, before re-throwing.
- `agent()` captures `fanoutScope.getStore()` **synchronously** at its start — while the enclosing fan-out's ALS context is still active, before it suspends on the limiter — and closes over it. Inside the limiter body, before the real API call, a still-queued agent throws if `batch?.cancelled`.

Effect: an agent bails before spending once **its own** fan-out breaches, bounding wasted work from `~maxAgents` to `~concurrency`.

### Why not a run-global flag

A first attempt used a single run-wide flag. Adversarial review caught that it wrongly cancelled a **concurrent, independently-caught sibling** `parallel()` that never breached — a correctness regression (it changed which script branches succeed vs. fail), reproduced directly. The ALS store scopes cancellation to the failing fan-out, so a sibling or an enclosing (nested) fan-out running concurrently is unaffected.

- **Tradeoff (documented in-code):** cancellation is bounded per-breaching-fan-out, not run-global. If one fan-out breaches while an unrelated in-cap sibling or nested inner fan-out is mid-flight, that other batch finishes its already-reserved agents (still capped at `maxAgents` total). Chasing full run-wide cascade would reintroduce the sibling regression, so it's deliberately out of scope.
- **Token budget is intentionally not wired.** It's a soft gate by design (in-flight agents may finish past the total); only the hard agent cap triggers cancellation. Verified `TOKEN_BUDGET_EXHAUSTED` never flips `cancelled` in either `parallel()` or `pipeline()`.
- Terminal error is unchanged: the run still rejects with `AGENT_LIMIT_EXCEEDED` (non-recoverable). A directly-awaited `agent()` (no enclosing fan-out) captures an `undefined` store and just throws as before.

## Tests

`tests/workflow-runtime.test.ts`:
- **Waste bound** — 100-way fan-out, `maxAgents=50`, `concurrency=4`, agents gated in-flight: asserts exactly `concurrency` agents execute before the fan-out aborts (deterministic — reservation is fully synchronous, `batch` is closure-captured).
- **Sibling isolation** (the regression guard) — two concurrent independent `parallel()` fan-outs, batch A (under cap) + batch B (breaches), each independently caught: A still resolves with all its results, B rejects with `AGENT_LIMIT_EXCEEDED`.
- **Nesting sanity** — a breach inside a nested `parallel()` rejects without corrupting outer state.

Full suite green (930), tsc clean, biome clean (pre-existing infos only). Also verified: ALS context survives an `await` inside a thunk before `agent()` is called (the queued agents are still cancellable), and two concurrent `runWorkflow()` invocations sharing the module-level scope don't cross-contaminate.

## Not included

Upfront fan-out **size** validation (rejecting an oversized array at entry) is deliberately left out: array length is not a reliable proxy for agent count — a stage may spawn zero or many agents, and a large pure-data `pipeline()` is legitimate — so a hard size cap risks rejecting valid workflows. This PR fixes the confirmed waste (in-flight spend) without that risk; a size guard can be a separate, opt-in discussion.
