### PR TITLE
fix: let workflow_control stop a persisted run not held in memory

### DIFF
--- a/src/workflow-control-tool.ts
+++ b/src/workflow-control-tool.ts
@@ -84,24 +84,32 @@ export function createWorkflowControlTool(
       const run = findRun(manager, params.runId);
       if (!run) return controlError(params.action, params.runId, "run not found", ["list"]);
 
-      switch (params.action) {
-        case "status": {
-          const summary = summarizeRun(run, manager.getSnapshot(run.runId));
-          return result(`action=status result=ok ${formatRun(summary)}`, {
-            action: "status",
-            result: "ok",
-            run: summary,
-          });
+      try {
+        switch (params.action) {
+          case "status": {
+            const summary = summarizeRun(run, manager.getSnapshot(run.runId));
+            return result(`action=status result=ok ${formatRun(summary)}`, {
+              action: "status",
+              result: "ok",
+              run: summary,
+            });
+          }
+          case "pause":
+            if (!manager.pause(run.runId)) return invalidTransition("pause", run);
+            return actionSuccess("pause", "paused", currentSummary(manager, run));
+          case "resume":
+            if (!(await manager.resume(run.runId))) return invalidTransition("resume", run);
+            return actionSuccess("resume", "resumed", currentSummary(manager, run));
+          case "stop":
+            if (!manager.stop(run.runId)) return invalidTransition("stop", run);
+            return actionSuccess("stop", "stopped", currentSummary(manager, run));
         }
-        case "pause":
-          if (!manager.pause(run.runId)) return invalidTransition("pause", run);
-          return actionSuccess("pause", "paused", currentSummary(manager, run));
-        case "resume":
-          if (!(await manager.resume(run.runId))) return invalidTransition("resume", run);
-          return actionSuccess("resume", "resumed", currentSummary(manager, run));
-        case "stop":
-          if (!manager.stop(run.runId)) return invalidTransition("stop", run);
-          return actionSuccess("stop", "stopped", currentSummary(manager, run));
+      } catch (err) {
+        // A transient persistence I/O error (or any unexpected throw from the
+        // manager) shouldn't surface as a raw stack trace to the model — report
+        // it via the tool's normal structured error shape instead.
+        const message = err instanceof Error ? err.message : String(err);
+        return controlError(params.action, run.runId, message, allowedActions(run.status));
       }
     },
   });

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -637,16 +637,39 @@ export class WorkflowManager extends EventEmitter {
 
   /**
    * Stop a running workflow.
+   *
+   * Fast path: the run is live in this process (`this.runs`) — abort its
+   * controller and persist "aborted" as before. Fallback: the run is not in
+   * memory but is persisted as "running" or "paused" — e.g. it belongs to a
+   * prior pi session that this process's recoverStaleRuns() flipped to
+   * "paused" on disk without repopulating this.runs (see workflow-control-tool's
+   * findRun(), which resolves candidates from disk via listRuns()). There is no
+   * live controller to abort in that case — the run simply isn't executing in
+   * this process — so mark it aborted on disk directly, mirroring resume()'s
+   * persisted-fallback lease handling.
    */
   stop(runId: string): boolean {
     const managed = this.runs.get(runId);
-    if (!managed || (managed.status !== "running" && managed.status !== "paused")) return false;
+    if (managed) {
+      if (managed.status !== "running" && managed.status !== "paused") return false;
+      managed.controller.abort();
+      managed.status = "aborted";
+      this.emit("stopped", { runId });
+      this.persistRun(managed);
+      this.releaseRunLease(managed);
+      return true;
+    }
 
-    managed.controller.abort();
-    managed.status = "aborted";
+    const persisted = this.persistence.load(runId);
+    if (!persisted || (persisted.status !== "running" && persisted.status !== "paused")) return false;
+    const lease = this.persistence.acquireRunLease(runId);
+    if (!lease) return false;
+    try {
+      this.persistence.save({ ...persisted, status: "aborted", updatedAt: new Date().toISOString() });
+    } finally {
+      this.persistence.releaseRunLease(lease);
+    }
     this.emit("stopped", { runId });
-    this.persistRun(managed);
-    this.releaseRunLease(managed);
     return true;
   }
 

--- a/tests/workflow-control-tool.test.ts
+++ b/tests/workflow-control-tool.test.ts
@@ -171,6 +171,59 @@ test("pause, resume, and stop call the shared manager lifecycle methods", async 
   );
 });
 
