### PR TITLE
perf: snapshot model-tiers.json per run and cache RunPersistence.list()

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -479,6 +479,12 @@ export class WorkflowAgent {
   private readonly sharedRegistry?: ModelRegistry;
   /** Lazily built once; shares the SDK's agentDir/auth so resolved models are authed. */
   private registry?: ModelRegistry;
+  /**
+   * Memoized model-tiers.json snapshot, boxed so a legitimately-null config
+   * (file absent/invalid) is distinguishable from "not loaded yet". See
+   * loadTierConfig() below for why this is scoped per-instance.
+   */
+  private tierConfigBox?: { value: ModelTierConfig | null };
 
   constructor(options: WorkflowAgentOptions = {}) {
     this.cwd = options.cwd ?? process.cwd();
@@ -507,6 +513,38 @@ export class WorkflowAgent {
       this.registry = await ensureFallbackRegistry();
     }
     return this.registry;
+  }
+
+  /**
+   * Read+parse ~/.pi/workflows/model-tiers.json at most once for this
+   * instance's lifetime, instead of on every run() call. `resolveAgentModelSpec`
+   * previously received `loadModelTierConfig` directly (sync existsSync +
+   * readFileSync + JSON.parse from disk), which it calls unconditionally for
+   * any agent without an explicit options.model — so a large fan-out did N
+   * redundant synchronous disk reads that blocked the event loop and stalled
+   * concurrent agents' I/O.
+   *
+   * `runWorkflow()` constructs a fresh `WorkflowAgent` per run (see
+   * `new WorkflowAgent(options)` in workflow.ts, unless a caller injects its
+   * own `options.agent` runner — a test-only escape hatch per
+   * WorkflowManagerOptions.agent's doc comment), so a WorkflowAgent instance's
+   * lifetime is one run in production. Memoizing on `this` therefore has the
+   * same scope and lifetime as the agentRegistry snapshot workflow.ts already
+   * takes once per run "for determinism" — the config file isn't expected to
+   * change mid-run, and two different runs (= two different WorkflowAgent
+   * instances) each get their own fresh read of whatever is on disk at the
+   * time, so this does not leak stale config across runs or break tests that
+   * construct fresh agents with different configs.
+   *
+   * `loader` is injectable for tests (defaults to the real disk read); it is
+   * only ever consulted once, on the first call, regardless of what is passed
+   * on later calls.
+   */
+  private loadTierConfig(loader: () => ModelTierConfig | null = loadModelTierConfig): ModelTierConfig | null {
+    if (!this.tierConfigBox) {
+      this.tierConfigBox = { value: loader() };
+    }
+    return this.tierConfigBox.value;
   }
 
   /**
@@ -580,8 +618,11 @@ export class WorkflowAgent {
     // Resolve the model spec (explicit model > tier > session default). This
     // composes with phase-based routing in workflow.ts, which only supplies
     // options.model when a phase pattern matches — so an explicit model wins.
-    const modelSpec = resolveAgentModelSpec(options, this.mainModel, loadModelTierConfig, () =>
-      warnTierUnconfiguredOnce(this.mainModel, modelRegistry),
+    const modelSpec = resolveAgentModelSpec(
+      options,
+      this.mainModel,
+      () => this.loadTierConfig(),
+      () => warnTierUnconfiguredOnce(this.mainModel, modelRegistry),
     );
 
     // Resolve a requested model spec to a Model object. Specs use Pi CLI-style

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -125,6 +125,18 @@ export type FsLayer = {
   writeFileSync: typeof writeFileSync;
 };
 
+/**
+ * `list()` does a full readdirSync + per-file readFileSync + JSON.parse of the
+ * entire lifetime run history. It is called on essentially every progress tick
+ * (task-panel re-render → WorkflowManager.listRuns()/listAllRuns()), so an
+ * unbounded number of ticks each re-walked and re-parsed every run file on
+ * disk. Cache the computed list for a short TTL — long enough to absorb a
+ * burst of same-tick reads, short enough that a read from a DIFFERENT process
+ * (or a mutation this instance doesn't own) still shows up quickly. Mirrors
+ * the ~1s settings-read TTL cache in task-panel.ts.
+ */
+const LIST_CACHE_TTL_MS = 300;
+
 export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>): RunPersistence {
   const _existsSync = fsOverride?.existsSync ?? existsSync;
   const _mkdirSync = fsOverride?.mkdirSync ?? mkdirSync;
@@ -173,6 +185,17 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
 
   const readLock = (runId: string): LockFile | null => readLockAt(primaryLockPath(runId));
 
+  // list() cache: recomputed lazily, invalidated synchronously by every
+  // mutation this instance performs (save()/delete()) so a stale read can
+  // never outlive a mutation this process made. A read from another process
+  // (or a direct fs write bypassing this instance) is picked up once the TTL
+  // elapses, same as before this cache existed on the next un-cached call.
+  let listCache: PersistedRunState[] | undefined;
+  let listCacheAt = 0;
+  const invalidateListCache = () => {
+    listCache = undefined;
+  };
+
   const removeStaleLegacyLock = (runId: string): boolean => {
     const lock = legacyLockPath(runId);
     const existing = readLockAt(lock);
@@ -201,6 +224,7 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
       } catch {
         // backup is best-effort; the primary write already succeeded
       }
+      invalidateListCache();
     },
 
     load(runId: string): PersistedRunState | null {
@@ -219,6 +243,13 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     },
 
     list(): PersistedRunState[] {
+      const now = Date.now();
+      // Return a fresh array on every call (a cheap ref-copy) so a caller that
+      // sorts/reverses/mutates the result in place can't corrupt the cache — the
+      // pre-cache code re-parsed into a new array each call, preserve that.
+      if (listCache && now - listCacheAt < LIST_CACHE_TTL_MS) {
+        return [...listCache];
+      }
       const byRunId = new Map<string, PersistedRunState>();
       for (const dir of [runsDir, legacyRunsDir]) {
         try {
@@ -236,7 +267,12 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
           // Skip unreadable directories; another storage location may still work.
         }
       }
-      return [...byRunId.values()].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      const result = [...byRunId.values()].sort(
+        (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+      );
+      listCache = result;
+      listCacheAt = now;
+      return [...result];
     },
 
     delete(runId: string): boolean {
@@ -264,6 +300,8 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
         return deleted;
       } catch {
         return deleted;
+      } finally {
+        invalidateListCache();
       }
     },
 

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -3,13 +3,15 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
+import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { AgentRunOptions, AgentUsage } from "../src/agent.js";
 import { listAvailableModelSpecs, resolveAgentModelSpec, usageFromStats, WorkflowAgent } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { resolveModelSpecWithThinking } from "../src/model-spec.js";
 import type { ModelTierConfig } from "../src/model-tier-config.js";
 import { runWorkflow } from "../src/workflow.js";
