### PR TITLE
fix: workflow_control schema must be a top-level object, not a union (fixes provider 400)

### DIFF
--- a/src/workflow-control-tool.ts
+++ b/src/workflow-control-tool.ts
@@ -4,26 +4,35 @@ import { aggregateAgentUsage, tokenFigures, type WorkflowAgentSnapshot, type Wor
 import type { PersistedRunState, RunStatus } from "./run-persistence.js";
 import type { WorkflowManager } from "./workflow-manager.js";
 
-const runActionSchema = Type.Union([
-  Type.Literal("status"),
-  Type.Literal("pause"),
-  Type.Literal("resume"),
-  Type.Literal("stop"),
-]);
-
-const workflowControlSchema = Type.Union([
-  Type.Object(
-    { action: Type.Literal("list", { description: "List workflow runs." }) },
-    { additionalProperties: false },
-  ),
-  Type.Object(
-    {
-      action: runActionSchema,
-      runId: Type.String({ minLength: 1, description: "Canonical workflow run ID." }),
-    },
-    { additionalProperties: false },
-  ),
-]);
+// A tool's top-level parameter schema must be a JSON Schema object (`type:
+// "object"`). A discriminated Type.Union of two objects serializes to a
+// top-level `anyOf` with no `type`, which strict providers (e.g. DeepSeek)
+// reject with "schema must be type object, got type: null". So the schema is a
+// single object: `action` is the full set of verbs and `runId` is optional at
+// the schema level. The per-action requirement (runId is mandatory for every
+// action except `list`, and `list` takes no runId) is enforced at runtime in
+// normalizeInput() and guarded again in execute().
+const workflowControlSchema = Type.Object(
+  {
+    action: Type.Union(
+      [
+        Type.Literal("list"),
+        Type.Literal("status"),
+        Type.Literal("pause"),
+        Type.Literal("resume"),
+        Type.Literal("stop"),
+      ],
+      { description: "list = all runs (no runId); status/pause/resume/stop act on one run and require runId." },
+    ),
+    runId: Type.Optional(
+      Type.String({
+        minLength: 1,
+        description: "Canonical workflow run ID. Required for status, pause, resume, and stop; omit for list.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
 
 export type WorkflowControlInput = Static<typeof workflowControlSchema>;
 
@@ -81,6 +90,11 @@ export function createWorkflowControlTool(
         );
       }
 
+      // runId is optional in the schema (see workflowControlSchema) but required
+      // for every non-list action; normalizeInput already enforces this, and this
+      // guard both narrows the type and returns a structured error if a model
+      // somehow calls a run action without one.
+      if (!params.runId) return controlError(params.action, "", "runId is required for this action", ["list"]);
       const run = findRun(manager, params.runId);
       if (!run) return controlError(params.action, params.runId, "run not found", ["list"]);
 

--- a/tests/workflow-control-tool.test.ts
+++ b/tests/workflow-control-tool.test.ts
@@ -72,20 +72,32 @@ test("workflow_control exposes only list, status, pause, resume, and stop in a s
   const tool = createWorkflowControlTool({ manager });
 
   assert.equal(tool.name, "workflow_control");
+
+  // The top-level parameter schema MUST be `type: "object"`. A discriminated
+  // Type.Union serialized to a top-level `anyOf` with no `type`, which strict
+  // providers (DeepSeek) reject with "schema must be type object, got type:
+  // null" — a 400 on every request. This is the regression guard for that.
+  assert.equal((tool.parameters as { type?: string }).type, "object");
+
+  // Schema level: every valid action verb is accepted; runId is optional at the
+  // schema level (the per-action requirement is enforced by prepareArguments).
   assert.equal(Check(tool.parameters, { action: "list" }), true);
   assert.equal(Check(tool.parameters, { action: "status", runId: "abc" }), true);
   assert.equal(Check(tool.parameters, { action: "pause", runId: "abc" }), true);
   assert.equal(Check(tool.parameters, { action: "resume", runId: "abc" }), true);
   assert.equal(Check(tool.parameters, { action: "stop", runId: "abc" }), true);
+  assert.equal(Check(tool.parameters, { action: "status" }), true, "runId is optional at the schema level");
   assert.equal(Check(tool.parameters, { action: "restart", runId: "abc" }), false);
   assert.equal(Check(tool.parameters, { action: "remove", runId: "abc" }), false);
   assert.equal(Check(tool.parameters, { action: "set_concurrency", runId: "abc", concurrency: 2 }), false);
-  assert.equal(Check(tool.parameters, { action: "status" }), false);
-  assert.equal(Check(tool.parameters, { action: "list", runId: "abc" }), false);
   assert.equal(Check(tool.parameters, { action: "status", runId: "abc", extra: true }), false);
 
+  // prepareArguments (normalizeInput) enforces the real per-action rules that the
+  // permissive object schema deliberately leaves open.
   const prepare = tool.prepareArguments as (value: unknown) => unknown;
   assert.throws(() => prepare({ action: "pause" }), /requires runId/);
+  assert.throws(() => prepare({ action: "status" }), /requires runId/);
+  assert.throws(() => prepare({ action: "list", runId: "abc" }), /does not accept runId/);
   assert.throws(() => prepare({ action: "status", runId: "abc", extra: true }), /does not accept extra/);
   assert.throws(() => prepare({ action: "restart", runId: "abc" }), /requires action/);
 });


### PR DESCRIPTION
## The bug (found via real-pi, missed by unit tests)

`workflow_control`'s `parameters` were a `Type.Union` of two objects (`list` vs `action`+`runId`). typebox serializes a union to a top-level `anyOf` with **no `type`**, so the tool's JSON Schema advertised `type: null`. Strict providers reject that — **DeepSeek returns `400 "schema must be a JSON Schema of 'type: object', got 'type: null'"` on every request once the tool is registered**, breaking the whole session.

Unit tests never caught it because they `Check()` inputs against the schema locally instead of sending the schema to a real provider. It surfaced immediately on a real-pi (deepseek-v4-flash) smoke run against the 3.0 build.

## Fix

Make the schema a single `Type.Object` (`type: "object"`): `action` is the full verb union and `runId` is `Type.Optional`. The real per-action rules — `runId` required for every action except `list`, and `list` accepts no `runId` — are still enforced at runtime by `normalizeInput()` (unchanged), plus a guard in `execute()` that returns a structured error and narrows the now-optional `runId`.

Added a regression assertion that the tool's top-level parameter schema is `type: "object"` — the invariant that actually matters to providers, which the previous "strict schema" test didn't check.

## Verification

- `npm test` — 952 pass, tsc + biome clean.
- **Real-pi on pi 0.80.10 + deepseek-v4-flash:** the `workflow` tool runs a parallel fan-out inline (RED/BLUE), and `workflow_control` `list` + `status` return real run details (status, agent counts, token totals) — no 400.