+test("stop succeeds via the tool for a run resolved from disk but not tracked in memory (cold pi restart)", async () => {
+  // Regression guard for the workflow_control "stop" bug: findRun() resolves
+  // candidates from manager.listRuns() (disk-backed), so a run persisted as
+  // "paused" by a prior pi session — never loaded into the manager's
+  // in-memory map — is still advertised with "stop" as an allowed action.
+  // Before the fix, manager.stop() only checked its in-memory map and
+  // returned false for such a run, so the tool reported invalidTransition
+  // even though "stop" was just advertised as allowed.
+  const coldRun = run("paused", "cold-restart-1");
+  const runs = new Map([[coldRun.runId, coldRun]]);
+  const manager = {
+    listRuns: () => [...runs.values()],
+    getSnapshot: () => null,
+    pause: () => false,
+    async resume() {
+      return false;
+    },
+    stop(runId: string) {
+      // Mirrors the real WorkflowManager.stop() persisted fallback: not in
+      // memory, but persisted status is stoppable, so it succeeds.
+      const item = runs.get(runId);
+      if (!item || (item.status !== "running" && item.status !== "paused")) return false;
+      item.status = "aborted";
+      return true;
+    },
+  } as unknown as WorkflowManager;
+
+  const response = await execute(manager, { action: "stop", runId: "cold-restart-1" });
+  assert.match(text(response), /^action=stop result=stopped /);
+  assert.equal(response.details.result, "stopped");
+  assert.doesNotMatch(text(response), /invalidTransition|cannot stop/);
+});
+
+test("a thrown error from the manager during an action is reported as a structured error, not a raw throw", async () => {
+  const throwingRun = run("paused", "throws-1");
+  const manager = {
+    listRuns: () => [throwingRun],
+    getSnapshot: () => null,
+    pause: () => false,
+    async resume() {
+      return false;
+    },
+    stop() {
+      throw new Error("disk I/O failed");
+    },
+  } as unknown as WorkflowManager;
+
+  const response = await execute(manager, { action: "stop", runId: "throws-1" });
+  assert.match(text(response), /^action=stop result=error runId=throws-1 error=disk I\/O failed/);
+  assert.equal(response.details.result, "error");
+  assert.equal(response.details.error, "disk I/O failed");
+});
+
 test("unknown IDs and illegal transitions return explicit errors with allowed actions", async () => {
   const fixture = fakeManager([run("completed"), run("running", "live-123")]);
 

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -1153,6 +1153,137 @@ test(
   }),
 );
 