-import { withFakeHome } from "./helpers/fake-home.js";
+import { withFakeHome, withFakeHomeAsync } from "./helpers/fake-home.js";
 
 // Private methods used for testing - cast to this type to access them without `any`
 type WorkflowAgentPrivates = {
@@ -155,6 +157,141 @@ test("resolveAgentModelSpec: untagged agent with a config lacking a medium tier 
 
 test("resolveAgentModelSpec: tier with no main model and no config yields undefined", () => {
   assert.equal(resolveAgentModelSpec({ tier: "small" }, undefined, noCfg), undefined);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// WorkflowAgent#loadTierConfig — memoize model-tiers.json once per instance
+// (perf fix: resolveAgentModelSpec's loadConfig previously re-read+parsed the
+// file from disk on every run() call for any agent without an explicit
+// options.model, which is a sync fs read on the hot per-agent path)
+// ═══════════════════════════════════════════════════════════════════════════
+
+type WorkflowAgentTierPrivates = {
+  loadTierConfig(loader?: () => ModelTierConfig | null): ModelTierConfig | null;
+};
+
+test("WorkflowAgent#loadTierConfig: the loader is invoked at most once across repeated calls", () => {
+  const agent = new WorkflowAgent({ cwd: "/tmp" }) as unknown as WorkflowAgentTierPrivates;
+  let calls = 0;
+  const loader = () => {
+    calls++;
+    return tierConfig;
+  };
+
+  const first = agent.loadTierConfig(loader);
+  const second = agent.loadTierConfig(loader);
+  // Even a loader that would blow up if called proves the memoized branch
+  // never reaches the loader again.
+  const third = agent.loadTierConfig(() => {
+    throw new Error("loader must not be invoked again once memoized");
+  });
+
+  assert.equal(calls, 1, "the real loader should only run once");
+  assert.deepEqual(first, tierConfig);
+  assert.equal(second, first, "repeated calls must return the memoized value");
+  assert.equal(third, first);
+});
+
+test("WorkflowAgent#loadTierConfig: a legitimately-null config (no file) is memoized too, not re-checked", () => {
+  const agent = new WorkflowAgent({ cwd: "/tmp" }) as unknown as WorkflowAgentTierPrivates;
+  let calls = 0;
+  const loader = () => {
+    calls++;
+    return null;
+  };
+
+  assert.equal(agent.loadTierConfig(loader), null);
+  assert.equal(agent.loadTierConfig(loader), null);
+  assert.equal(calls, 1, "null is a valid memoized result, not a 'try again' signal");
+});
+
+test("WorkflowAgent#loadTierConfig: memoization is per-instance (two agents, two runs, don't leak into each other)", () => {
+  const a = new WorkflowAgent({ cwd: "/tmp" }) as unknown as WorkflowAgentTierPrivates;
+  const b = new WorkflowAgent({ cwd: "/tmp" }) as unknown as WorkflowAgentTierPrivates;
+  const cfgA: ModelTierConfig = { tiers: { medium: "vendor-a/model" } };
+  const cfgB: ModelTierConfig = { tiers: { medium: "vendor-b/model" } };
+
+  assert.equal(
+    a.loadTierConfig(() => cfgA),
+    cfgA,
+  );
+  assert.equal(
+    b.loadTierConfig(() => cfgB),
+    cfgB,
+  );
+  // `a` stays pinned to cfgA even when handed a different loader later — a
+  // fresh WorkflowAgent per run (the production lifetime; see workflow.ts's
+  // `new WorkflowAgent(options)` per runWorkflow() call) means two runs with
+  // different on-disk configs still each see their own correct snapshot,
+  // without a process-global cache leaking state across them.
+  assert.equal(
+    a.loadTierConfig(() => cfgB),
+    cfgA,
+  );
+});
+
+test("WorkflowAgent.run(): tier routing resolves correctly through the real (non-injected) disk loader, read only once across two run() calls", async () => {
+  // End-to-end proof that memoization doesn't break the real wiring: writes an
+  // actual model-tiers.json to a fake home, runs two real subagents against a
+  // faux (no-network) provider, and confirms both resolve the tier-configured
+  // model AND that the underlying config object is reused (same reference)
+  // across both run() calls rather than re-read/re-parsed.
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-tier-memo-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-tier-memo-cwd-"));
+  const core = createFauxCore({
+    provider: "fauxtest",
+    models: [{ id: "faux-model", name: "Faux Model", contextWindow: 128000, maxTokens: 4096 }],
+  });
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const tiersDir = join(home, ".pi", "workflows");
+      mkdirSync(tiersDir, { recursive: true });
+      writeFileSync(join(tiersDir, "model-tiers.json"), JSON.stringify({ tiers: { medium: "fauxtest/faux-model" } }));
+
+      const runtime = await ModelRuntime.create({ authPath: join(home, "auth.json"), modelsPath: null });
+      runtime.registerProvider("fauxtest", {
+        name: "Faux Test",
+        baseUrl: "http://127.0.0.1:9/faux",
+        apiKey: "faux-dummy-key-not-used",
+        api: core.api,
+        streamSimple: core.streamSimple as never,
+        models: core.models.map((m) => ({
+          id: m.id,
+          name: m.name ?? m.id,
+          reasoning: false,
+          input: ["text"] as ("text" | "image")[],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: m.contextWindow ?? 128000,
+          maxTokens: m.maxTokens ?? 4096,
+        })),
+      });
+      const registry = new ModelRegistry(runtime);
+      core.setResponses([
+        fauxAssistantMessage("tier-routed-first", { stopReason: "stop" }),
+        fauxAssistantMessage("tier-routed-second", { stopReason: "stop" }),
+      ]);
+
+      const agent = new WorkflowAgent({ cwd, modelRegistry: registry });
+      const spy = test.mock.method(agent as unknown as WorkflowAgentTierPrivates, "loadTierConfig");
+
+      const first = await agent.run("task one", { label: "a", tier: "medium" });
+      const second = await agent.run("task two", { label: "b", tier: "medium" });
+
+      assert.ok(first.includes("tier-routed-first"), "first agent should route through the tiered faux model");
+      assert.ok(second.includes("tier-routed-second"), "second agent should route through the tiered faux model");
+
+      assert.equal(spy.mock.callCount(), 2, "loadTierConfig() is called once per run(), as expected");
+      const [firstResult, secondResult] = spy.mock.calls.map((c) => c.result);
+      assert.equal(
+        firstResult,
+        secondResult,
+        "the SAME config object must be reused across run() calls — the file was read/parsed only once",
+      );
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
 });
 
 test("WorkflowAgent constructor accepts all option shapes without throwing", () => {

--- a/tests/run-persistence.test.ts
+++ b/tests/run-persistence.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -440,6 +440,137 @@ test(
 
     const runs = rp.list();
     assert.deepEqual(runs, []);
+  }),
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// list() caching (perf fix) — list() is called on essentially every progress
+// tick (task-panel re-render), and previously did a full readdirSync +
+// per-file readFileSync + JSON.parse of the entire run history on every call.
+// A short in-memory TTL cache lets repeated same-tick reads reuse the parse,
+// invalidated synchronously by every save()/delete() this instance performs.
+// ═══════════════════════════════════════════════════════════════════════════
+
+function baseRunState(runId: string, updatedAt = "2024-01-01T00:00:00.000Z"): PersistedRunState {
+  return {
+    runId,
+    workflowName: "wf",
+    script: "export const meta = { name: 'w', description: 'w' }",
+    status: "completed",
+    phases: [],
+    agents: [],
+    logs: [],
+    startedAt: updatedAt,
+    updatedAt,
+  };
+}
+
+test(
+  "createRunPersistence list() caches within the TTL: a repeated call does not re-read disk",
+  withTempCwd(async (cwd) => {
+    let readdirCalls = 0;
+    let readFileCalls = 0;
+    const rp = createRunPersistence(cwd, {
+      readdirSync: ((...args: Parameters<typeof readdirSync>) => {
+        readdirCalls++;
+        return readdirSync(...args);
+      }) as typeof readdirSync,
+      readFileSync: ((...args: Parameters<typeof readFileSync>) => {
+        readFileCalls++;
+        return readFileSync(...args);
+      }) as typeof readFileSync,
+    });
+
+    rp.save(baseRunState("cache-1"));
+    // save() doesn't touch readdirSync/readFileSync, but reset for clarity.
+    readdirCalls = 0;
+    readFileCalls = 0;
+
+    const first = rp.list();
+    assert.equal(first.length, 1);
+    assert.ok(readdirCalls > 0, "the first (uncached) list() call should read the directory");
+    assert.ok(readFileCalls > 0, "the first (uncached) list() call should read+parse the run file");
+    const readdirAfterFirst = readdirCalls;
+    const readFileAfterFirst = readFileCalls;
+
+    const second = rp.list();
+    assert.equal(
+      readdirCalls,
+      readdirAfterFirst,
+      "a repeated list() within the TTL must not re-read the runs directory",
+    );
+    assert.equal(readFileCalls, readFileAfterFirst, "a repeated list() within the TTL must not re-parse the run files");
+    assert.deepEqual(second, first, "cached data must be identical to the freshly-computed data");
+  }),
+);
+
+test(
+  "createRunPersistence list() cache is invalidated by save(): a new run appears on the very next call",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    rp.save(baseRunState("a"));
+    const before = rp.list();
+    assert.equal(before.length, 1);
+
+    rp.save(baseRunState("b"));
+    const after = rp.list();
+    assert.equal(after.length, 2, "save() must invalidate the cache so the next list() reflects the new run");
+    assert.ok(after.some((r) => r.runId === "b"));
+  }),
+);
+
+test(
+  "createRunPersistence list() cache is invalidated by an update to an existing run's data",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    rp.save(baseRunState("a", "2024-01-01T00:00:00.000Z"));
+    const before = rp.list();
+    assert.equal(before[0].status, "completed");
+
+    rp.save({ ...baseRunState("a", "2024-01-02T00:00:00.000Z"), status: "running" });
+    const after = rp.list();
+    assert.equal(after[0].status, "running", "save() must invalidate the cache so an updated field is visible");
+  }),
+);
+
+test(
+  "createRunPersistence list() cache is invalidated by delete()",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    rp.save(baseRunState("a"));
+    rp.save(baseRunState("b"));
+    const before = rp.list();
+    assert.equal(before.length, 2);
+
+    rp.delete("a");
+    const after = rp.list();
+    assert.equal(after.length, 1, "delete() must invalidate the cache");
+    assert.equal(after[0].runId, "b");
+  }),
+);
+
+test(
+  "createRunPersistence list() re-reads disk again once the TTL has elapsed (not cached forever)",
+  withTempCwd(async (cwd) => {
+    let readdirCalls = 0;
+    const rp = createRunPersistence(cwd, {
+      readdirSync: ((...args: Parameters<typeof readdirSync>) => {
+        readdirCalls++;
+        return readdirSync(...args);
+      }) as typeof readdirSync,
+    });
+
+    rp.save(baseRunState("ttl-test"));
+    readdirCalls = 0;
+    rp.list();
+    assert.equal(readdirCalls, 1);
+
+    // Wait past the TTL window (well beyond any reasonable short cache) and
+    // confirm a later call does read disk again — this is a cache, not a
+    // permanent snapshot.
+    await new Promise((r) => setTimeout(r, 400));
+    rp.list();
+    assert.ok(readdirCalls >= 2, "list() should read disk again once the TTL has elapsed");
   }),
 );
 


