### PR TITLE
chore: 3.0 cleanup — drop dead createSharedStoreTools, dedupe ThemeLike, use isProviderUsageLimit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ export {
   registerAllSavedWorkflows,
   registerSavedWorkflow,
 } from "./saved-commands.js";
-export { createSharedStoreTools, SharedStore } from "./shared-store.js";
+export { SharedStore } from "./shared-store.js";
 export type { StructuredOutputCapture, StructuredOutputToolOptions } from "./structured-output.js";
 export { createStructuredOutputTool } from "./structured-output.js";
 export { deliverText, installResultDelivery, installTaskPanel, type TaskPanelOptions } from "./task-panel.js";

--- a/src/shared-store.ts
+++ b/src/shared-store.ts
@@ -109,62 +109,6 @@ export class SharedStore {
 }
 
 /**
- * Create the `store_put` and `store_get` tool definitions bound to a specific
- * `SharedStore` instance. Inject the returned array into every agent in the run
- * via `systemTools` so all agents, including those with a restrictive
- * `tools` allowlist, can read and write shared state.
- *
- * For workflow-internal use where delta-journaling is needed, use
- * `createAgentStoreTools(store, deltaKey)` instead — it attributes each put to
- * the given agent (via a run-unique deltaKey) so the write can be replayed
- * correctly on resume.
- */
-export function createSharedStoreTools(store: SharedStore): ToolDefinition[] {
-  const storePut = defineTool({
-    name: "store_put",
-    label: "Store Put",
-    description:
-      "Write a value to the shared run store. Any other agent in this workflow run can read it with store_get. Overwrites any existing value for the key. Note: when two parallel agents write the same key, the last write wins — no merge is performed.",
-    promptSnippet: "Write a value to the shared store",
-    parameters: Type.Object({
-      key: Type.String({ description: "The key to store the value under." }),
-      value: Type.Any({ description: "The value to store (any JSON-serializable value)." }),
-    }),
-    async execute(_id: string, params: { key: string; value: unknown }) {
-      store.put(params.key, params.value);
-      return {
-        content: [{ type: "text", text: `Stored value under key "${params.key}".` }],
-        details: { key: params.key },
-      };
-    },
-  }) as unknown as ToolDefinition;
-
-  const storeGet = defineTool({
-    name: "store_get",
-    label: "Store Get",
-    description:
-      "Read a value from the shared run store previously written by store_put. Returns the stored value, or null when the key does not exist.",
-    promptSnippet: "Read a value from the shared store",
-    parameters: Type.Object({
-      key: Type.String({ description: "The key to read." }),
-    }),
-    async execute(_id: string, params: { key: string }) {
-      const found = store.has(params.key);
-      const value = store.get(params.key);
-      const text = found
-        ? `Value for key "${params.key}": ${JSON.stringify(value)}`
-        : `Key "${params.key}" not found in store.`;
-      return {
-        content: [{ type: "text", text }],
-        details: { key: params.key, value: found ? value : null, found },
-      };
-    },
-  }) as unknown as ToolDefinition;
-
-  return [storePut, storeGet];
-}
-
-/**
  * Create per-agent store tools that attribute writes to `deltaKey`, a
  * run-unique `${runId}:${callIndex}` string (see the `SharedStore` class doc
  * for why the bare callIndex alone is not enough once a nested `workflow()`

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from "node:events";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { WorkflowAgent } from "./agent.js";
 import { preview, type WorkflowSnapshot } from "./display.js";
-import { WorkflowError, WorkflowErrorCode } from "./errors.js";
+import { isProviderUsageLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import {
   createRunPersistence,
   generateRunId,
@@ -473,8 +473,7 @@ export class WorkflowManager extends EventEmitter {
               { recoverable: true },
             );
 
-      const usageLimitPaused =
-        !managed.controller.signal.aborted && workflowError.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT;
+      const usageLimitPaused = !managed.controller.signal.aborted && isProviderUsageLimit(workflowError);
       if (managed.controller.signal.aborted) {
         // Intentional abort (pause/stop/Esc) — preserve status set by pause()/stop()
         if (managed.status === "running") {
@@ -577,14 +576,9 @@ export class WorkflowManager extends EventEmitter {
         autoResume: managed.autoResume,
         // Why a usage-limit pause happened, so the navigator / a future cold start
         // can show it and (eventually) re-arm resume after the budget refills.
-        pauseReason:
-          managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
-            ? "usage_limit"
-            : undefined,
+        pauseReason: managed.status === "paused" && isProviderUsageLimit(managed.error) ? "usage_limit" : undefined,
         resetHint:
-          managed.status === "paused" && managed.error?.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT
-            ? managed.error.resetHint
-            : undefined,
+          managed.status === "paused" && isProviderUsageLimit(managed.error) ? managed.error.resetHint : undefined,
         phases: managed.snapshot.phases,
         currentPhase: managed.snapshot.currentPhase,
         // Real per-agent timestamps only (see agentTimestamps) — never the run's

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -17,7 +17,7 @@ import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi
 import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
 import { parseKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentUsage } from "./agent.js";
-import type { WorkflowAgentSnapshot, WorkflowSnapshot } from "./display.js";
+import type { ThemeLike, WorkflowAgentSnapshot, WorkflowSnapshot } from "./display.js";
 import { aggregateAgentUsage, fmtCost, fmtTokenSegment, tokenFigures } from "./display.js";
 import type { PersistedRunState } from "./run-persistence.js";
 import { registerSavedWorkflow } from "./saved-commands.js";
@@ -36,12 +36,6 @@ const STATUS_ICON: Record<string, string> = {
   aborted: "⊘",
   skipped: "⊘",
 };
-
-/** Minimal theme surface so rendering is testable without the real Theme class. */
-export interface ThemeLike {
-  fg(color: string, text: string): string;
-  bold(text: string): string;
-}
 
 const PLAIN: ThemeLike = { fg: (_c, t) => t, bold: (t) => t };
 


### PR DESCRIPTION
Three small cleanups timed to the 3.0 major.

- **Remove dead `createSharedStoreTools`** — zero callers (only its definition + the `index.ts` re-export; `createAgentStoreTools` is the one used internally, and `createSharedStoreTools`'s own doc said so). Deleted the function and its `index.ts` export. **BREAKING** for any external importer of it — hence doing it in the major; use `createAgentStoreTools` instead.
- **De-duplicate `ThemeLike`** — the interface was declared byte-identically in `display.ts` and `workflow-ui.ts`. Keep the canonical one in `display.ts`, import it in `workflow-ui.ts`. Nothing imported it from `workflow-ui.js` externally, so no re-export shim needed.
- **Use `isProviderUsageLimit()`** — three inline `.code === PROVIDER_USAGE_LIMIT` checks in `workflow-manager.ts` now use the existing tested helper. Behavior-identical (it returns false for `undefined`, matching the old optional-chained checks); `tsc` confirms the true-branch narrowing at the `resetHint` site.

Net −74/+6 lines. Full suite 952 pass, tsc + biome clean.