+test(
+  "cold-start stop: a persisted paused run not in this.runs can be stopped from disk",
+  withTempCwd(async (cwd) => {
+    // Simulate a prior pi session: a run persisted as "paused" (e.g. by
+    // recoverStaleRuns() flipping a stale "running" run on a previous cold
+    // start) that this fresh manager never loaded into its in-memory map.
+    const manager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    const pers = manager.getPersistence();
+    const runId = "cold-start-stop-paused-1";
+
+    pers.save({
+      runId,
+      workflowName: "cold_start_stop",
+      script: oneAgentScript,
+      args: undefined,
+      status: "paused",
+      phases: [],
+      agents: [],
+      logs: [],
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    assert.equal(manager.getRun(runId), undefined, "run is not in memory (cold-start simulation)");
+
+    const stopped = manager.stop(runId);
+    assert.equal(stopped, true, "stop should succeed for a cold-start persisted paused run");
+
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.equal(persisted?.status, "aborted", "persisted status should become aborted");
+  }),
+);
+
+test(
+  "cold-start stop: a persisted running run not in this.runs can be stopped from disk",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    const pers = manager.getPersistence();
+    const runId = "cold-start-stop-running-1";
+
+    pers.save({
+      runId,
+      workflowName: "cold_start_stop_running",
+      script: oneAgentScript,
+      args: undefined,
+      status: "running",
+      phases: [],
+      agents: [],
+      logs: [],
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const stopped = manager.stop(runId);
+    assert.equal(stopped, true, "stop should succeed for a cold-start persisted running run");
+
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.equal(persisted?.status, "aborted", "persisted status should become aborted");
+  }),
+);
+
+test(
+  "cold-start stop: a persisted completed run cannot be stopped",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd });
+    const pers = manager.getPersistence();
+    const runId = "cold-start-stop-completed-1";
+
+    pers.save({
+      runId,
+      workflowName: "cold_start_stop_completed",
+      script: oneAgentScript,
+      args: undefined,
+      status: "completed",
+      phases: [],
+      agents: [],
+      logs: [],
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      completedAt: new Date().toISOString(),
+    });
+
+    assert.equal(manager.stop(runId), false, "completed persisted run cannot be stopped");
+  }),
+);
+
+test(
+  "cold-start stop: an unknown run ID returns false",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd });
+    assert.equal(manager.stop("does-not-exist"), false);
+  }),
+);
+
+test(
+  "cold-start stop: a second manager cannot stop a run while another manager owns the lease",
+  withTempCwd(async (cwd) => {
+    const ownerAgent = deferredAgent();
+    const owner = new WorkflowManager({ cwd, agent: ownerAgent.runner });
+    owner.on("error", () => {});
+    const runId = "cold-start-stop-leased-1";
+    owner.getPersistence().save({
+      runId,
+      workflowName: "leased_stop",
+      script: oneAgentScript,
+      status: "paused",
+      phases: [],
+      agents: [],
+      logs: [],
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    // Owner resumes the run, so it's live in owner's this.runs and owner holds
+    // the cross-process lease.
+    assert.equal(await owner.resume(runId), true, "owner should acquire the lease and start");
+    await new Promise((r) => setTimeout(r, 20));
+
+    // A second manager doesn't have the run in memory, so stop() takes the
+    // persisted fallback path — but the owner still holds the lease, so the
+    // contender must not be able to mark it aborted on disk.
+    const contender = new WorkflowManager({ cwd, agent: fakeAgent() });
+    assert.equal(contender.stop(runId), false, "contender cannot steal the lease to stop the run");
+    assert.equal(contender.getPersistence().load(runId)?.status, "running", "run is untouched by the contender");
+
+    ownerAgent.resolve("done");
+    await new Promise((r) => setTimeout(r, 50));
+    assert.equal(owner.getRun(runId)?.status, "completed", "leased owner should still finish");
+  }),
+);
+
 // ─── getRun tests ──────────────────────────────────────────────────────────────
 
 test(


### PR DESCRIPTION
## Problem

The `workflow_control` tool (#83) can advertise `stop` for a run it then cannot stop. It resolves runs from `manager.listRuns()` (disk), so it sees runs persisted by a prior pi session that aren't in `WorkflowManager.runs`, and `allowedActions("paused")` lists `stop` for them. But `stop()` only checked the in-memory `this.runs` map and returned `false` otherwise — so after a restart, a run paused in a prior session advertised `stop` yet `workflow_control({action:'stop'})` returned `invalidTransition` and the run could never be stopped through the tool. Only `resume()` had a persisted fallback; `stop()` didn't.

(`recoverStaleRuns()` flips a stale disk `running` run to `paused` on startup without repopulating `this.runs`, so the paused-cold case is the common one.)

## Fix

- **`stop()` persisted fallback** — when the run isn't in `this.runs`, load it; if it's persisted as `running`/`paused`, acquire the run lease, save it `aborted`, release the lease, emit `stopped`, return `true`. Mirrors `resume()`'s lease handling. There's no live controller to abort in that path (the run isn't executing here), so persisting the terminal state is the correct action. The in-memory fast path is unchanged.
- **`pause()` left in-memory-only** — a cold run is never advertised as pausable (`allowedActions` only lists `pause` for `running`, and cold `running` is flipped to `paused` before the tool sees it), and there's nothing live to interrupt.
- **`workflow_control` hardening** — wrap the action dispatch in try/catch so a transient persistence error returns the tool's structured `controlError` shape instead of a raw throw.

## Tests

`tests/workflow-manager.test.ts`: cold-start stop of a persisted paused run and a persisted running run (both succeed + status becomes `aborted`); persisted completed run and unknown id return false; a second manager can't steal the lease to stop a run another manager is resuming.
`tests/workflow-control-tool.test.ts`: tool-level guard (stop succeeds for a cold disk-only paused run, not `invalidTransition`); a thrown manager error returns the structured error shape.

Full suite 939 pass, tsc + biome clean.
