### PR TITLE
fix: persist real per-agent timestamps and throttle progress writes

### DIFF
--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -45,6 +45,13 @@ export interface ManagedRun {
    * Undefined means eligible (default-on); false opts out.
    */
   autoResume?: boolean;
+  /**
+   * Real per-agent start/end timestamps, captured at onAgentStart/onAgentEnd
+   * (never fabricated), keyed by the agent's snapshot id. A running agent has
+   * an entry with no endedAt; persistRun() reads from here instead of stamping
+   * every agent with the run's startedAt / "now".
+   */
+  agentTimestamps: Map<number, { startedAt: string; endedAt?: string }>;
 }
 
 /** Per-execution options shared by sync, background, and resume runs. */
@@ -229,6 +236,7 @@ export class WorkflowManager extends EventEmitter {
       background: true,
       lease,
       autoResume: exec.autoResume,
+      agentTimestamps: new Map(),
     };
 
     this.runs.set(runId, managed);
@@ -316,6 +324,7 @@ export class WorkflowManager extends EventEmitter {
       args,
       journal: [],
       background: false,
+      agentTimestamps: new Map(),
     };
   }
 
@@ -370,9 +379,13 @@ export class WorkflowManager extends EventEmitter {
         resumeFromRunId: resumeJournal ? managed.runId : undefined,
         onAgentJournal: (entry) => {
           // Append (crash-safe-ish): keep the latest entry per index, then persist.
+          // This is the high-frequency progress persist (fires once per completed
+          // agent, can burst under concurrency) — throttled (trailing edge). Every
+          // lifecycle-critical persist below (status transitions, run end,
+          // pause/resume/stop) still calls persistRun() directly and flushes this.
           managed.journal = managed.journal.filter((e) => e.index !== entry.index);
           managed.journal.push(entry);
-          this.persistRun(managed);
+          this.schedulePersist(managed);
         },
         onLog: (message) => {
           managed.snapshot.logs.push(message);
@@ -388,14 +401,18 @@ export class WorkflowManager extends EventEmitter {
           progress();
         },
         onAgentStart: (event) => {
+          const id = managed.snapshot.agents.length + 1;
           managed.snapshot.agents.push({
-            id: managed.snapshot.agents.length + 1,
+            id,
             label: event.label,
             phase: event.phase,
             prompt: event.prompt,
             status: "running",
             model: event.model,
           });
+          // Real per-agent start time, captured the moment the agent actually
+          // starts (not the run's startedAt) — see agentTimestamps.
+          managed.agentTimestamps.set(id, { startedAt: new Date().toISOString() });
           this.emit("agentStart", { runId: managed.runId, ...event });
           progress();
         },
@@ -412,6 +429,10 @@ export class WorkflowManager extends EventEmitter {
             agent.tokens = event.tokens;
             if (event.tokenUsage) agent.tokenUsage = event.tokenUsage;
             if (event.model) agent.model = event.model;
+            // Real per-agent end time — only terminal agents get one; a still-
+            // running agent's entry keeps endedAt undefined.
+            const ts = managed.agentTimestamps.get(agent.id);
+            if (ts) ts.endedAt = new Date().toISOString();
           }
           this.emit("agentEnd", { runId: managed.runId, ...event });
           progress();
@@ -493,7 +514,52 @@ export class WorkflowManager extends EventEmitter {
     managed.lease = undefined;
   }
 
-  private persistRun(managed: ManagedRun) {
+  /** Trailing-edge throttle window for high-frequency progress persists (see schedulePersist). */
+  private static readonly PERSIST_THROTTLE_MS = 400;
+
+  /** Pending trailing-edge persist timers for high-frequency progress events, keyed by runId. */
+  private persistTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  /**
+   * Coalesce rapid progress persists (currently: onAgentJournal, which fires
+   * once per completed agent and can burst under concurrency) to at most one
+   * disk write per PERSIST_THROTTLE_MS (trailing edge) instead of one write
+   * per tick — persistRun() does a full JSON.stringify of the run plus up to
+   * 3 sync writes, so firing it once per agent in a long run is O(N^2).
+   *
+   * Lifecycle-critical writes (status transitions, run end, pause/resume/stop)
+   * must NOT use this — call persistRun() directly, which flushes (and cancels)
+   * any pending timer first so a stale trailing write can never fire after, and
+   * resurrect, a terminal state.
+   */
+  private schedulePersist(managed: ManagedRun): void {
+    if (this.persistTimers.has(managed.runId)) return; // already scheduled; the trailing write reads live state
+    const timer = setTimeout(() => {
+      this.persistTimers.delete(managed.runId);
+      this.writeRunToDisk(managed);
+    }, WorkflowManager.PERSIST_THROTTLE_MS);
+    // A pending progress persist should never keep the process alive on its own.
+    timer.unref?.();
+    this.persistTimers.set(managed.runId, timer);
+  }
+
+  /**
+   * Persist immediately and synchronously. Cancels any pending throttled write
+   * for this run first, so the write that lands is always the caller's current
+   * (final) state — never superseded by a stale deferred write. Use this for
+   * every lifecycle-critical persist: run start, status transitions, run end,
+   * pause()/resume()/stop().
+   */
+  private persistRun(managed: ManagedRun): void {
+    const timer = this.persistTimers.get(managed.runId);
+    if (timer) {
+      clearTimeout(timer);
+      this.persistTimers.delete(managed.runId);
+    }
+    this.writeRunToDisk(managed);
+  }
+
+  private writeRunToDisk(managed: ManagedRun) {
     try {
       this.persistence.save({
         runId: managed.runId,
@@ -521,11 +587,17 @@ export class WorkflowManager extends EventEmitter {
             : undefined,
         phases: managed.snapshot.phases,
         currentPhase: managed.snapshot.currentPhase,
-        agents: managed.snapshot.agents.map((a) => ({
-          ...a,
-          startedAt: managed.startedAt.toISOString(),
-          endedAt: new Date().toISOString(),
-        })),
+        // Real per-agent timestamps only (see agentTimestamps) — never the run's
+        // own startedAt or "now" stamped onto every agent on every write. A
+        // still-running agent is persisted with no endedAt.
+        agents: managed.snapshot.agents.map((a) => {
+          const ts = managed.agentTimestamps.get(a.id);
+          return {
+            ...a,
+            startedAt: ts?.startedAt,
+            endedAt: ts?.endedAt,
+          };
+        }),
         logs: managed.snapshot.logs,
         result: managed.result?.result,
         tokenUsage: managed.snapshot.tokenUsage
@@ -622,6 +694,10 @@ export class WorkflowManager extends EventEmitter {
       // Carry the original opt-out forward across resumes; it's fixed at
       // run-start and persistRun() re-persists it on every subsequent write.
       autoResume: persisted.autoResume,
+      // Fresh per-resume: agents (and any prior timing) are rebuilt live as
+      // onAgentStart/onAgentEnd fire again for this attempt (see `agents: []`
+      // above); the journal, not this map, is what makes replayed agents cheap.
+      agentTimestamps: new Map(),
     };
     this.runs.set(runId, managed);
     // Persist before notifying renderers: listRuns() is their source of truth for
@@ -712,6 +788,13 @@ export class WorkflowManager extends EventEmitter {
     const managed = this.runs.get(runId);
     if (managed) this.releaseRunLease(managed);
     this.runs.delete(runId);
+    // Cancel any pending throttled write so a deferred persist can't fire after
+    // deletion and resurrect the run's file on disk.
+    const timer = this.persistTimers.get(runId);
+    if (timer) {
+      clearTimeout(timer);
+      this.persistTimers.delete(runId);
+    }
     return this.persistence.delete(runId);
   }
 

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -67,6 +67,39 @@ phase('Work')
 const a = await agent('do it', { label: 'a' })
 return { a }`;
 
+/** Two sequential agents: 'a' finishes, then 'b' starts. */
+const twoAgentScript = `export const meta = { name: 'two_agent_demo', description: 'two sequential agents' }
+phase('Work')
+const a = await agent('first', { label: 'a' })
+const b = await agent('second', { label: 'b' })
+return { a, b }`;
+
+/** Six agents fired in parallel, all resolving instantly — used to exercise a burst of persist ticks. */
+const burstAgentScript = `export const meta = { name: 'burst_demo', description: 'six agents in parallel' }
+const xs = await parallel(['a','b','c','d','e','f'].map((label) => () => agent(label, { label })))
+return xs`;
+
+/**
+ * Agent runner for twoAgentScript: 'a' resolves immediately, 'b' hangs forever
+ * (until the run is aborted by pause()/stop()). Lets a test observe a run with
+ * one done agent and one genuinely still-running agent at the same time.
+ */
+function firstThenHangAgent() {
+  return {
+    async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+      options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
+      if (prompt === "first") {
+        // A tiny real delay so 'a' and 'b' get distinguishable (not same-millisecond)
+        // start times — proving persisted timestamps are real wall-clock captures,
+        // not both stamped with one fabricated value.
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        return "a-done";
+      }
+      return new Promise(() => {}); // 'second' never resolves on its own
+    },
+  };
+}
+
 /** Run each manager test with isolated cwd and HOME so workflow state is isolated. */
 function withTempCwd(fn: (cwd: string) => Promise<void>) {
   return async () => {
@@ -937,6 +970,132 @@ test(
     assert.equal(manager.getRun(runId)?.status, "failed");
     const persisted = manager.listRuns().find((r) => r.runId === runId);
     assert.equal(persisted?.pauseReason, undefined, "a real failure carries no usage-limit pause reason");
+  }),
+);
+
+// ─── persistRun: honest per-agent timestamps + throttled progress persists ────
+
+test(
+  "persisted per-agent timestamps are real, not fabricated from the run's startedAt/now",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: firstThenHangAgent() });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(twoAgentScript);
+
+    // Wait until 'a' has finished and 'b' has started (and is hanging) so both
+    // a terminal and a still-running agent coexist in the snapshot.
+    await new Promise((resolve) => {
+      manager.on("agentStart", (event) => {
+        if ((event as { label?: string }).label === "b") resolve(undefined);
+      });
+    });
+
+    // pause() forces a synchronous flush (see the "safety net" tests below), so
+    // this reads the true current state without any arbitrary wait.
+    manager.pause(runId);
+
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    const agentA = persisted?.agents.find((a) => a.label === "a");
+    const agentB = persisted?.agents.find((a) => a.label === "b");
+
+    assert.equal(agentA?.status, "done");
+    assert.ok(agentA?.startedAt, "finished agent has a real startedAt");
+    assert.ok(agentA?.endedAt, "finished agent has a real endedAt");
+
+    assert.equal(agentB?.status, "running");
+    assert.ok(agentB?.startedAt, "running agent has a real startedAt too");
+    assert.equal(agentB?.endedAt, undefined, "a still-running agent must NOT get a fabricated endedAt");
+
+    assert.notEqual(
+      agentA?.startedAt,
+      agentB?.startedAt,
+      "agents must not all share one fabricated run-start timestamp",
+    );
+
+    // firstThenHangAgent's 'second' call never resolves on its own (only pause()
+    // marks the run as aborted in bookkeeping — the in-flight call has no timeout
+    // to race against), so don't await it; just avoid an unhandled rejection.
+    promise.catch(() => {});
+  }),
+);
+
+test(
+  "a burst of agent completions coalesces to a small, bounded number of disk writes",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: fakeAgent(), concurrency: 8 });
+    const persistence = manager.getPersistence();
+    let saveCount = 0;
+    const originalSave = persistence.save.bind(persistence);
+    persistence.save = ((...args: Parameters<typeof persistence.save>) => {
+      saveCount++;
+      return originalSave(...args);
+    }) as typeof persistence.save;
+
+    const result = await manager.runSync(burstAgentScript);
+
+    assert.equal((result.result as unknown[]).length, 6);
+    // Unthrottled, each of the 6 near-simultaneous agent completions would persist
+    // on its own: 1 (initial) + 6 (one per agent) + 1 (final) = 8 writes. Throttled,
+    // the whole burst coalesces into at most one trailing write, so the total stays
+    // small regardless of agent count.
+    assert.ok(saveCount <= 3, `expected a coalesced write count (<=3), got ${saveCount}`);
+  }),
+);
+
+test(
+  "pause() flushes a pending throttled progress persist synchronously — no stale read",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: firstThenHangAgent() });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(twoAgentScript);
+
+    // 'a' finishing schedules a throttled (trailing-edge) write via onAgentJournal
+    // that would normally not hit disk for hundreds of ms.
+    await new Promise((resolve) => {
+      manager.on("agentStart", (event) => {
+        if ((event as { label?: string }).label === "b") resolve(undefined);
+      });
+    });
+
+    manager.pause(runId);
+
+    // Read persisted state immediately — no sleep/setTimeout. If pause() didn't
+    // flush the pending write first (and write the current, final state), this
+    // would race a stale read or a delayed write clobbering the paused status.
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.equal(persisted?.status, "paused", "terminal status must be visible immediately, with no wait");
+    const agentA = persisted?.agents.find((a) => a.label === "a");
+    assert.equal(agentA?.status, "done", "the already-completed agent's state is flushed synchronously too");
+    assert.ok(agentA?.endedAt, "flushed agent state carries its real endedAt, not stale/missing data");
+
+    // 'second' never resolves on its own; don't await it, just avoid an unhandled rejection.
+    promise.catch(() => {});
+  }),
+);
+
+test(
+  "stop() flushes a pending throttled progress persist synchronously — no stale read",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: firstThenHangAgent() });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(twoAgentScript);
+
+    await new Promise((resolve) => {
+      manager.on("agentStart", (event) => {
+        if ((event as { label?: string }).label === "b") resolve(undefined);
+      });
+    });
+
+    manager.stop(runId);
+
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.equal(persisted?.status, "aborted", "terminal status must be visible immediately, with no wait");
+    const agentA = persisted?.agents.find((a) => a.label === "a");
+    assert.equal(agentA?.status, "done");
+    assert.ok(agentA?.endedAt, "flushed agent state carries its real endedAt, not stale/missing data");
+
+    // 'second' never resolves on its own; don't await it, just avoid an unhandled rejection.
+    promise.catch(() => {});
   }),
 );
 


### PR DESCRIPTION
Two fixes in `persistRun`, correctness only.

## Real per-agent timestamps (data fidelity)
`persistRun` stamped every agent with the RUN's `startedAt` and `new Date()` (now) as `endedAt` on every write — so persisted per-agent durations were meaningless (any UI reading them was wrong). `WorkflowAgentSnapshot` carried no real timing. Added `ManagedRun.agentTimestamps`, captured at `onAgentStart`/`onAgentEnd` (real per-agent start; `endedAt` only for a terminal agent). A still-running agent now persists with no `endedAt` instead of a fabricated one. `PersistedAgentState.startedAt/endedAt` were already optional.

## Throttled progress writes (perf)
`persistRun` (full `JSON.stringify` of the run + up to 3 sync writes) fired once per completed agent via `onAgentJournal` — ~O(N²) over a run, blocking the event loop. That single high-frequency site now uses a trailing-edge throttle (`schedulePersist`, 400ms, one `unref`'d timer per run).

**Correctness invariant:** every lifecycle-critical persist — run start, complete, error, `pause()`, `resume()`, `stop()` — still calls `persistRun()` directly, which **flushes and cancels** any pending throttled write first, so a caller reading persisted state right after (tests, `UsageLimitScheduler`, the `workflow_control` tool, cross-session recovery) always sees final, non-stale data. `deleteRun()` cancels any pending timer so a late write can't resurrect a deleted run. Only `onAgentJournal` is throttled.

## Tests
Per-agent timestamps are real and distinct (running agent has no `endedAt`); a burst of 6 completions coalesces to ≤3 writes; `pause()` and `stop()` each flush synchronously (read `listRuns()` immediately, final state present — the safety net for the throttle).

Full suite 943 pass, tsc + biome clean.

(Investigation note, pre-existing: with no `agentTimeoutMs`, `pause()`/`stop()` mark a run aborted in bookkeeping but don't force an in-flight `agent()` to settle — surfaced while testing, not introduced here.)