### PR DESCRIPTION
Two hot-path read caches, no behavior change.

## `model-tiers.json` — snapshot once per run
`resolveAgentModelSpec` read+parsed `model-tiers.json` from disk (sync `existsSync`+`readFileSync`+`JSON.parse`) for every agent without an explicit `model` — i.e. once per `agent()` call. A large fan-out did N redundant blocking reads that stall concurrent agents' I/O. Now memoized once per `WorkflowAgent` instance (= once per run, the same scope `agentRegistry` is already snapshotted at), boxed so a legitimately-null config is distinct from "not loaded". `resolveAgentModelSpec` stays pure/test-injectable (unchanged signature).

## `RunPersistence.list()` — 300ms TTL cache
`list()` did a full `readdirSync` + per-file `readFileSync` + `JSON.parse` of the entire lifetime run history on essentially every progress tick (task-panel re-render → `listRuns()`/`listAllRuns()`). Now cached for 300ms, invalidated synchronously by `save()`/`delete()` so a mutation this instance makes is never masked. Returns a fresh array copy each call so an in-place mutation by a caller can't corrupt the cache. No retention/pruning added (out of scope; noted as a possible follow-up). Ordering/data unchanged.

## Tests
`tests/agent.test.ts`: config read at most once across multiple agents in a run (incl. a real faux-core end-to-end asserting same-reference reuse); null memoized; per-instance (no cross-run leak). `tests/run-persistence.test.ts`: repeated `list()` within TTL doesn't touch disk; `save()`/`delete()`/update invalidate; cache expires after TTL.

Full suite 948 pass, tsc + biome clean.
