### PR TITLE
feat: make workflow capabilities self-documenting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 scripts/verify-npm-install.sh
 __pycache__/
 .context/
+.auto/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Repository guidance
+
+## Workflow documentation
+
+Before changing the workflow runtime, tool API, capability contract, or `workflow-authoring` skill, read [Protected workflow-authoring guidance](CONTRIBUTING.md#protected-workflow-authoring-guidance).
+
+- Keep stable capability facts in the executable capability contract and generated documentation.
+- Keep detailed authoring guidance in the on-demand skill, not the always-on prompt.
+- Do not copy live model or agent-type catalogues into static guidance.
+- Run `npm run context:check` with the other checks listed in the contributor guide.
+- If a protected file changes, review it before running `npm run guidance:accept -- <path>`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ A throwaway harness for this should live in the repo root (not `/tmp`, whose sym
 
 ## Protected workflow-authoring guidance
 
+The goal is to keep workflow guidance accurate as the runtime changes without bloating the context sent to every model. Stable capability facts come from the executable capability contract and generated documentation. Detailed authoring guidance lives in the on-demand `workflow-authoring` skill instead of the permanent prompt. Context checks keep these surfaces from growing unnoticed.
+
 Some files under `skills/workflow-authoring/` contain mixed or partially behavior-covered guidance. Their full-file SHA-256 hashes in `WORKFLOW_AUTHORING_FROZEN_FILES` (`src/workflow-authoring-coverage.ts`) are explicit review checkpoints, not proof that the wording is correct.
 
 If `PROTECTED_GUIDANCE_DRIFT` reports an accidental change, revert it. For housekeeping such as a typo, link, formatting, or version update, deterministic checks and review are enough. For a semantic guidance change, inspect the affected coverage manifest entry, update relevant behavioral tests, and review provider evidence when needed. Required anchors and required text in the manifest may also need deliberate updates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for contributing to pi-dynamic-workflows. This project values small, well
 
 ```bash
 npm install
-npm test     # biome check + tsc build + unit tests — must pass
+npm test     # Biome, TypeScript, unit tests, and release checks — must pass
 ```
 
 `npm test` runs exactly what CI runs. If it's green locally it should be green in CI. CI runs on every PR to `main`; for fork PRs a maintainer approves the first run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,21 @@ Fake-agent unit tests are necessary but not sufficient. Any change to how agents
 
 A throwaway harness for this should live in the repo root (not `/tmp`, whose symlink breaks relative imports), import from `./src`, and be deleted before commit — don't commit harnesses.
 
+## Protected workflow-authoring guidance
+
+Some files under `skills/workflow-authoring/` contain mixed or behaviorally uncovered guidance. Their full-file SHA-256 hashes in `WORKFLOW_AUTHORING_FROZEN_FILES` (`src/workflow-authoring-coverage.ts`) are deliberate review barriers, not generated output.
+
+If `PROTECTED_GUIDANCE_DRIFT` reports an accidental change, revert it. For an intentional change, inspect the affected coverage manifest entry and its relevant behavioral tests and provider evidence before accepting it. Required anchors and required text in the manifest may also need deliberate updates. Only after that review should you recompute the exact SHA-256 and manually update the matching `sha256` in `WORKFLOW_AUTHORING_FROZEN_FILES`; never change a hash only to make the gate green.
+
+`npm run guidance:generate` refreshes only the non-contractual prose baseline; it does not update protected hashes. There is intentionally no protected-hash refresh command. Validate the reviewed change with exactly:
+
+```bash
+npm run docs:check
+npm run context:check
+npm run guidance:check
+npm run release:verify
+```
+
 ## Style
 
 Formatting and linting are handled by Biome (`npm run format`, `npm run lint`). Match the existing code; don't reformat files you aren't otherwise changing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,11 +29,17 @@ A throwaway harness for this should live in the repo root (not `/tmp`, whose sym
 
 ## Protected workflow-authoring guidance
 
-Some files under `skills/workflow-authoring/` contain mixed or behaviorally uncovered guidance. Their full-file SHA-256 hashes in `WORKFLOW_AUTHORING_FROZEN_FILES` (`src/workflow-authoring-coverage.ts`) are deliberate review barriers, not generated output.
+Some files under `skills/workflow-authoring/` contain mixed or partially behavior-covered guidance. Their full-file SHA-256 hashes in `WORKFLOW_AUTHORING_FROZEN_FILES` (`src/workflow-authoring-coverage.ts`) are explicit review checkpoints, not proof that the wording is correct.
 
-If `PROTECTED_GUIDANCE_DRIFT` reports an accidental change, revert it. For an intentional change, inspect the affected coverage manifest entry and its relevant behavioral tests and provider evidence before accepting it. Required anchors and required text in the manifest may also need deliberate updates. Only after that review should you recompute the exact SHA-256 and manually update the matching `sha256` in `WORKFLOW_AUTHORING_FROZEN_FILES`; never change a hash only to make the gate green.
+If `PROTECTED_GUIDANCE_DRIFT` reports an accidental change, revert it. For housekeeping such as a typo, link, formatting, or version update, deterministic checks and review are enough. For a semantic guidance change, inspect the affected coverage manifest entry, update relevant behavioral tests, and review provider evidence when needed. Required anchors and required text in the manifest may also need deliberate updates.
 
-`npm run guidance:generate` refreshes only the non-contractual prose baseline; it does not update protected hashes. There is intentionally no protected-hash refresh command. Validate the reviewed change with exactly:
+After that review, explicitly accept each changed frozen file:
+
+```bash
+npm run guidance:accept -- skills/workflow-authoring/path/to/file
+```
+
+The command updates only explicitly named frozen files and prints each old and new hash for review. It does not update protected anchors or required text. `npm run guidance:generate` refreshes only the non-contractual prose baseline; it does not update protected hashes. Validate the accepted change with exactly:
 
 ```bash
 npm run docs:check

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Library API note: the unused `createSharedStoreTools` export was removed — use
 
 ```bash
 npm install
-npm test     # Biome + TypeScript + unit tests
+npm test     # Biome, TypeScript, unit tests, and release checks
 ```
 
 ### Optional model-comprehension evidence

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ The installed extension generates this compact index from its executable capabil
 | maxAgents | workflow-tool-input | `maxAgents?: number = 1000` | — |
 | concurrency | workflow-tool-input | `concurrency?: number` | — |
 | agentRetries | workflow-tool-input | `agentRetries?: number = configured value or 0` | — |
-| agentTimeoutMs | workflow-tool-input | `agentTimeoutMs?: number = configured value or unbounded` | — |
-| tokenBudget | workflow-tool-input | `tokenBudget?: number = unlimited` | — |
+| agentTimeoutMs | workflow-tool-input | `agentTimeoutMs?: number = configured default or unbounded` | — |
+| tokenBudget | workflow-tool-input | `tokenBudget?: number = configured default or unlimited` | — |
 | resumeFromRunId | workflow-tool-input | `resumeFromRunId?: string` | — |
 <!-- END GENERATED SUPPORTED WORKFLOW CAPABILITIES -->
 
@@ -205,7 +205,7 @@ Model tiers live at `~/.pi/workflows/model-tiers.json` and accept Pi CLI-style t
 
 Use `/workflows-models` to edit them interactively. Without a config, the extension ranks authenticated models by capability hints and assigns distinct models when possible.
 
-Runs have no default token budget or per-agent hard timeout. Add `tokenBudget`, `agentTimeoutMs`, phase budgets, or agent `timeoutMs` when you need explicit gates. `concurrency` is clamped to 16; `agentRetries` retries only recoverable failures. Defaults can be set in `~/.pi/workflows/settings.json` — e.g. `defaultTokenBudget` applies a hard budget to every run that doesn't pass its own `tokenBudget` (a project-level override of `null` cancels a global budget).
+Omitted `tokenBudget` and `agentTimeoutMs` values use configured `defaultTokenBudget` and `defaultAgentTimeoutMs` settings; without them, runs are unlimited and have no hard per-agent timeout. Add per-run or per-agent values when you need explicit gates. `concurrency` is clamped to 16; `agentRetries` retries only recoverable failures. Defaults live in `~/.pi/workflows/settings.json`; `defaultTokenBudget` is a soft pre-call gate, and a project-level override of `null` cancels a global budget.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,41 @@ return await agent(
 - **Quality patterns** — compose `verify()`, `judgePanel()`, `loopUntilDry()`, and `completenessCheck()` instead of rebuilding review loops.
 - **Reusable workflows** — save any run as a command and call saved workflows from other workflows.
 
+## Supported workflow capabilities
+
+The installed extension generates this compact index from its executable capability contract. Read the [workflow authoring guide](docs/workflow-authoring.md) or use the packaged `workflow-authoring` skill for constraints, lifecycle guidance, and adaptable examples; configured route and agent-type values remain environment-specific.
+
+<!-- BEGIN GENERATED SUPPORTED WORKFLOW CAPABILITIES -->
+| Name | Classification | Signature | Options and defaults |
+| --- | --- | --- | --- |
+| agent | runtime-global | `agent(prompt, options?) => Promise<string \| structured value \| null>` | `label`: string (optional; default: derived from phase and call count)<br>`phase`: string (optional; default: current phase)<br>`schema`: plain JSON Schema (optional)<br>`model`: string (optional)<br>`tier`: string (optional)<br>`isolation`: "worktree" (optional)<br>`agentType`: string (optional)<br>`timeoutMs`: number \| null (optional; default: run timeout; null disables)<br>`retries`: number (optional; default: run retry count) |
+| parallel | runtime-global | `parallel(thunks) => Promise<Array<unknown \| null>>` | — |
+| pipeline | runtime-global | `pipeline(items, ...stages) => Promise<Array<unknown \| null>>` | — |
+| workflow | runtime-global | `workflow(savedName, childArgs?) => Promise<unknown>` | — |
+| verify | runtime-global | `verify(item: unknown, options?: { reviewers?: number; threshold?: number; lens?: string \| string[] }) => Promise<{ real: boolean; realCount: number; total: number; votes: Array<{ real: boolean; reason?: string }> }>` | `reviewers`: number (optional; default: 2)<br>`threshold`: number (optional; default: 0.5)<br>`lens`: string \| string[] (optional) |
+| judgePanel | runtime-global | `judgePanel(attempts: unknown[], options?: { judges?: number; rubric?: string }) => Promise<{ index: number; attempt: unknown; score: number; judgments: Array<{ score: number; reason?: string }> } \| undefined>` | `judges`: number (optional; default: 3)<br>`rubric`: string (optional; default: "overall quality and correctness") |
+| loopUntilDry | runtime-global | `loopUntilDry(options: { round: (roundIndex: number) => unknown[] \| Promise<unknown[]>; key?: (item: unknown) => string; consecutiveEmpty?: number; maxRounds?: number }) => Promise<unknown[]>` | `round`: (roundIndex: number) => unknown[] \| Promise<unknown[]> (required)<br>`key`: (item: unknown) => string (optional; default: JSON.stringify)<br>`consecutiveEmpty`: number (optional; default: 2)<br>`maxRounds`: number (optional; default: 50) |
+| completenessCheck | runtime-global | `completenessCheck(taskArgs: unknown, results: unknown) => Promise<{ complete: boolean; missing?: string[] } \| null>` | — |
+| retry | runtime-global | `retry(thunk: (attempt: number) => unknown \| Promise<unknown>, options?: { attempts?: number; until?: (result: unknown) => boolean }) => Promise<unknown>` | `attempts`: number (optional; default: 3)<br>`until`: (result: unknown) => boolean (optional; default: accept first result when omitted) |
+| gate | runtime-global | `gate(thunk: (feedback: string \| undefined, attempt: number) => unknown \| Promise<unknown>, validator: (value: unknown) => { ok: boolean; feedback?: string } \| Promise<{ ok: boolean; feedback?: string }>, options?: { attempts?: number }) => Promise<{ ok: boolean; value: unknown; attempts: number }>` | `attempts`: number (optional; default: 3) |
+| checkpoint | runtime-global | `checkpoint(prompt, options?) => Promise<unknown>` | `default`: unknown (optional; default: true when no UI and omitted)<br>`headless`: "default" \| "abort" (optional; default: "default")<br>`kind`: "confirm" \| "input" \| "select" (optional; default: "confirm")<br>`choices`: string[] (optional)<br>`timeoutMs`: number (optional) |
+| log | runtime-global | `log(message) => void` | — |
+| phase | runtime-global | `phase(title, options?) => void` | `budget`: number (optional) |
+| args | runtime-global | `args: unknown` | — |
+| cwd | runtime-global | `cwd: string` | — |
+| process | runtime-global | `process: { cwd(): string }` | — |
+| budget | runtime-global | `budget: { total, spent(), remaining() }` | — |
+| script | workflow-tool-input | `script: string` | — |
+| args | workflow-tool-input | `args?: unknown` | — |
+| background | workflow-tool-input | `background?: boolean = true` | — |
+| maxAgents | workflow-tool-input | `maxAgents?: number = 1000` | — |
+| concurrency | workflow-tool-input | `concurrency?: number` | — |
+| agentRetries | workflow-tool-input | `agentRetries?: number = configured value or 0` | — |
+| agentTimeoutMs | workflow-tool-input | `agentTimeoutMs?: number = configured value or unbounded` | — |
+| tokenBudget | workflow-tool-input | `tokenBudget?: number = unlimited` | — |
+| resumeFromRunId | workflow-tool-input | `resumeFromRunId?: string` | — |
+<!-- END GENERATED SUPPORTED WORKFLOW CAPABILITIES -->
+
 ## Built-in workflows
 
 ```text
@@ -242,6 +277,18 @@ Library API note: the unused `createSharedStoreTools` export was removed — use
 npm install
 npm test     # Biome + TypeScript + unit tests
 ```
+
+### Optional model-comprehension evidence
+
+The comprehension harness is manual and never runs in normal CI, `npm test`, or the release gate. Select an available model explicitly; the harness never embeds or chooses from a static model or agent-type catalogue.
+
+```bash
+npm run comprehension -- --model provider/model                    # quick writing scenario
+npm run comprehension -- --model provider/model --suite full       # write, edit, review, and debug
+npm run comprehension -- --model provider/model --output runs/a.json
+```
+
+By default, evidence is written under ignored `.pi/model-comprehension/`. Each JSON run records the exact prompts and versions, generated workflows, skill reads, provider token usage, deterministic runtime calls/topology/results, assertions, and failure details. Scenario failures are retained as non-blocking evidence and do not produce a failing exit status; argument, model-selection, and setup errors do.
 
 Features are also verified end-to-end against real Pi subagent sessions before release. See [CONTRIBUTING.md](./CONTRIBUTING.md) to contribute.
 

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,14 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "files": {
-    "includes": ["**", "!dist", "!node_modules", "!.pi"]
+    "includes": [
+      "**",
+      "!dist",
+      "!node_modules",
+      "!.pi",
+      "!docs/workflow-context-surfaces.json",
+      "!skills/workflow-authoring/examples/*.js"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/docs/workflow-authoring-evidence.md
+++ b/docs/workflow-authoring-evidence.md
@@ -1,0 +1,62 @@
+# Workflow authoring evidence
+
+This report records review evidence for the compact workflow tool contract and the packaged `workflow-authoring` skill. Provider-backed results are samples, not release gates. Normal tests and publishing remain deterministic and model-free.
+
+## Context surfaces
+
+Measurements use UTF-8 bytes. The current `origin/main` baseline is `818fdd8`; the candidate is the final tree on `feat/self-documenting-workflow-capabilities`.
+
+| Surface | `origin/main` | Candidate | Change |
+| --- | ---: | ---: | ---: |
+| Permanent workflow prompt | 766 | 742 | -24 |
+| Provider-visible workflow tool definition | 9,558 | 3,802 | -5,756 |
+| Workflow-authoring skill discovery | 0 | 338 | +338 |
+| Ordinary workflow-owned always-on total | 10,324 | 4,882 | -5,442 (-52.7%) |
+
+The candidate also records 66,847 bytes across 27 on-demand skill files. Six representative authoring profiles have a median of 11,662 bytes. `docs/workflow-context-surfaces.json` is the generated, release-checked source for candidate measurements.
+
+## Post-tuning comprehension validation
+
+This validation reused the scenario families that informed the guidance changes, so it is not an independent holdout. It held the rebased runtime, prompts, deterministic fixtures, semantic oracles, model settings, and three repetitions constant. It changed only the installed workflow-authoring skill:
+
+- **Pre-trim:** skill content from `7a41a19fb2352b2efce19e5f29af556669d150fe`.
+- **Candidate:** the skill in this branch.
+
+Each condition ran three coverage scenarios—fan-out-and-synthesize, generate-and-filter, and `judgePanel()`—three times on each of nine model configurations, for 81 generated workflows per condition:
+
+- `openai-codex/gpt-5.3-codex-spark:medium`
+- `openai-codex/gpt-5.4-mini:medium`
+- `openai-codex/gpt-5.5:medium`
+- `openai-codex/gpt-5.6-luna:medium`
+- `openai-codex/gpt-5.6-terra:medium`
+- `openai-codex/gpt-5.6-sol:medium`
+- `local-vllm/cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4:medium`
+- `zai/glm-5.2:high`
+- `zai/glm-5.2:max`
+
+Captured workflows were replayed through the final parser, runtime, deterministic fixtures, and semantic oracles without provider calls.
+
+| Result | Pre-trim | Candidate |
+| --- | ---: | ---: |
+| Semantic passes | 73/81 (90.12%) | 74/81 (91.36%) |
+| Fan-out-and-synthesize | 25/27 | 25/27 |
+| Generate-and-filter | 26/27 | 27/27 |
+| `judgePanel()` | 22/27 | 22/27 |
+| Median loaded skill context | 8,096 tokens | 2,564 tokens |
+| p90 loaded skill context | 9,454 tokens | 4,075 tokens |
+| Maximum loaded skill context | 10,686 tokens | 6,747 tokens |
+| Observed provider tokens | 2,344,438 | 1,564,872 |
+
+The candidate reduced median loaded skill context by 68.3% without reducing the sampled pass count. All seven configurations other than Qwen and Spark passed 63/63 candidate scenarios. The seven remaining candidate failures were model-generated JavaScript or authoring mistakes; provider-free replay found no remaining fixture or oracle false negatives.
+
+An earlier corrected-harness sample scored pre-trim at 75/81 and optimized at 71/81. The parent prompt, fixture calibration, final guidance, and generated model outputs changed before the result above. Provider scores therefore show sampled behavior, not a stable benchmark. This is why they remain non-blocking.
+
+A separate protected check ran the six core scenarios three times on GPT-5.4 Mini and GPT-5.6 Luna and passed 36/36. Their three-scenario coverage gate passed 18/18. The final candidate did not repeat the earlier nine-model, 162-case core panel.
+
+## Reproduction and retention
+
+The optional harness is available through `npm run comprehension -- --suite coverage --model <provider/model:thinking> --output <path>`. It records the selected and resolved model, thinking level, skill-loading evidence, generated workflow, runtime evidence, assertions, and token usage.
+
+The delivery-choice harness has a deterministic scorer and optional provider CLI for default background delivery versus `background:false` inline delivery. This report includes no provider-run delivery-choice result.
+
+Raw provider evidence remains local and uncommitted because it is large and variable. The committed release gate verifies the harness, parser/runtime replay seam, package discovery, coverage manifest, generated references, context measurements, and all model-free examples without making provider calls.

--- a/docs/workflow-authoring-evidence.md
+++ b/docs/workflow-authoring-evidence.md
@@ -4,16 +4,16 @@ This report records review evidence for the compact workflow tool contract and t
 
 ## Context surfaces
 
-Measurements use UTF-8 bytes. The current `origin/main` baseline is `818fdd8`; the candidate is the final tree on `feat/self-documenting-workflow-capabilities`.
+Measurements use UTF-8 bytes. The historical baseline is `818fdd8` (release 3.0.0), captured when concision work began. The candidate is the final tree on `feat/self-documenting-workflow-capabilities`.
 
-| Surface | `origin/main` | Candidate | Change |
+| Surface | Baseline (`818fdd8`) | Candidate | Change |
 | --- | ---: | ---: | ---: |
 | Permanent workflow prompt | 766 | 742 | -24 |
-| Provider-visible workflow tool definition | 9,558 | 3,802 | -5,756 |
+| Provider-visible workflow tool definition | 9,558 | 3,918 | -5,640 |
 | Workflow-authoring skill discovery | 0 | 338 | +338 |
-| Ordinary workflow-owned always-on total | 10,324 | 4,882 | -5,442 (-52.7%) |
+| Ordinary workflow-owned always-on total | 10,324 | 4,998 | -5,326 (-51.6%) |
 
-The candidate also records 66,847 bytes across 27 on-demand skill files. Six representative authoring profiles have a median of 11,662 bytes. `docs/workflow-context-surfaces.json` is the generated, release-checked source for candidate measurements.
+The candidate also records 67,089 bytes across 27 on-demand skill files. Six representative authoring profiles have a median of 11,662 bytes. `docs/workflow-context-surfaces.json` is the generated, release-checked source for candidate measurements.
 
 ## Post-tuning comprehension validation
 

--- a/docs/workflow-authoring.md
+++ b/docs/workflow-authoring.md
@@ -34,7 +34,7 @@ See [Workflow prompt guidance rationale](workflow-prompt-guidance-rationale.md) 
 | maxAgents | workflow-tool-input | `maxAgents?: number = 1000` | — |
 | concurrency | workflow-tool-input | `concurrency?: number` | — |
 | agentRetries | workflow-tool-input | `agentRetries?: number = configured value or 0` | — |
-| agentTimeoutMs | workflow-tool-input | `agentTimeoutMs?: number = configured value or unbounded` | — |
-| tokenBudget | workflow-tool-input | `tokenBudget?: number = unlimited` | — |
+| agentTimeoutMs | workflow-tool-input | `agentTimeoutMs?: number = configured default or unbounded` | — |
+| tokenBudget | workflow-tool-input | `tokenBudget?: number = configured default or unlimited` | — |
 | resumeFromRunId | workflow-tool-input | `resumeFromRunId?: string` | — |
 <!-- END GENERATED SUPPORTED WORKFLOW CAPABILITIES -->

--- a/docs/workflow-authoring.md
+++ b/docs/workflow-authoring.md
@@ -1,0 +1,40 @@
+# Workflow authoring
+
+Workflows are JavaScript orchestration programs executed by the `workflow` tool. The table below is generated from the extension's executable capability contract, so its names, signatures, options, and defaults match the installed runtime.
+
+Use the packaged `workflow-authoring` skill for pattern selection, lifecycle rules, review and debugging guidance, and adaptable examples. Those explanations remain hand-written. Configured model routes and agent types are dynamic references; obtain their names and purposes from the active user or project context rather than this static page.
+
+See [Workflow prompt guidance rationale](workflow-prompt-guidance-rationale.md) for the decision-by-decision record of prompt insertions, removals, and compactions. See [Workflow authoring evidence](workflow-authoring-evidence.md) for context measurements and the non-gating model-comprehension comparison.
+
+## Supported capabilities
+
+<!-- BEGIN GENERATED SUPPORTED WORKFLOW CAPABILITIES -->
+| Name | Classification | Signature | Options and defaults |
+| --- | --- | --- | --- |
+| agent | runtime-global | `agent(prompt, options?) => Promise<string \| structured value \| null>` | `label`: string (optional; default: derived from phase and call count)<br>`phase`: string (optional; default: current phase)<br>`schema`: plain JSON Schema (optional)<br>`model`: string (optional)<br>`tier`: string (optional)<br>`isolation`: "worktree" (optional)<br>`agentType`: string (optional)<br>`timeoutMs`: number \| null (optional; default: run timeout; null disables)<br>`retries`: number (optional; default: run retry count) |
+| parallel | runtime-global | `parallel(thunks) => Promise<Array<unknown \| null>>` | — |
+| pipeline | runtime-global | `pipeline(items, ...stages) => Promise<Array<unknown \| null>>` | — |
+| workflow | runtime-global | `workflow(savedName, childArgs?) => Promise<unknown>` | — |
+| verify | runtime-global | `verify(item: unknown, options?: { reviewers?: number; threshold?: number; lens?: string \| string[] }) => Promise<{ real: boolean; realCount: number; total: number; votes: Array<{ real: boolean; reason?: string }> }>` | `reviewers`: number (optional; default: 2)<br>`threshold`: number (optional; default: 0.5)<br>`lens`: string \| string[] (optional) |
+| judgePanel | runtime-global | `judgePanel(attempts: unknown[], options?: { judges?: number; rubric?: string }) => Promise<{ index: number; attempt: unknown; score: number; judgments: Array<{ score: number; reason?: string }> } \| undefined>` | `judges`: number (optional; default: 3)<br>`rubric`: string (optional; default: "overall quality and correctness") |
+| loopUntilDry | runtime-global | `loopUntilDry(options: { round: (roundIndex: number) => unknown[] \| Promise<unknown[]>; key?: (item: unknown) => string; consecutiveEmpty?: number; maxRounds?: number }) => Promise<unknown[]>` | `round`: (roundIndex: number) => unknown[] \| Promise<unknown[]> (required)<br>`key`: (item: unknown) => string (optional; default: JSON.stringify)<br>`consecutiveEmpty`: number (optional; default: 2)<br>`maxRounds`: number (optional; default: 50) |
+| completenessCheck | runtime-global | `completenessCheck(taskArgs: unknown, results: unknown) => Promise<{ complete: boolean; missing?: string[] } \| null>` | — |
+| retry | runtime-global | `retry(thunk: (attempt: number) => unknown \| Promise<unknown>, options?: { attempts?: number; until?: (result: unknown) => boolean }) => Promise<unknown>` | `attempts`: number (optional; default: 3)<br>`until`: (result: unknown) => boolean (optional; default: accept first result when omitted) |
+| gate | runtime-global | `gate(thunk: (feedback: string \| undefined, attempt: number) => unknown \| Promise<unknown>, validator: (value: unknown) => { ok: boolean; feedback?: string } \| Promise<{ ok: boolean; feedback?: string }>, options?: { attempts?: number }) => Promise<{ ok: boolean; value: unknown; attempts: number }>` | `attempts`: number (optional; default: 3) |
+| checkpoint | runtime-global | `checkpoint(prompt, options?) => Promise<unknown>` | `default`: unknown (optional; default: true when no UI and omitted)<br>`headless`: "default" \| "abort" (optional; default: "default")<br>`kind`: "confirm" \| "input" \| "select" (optional; default: "confirm")<br>`choices`: string[] (optional)<br>`timeoutMs`: number (optional) |
+| log | runtime-global | `log(message) => void` | — |
+| phase | runtime-global | `phase(title, options?) => void` | `budget`: number (optional) |
+| args | runtime-global | `args: unknown` | — |
+| cwd | runtime-global | `cwd: string` | — |
+| process | runtime-global | `process: { cwd(): string }` | — |
+| budget | runtime-global | `budget: { total, spent(), remaining() }` | — |
+| script | workflow-tool-input | `script: string` | — |
+| args | workflow-tool-input | `args?: unknown` | — |
+| background | workflow-tool-input | `background?: boolean = true` | — |
+| maxAgents | workflow-tool-input | `maxAgents?: number = 1000` | — |
+| concurrency | workflow-tool-input | `concurrency?: number` | — |
+| agentRetries | workflow-tool-input | `agentRetries?: number = configured value or 0` | — |
+| agentTimeoutMs | workflow-tool-input | `agentTimeoutMs?: number = configured value or unbounded` | — |
+| tokenBudget | workflow-tool-input | `tokenBudget?: number = unlimited` | — |
+| resumeFromRunId | workflow-tool-input | `resumeFromRunId?: string` | — |
+<!-- END GENERATED SUPPORTED WORKFLOW CAPABILITIES -->

--- a/docs/workflow-context-surfaces.json
+++ b/docs/workflow-context-surfaces.json
@@ -12,7 +12,7 @@
     },
     "providerVisibleWorkflowToolDefinition": {
       "serialization": "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
-      "bytes": 3802
+      "bytes": 3918
     },
     "workflowAuthoringSkillDiscovery": {
       "serialization": "UTF-8 bytes of normalized Pi skill XML with package-relative location",
@@ -20,12 +20,12 @@
     },
     "ordinaryWorkflowOwnedAlwaysOn": {
       "serialization": "sum of permanent prompt, provider-visible tool definition, and normalized skill discovery bytes",
-      "bytes": 4882
+      "bytes": 4998
     },
     "workflowAuthoringSkillCorpus": {
       "serialization": "sum of UTF-8 bytes for every file under skills/workflow-authoring",
       "files": 27,
-      "bytes": 66847
+      "bytes": 67089
     },
     "representativeAuthoringProfiles": {
       "serialization": "sum of UTF-8 bytes for each profile's declared package-relative files",
@@ -53,7 +53,7 @@
             "skills/workflow-authoring/examples/phased-budgets.js",
             "skills/workflow-authoring/examples/saved-nested-workflows.js"
           ],
-          "bytes": 14634
+          "bytes": 14828
         },
         {
           "name": "review",
@@ -88,7 +88,7 @@
             "skills/workflow-authoring/examples/loop-until-done.js",
             "skills/workflow-authoring/examples/structured-output.js"
           ],
-          "bytes": 15222
+          "bytes": 15416
         },
         {
           "name": "retry",

--- a/docs/workflow-context-surfaces.json
+++ b/docs/workflow-context-surfaces.json
@@ -1,0 +1,108 @@
+{
+  "formatVersion": 2,
+  "encoding": "utf8",
+  "sources": [
+    "src/workflow-tool.ts",
+    "skills/workflow-authoring"
+  ],
+  "surfaces": {
+    "permanentWorkflowPrompt": {
+      "serialization": "UTF-8 bytes of LF-joined Pi prompt lines",
+      "bytes": 742
+    },
+    "providerVisibleWorkflowToolDefinition": {
+      "serialization": "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
+      "bytes": 3802
+    },
+    "workflowAuthoringSkillDiscovery": {
+      "serialization": "UTF-8 bytes of normalized Pi skill XML with package-relative location",
+      "bytes": 338
+    },
+    "ordinaryWorkflowOwnedAlwaysOn": {
+      "serialization": "sum of permanent prompt, provider-visible tool definition, and normalized skill discovery bytes",
+      "bytes": 4882
+    },
+    "workflowAuthoringSkillCorpus": {
+      "serialization": "sum of UTF-8 bytes for every file under skills/workflow-authoring",
+      "files": 27,
+      "bytes": 66847
+    },
+    "representativeAuthoringProfiles": {
+      "serialization": "sum of UTF-8 bytes for each profile's declared package-relative files",
+      "medianBytes": 11662,
+      "profiles": [
+        {
+          "name": "write",
+          "files": [
+            "skills/workflow-authoring/SKILL.md",
+            "skills/workflow-authoring/references/runtime.md",
+            "skills/workflow-authoring/references/pattern-selection.md",
+            "skills/workflow-authoring/references/focused-recipes.md",
+            "skills/workflow-authoring/examples/fan-out-and-synthesize.js",
+            "skills/workflow-authoring/examples/structured-output.js"
+          ],
+          "bytes": 11590
+        },
+        {
+          "name": "edit",
+          "files": [
+            "skills/workflow-authoring/SKILL.md",
+            "skills/workflow-authoring/references/runtime.md",
+            "skills/workflow-authoring/references/lifecycle.md",
+            "skills/workflow-authoring/references/focused-recipes.md",
+            "skills/workflow-authoring/examples/phased-budgets.js",
+            "skills/workflow-authoring/examples/saved-nested-workflows.js"
+          ],
+          "bytes": 14634
+        },
+        {
+          "name": "review",
+          "files": [
+            "skills/workflow-authoring/SKILL.md",
+            "skills/workflow-authoring/references/runtime.md",
+            "skills/workflow-authoring/references/review.md",
+            "skills/workflow-authoring/references/quality-helpers.md",
+            "skills/workflow-authoring/examples/adversarial-verification.js"
+          ],
+          "bytes": 10772
+        },
+        {
+          "name": "debug",
+          "files": [
+            "skills/workflow-authoring/SKILL.md",
+            "skills/workflow-authoring/references/runtime.md",
+            "skills/workflow-authoring/references/debugging.md",
+            "skills/workflow-authoring/references/specialized-helpers.md",
+            "skills/workflow-authoring/examples/validated-gate.js"
+          ],
+          "bytes": 11734
+        },
+        {
+          "name": "loop",
+          "files": [
+            "skills/workflow-authoring/SKILL.md",
+            "skills/workflow-authoring/references/runtime.md",
+            "skills/workflow-authoring/references/pattern-selection.md",
+            "skills/workflow-authoring/references/lifecycle.md",
+            "skills/workflow-authoring/references/focused-recipes.md",
+            "skills/workflow-authoring/examples/loop-until-done.js",
+            "skills/workflow-authoring/examples/structured-output.js"
+          ],
+          "bytes": 15222
+        },
+        {
+          "name": "retry",
+          "files": [
+            "skills/workflow-authoring/SKILL.md",
+            "skills/workflow-authoring/references/runtime.md",
+            "skills/workflow-authoring/references/retry-helper.md",
+            "skills/workflow-authoring/references/focused-recipes.md",
+            "skills/workflow-authoring/examples/bounded-semantic-retry.js",
+            "skills/workflow-authoring/examples/structured-output.js"
+          ],
+          "bytes": 10568
+        }
+      ]
+    }
+  }
+}

--- a/docs/workflow-guidance-baseline.json
+++ b/docs/workflow-guidance-baseline.json
@@ -1,0 +1,8 @@
+{
+  "formatVersion": 1,
+  "algorithm": "sha256",
+  "surfaces": {
+    "compactGuidance": "d54bd6a5ee776bceb0b097ece5c6cc7474d9802e634ea4f9590f4ed6a28763e7",
+    "detailedProse": "362760380420405a691e408e1bf279c1015a43e4aa9cb7442fd11fe53cd5911e"
+  }
+}

--- a/docs/workflow-guidance-baseline.json
+++ b/docs/workflow-guidance-baseline.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "algorithm": "sha256",
   "surfaces": {
-    "compactGuidance": "d54bd6a5ee776bceb0b097ece5c6cc7474d9802e634ea4f9590f4ed6a28763e7",
-    "detailedProse": "362760380420405a691e408e1bf279c1015a43e4aa9cb7442fd11fe53cd5911e"
+    "compactGuidance": "7d6cdc184667d71e1aa1121ca294d8bc82f8eb9556df75b8f6571319cfea5434",
+    "detailedProse": "bb5918e57601742a5cd57ca6ddda17cb8354a5cdcb773d60e2ffcd7ec7f32fab"
   }
 }

--- a/docs/workflow-prompt-guidance-rationale.md
+++ b/docs/workflow-prompt-guidance-rationale.md
@@ -1,0 +1,802 @@
+# Workflow prompt guidance rationale
+
+This document preserves the decision-by-decision record behind the workflow tool's compact model guidance. It records each reviewed insertion, removal, and compaction with its reasoning, evidence, and confidence.
+
+## Current placement in 3.0.0
+
+The record originated in [Whamp/pi-dynamic-workflows#23](https://github.com/Whamp/pi-dynamic-workflows/pull/23). The 3.0.0 target later merged [QuintinShaw/pi-dynamic-workflows#93](https://github.com/QuintinShaw/pi-dynamic-workflows/pull/93), which changed workflow triggering from forced execution to authorization and established one always-on workflow gate. The current implementation preserves that gate and its background-delivery behavior while applying the concision decisions recorded below.
+
+| Decision area | Current authority |
+| --- | --- |
+| Capability summary | `description` and `promptSnippet` in [`src/workflow-tool.ts`](../src/workflow-tool.ts) |
+| First-attempt script syntax and composition | `script.description` in [`src/workflow-tool.ts`](../src/workflow-tool.ts) |
+| Background and outer resource controls | Their parameter descriptions plus runtime behavior |
+| Workflow authorization | The single `WORKFLOW_GATE_GUIDELINE`; #93 supersedes the older exact selection wording below |
+| Detailed authoring policy | The on-demand [`workflow-authoring` skill](../skills/workflow-authoring/SKILL.md), not permanent prompt guidelines |
+| Exact capability facts | The executable contract and generated [workflow-authoring reference](workflow-authoring.md) |
+| Dynamic model routes and agent types | Active user and project configuration, not static prompt catalogues |
+| Context and comprehension evidence | [Workflow authoring evidence](workflow-authoring-evidence.md) and generated context measurements |
+
+The original reviewed record follows. Its quoted before-and-after text documents the decisions made at that point; it is not a second source of current model-facing wording. Current source, generated references, and release checks are authoritative.
+
+## Prompt surfaces
+
+Pi renders `promptSnippet` as the workflow tool's one-line entry in the system prompt's `Available tools` section. Pi appends each `promptGuidelines` entry as a flat bullet in the system prompt's `Guidelines` section. The provider-visible tool definition separately carries the tool `description` and parameter schema.
+
+## Original approved changes
+
+### Describe the workflow capability in `promptSnippet`
+
+Replace:
+
+```text
+Run a deterministic JavaScript workflow. Required script header: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }.
+```
+
+with:
+
+```text
+Delegate substantive independent or staged work to subagents with a JavaScript workflow, optionally composing agent calls with parallel(), pipeline(), or both
+```
+
+#### Reasoning
+
+The Available-tools entry should tell the parent model what the workflow tool does when the model selects a tool. The replacement names the tool's purpose, suitable task scale, and supported composition shapes.
+
+The old entry duplicated the required `meta` declaration from the `script` parameter description. Keeping that syntax in the parameter schema gives it one authoritative home and keeps the Available-tools entry focused on capability.
+
+The phrase `parallel(), pipeline(), or both` covers simple workflows that use neither helper and composed workflows that use either helper or both. It names the real functions instead of implying that “parallel agents” and “pipeline agents” are distinct agent types.
+
+The replacement also removes the claim that the workflow is deterministic. The runtime restricts nondeterministic script APIs, but real subagent output remains nondeterministic.
+
+#### Evidence
+
+Pi documents `promptSnippet` as a short one-line Available-tools entry and uses capability-oriented text in its example custom tool. See [Pi extension tool guidance](https://github.com/earendil-works/pi/blob/2b3fda9921b5590f285165287bd442a25817f17b/packages/coding-agent/docs/extensions.md#L1321-L1358).
+
+The project's prompt-budget research classifies the old snippet as duplicated and recommends leaving the metadata header in `script.description`. See [Minimal workflow prompt and budgets](https://github.com/Whamp/pi-dynamic-workflows/blob/7fa8a5944c5ad4182aee0c43d757350c61e3a5da/docs/research/minimal-workflow-prompt-and-budgets.md).
+
+The schema-comprehension experiment showed that the tool definition and schema supported parser-valid workflow scripts across four tested parent models after removing `promptGuidelines`. The experiment retained the old `promptSnippet`, so it does not isolate whether the schema alone teaches the metadata header. See [What the workflow schema teaches parent models](https://github.com/Whamp/pi-dynamic-workflows/blob/f8b6f5c34e9476e014d2906a257344e410a00364/docs/research/workflow-schema-comprehension.md).
+
+#### Confidence
+
+Confidence is high that `promptSnippet` should describe capability while `script.description` owns the metadata syntax. Confidence is moderate that removing the duplicated header causes no authoring regression because the existing experiment did not isolate that variable.
+
+### Focus the tool description on delegation
+
+Replace:
+
+```text
+Execute a deterministic JavaScript workflow that orchestrates multiple subagents with agent(), parallel(), and pipeline(). script is required raw JavaScript. It must start with export const meta = { name, description, phases? } and must call agent() at least once.
+```
+
+with:
+
+```text
+Run a JavaScript workflow that delegates work to subagents with agent(), optionally composing calls with parallel() and pipeline().
+```
+
+#### Reasoning
+
+The provider-visible tool description should state the capability, while the `script` parameter description owns exact input syntax. Removing the metadata declaration and raw-script requirements from the description leaves one authoritative home for those facts.
+
+“JavaScript workflow” distinguishes this constrained orchestration environment from a general JavaScript runner. “Delegates work” follows the approved domain language used for workflow selection and agent work units.
+
+The runtime requires at least one `agent()` invocation but not multiple subagents. `parallel()` and `pipeline()` are optional composition helpers, so the new description identifies `agent()` as the delegation primitive and marks composition as optional.
+
+The old “deterministic” claim described only the restricted orchestration shell. Subagent model output remains nondeterministic, making the claim misleading for the tool as a whole.
+
+#### Evidence
+
+The `script` parameter description already specifies raw JavaScript, the required metadata declaration, available globals, the `parallel()` thunk shape, and the requirement to call `agent()` at least once. The runtime rejects a workflow that launches no agents.
+
+Pi exposes the description in the provider-visible tool definition and renders `promptSnippet` separately in the system prompt's Available-tools list. Both surfaces need capability language, but only the parameter schema needs the complete input contract.
+
+#### Confidence
+
+Confidence is very high that the description should omit duplicated syntax, avoid “deterministic” and “multiple subagents,” and distinguish required delegation through `agent()` from optional composition through `parallel()` and `pipeline()`.
+
+### Put enforced script syntax in `script.description`
+
+Remove these permanent guidelines:
+
+```text
+For workflow, always pass one raw JavaScript string in the required script parameter; do not include Markdown fences or prose around the script.
+```
+
+```text
+For workflow, the script's first statement must be `export const meta = { name: 'short_snake_case', description: 'non-empty human description', phases: [{ title: 'Phase name' }] }`; meta.name and meta.description are required non-empty strings.
+```
+
+```text
+For workflow, write plain JavaScript after the meta export. Do not use TypeScript syntax, imports, require(), fs, Date.now(), Math.random(), or new Date().
+```
+
+```text
+For workflow, available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), args, cwd, process.cwd(), and budget. Every workflow must call agent() at least once; do not use workflow only to declare phases or return a static object.
+```
+
+```text
+For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.
+```
+
+Replace them with no permanent guideline. Keep the complete first-attempt contract in the `script` parameter description:
+
+```text
+Required raw JavaScript workflow script, with no Markdown fences. First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] } Use plain JavaScript only; imports, require(), filesystem modules, Date.now(), Math.random(), and new Date() are unavailable. Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, cwd, process.cwd(), and budget. The workflow must call agent() at least once. parallel() requires functions, not promises: await parallel(items.map(item => () => agent(...))).
+```
+
+The three dots in the quoted examples are literal JavaScript spread or placeholder syntax from the model-facing text; they do not omit wording from this record.
+
+#### Reasoning
+
+These are input-shape facts rather than selection or judgment policy. `script.description` is visible where the model constructs the tool argument and gives the facts one authoritative authoring home. The parser and runtime remain authoritative for enforcement and return corrective errors after violations.
+
+The shortened schema had retained raw JavaScript, metadata, common globals, the minimum agent count, and the `parallel()` thunk requirement. This change restores two useful facts lost during shortening: the restricted JavaScript environment and the available `cwd` and `process.cwd()` path globals.
+
+#### Evidence
+
+The schema-comprehension experiment produced parser-valid scripts and correct `parallel()` thunk shapes across four tested parent models without `promptGuidelines`. Because that experiment retained the old metadata-bearing `promptSnippet`, it does not isolate metadata comprehension; keeping the declaration in `script.description` addresses that limitation. See [What the workflow schema teaches parent models](https://github.com/Whamp/pi-dynamic-workflows/blob/f8b6f5c34e9476e014d2906a257344e410a00364/docs/research/workflow-schema-comprehension.md).
+
+Runtime and parser tests cover metadata placement, nondeterministic APIs, VM escapes, and invalid `parallel()` arguments. The implementation lives in [`src/workflow.ts`](../src/workflow.ts).
+
+#### Confidence
+
+Confidence is very high that enforced syntax belongs in the parameter schema and runtime instead of duplicated permanent guidelines. Confidence is high that the concise environment restriction and path globals are necessary for a valid first attempt.
+
+### Preserve composition mechanics in `script.description`
+
+Keep these first-attempt mechanics in the `script` parameter description rather than permanent guidance:
+
+```text
+parallel() requires functions, not promises, and returns results in input order: await parallel(items.map(item => () => agent(...))).
+```
+
+```text
+pipeline(items, ...stages) runs stages sequentially for each item while items proceed concurrently; each stage receives (previousValue, originalItem, index).
+```
+
+#### Reasoning
+
+The approved permanent topology rule tells the parent when to use `parallel()` and `pipeline()`. These schema sentences separately state how to call them correctly. Result ordering preserves the association between parallel results and input work-unit identities despite completion timing. The pipeline sentence provides the callback contract needed to use prior stage output, recover the original item, and identify its input position.
+
+These facts were present in the old permanent guidance or README but were accidentally absent from the shortened schema. Restoring them to `script.description` preserves first-attempt authoring capability without growing permanent system-prompt text.
+
+#### Evidence
+
+`src/workflow.ts` implements `parallel()` with `Promise.all`, which preserves input order, and implements `pipeline()` by running each item through its stages sequentially while item pipelines proceed through `Promise.all`. Each stage is invoked with `(previousValue, originalItem, index)`.
+
+#### Confidence
+
+Confidence is very high that both mechanics are stable runtime contracts, useful for valid first attempts, and correctly placed in the parameter schema rather than permanent guidance.
+
+### Keep background behavior in the parameter schema and tool result
+
+Remove this permanent guideline without replacement:
+
+```text
+For workflow, runs are background by default: the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when the run finishes. Pass background: false only when you must use the result inline in this same turn (it will block).
+```
+
+Retain the pre-call contract in `background.description`:
+
+```text
+Run the workflow in the background. Default: true — the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when it finishes. Set to false only when you need the result inline in this same turn (the call will block until the workflow completes).
+```
+
+#### Reasoning
+
+Background execution is a parameter choice rather than permanent selection policy. The parameter description presents the default and tradeoff when the parent constructs the call. After a background run starts, the tool result confirms that execution continues independently, automatic result delivery is enabled, and the run can be inspected or stopped.
+
+Keeping the same behavior in a permanent guideline would duplicate the parameter contract and create another surface that could drift when execution behavior changes.
+
+#### Evidence
+
+`src/workflow-tool.ts` defaults omitted `background` to `true`. `backgroundStartedText()` supplies the post-call explanation and run-management commands. The prompt-placement research recommends placing background behavior and parameter defaults in schema and runtime rather than permanent guidance.
+
+#### Confidence
+
+Confidence is very high that `background.description` and the actual tool result are sufficient authorities and that no permanent replacement is needed.
+
+### Keep conditional phase guidance in `script.description`
+
+Remove this permanent guideline:
+
+```text
+For workflow, when meta.phases declares more than one phase, call phase('Exact Title') at the start of each phase's work (or set opts.phase on each agent) so every agent groups under the correct phase; never declare a phase you don't switch into — a declared phase with no agents shows as 0/0 and any agent you forgot to move stays in the previous phase.
+```
+
+Replace the required metadata example:
+
+```text
+First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }
+```
+
+with this conditional contract in `script.description`:
+
+```text
+First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description' }. Add phases: [{ title: 'Phase' }] only when the workflow has named phases, and declare only phases it will use. With multiple phases, call phase('Exact Title') before each phase's work or set `phase` in the agent options.
+```
+
+#### Reasoning
+
+`meta.phases` is optional, so the minimal executable example should not make a phase declaration look mandatory. Simple workflows avoid meaningless one-phase metadata, while models choosing multiple phases receive the switching rule where they author the script.
+
+The rule affects execution as well as display. Agents default to the first declared phase; `phase(title)` changes the current assignment; an agent's `phase` option overrides it. Assigned phases select grouping, phase-specific model routing, and phase budgets. A multi-phase script that never switches can therefore silently apply the first phase's configuration to every agent.
+
+The runtime currently permits undeclared titles and does not diagnose declared phases without agents. Runtime diagnostics are tracked separately so the model-facing schema does not remain the only guard.
+
+#### Evidence
+
+`src/workflow.ts` initializes the current phase to the first declared title and resolves each agent's assigned phase from its explicit option or that current phase. Runtime regression tests confirm the first-phase default and the absence of a synthetic phase when none is declared.
+
+#### Confidence
+
+Confidence is high that the long conditional rule does not belong in permanent guidance, that the minimal metadata example should omit optional phases, and that `script.description` should retain concise multi-phase instructions.
+
+### Make saved-workflow nesting discoverable in `script.description`
+
+Remove this permanent guideline:
+
+```text
+For workflow, you may call `await workflow('saved-name', argsObject)` to run a saved workflow inline and use its result; nesting is one level deep only, and the global 16-concurrent / 1000-total caps hold across the nesting.
+```
+
+Add this sentence to `script.description`:
+
+```text
+Use `await workflow(savedName, childArgs)` to run a saved workflow inline; nesting is limited to one level and shares the parent run's concurrency, agent, and token limits.
+```
+
+#### Reasoning
+
+Saved-workflow composition is an optional script capability rather than permanent workflow-selection policy. Removing its guideline without another model-facing home made the `workflow()` global undiscoverable from the tool definition. The parameter description restores concise capability discovery where scripts are authored.
+
+The replacement avoids fixed `16-concurrent / 1000-total` wording. Those are global maxima rather than every run's effective settings; nested workflows inherit the parent run's configured limiter, total agent count, and token budget.
+
+Arguments, returned results, shared-store behavior, nested run IDs, resume-journal isolation, and log persistence remain runtime and documentation details rather than first-attempt syntax.
+
+#### Evidence
+
+The README documents `workflow(name, args)` as the inline saved-workflow global. Runtime tests cover child arguments and results, shared agent counting, one-level nesting, and shared-store identity. The implementation is in [`src/workflow.ts`](../src/workflow.ts).
+
+#### Confidence
+
+Confidence is high that saved-workflow composition should stay out of permanent guidance but remain discoverable through this concise parameter-schema sentence. Confidence is very high that inherited-limit language is more accurate than fixed maxima.
+
+### Keep quality-helper names discoverable without a permanent catalogue
+
+Remove this detailed permanent guideline:
+
+```text
+For workflow, prefer the built-in quality helpers when they fit (each is built on agent()/parallel() and returns plain data): verify(item, {reviewers, threshold, lens}) for adversarial fact-checking; judgePanel(attempts, {judges, rubric}) to score N candidates and return the best; loopUntilDry({round, key, consecutiveEmpty}) to keep finding until rounds stop yielding new items; completenessCheck(args, results) as a final 'what's missing' critic.
+```
+
+Add this concise capability sentence to `script.description`:
+
+```text
+Optional quality helpers include verify(), judgePanel(), loopUntilDry(), and completenessCheck().
+```
+
+Retain the separately approved permanent policy:
+
+```text
+Add verification when results would materially benefit from cross-checking, or a final synthesis agent when the deliverable needs comparison or prose.
+```
+
+#### Reasoning
+
+The old catalogue combined capability discovery, full signatures, and a default preference for extra quality stages. Its “prefer” instruction conflicted with selecting verification according to material benefit, and the detailed signatures were irrelevant to most workflows.
+
+Complete removal would make novel extension capabilities effectively invisible. The concise schema sentence preserves their names without turning permanent guidance into an advanced API reference. The permanent sentence separately governs when additional quality calls justify their cost.
+
+Detailed option and return semantics remain in the README, website, tests, and source. Workflows can also construct equivalent topologies directly from `agent()` and `parallel()`.
+
+#### Evidence
+
+The prompt research classifies the quality-helper catalogue as detailed-only or on-demand and recommends presenting helpers as optional patterns rather than default stages. The runtime and `tests/quality-stdlib.test.ts` cover each helper's behavior.
+
+#### Confidence
+
+Confidence is very high that the detailed permanent catalogue and default preference should be removed. Confidence is high that a concise name catalogue in `script.description` provides an appropriate minimum level of discovery for an unfamiliar model.
+
+### Keep outer resource controls in parameter descriptions
+
+Remove these permanent guidelines:
+
+```text
+For workflow, do not set tokenBudget or agentTimeoutMs unless the user explicitly asks to cap spend or time; the defaults are unbounded.
+```
+
+```text
+For workflow, use low concurrency and agentRetries for unstable provider/transport fan-out runs; retries apply only to recoverable agent failures and still require explicit null handling after exhaustion.
+```
+
+Add no replacement to `promptGuidelines`. Retain the existing `tokenBudget`, `agentTimeoutMs`, `concurrency`, and `agentRetries` parameter descriptions, and replace `maxAgents.description`:
+
+```text
+Maximum number of agents allowed in this run. Default: 1000.
+```
+
+with:
+
+```text
+Maximum number of agents allowed in this run. Default: 1000; this is a safety ceiling, not a target. Set a lower limit for dynamic or exploratory fan-out, and reserve large fan-outs for explicit user intent.
+```
+
+#### Reasoning
+
+Outer resource controls matter while constructing the tool call, so their parameter descriptions are the direct authority. Permanent copies duplicate defaults and conditional advice.
+
+Workflow selection and workflow scale are separate authorization decisions. Explicit workflow intent permits delegation, but it does not make the runtime's 1,000-agent maximum an appropriate target. The amended field trusts normal model judgment while requiring clearer authority for unusually large fan-outs and recommending a lower safety limit for dynamic expansion.
+
+The detailed in-script budget, retry, gate, and graceful-degradation recipe remains a separate decision.
+
+#### Evidence
+
+The runtime enforces total-agent, concurrency, token-budget, timeout, and recoverable-retry behavior. The parameter schema describes each outer control where the model chooses its value. The public-workflow research assigns these facts to parameter schema and runtime while treating operational recipes as detailed guidance.
+
+#### Confidence
+
+Confidence is very high that outer control facts belong in their field descriptions and that 1,000 should be described as a ceiling rather than a target. Confidence is high that large fan-outs should require explicit user intent.
+
+### Compress advanced control recipes into capability discovery
+
+Remove this detailed permanent guideline:
+
+```text
+For workflow, to bound spend: pass tokenBudget for a hard run-wide cap; carve a per-phase ceiling with phase('Name', {budget: N}) (that phase throws at its sub-budget without touching the run total — wrap its work in try/catch so later phases proceed); use retry(thunk, {attempts, until}) for bounded retry, and gate(thunk, validator, {attempts}) when a validator's feedback should steer the next attempt. To degrade gracefully, branch on budget.remaining() to skip optional rounds or choose a lighter tier.
+```
+
+Add this concise sentence to `script.description`:
+
+```text
+Optional control helpers include retry() and gate(); budget exposes total, spent(), and remaining(), and phase('Name', { budget: N }) sets a phase token limit.
+```
+
+#### Reasoning
+
+The old guideline combined hard run caps, phase limits, authored retry loops, validator-feedback loops, exception structure, and graceful degradation. Most workflows do not need that operational recipe, and its strategy should not be a permanent default.
+
+Complete removal would make `retry()`, `gate()`, `budget` methods, and phase token limits undiscoverable to models unfamiliar with the extension. The concise schema sentence exposes their existence and essential shape without prescribing them.
+
+Outer `tokenBudget`, `agentRetries`, and `agentTimeoutMs` remain documented by their tool parameters. `agentRetries` repeats recoverable failed executions; the script-level `retry()` repeats an authored thunk according to its `until` condition; `gate()` feeds validator feedback into another authored attempt. Full signatures and return semantics remain in detailed documentation.
+
+#### Evidence
+
+The prompt research classifies budgets, retry, gate, and graceful-degradation recipes as detailed-only or on-demand while keeping parameter facts in schema. Runtime tests in `tests/quality-stdlib.test.ts` cover `retry()` and `gate()`, and workflow runtime tests cover run and phase budgets. Broader static capability discovery and documentation drift are tracked in [issue #22](https://github.com/Whamp/pi-dynamic-workflows/issues/22).
+
+#### Confidence
+
+Confidence is very high that the detailed operational recipe should leave permanent guidance. Confidence is high that concise capability discovery in `script.description` is appropriate until a broader self-documenting capability architecture exists.
+
+### Keep `agentType` static while moving exact names to deliberate discovery
+
+Remove the dynamic `agentTypeGuideline()` call and its machine- and project-specific catalogue from permanent guidance. Keep `promptGuidelines` as a static array, and add this sentence to `script.description`:
+
+```text
+The optional `agentType` option selects a named user or project definition that can bind tools, a model, and role instructions; use it only when its name and purpose are provided in context. Its bound model overrides `tier`; an explicit `model` overrides both.
+```
+
+#### Reasoning
+
+`agentType` is a stable extension capability, but available definitions are live filesystem data from the current project and user configuration. Injecting those names and descriptions into the permanent system prompt makes its size and contents environment-dependent and risks cache invalidation as definitions change.
+
+Complete removal would make the option undiscoverable. The static schema sentence explains the capability, authority boundary, and model precedence. Exact names and purposes must come from the user's context or a deliberate cache-safe discovery mechanism after workflow selection.
+
+The runtime currently warns and falls back to default tools and model for an unknown `agentType`; failing closed or returning a structured diagnostic remains a runtime hardening opportunity.
+
+#### Evidence
+
+Issue #12 researched cache-safe discovery for exact model and `agentType` catalogues. Issue #22 tracks a broader self-documenting capability architecture. Runtime model precedence is explicit `model`, then the `agentType`-bound model, then `tier`, then phase routing.
+
+#### Confidence
+
+Confidence is very high that the live catalogue should leave permanent context and that `promptGuidelines` should remain static. Confidence is high that the concise schema sentence preserves appropriate discovery without authorizing guessed names.
+
+### Delete obsolete prompt-helper exports
+
+Delete `modelRoutingGuideline()` and `agentTypeGuideline()` from `src/workflow-tool.ts`, along with their registry imports and direct string tests. Add no replacement helper functions.
+
+#### Reasoning
+
+Neither helper is exported from the package root defined by `package.json` and `src/index.ts`, so removal does not change the supported package API. Their only production use was constructing the old permanent guidance.
+
+`modelRoutingGuideline()` encoded superseded policy: mandatory tier tags, a closed three-tier vocabulary, and embedded exact-model examples. The approved static routing language supports standard and user-configured routes and reserves exact `model` overrides for user-named models.
+
+`agentTypeGuideline()` read live filesystem definitions and flattened them into permanent system-prompt text. That conflicts with the approved static capability sentence and deliberate, cache-safe exact-name discovery.
+
+Removing both helpers lets `promptGuidelines` remain a plain static array. `WorkflowManager` still receives the model registry for runtime model resolution, so execution behavior does not depend on either text helper.
+
+#### Evidence
+
+`package.json` exports only the package root. `src/index.ts` exports `WorkflowToolInput`, `WorkflowToolOptions`, `backgroundStartedText`, and `createWorkflowTool` from `workflow-tool.ts`, but not either helper. Repository search found no remaining production caller after the prompt rewrite.
+
+#### Confidence
+
+Confidence is very high that the helpers are unsupported internal exports with obsolete responsibilities and should be deleted rather than preserved or deprecated.
+
+### Test intent and placement instead of guideline count
+
+Delete this provisional assertion:
+
+```text
+assert.ok(tool.promptGuidelines.length <= 5, "permanent guidance should stay scannable");
+```
+
+Retain intent-level assertions for the approved authoring contracts, static guidance, omission of live catalogues and advanced recipes, and relocation of syntax and parameter facts to their authoritative schema fields.
+
+#### Reasoning
+
+Guideline count does not measure prompt size or clarity. Five arbitrarily long bullets pass, six concise bullets fail, and the limit encourages unrelated contracts to be combined. The approved guidance should group related ideas naturally rather than target an arbitrary array length.
+
+Rendered system-prompt bytes and provider-visible tool-definition bytes remain useful audit measurements, but they should not become byte-level test ratchets. Prompt quality depends on what each surface teaches and where the contract belongs, not on freezing an incidental serialized size.
+
+Exact-copy tests also remain inappropriate for prose that may receive harmless editorial improvements. Intent, placement, absence, and runtime behavior provide the regression signals; surface sizes may be reported during review as evidence without becoming pass/fail thresholds.
+
+#### Confidence
+
+Confidence is very high that guideline-count and byte-level ratchet tests should be omitted while behavioral, static-guidance, and placement assertions remain.
+
+### Require explicit workflow intent
+
+Replace:
+
+```text
+Use workflow only when the user explicitly asks for a workflow, workflows, fan-out, or multi-agent orchestration.
+```
+
+and:
+
+```text
+For workflow, prefer it for decomposable work: repository inspection, independent research/checks, multi-perspective review, or fan-out/fan-in synthesis. Do not use it for a single quick file read/edit or when ordinary tools are enough.
+```
+
+with:
+
+```text
+Use workflow only for explicit workflow intent: a request for a workflow, subagent delegation, fan-out, or multi-agent orchestration, or an enabled mode that requires workflow. Use ordinary tools for work you can perform directly.
+```
+
+#### Reasoning
+
+Workflow selection is an authorization decision rather than a test of whether a parent model can recognize decomposable work. One run permits up to 1,000 agents, up to 16 concurrently, and no token budget by default. A capable model can choose an appropriate topology after authorization, but it cannot infer the user's tolerance for that potential expense from task complexity alone.
+
+The boundary does not require a magic trigger word. Explicit intent includes a direct workflow request, delegation to even one subagent, fan-out, multi-agent orchestration, or standing intent established by an enabled workflow or effort mode. The runtime requires at least one agent rather than multiple agents, so singular subagent delegation is valid.
+
+Enabled modes must count because the extension deliberately transforms matching messages into a workflow requirement. Recognizing that standing opt-in prevents the permanent guidance from conflicting with the extension's own trigger behavior.
+
+“Work you can perform directly” replaces arbitrary one-read, one-edit, and one-command tests. Decomposability shapes the workflow after selection; it does not independently authorize delegation.
+
+Permission to use workflow is distinct from permission for a large fan-out. Scale policy remains a separate operational decision so this selection rule stays focused.
+
+#### Evidence
+
+The workflow runtime enforces a 1,000-agent total cap and a 16-agent concurrency cap, while `tokenBudget` is unbounded by default. The workflow editor's forced-mode prompt requires at least one `agent()` call even for a small task. See [`src/config.ts`](../src/config.ts), [`src/workflow-tool.ts`](../src/workflow-tool.ts), and [`src/workflow-editor.ts`](../src/workflow-editor.ts).
+
+The schema-comprehension experiment showed that all four tested parent models selected the workflow tool for an explicit orchestration request. It did not test autonomous workflow selection, so it supports comprehension of explicit intent rather than broad autonomous permission. See [What the workflow schema teaches parent models](https://github.com/Whamp/pi-dynamic-workflows/blob/f8b6f5c34e9476e014d2906a257344e410a00364/docs/research/workflow-schema-comprehension.md).
+
+#### Confidence
+
+Confidence is high that potentially high-scale delegation requires explicit current or standing user intent, that one-subagent delegation is valid intent, and that ordinary tools should handle work the parent can perform directly. Large-fan-out authorization should be decided separately from workflow selection.
+
+### Scope each agent at a natural, context-sized boundary
+
+Replace:
+
+```text
+For workflow, give each subagent a substantive, self-contained task: do not spawn an agent just to read one file or run one command, and do not use one agent only to check on another. Prefer fewer, higher-level agents over many trivial micro-tasks.
+```
+
+and:
+
+```text
+For workflow, do not assume the parent assistant has repository code context inside subagents; include enough task context and relevant paths in each agent prompt.
+```
+
+with:
+
+```text
+For workflow, assign each agent a substantive work unit at a natural task boundary that it can complete comfortably within one context window. Split larger work at additional natural boundaries. Make each agent prompt self-contained with relevant context, paths, constraints, and expected output.
+```
+
+#### Reasoning
+
+A file or command count is a poor proxy for task quality. One file can be the right work unit when each file needs substantive independent analysis or a complete implementation-and-verification pipeline. A task spanning many files can still be too small, coupled, or vague to delegate. Agent count should follow the task's natural boundaries rather than an unconditional preference for fewer agents.
+
+A natural boundary is not sufficient when the resulting unit is too large for one subagent to complete coherently. Requiring the unit to fit comfortably within one context window leaves room for instructions, investigation, tool results, reasoning, and final output. Larger work should split at additional domain boundaries rather than arbitrary token intervals.
+
+The guidance does not name a token limit because workflow agents may use configured models with different context windows. A model-relative rule remains accurate as model configurations change and avoids treating the whole advertised window as available task capacity.
+
+Each workflow agent starts a fresh Pi session. It receives its working directory, normal Pi resources, runner instructions, per-agent instructions, label, and authored prompt, but not the parent conversation or the parent's tool results. Its prompt must therefore carry the task-specific context and completion contract.
+
+#### Evidence
+
+The public-workflow corpus found concrete work units to be the strongest recurring structure across 95 scripts from 92 repositories. Observed boundaries included directory and review dimension, document group, finding, module, test, and issue. See [Dynamic workflow authoring patterns](https://github.com/Whamp/pi-dynamic-workflows/blob/8bfe12fc020159748e5c0519951896086c493ce2/docs/research/claude-code-dynamic-workflow-patterns.md#recurring-structures).
+
+The Bun `phase-a-port` workflow pipelines one source file through implementation, verification, and conditional repair, directly contradicting a blanket prohibition on one-file agents. See [Bun `phase-a-port.workflow.js`](https://github.com/oven-sh/bun/blob/23427dbc12fdcff30c23a96a3d6a66d62fdc091d/.claude/workflows/phase-a-port.workflow.js#L148-L224).
+
+The source-author guidance recommends self-contained worker prompts and bounded scale. See [Agent script authoring skill](https://github.com/YuanpingSong/ultracodex/blob/5519ed1da818b4b43e23b7547063fac4759f6809/skills/agent-script-authoring/SKILL.md#L145-L164).
+
+Pi model configuration exposes model-specific `contextWindow` and `maxTokens` values rather than one universal limit. See [Pi model configuration](https://github.com/earendil-works/pi/blob/2b3fda9921b5590f285165287bd442a25817f17b/packages/coding-agent/docs/models.md#L194-L207).
+
+The fresh-session prompt assembly is implemented in [`src/agent.ts`](../src/agent.ts).
+
+#### Confidence
+
+Confidence is high that work should follow natural task boundaries rather than file or command counts, that oversized work should split further, and that agent prompts must be self-contained. The corpus supports bounded concrete work units, but it did not directly compare a one-context-window rule against another sizing heuristic.
+
+### Select verification and synthesis by need
+
+Replace:
+
+```text
+For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.
+```
+
+and the permanent default recipe:
+
+```text
+For workflow, the default quality shape for fan-out work is finder -> verify -> merge: run one agent per angle or work-unit (in parallel), pass each candidate finding through verify() and drop the unconfirmed, then a single synthesis agent that de-duplicates, ranks by confidence/severity, and caps the output. If nothing survives verification, return an empty result and say so rather than padding.
+```
+
+with:
+
+```text
+Add verification when results would materially benefit from cross-checking, or a final synthesis agent when the deliverable needs comparison or prose.
+```
+
+#### Reasoning
+
+Verification and synthesis solve different problems. Verification cross-checks results whose errors matter enough to justify another model call. The word `materially` prevents verification from becoming an automatic stage merely because any result could benefit slightly from review.
+
+A final synthesis agent is useful when the deliverable requires comparison, judgment across results, or coherent prose. It is unnecessary when JavaScript already has exact paths, counts, keyed records, pass/fail rows, deduplicated findings, or threshold decisions. Another model call can damage those results by changing identifiers or counts.
+
+The old `finder -> verify -> merge` recipe remains available as an authoring pattern, but it is not the universal topology. The approved wording selects quality stages from the deliverable instead of requiring them by default. It also removes mandatory `ok` and `verdict` fields; each workflow should return the structure its contract requires.
+
+#### Evidence
+
+The public corpus found synthesis or merge language in 57 of 95 scripts and identified four recurring endings: direct structured return, plain-JavaScript reduction, final narrative synthesis, and judge-and-graft synthesis. See [Dynamic workflow authoring patterns: synthesis strategies](https://github.com/Whamp/pi-dynamic-workflows/blob/8bfe12fc020159748e5c0519951896086c493ce2/docs/research/claude-code-dynamic-workflow-patterns.md#synthesis-strategies).
+
+The same corpus observed verification at the cost boundary: expensive or actionable findings received independent refutation, while cheap discovery often did not. See [Dynamic workflow authoring patterns: recurring structures](https://github.com/Whamp/pi-dynamic-workflows/blob/8bfe12fc020159748e5c0519951896086c493ce2/docs/research/claude-code-dynamic-workflow-patterns.md#recurring-structures).
+
+#### Confidence
+
+Confidence is high that verification and final synthesis should be conditional rather than universal. The corpus directly contains workflows that return structured results, reduce them in JavaScript, or synthesize them with a final agent according to the deliverable.
+
+### Choose and compose topology by dependency shape
+
+Replace:
+
+```text
+For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.
+```
+
+and:
+
+```text
+For workflow, pipeline(items, ...stages) runs each item through stages sequentially, while different items may run concurrently. Each stage receives (previousValue, originalItem, index).
+```
+
+with:
+
+```text
+For workflow, compose parallel() and pipeline() when the work has both shapes: use parallel() for independent work and between stages when the next stage needs all prior results; use pipeline() when each item can pass through its stages independently.
+```
+
+#### Reasoning
+
+Permanent guidance should teach the topology decision rather than repeat call syntax. Use `pipeline()` while each item can advance through dependent stages without seeing other items. Use separate `parallel()` calls when work is independent or when the next stage requires the complete preceding result set for a whole-set operation such as deduplication, merging, a count-based decision, or cross-item comparison.
+
+A workflow may contain either helper or both. Explicitly naming composition prevents readers from treating `parallel()` and `pipeline()` as mutually exclusive workflow types. The work's dependency shape determines whether to use per-item pipelines, whole-set barriers, or both.
+
+The `script` parameter description remains the authoritative prompt-level home for the `parallel()` thunk requirement. Runtime validation supplies a concrete corrective error when a script passes promises instead of functions. Detailed callback signatures and nesting examples do not need permanent system-prompt space.
+
+#### Evidence
+
+The runtime implements `parallel()` with `Promise.all()` over supplied thunks. It implements `pipeline()` with concurrent items and sequential stages for each item. See [`src/workflow.ts`](../src/workflow.ts).
+
+All four parent models in the schema-only experiment produced runtime-valid parallel fan-out without `promptGuidelines`, showing that the schema communicated the thunk shape for the tested task. The experiment did not test the `pipeline()` versus whole-set-barrier decision. See [What the workflow schema teaches parent models](https://github.com/Whamp/pi-dynamic-workflows/blob/f8b6f5c34e9476e014d2906a257344e410a00364/docs/research/workflow-schema-comprehension.md).
+
+The public authoring research recommends `pipeline()` for per-item staged work and separate `parallel()` barriers when a later stage needs whole-set deduplication, merging, a count-based exit, or cross-item comparison. See [Dynamic workflow authoring patterns: profile recommendation](https://github.com/Whamp/pi-dynamic-workflows/blob/8bfe12fc020159748e5c0519951896086c493ce2/docs/research/claude-code-dynamic-workflow-patterns.md#profile-recommendation).
+
+#### Confidence
+
+Confidence is high in the runtime semantics, the per-item versus whole-set deciding rule, and keeping detailed thunk syntax out of permanent guidance. Confidence is moderately high that the concise topology rule earns permanent space because the composition model is novel and cannot be inferred reliably from the function names alone.
+
+### Require an explicit JSON-serializable result
+
+Replace the return clause in:
+
+```text
+For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.
+```
+
+with an independent contract:
+
+```text
+For workflow, explicitly `return` a JSON-serializable result.
+```
+
+#### Reasoning
+
+Every workflow needs a final result regardless of whether it returns records directly, reduces them in JavaScript, verifies findings, or calls a final synthesis agent. The old wording incorrectly associated the return contract with synthesis and prescribed `ok` and `verdict` fields that many workflows do not need.
+
+`JSON-serializable` establishes the provider-facing boundary without prescribing a domain-specific shape. The explicit JavaScript keyword distinguishes `return result` from a bare final expression such as `result;`, which does not return from the generated async function.
+
+The runtime currently accepts `undefined`, so the model-facing instruction remains necessary. Runtime validation should become authoritative and produce an actionable error instead of allowing a successful run with no usable result. Follow-up: [#19 Reject workflows that return undefined](https://github.com/Whamp/pi-dynamic-workflows/issues/19).
+
+#### Evidence
+
+In the schema-only experiment, two of four parent models produced runtime-valid scripts without an explicit return. Terra logged its synthesis result without returning it. GLM ended with `result;` rather than `return result`. Both workflows completed without a result and caused empty parent responses. See [What the workflow schema teaches parent models](https://github.com/Whamp/pi-dynamic-workflows/blob/f8b6f5c34e9476e014d2906a257344e410a00364/docs/research/workflow-schema-comprehension.md).
+
+When rerun with the current guidance, all four tested models explicitly returned the requested result. Those reruns used the complete guidance rather than isolating this sentence, but the observed failures and corrective instruction both concern the missing JavaScript `return` directly.
+
+#### Confidence
+
+Confidence is very high that workflows must explicitly return a result and that this contract should remain permanently visible until runtime rejects `undefined`. Confidence is high that the result should be JSON-serializable without mandatory field names.
+
+### Treat recoverable failures as missing coverage
+
+Replace:
+
+```text
+For workflow, failed agent(), parallel(), or pipeline() branches return null and log the failure unless the workflow is aborted. Check for nulls before synthesizing conclusions.
+```
+
+with:
+
+```text
+For workflow, treat `null` from recoverable agent(), parallel(), or pipeline() failures as missing coverage, not a negative finding. Record failed work-unit identities before filtering, and report any coverage that remains incomplete.
+```
+
+#### Reasoning
+
+Checking for `null` is not enough unless the author understands its meaning. A recoverable failure means the intended work produced no result. It does not mean the work ran and found nothing. Treating a failed scanner, verifier, or auditor as a negative finding can turn missing work into a false clean result.
+
+Recording failed work-unit identities before filtering preserves the distinction between checked and clean, checked with findings, and not checked because execution failed. Reporting only coverage that remains incomplete allows a retry or fallback path to restore coverage without forcing an inaccurate incomplete status.
+
+The wording names recoverable failures because non-recoverable failures and aborts propagate instead of becoming `null`. This is more accurate than saying that every failed branch returns `null`.
+
+#### Evidence
+
+In the schema-only experiment, two of four parent models expected failed agents to throw. The runtime resolved recoverable failures to `null`, so those scripts treated missing checker results as successful evidence. With current guidance, all four models detected the simulated `null`, preserved the failed checker, and returned the requested incomplete-coverage information. See [What the workflow schema teaches parent models](https://github.com/Whamp/pi-dynamic-workflows/blob/f8b6f5c34e9476e014d2906a257344e410a00364/docs/research/workflow-schema-comprehension.md).
+
+In the 95-script public corpus, 79 scripts contained an explicit null or failure guard and 69 used `.filter(Boolean)`. The strongest examples recorded failed work-unit identities before filtering and marked results incomplete rather than clean. See [Dynamic workflow authoring patterns: failure handling](https://github.com/Whamp/pi-dynamic-workflows/blob/8bfe12fc020159748e5c0519951896086c493ce2/docs/research/claude-code-dynamic-workflow-patterns.md#failure-handling).
+
+The runtime returns `null` for recoverable direct-agent failures, recoverable `parallel()` branches, and items whose `pipeline()` stage fails recoverably. Non-recoverable failures halt the run. See [`src/workflow.ts`](../src/workflow.ts).
+
+#### Confidence
+
+Confidence is very high that the `null` contract, the distinction between missing coverage and negative evidence, and failed-work identity must remain permanently visible while the runtime represents recoverable failures with `null`.
+
+### Label each agent invocation by work unit
+
+Replace:
+
+```text
+For workflow, every agent() call should include a unique short label option, 2-5 words, such as { label: 'repo inventory' } or { label: 'source modules' }; unique labels make live status and error reporting readable.
+```
+
+with:
+
+```text
+For workflow, give each agent() invocation a short, unique `label` that identifies its work unit.
+```
+
+#### Reasoning
+
+Meaningful labels make live status, task-panel rows, failure messages, persisted runs, and missing-coverage reports understandable. The requirement applies to each invocation rather than only each authored call site because one `agent()` expression inside a loop may create many work units.
+
+The old 2–5-word requirement was an arbitrary proxy. A useful label need only remain short, distinguish the invocation, and identify its work. Stating that purpose is more durable than permanent examples.
+
+The runtime can generate fallback labels, so omission does not invalidate execution. This is an observability and failure-accounting contract rather than parser syntax. It supports the approved requirement to record failed work-unit identities before filtering.
+
+#### Evidence
+
+In the public corpus, 94 of 95 scripts supplied a label to an agent call, making labels the most consistently observed inner-agent option after explicit top-level returns. See [Dynamic workflow authoring patterns: corpus results](https://github.com/Whamp/pi-dynamic-workflows/blob/8bfe12fc020159748e5c0519951896086c493ce2/docs/research/claude-code-dynamic-workflow-patterns.md#public-workflow-corpus).
+
+The schema-only research concluded that the outer workflow schema cannot describe options nested inside the JavaScript `agent()` call. During reruns with current guidance, all four tested parent models supplied short labels. See [What the workflow schema teaches parent models](https://github.com/Whamp/pi-dynamic-workflows/blob/f8b6f5c34e9476e014d2906a257344e410a00364/docs/research/workflow-schema-comprehension.md).
+
+#### Confidence
+
+Confidence is high that each invocation should have a short, meaningful label tied to its work unit and that the arbitrary word-count rule and permanent examples should be removed.
+
+### Treat tiers as an open set of configured model routes
+
+Replace:
+
+```text
+For workflow, the user configures per-tier models (/workflows-models), so TAG EVERY agent with opts.tier by role so those models are actually used. opts.tier accepts 'small', 'medium', or 'big' and is enforced at runtime. Small tier: lightweight exploration/search/inventory agents. Medium tier: balanced analysis agents. Big tier: synthesis/judgment/decision agents spanning the full context. An agent with no opts.tier and no opts.model falls back to the user's medium tier; do not rely on that — tag agents explicitly so small/big are used where they fit.
+```
+
+with:
+
+```text
+For workflow, `tier` selects a configured model route. Standard routes are `small` for lightweight or high-volume work, `medium` for routine work, and `big` for the hardest or highest-stakes work; use another user-configured route only when its name and purpose are provided in context.
+```
+
+#### Reasoning
+
+The permanent language must not make `small`, `medium`, and `big` a closed enumeration. They are stable standard routes with useful default meanings, while the model-routing interface can grow to include user-configured routes such as an alternative high-capability model for independent judgment or routes tuned for cheaper and more expensive implementation.
+
+A **model route** answers which model configuration should execute the work. An `agentType` answers which role, instructions, and tools an agent should have. A review-specialized model can therefore be a custom route, while a reviewer with specialized instructions or tools remains an `agentType`.
+
+The parent must not invent route names. A custom route is usable only when cache-safe, post-selection discovery has supplied both its name and purpose. The permanent prompt therefore exposes the open interface without injecting a live user-specific catalogue or changing the system prompt between turns.
+
+The role descriptions are deliberately broad. `small` covers lightweight or high-volume work, `medium` covers routine work rather than analysis alone, and `big` describes difficulty or stakes rather than the ambiguous phrase “cross-context judgment.”
+
+#### Evidence
+
+The current configuration and runtime already preserve an extensible seam: `ModelTierConfig.tiers` is a `Record<string, string>`, `resolveTierModel()` accepts any string, `WorkflowAgentOptions.tier` is a string, and `sortedTierNames()` orders additional names after the three standard routes. The existing command can display additional keys present in the configuration, although it cannot yet create or remove them and the configuration cannot describe their purposes.
+
+The dynamic-workflow prompting research recommends keeping the stable `small`/`medium`/`big` vocabulary always-on, moving live catalogues to deliberate discovery, and avoiding a concrete model list in permanent context. See [Dynamic workflow authoring patterns: placement matrix](https://github.com/Whamp/pi-dynamic-workflows/blob/8bfe12fc020159748e5c0519951896086c493ce2/docs/research/claude-code-dynamic-workflow-patterns.md#placement-matrix-for-the-current-guidance).
+
+#### Confidence
+
+Confidence is high that the permanent interface should present `small`, `medium`, and `big` as standard routes rather than the only valid values. Confidence is also high that custom routes require purpose metadata and cache-safe discovery before a parent model can select them reliably.
+
+Implementation of user-configured routes and post-selection discovery is tracked in [#20](https://github.com/Whamp/pi-dynamic-workflows/issues/20).
+
+### Reserve explicit model selection for user-named overrides
+
+Replace:
+
+```text
+Use opts.model only when the user names a specific model; pass that exact provider/id. opts.model always takes precedence over opts.tier. Exact model specs may include Pi CLI-style thinking suffixes such as openai-codex/gpt-5.5:xhigh or anthropic/claude-fable-5:max when the user requests a specific effort level.
+```
+
+with:
+
+```text
+Use `model` instead of `tier` only to honor an exact model named by the user.
+```
+
+#### Reasoning
+
+Normal routing should use a configured model route through `tier`. An explicit `model` bypasses that abstraction and should therefore represent a direct user choice rather than an autonomous concrete-model decision by the workflow author.
+
+“Instead of” encodes the runtime precedence as an authoring decision: do not provide both options and leave a misleading, unused route in the invocation. The runtime accepts an unambiguous `provider/modelId` or a resolvable bare `modelId`, so requiring a provider-qualified ID is unnecessarily strict.
+
+Concrete provider examples and thinking-suffix syntax do not belong in permanent guidance. They become stale, privilege particular providers, and are unnecessary when the user supplies the exact model specification to honor.
+
+#### Evidence
+
+The schema-only experiment recorded a parent inventing the concrete model name `sonnet` even though neither the user nor the tool schema supplied it. The resulting recommendation was to route normal work through semantic tiers and use an exact model only when the user names one. See [What the workflow schema teaches parent models](https://github.com/Whamp/pi-dynamic-workflows/blob/f8b6f5c34e9476e014d2906a257344e410a00364/docs/research/workflow-schema-comprehension.md).
+
+The runtime resolves explicit `model` before an `agentType`-bound model, `tier`, phase routing, and the default route. Encoding the choice with “instead of” removes the need to teach that precedence separately.
+
+#### Confidence
+
+Confidence is very high that explicit `model` selection should only honor an exact user-named model, that authors should choose it instead of `tier`, and that concrete model-spec examples should be omitted from permanent guidance.
+
+### Describe the structured-output return contract
+
+Replace:
+
+```text
+For workflow, if agent() needs machine-readable output, pass a plain JSON Schema via opts.schema; agent() will return the validated object. Use JSON Schema syntax, not TypeScript or TypeBox constructors.
+```
+
+with:
+
+```text
+When an agent must return structured data, pass a plain JSON Schema in its `schema` option; on success, `agent()` returns the validated object.
+```
+
+#### Reasoning
+
+The concise replacement retains the deciding condition, the required schema format, the nested option name, and the changed return contract. “On success” keeps it consistent with the separately documented recoverable-failure path, where an invocation may yield `null` instead.
+
+The return contract matters because an agent without `schema` returns text, while a successful schema-constrained agent returns the validated object. Stating that result prevents workflow authors from treating it as prose or parsing it again.
+
+TypeScript and TypeBox prohibitions are unnecessary permanent guidance. The workflow script contract already permits plain JavaScript without imports, and “plain JSON Schema” states the usable representation positively.
+
+#### Evidence
+
+When `schema` is present, the runtime creates a terminating `structured_output` tool with that schema. Pi validates its arguments before capture. If the subagent omits the tool call, the runtime re-prompts and accepts prose recovery only after conversion and schema validation; unresolved noncompliance fails rather than returning unvalidated data.
+
+JSON Schema appeared in 86 of 95 scripts in the public workflow corpus. In the schema-comprehension experiment, all four reruns with current guidance used JSON schemas for structured subagent output. The research concluded that concise `schema` guidance belongs in the always-on inner-agent contract because the outer workflow schema cannot describe options nested inside JavaScript. See [Dynamic workflow authoring patterns: corpus results](https://github.com/Whamp/pi-dynamic-workflows/blob/8bfe12fc020159748e5c0519951896086c493ce2/docs/research/claude-code-dynamic-workflow-patterns.md#public-workflow-corpus) and [What the workflow schema teaches parent models](https://github.com/Whamp/pi-dynamic-workflows/blob/f8b6f5c34e9476e014d2906a257344e410a00364/docs/research/workflow-schema-comprehension.md).
+
+#### Confidence
+
+Confidence is very high that concise `schema` guidance and the successful validated-object return contract should remain permanently visible, while TypeScript and TypeBox warnings should move out of permanent guidance.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "context:check": "tsx scripts/generate-workflow-context-measurement.ts --check",
     "guidance:generate": "tsx scripts/generate-workflow-guidance-baseline.ts",
     "guidance:check": "tsx scripts/generate-workflow-guidance-baseline.ts --check",
+    "guidance:accept": "tsx scripts/accept-workflow-guidance.ts",
     "comprehension": "tsx scripts/run-workflow-comprehension.ts",
     "delivery-choice": "tsx scripts/run-workflow-delivery-choice.ts",
     "dev": "tsx src/index.ts",

--- a/package.json
+++ b/package.json
@@ -17,19 +17,31 @@
   "files": [
     "dist/",
     "extensions/",
+    "skills/",
     "src/",
     "assets/readme/",
     "README.md"
   ],
   "scripts": {
-    "test": "npm run check && npm run build && npm run test:unit",
+    "test": "npm run check && npm run release:check",
     "test:unit": "tsx --test tests/**/*.test.ts",
-    "check": "biome check .",
+    "release:check": "npm run build && npm run docs:check && npm run context:check && npm run test:unit && npm run release:verify",
+    "release:verify": "tsx scripts/check-workflow-release.ts",
+    "check": "biome check . && npm run check:scripts",
+    "check:scripts": "tsc -p tsconfig.scripts.json",
     "format": "biome format --write .",
     "lint": "biome lint .",
     "build": "tsc",
+    "docs:generate": "tsx scripts/generate-workflow-capabilities.ts",
+    "docs:check": "tsx scripts/generate-workflow-capabilities.ts --check",
+    "context:generate": "tsx scripts/generate-workflow-context-measurement.ts",
+    "context:check": "tsx scripts/generate-workflow-context-measurement.ts --check",
+    "guidance:generate": "tsx scripts/generate-workflow-guidance-baseline.ts",
+    "guidance:check": "tsx scripts/generate-workflow-guidance-baseline.ts --check",
+    "comprehension": "tsx scripts/run-workflow-comprehension.ts",
+    "delivery-choice": "tsx scripts/run-workflow-delivery-choice.ts",
     "dev": "tsx src/index.ts",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run release:check"
   },
   "keywords": [
     "pi-package",
@@ -53,6 +65,9 @@
   "pi": {
     "extensions": [
       "extensions/workflow.ts"
+    ],
+    "skills": [
+      "skills/workflow-authoring"
     ],
     "image": "https://raw.githubusercontent.com/QuintinShaw/pi-dynamic-workflows/main/assets/readme/package-cover.png"
   },

--- a/scripts/accept-workflow-guidance.ts
+++ b/scripts/accept-workflow-guidance.ts
@@ -1,0 +1,14 @@
+import { resolve } from "node:path";
+import { acceptWorkflowGuidance } from "../src/accept-workflow-guidance.js";
+
+const root = resolve(import.meta.dirname, "..");
+
+try {
+  const accepted = acceptWorkflowGuidance(root, process.argv.slice(2));
+  for (const { path, previousSha256, sha256, changed } of accepted) {
+    console.log(changed ? `Accepted ${path}: ${previousSha256} -> ${sha256}` : `Already accepted ${path}: ${sha256}`);
+  }
+} catch (error: unknown) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/check-workflow-release.ts
+++ b/scripts/check-workflow-release.ts
@@ -1,0 +1,24 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { checkWorkflowRelease, parseNpmPackFilePaths } from "../src/workflow-release-gate.js";
+
+const root = resolve(import.meta.dirname, "..");
+const output = execFileSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+  cwd: root,
+  encoding: "utf8",
+});
+const publishableFiles = parseNpmPackFilePaths(output);
+const diagnostics = checkWorkflowRelease({ root, publishableFiles });
+
+for (const item of diagnostics) {
+  const stream = item.severity === "error" ? console.error : console.warn;
+  stream(`[${item.severity}] ${item.code} (${item.subject}): ${item.message}`);
+}
+
+const errors = diagnostics.filter(({ severity }) => severity === "error");
+if (errors.length > 0) {
+  console.error(`Workflow release gate failed with ${errors.length} error(s).`);
+  process.exitCode = 1;
+} else {
+  console.log(`Workflow release gate passed with ${diagnostics.length} warning(s).`);
+}

--- a/scripts/generate-workflow-capabilities.ts
+++ b/scripts/generate-workflow-capabilities.ts
@@ -1,0 +1,21 @@
+import { resolve } from "node:path";
+import {
+  checkWorkflowCapabilityPublications,
+  writeWorkflowCapabilityPublications,
+} from "../src/workflow-authoring-reference.js";
+
+const root = resolve(import.meta.dirname, "..");
+const check = process.argv.includes("--check");
+
+if (check) {
+  const stale = checkWorkflowCapabilityPublications(root);
+  if (stale.length > 0) {
+    console.error(`Stale generated workflow capability publications:\n${stale.map((path) => `- ${path}`).join("\n")}`);
+    process.exitCode = 1;
+  } else {
+    console.log("Generated workflow capability publications are fresh.");
+  }
+} else {
+  writeWorkflowCapabilityPublications(root);
+  console.log("Generated workflow capability publications.");
+}

--- a/scripts/generate-workflow-context-measurement.ts
+++ b/scripts/generate-workflow-context-measurement.ts
@@ -1,0 +1,35 @@
+import { resolve } from "node:path";
+import {
+  checkWorkflowContextMeasurement,
+  measureWorkflowContextSurfaces,
+  WORKFLOW_CONTEXT_MEASUREMENT_PATH,
+  writeWorkflowContextMeasurement,
+} from "../src/workflow-context-measurement.js";
+
+const root = resolve(import.meta.dirname, "..");
+const check = process.argv.includes("--check");
+const measurement = check ? measureWorkflowContextSurfaces() : writeWorkflowContextMeasurement(root);
+const {
+  permanentWorkflowPrompt,
+  providerVisibleWorkflowToolDefinition,
+  workflowAuthoringSkillDiscovery,
+  workflowAuthoringSkillCorpus,
+  representativeAuthoringProfiles,
+} = measurement.surfaces;
+
+console.log(`Permanent workflow prompt: ${permanentWorkflowPrompt.bytes} bytes`);
+console.log(`Provider-visible workflow tool definition: ${providerVisibleWorkflowToolDefinition.bytes} bytes`);
+console.log(`Workflow-authoring skill discovery: ${workflowAuthoringSkillDiscovery.bytes} bytes`);
+console.log(
+  `Workflow-authoring skill corpus: ${workflowAuthoringSkillCorpus.bytes} bytes across ${workflowAuthoringSkillCorpus.files} files`,
+);
+console.log(`Representative authoring profile median: ${representativeAuthoringProfiles.medianBytes} bytes`);
+
+if (check && !checkWorkflowContextMeasurement(root)) {
+  console.error(`Stale workflow context measurement: ${WORKFLOW_CONTEXT_MEASUREMENT_PATH}`);
+  process.exitCode = 1;
+} else if (check) {
+  console.log("Workflow context measurement is fresh.");
+} else {
+  console.log(`Generated ${WORKFLOW_CONTEXT_MEASUREMENT_PATH}.`);
+}

--- a/scripts/generate-workflow-guidance-baseline.ts
+++ b/scripts/generate-workflow-guidance-baseline.ts
@@ -1,0 +1,21 @@
+import { resolve } from "node:path";
+import {
+  renderWorkflowGuidanceBaseline,
+  WORKFLOW_GUIDANCE_BASELINE_PATH,
+  writeWorkflowGuidanceBaseline,
+} from "../src/workflow-release-gate.js";
+
+const root = resolve(import.meta.dirname, "..");
+const check = process.argv.includes("--check");
+
+if (check) {
+  const { readFileSync } = await import("node:fs");
+  if (readFileSync(resolve(root, WORKFLOW_GUIDANCE_BASELINE_PATH), "utf8") !== renderWorkflowGuidanceBaseline(root)) {
+    console.warn(`Non-contractual workflow prose drift: ${WORKFLOW_GUIDANCE_BASELINE_PATH}`);
+  } else {
+    console.log("Workflow guidance prose baseline is unchanged.");
+  }
+} else {
+  writeWorkflowGuidanceBaseline(root);
+  console.log(`Generated ${WORKFLOW_GUIDANCE_BASELINE_PATH}.`);
+}

--- a/scripts/run-workflow-comprehension.ts
+++ b/scripts/run-workflow-comprehension.ts
@@ -1,0 +1,296 @@
+import { readFileSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import type { Api, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  getAgentDir,
+  ModelRegistry,
+  ModelRuntime,
+  resolveCliModel,
+  SessionManager,
+  SettingsManager,
+  type Skill,
+} from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import packageJson from "../package.json" with { type: "json" };
+import { createStructuredOutputTool, type StructuredOutputCapture } from "../src/structured-output.js";
+import { WORKFLOW_CAPABILITY_DEFINITION } from "../src/workflow-capability-contract.js";
+import {
+  COMPREHENSION_SCENARIOS,
+  type ComprehensionScenario,
+  ComprehensionSuite,
+  type ComprehensionTokenUsage,
+  type ModelGeneration,
+  ModelGenerationError,
+  runComprehensionScenario,
+  selectComprehensionScenarios,
+} from "../src/workflow-comprehension.js";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const SKILL_PATH = join(ROOT, "skills/workflow-authoring/SKILL.md");
+const OUTPUT_SCHEMA = Type.Object({
+  workflow: Type.String({ description: "The complete plain-JavaScript workflow source" }),
+});
+
+interface CliOptions {
+  suite: ComprehensionSuite;
+  scenario: string | null;
+  model: string;
+  output: string;
+}
+
+async function main(): Promise<void> {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    printUsage();
+    return;
+  }
+  const cli = parseArgs(process.argv.slice(2));
+  const agentDir = getAgentDir();
+  const modelRuntime = await ModelRuntime.create({
+    authPath: join(agentDir, "auth.json"),
+    modelsPath: join(agentDir, "models.json"),
+  });
+  await modelRuntime.getAvailable();
+  const modelRegistry = new ModelRegistry(modelRuntime);
+  const resolvedModel = resolveCliModel({ cliModel: cli.model, modelRuntime });
+  if (resolvedModel.error || !resolvedModel.model)
+    throw new Error(resolvedModel.error ?? `Could not resolve ${cli.model}`);
+  if (!modelRegistry.hasConfiguredAuth(resolvedModel.model)) {
+    throw new Error(
+      `Selected model ${resolvedModel.model.provider}/${resolvedModel.model.id} is not currently available`,
+    );
+  }
+  if (resolvedModel.warning) console.warn(`[model] ${resolvedModel.warning}`);
+
+  const model = resolvedModel.model;
+  const modelSelection = {
+    requested: cli.model,
+    resolved: `${model.provider}/${model.id}`,
+    thinkingLevel: resolvedModel.thinkingLevel ?? null,
+  };
+  const skillVersion = readSkillVersion();
+  const selectedScenarios = cli.scenario
+    ? COMPREHENSION_SCENARIOS.filter(({ id }) => id === cli.scenario)
+    : selectComprehensionScenarios(cli.suite);
+  const scenarios = [];
+  for (const scenario of selectedScenarios) {
+    console.log(
+      `[comprehension] ${scenario.id} with ${modelSelection.resolved}${modelSelection.thinkingLevel ? `:${modelSelection.thinkingLevel}` : ""}`,
+    );
+    scenarios.push(
+      await runComprehensionScenario({
+        scenario,
+        provider: resolvedModel.model.provider,
+        modelSelection,
+        extensionVersion: packageJson.version,
+        contractVersions: {
+          format: WORKFLOW_CAPABILITY_DEFINITION.versions.format.version,
+          content: WORKFLOW_CAPABILITY_DEFINITION.versions.content.version,
+        },
+        skillVersion,
+        generate: (task) =>
+          generateWorkflow(task, {
+            modelRuntime,
+            model,
+            thinkingLevel: resolvedModel.thinkingLevel,
+          }),
+      }),
+    );
+  }
+
+  const output = {
+    formatVersion: 2,
+    suite: selectedScenarios[0]?.suite ?? cli.suite,
+    targetedScenario: cli.scenario,
+    modelSelection,
+    summary: {
+      total: scenarios.length,
+      passed: scenarios.filter(({ passed }) => passed).length,
+      failed: scenarios.filter(({ passed }) => !passed).length,
+    },
+    scenarios,
+  };
+  await mkdir(dirname(cli.output), { recursive: true });
+  await writeFile(cli.output, `${JSON.stringify(output, null, 2)}\n`, "utf8");
+  console.log(`[comprehension] evidence written to ${cli.output}`);
+  console.log(
+    `[comprehension] ${output.summary.passed}/${output.summary.total} scenarios passed (evidence only; non-blocking)`,
+  );
+}
+
+async function generateWorkflow(
+  scenario: ComprehensionScenario,
+  options: {
+    modelRuntime: ModelRuntime;
+    model: Model<Api>;
+    thinkingLevel: ModelThinkingLevel | undefined;
+  },
+): Promise<ModelGeneration> {
+  const isolatedRoot = await mkdtemp(join(tmpdir(), "workflow-comprehension-"));
+  const settingsManager = SettingsManager.inMemory({ compaction: { enabled: false }, retry: { enabled: false } });
+  const skill: Skill = {
+    name: "workflow-authoring",
+    description:
+      "Guidance for writing, editing, reviewing, and debugging JavaScript workflow code for pi-dynamic-workflows.",
+    filePath: SKILL_PATH,
+    baseDir: dirname(SKILL_PATH),
+    sourceInfo: {
+      path: SKILL_PATH,
+      source: "pi-dynamic-workflows comprehension harness",
+      scope: "temporary",
+      origin: "package",
+      baseDir: dirname(SKILL_PATH),
+    },
+    disableModelInvocation: false,
+  };
+  const loader = new DefaultResourceLoader({
+    cwd: isolatedRoot,
+    agentDir: isolatedRoot,
+    settingsManager,
+    skillsOverride: (current) => ({ skills: [skill], diagnostics: current.diagnostics }),
+    agentsFilesOverride: () => ({ agentsFiles: [] }),
+    appendSystemPromptOverride: () => [
+      "This is a clean comprehension session. Consult applicable installed skills before producing the requested code.",
+    ],
+  });
+  await loader.reload();
+
+  const capture: StructuredOutputCapture<{ workflow: string }> = { called: false, value: undefined };
+  const submit = createStructuredOutputTool({ schema: OUTPUT_SCHEMA, capture, name: "submit_comprehension" });
+  const customTools = [submit];
+  const skillToolCalls: Array<{ tool: string; path?: string }> = [];
+  const { session } = await createAgentSession({
+    cwd: isolatedRoot,
+    agentDir: isolatedRoot,
+    model: options.model,
+    thinkingLevel: options.thinkingLevel,
+    modelRuntime: options.modelRuntime,
+    resourceLoader: loader,
+    settingsManager,
+    sessionManager: SessionManager.inMemory(isolatedRoot),
+    tools: ["read", "submit_comprehension"],
+    customTools,
+  });
+  const unsubscribe = session.subscribe((event) => {
+    if (event.type !== "tool_execution_start") return;
+    const path = event.toolName === "read" && typeof event.args?.path === "string" ? event.args.path : undefined;
+    if (path?.includes("workflow-authoring")) skillToolCalls.push({ tool: event.toolName, path });
+  });
+
+  try {
+    try {
+      await session.prompt(
+        `${scenario.prompt}\n\nYour final action must call submit_comprehension exactly once with the complete workflow source. Do not return prose instead.`,
+      );
+      if (!capture.called || !capture.value) {
+        throw new Error(session.agent.state.errorMessage ?? "Model did not submit a workflow");
+      }
+      return {
+        workflow: capture.value.workflow,
+        skillLoadingEvidence: skillEvidence(skillToolCalls),
+        tokenUsage: sessionTokenUsage(session.getSessionStats()),
+      };
+    } catch (error) {
+      throw new ModelGenerationError(
+        error instanceof Error ? error.message : String(error),
+        skillEvidence(skillToolCalls),
+        sessionTokenUsage(session.getSessionStats()),
+      );
+    }
+  } finally {
+    unsubscribe();
+    session.dispose();
+    await rm(isolatedRoot, { recursive: true, force: true });
+  }
+}
+
+function skillEvidence(toolCalls: Array<{ tool: string; path?: string }>) {
+  return {
+    discovered: toolCalls.length > 0,
+    loaded: toolCalls.some(({ path }) => path?.endsWith("/SKILL.md")),
+    toolCalls,
+  };
+}
+
+function sessionTokenUsage(
+  stats: ReturnType<Awaited<ReturnType<typeof createAgentSession>>["session"]["getSessionStats"]>,
+): ComprehensionTokenUsage {
+  return {
+    input: stats.tokens.input,
+    output: stats.tokens.output,
+    total: stats.tokens.total,
+    cost: stats.cost,
+    cacheRead: stats.tokens.cacheRead,
+    cacheWrite: stats.tokens.cacheWrite,
+  };
+}
+
+function parseArgs(args: string[]): CliOptions {
+  let suite = ComprehensionSuite.QUICK;
+  let suiteWasSet = false;
+  let scenario: string | null = null;
+  let model: string | undefined;
+  let output: string | undefined;
+  for (let index = 0; index < args.length; index++) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (flag === "--suite" && value) {
+      if (value === ComprehensionSuite.QUICK) {
+        suite = ComprehensionSuite.QUICK;
+      } else if (value === ComprehensionSuite.FULL) {
+        suite = ComprehensionSuite.FULL;
+      } else if (value === ComprehensionSuite.COVERAGE) {
+        suite = ComprehensionSuite.COVERAGE;
+      } else {
+        throw new Error(`Unknown suite ${value}; expected quick, full, or coverage`);
+      }
+      suiteWasSet = true;
+      index++;
+    } else if (flag === "--scenario" && value) {
+      scenario = value;
+      index++;
+    } else if (flag === "--model" && value) {
+      model = value;
+      index++;
+    } else if (flag === "--output" && value) {
+      output = resolve(value);
+      index++;
+    } else {
+      throw new Error(`Unknown or incomplete argument: ${flag ?? ""}`);
+    }
+  }
+  if (suiteWasSet && scenario) throw new Error("--suite and --scenario are mutually exclusive");
+  if (scenario && !COMPREHENSION_SCENARIOS.some(({ id }) => id === scenario)) {
+    throw new Error(`Unknown scenario ${scenario}`);
+  }
+  if (!model) throw new Error("--model <provider/model> is required; the harness never chooses a model implicitly");
+  const safeModel = model.replaceAll(/[^a-zA-Z0-9._-]+/g, "-");
+  const selectionName = scenario ?? suite;
+  return {
+    suite,
+    scenario,
+    model,
+    output: output ?? join(ROOT, ".pi/model-comprehension", `${selectionName}-${safeModel}.json`),
+  };
+}
+
+function readSkillVersion(): string {
+  const match = readFileSync(SKILL_PATH, "utf8").match(/^\s*version:\s*["']?([^"'\s]+)["']?\s*$/m);
+  if (!match?.[1]) throw new Error(`Could not read skill version from ${SKILL_PATH}`);
+  return match[1];
+}
+
+function printUsage(): void {
+  console.log(`Usage: npm run comprehension -- --model <provider/model> [--suite quick|full|coverage | --scenario <id>] [--output path]
+
+Runs optional model-comprehension scenarios and writes comparison-ready JSON evidence.
+Scenario failures are recorded but do not set a failing exit status. Setup and argument errors do fail.`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/run-workflow-comprehension.ts
+++ b/scripts/run-workflow-comprehension.ts
@@ -126,7 +126,7 @@ async function generateWorkflow(
   options: {
     modelRuntime: ModelRuntime;
     model: Model<Api>;
-    thinkingLevel: ModelThinkingLevel | undefined;
+    thinkingLevel?: ModelThinkingLevel;
   },
 ): Promise<ModelGeneration> {
   const isolatedRoot = await mkdtemp(join(tmpdir(), "workflow-comprehension-"));

--- a/scripts/run-workflow-delivery-choice.ts
+++ b/scripts/run-workflow-delivery-choice.ts
@@ -1,0 +1,195 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import type { Api, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
+import {
+  createAgentSession,
+  defineTool,
+  getAgentDir,
+  ModelRegistry,
+  ModelRuntime,
+  resolveCliModel,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import packageJson from "../package.json" with { type: "json" };
+import {
+  evaluateWorkflowDeliveryChoice,
+  WORKFLOW_DELIVERY_CHOICE_SCENARIOS,
+  type WorkflowDeliveryChoiceScenario,
+} from "../src/workflow-delivery-choice.js";
+import { createWorkflowTool, type WorkflowToolInput } from "../src/workflow-tool.js";
+
+const ROOT = resolve(import.meta.dirname, "..");
+
+interface CliOptions {
+  model: string;
+  output: string;
+}
+
+async function main(): Promise<void> {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    printUsage();
+    return;
+  }
+  const cli = parseArgs(process.argv.slice(2));
+  const agentDir = getAgentDir();
+  const modelRuntime = await ModelRuntime.create({
+    authPath: join(agentDir, "auth.json"),
+    modelsPath: join(agentDir, "models.json"),
+  });
+  await modelRuntime.getAvailable();
+  const modelRegistry = new ModelRegistry(modelRuntime);
+  const resolvedModel = resolveCliModel({ cliModel: cli.model, modelRuntime });
+  if (resolvedModel.error || !resolvedModel.model) {
+    throw new Error(resolvedModel.error ?? `Could not resolve ${cli.model}`);
+  }
+  if (!modelRegistry.hasConfiguredAuth(resolvedModel.model)) {
+    throw new Error(
+      `Selected model ${resolvedModel.model.provider}/${resolvedModel.model.id} is not currently available`,
+    );
+  }
+  if (resolvedModel.warning) {
+    process.stderr.write(`[model] ${resolvedModel.warning}\n`);
+  }
+
+  const model = resolvedModel.model;
+  const modelSelection = {
+    requested: cli.model,
+    resolved: `${model.provider}/${model.id}`,
+    thinkingLevel: resolvedModel.thinkingLevel ?? null,
+  };
+  const scenarios = [];
+  for (const scenario of WORKFLOW_DELIVERY_CHOICE_SCENARIOS) {
+    process.stdout.write(`[delivery-choice] ${scenario.id} with ${modelSelection.resolved}\n`);
+    scenarios.push(
+      await runScenario(scenario, {
+        modelRuntime,
+        model,
+        thinkingLevel: resolvedModel.thinkingLevel,
+      }),
+    );
+  }
+  const output = {
+    formatVersion: 1,
+    extensionVersion: packageJson.version,
+    modelSelection,
+    summary: {
+      total: scenarios.length,
+      passed: scenarios.filter(({ passed }) => passed).length,
+      failed: scenarios.filter(({ passed }) => !passed).length,
+    },
+    scenarios,
+  };
+  await mkdir(dirname(cli.output), { recursive: true });
+  await writeFile(cli.output, `${JSON.stringify(output, null, 2)}\n`, "utf8");
+  process.stdout.write(`[delivery-choice] evidence written to ${cli.output}\n`);
+  process.stdout.write(
+    `[delivery-choice] ${output.summary.passed}/${output.summary.total} scenarios passed (non-blocking)\n`,
+  );
+}
+
+async function runScenario(
+  scenario: WorkflowDeliveryChoiceScenario,
+  options: {
+    modelRuntime: ModelRuntime;
+    model: Model<Api>;
+    thinkingLevel?: ModelThinkingLevel;
+  },
+) {
+  const isolatedRoot = await mkdtemp(join(tmpdir(), "workflow-delivery-choice-"));
+  const captured: { value?: WorkflowToolInput } = {};
+  const workflow = createWorkflowTool({ cwd: isolatedRoot });
+  const captureTool = defineTool({
+    name: workflow.name,
+    label: workflow.label,
+    description: workflow.description,
+    promptSnippet: workflow.promptSnippet,
+    promptGuidelines: workflow.promptGuidelines,
+    parameters: workflow.parameters,
+    async execute(toolCallId, params) {
+      void toolCallId;
+      captured.value = params;
+      return {
+        content: [{ type: "text" as const, text: "Workflow invocation captured for delivery-choice evidence." }],
+        details: { captured: true },
+      };
+    },
+  });
+  const settingsManager = SettingsManager.inMemory({ compaction: { enabled: false }, retry: { enabled: false } });
+  const { session } = await createAgentSession({
+    cwd: isolatedRoot,
+    agentDir: isolatedRoot,
+    modelRuntime: options.modelRuntime,
+    model: options.model,
+    thinkingLevel: options.thinkingLevel,
+    settingsManager,
+    sessionManager: SessionManager.inMemory(isolatedRoot),
+    tools: ["workflow"],
+    customTools: [captureTool],
+  });
+  try {
+    await session.prompt(`${scenario.prompt}\n\nCall the workflow tool exactly once. Do not answer in prose instead.`);
+    const evaluation = evaluateWorkflowDeliveryChoice(scenario, captured.value);
+    return {
+      task: scenario,
+      capturedArguments: captured.value ?? null,
+      tokenUsage: sessionTokenUsage(session.getSessionStats()),
+      ...evaluation,
+    };
+  } finally {
+    session.dispose();
+    await rm(isolatedRoot, { recursive: true, force: true });
+  }
+}
+
+function sessionTokenUsage(
+  stats: ReturnType<Awaited<ReturnType<typeof createAgentSession>>["session"]["getSessionStats"]>,
+) {
+  return {
+    input: stats.tokens.input,
+    output: stats.tokens.output,
+    total: stats.tokens.total,
+    cost: stats.cost,
+    cacheRead: stats.tokens.cacheRead,
+    cacheWrite: stats.tokens.cacheWrite,
+  };
+}
+
+function parseArgs(args: string[]): CliOptions {
+  let model: string | undefined;
+  let output: string | undefined;
+  for (let index = 0; index < args.length; index++) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (flag === "--model" && value) {
+      model = value;
+      index++;
+    } else if (flag === "--output" && value) {
+      output = resolve(value);
+      index++;
+    } else {
+      throw new Error(`Unknown or incomplete argument: ${flag ?? ""}`);
+    }
+  }
+  if (!model) {
+    throw new Error("--model <provider/model> is required; the harness never chooses a model implicitly");
+  }
+  const safeModel = model.replaceAll(/[^a-zA-Z0-9._-]+/g, "-");
+  return {
+    model,
+    output: output ?? join(ROOT, ".pi/model-comprehension", `delivery-choice-${safeModel}.json`),
+  };
+}
+
+function printUsage(): void {
+  process.stdout.write(`Usage: npm run delivery-choice -- --model <provider/model> [--output <path>]
+
+Runs two optional delivery-choice scenarios against the real workflow tool definition.
+The evidence records whether the model kept the default background run or selected background:false for same-turn use.\n`);
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/skills/workflow-authoring/SKILL.md
+++ b/skills/workflow-authoring/SKILL.md
@@ -2,7 +2,7 @@
 name: workflow-authoring
 description: Guidance for writing, editing, reviewing, and debugging JavaScript workflow code for pi-dynamic-workflows. Use when authoring or changing workflow scripts; not for merely running an existing workflow.
 metadata:
-  version: "3.0.0"
+  version: "3.2.2"
 ---
 
 # Workflow authoring

--- a/skills/workflow-authoring/SKILL.md
+++ b/skills/workflow-authoring/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: workflow-authoring
+description: Guidance for writing, editing, reviewing, and debugging JavaScript workflow code for pi-dynamic-workflows. Use when authoring or changing workflow scripts; not for merely running an existing workflow.
+metadata:
+  version: "3.0.0"
+---
+
+# Workflow authoring
+
+Load this skill when workflow JavaScript changes. Running an existing workflow needs no authoring reference.
+
+## Choose a branch
+
+Read only what the task needs:
+
+- **Write or edit:** start with [runtime](references/runtime.md). Add [pattern selection](references/pattern-selection.md) for topology, [lifecycle](references/lifecycle.md) for limits or resume, and [focused recipes](references/focused-recipes.md) for the matching concern.
+- **Helper task:** read [quality helpers](references/quality-helpers.md) only for `verify` or `judgePanel`, the [retry helper](references/retry-helper.md) only for `retry`, and [specialized helpers](references/specialized-helpers.md) only for `completenessCheck`, `loopUntilDry`, `gate`, or `checkpoint`.
+- **Review:** use the [review checklist](references/review.md), plus only the matching [quality](references/quality-helpers.md) or [specialized](references/specialized-helpers.md) helper contracts.
+- **Debug:** use the [debugging map](references/debugging.md).
+- **Routing:** read [registry ownership](references/registry-ownership.md) before using `model`, `tier`, phase models, or `agentType`; use environment-specific names only when context supplies them.
+- **Exact lookup or portability:** start with the generated [capability index](references/capabilities.md). Follow its exhaustive-facts pointer only for constraints or support boundaries. Use [versions](references/versions.md) when moving scripts between installations.
+
+## Invariants
+
+- Start with literal `export const meta = { name, description }`; declare phases as an array of used `{ title }` objects and enter each named phase.
+- Call `agent()` at least once, give every call a short unique `label`, and return plain JSON data explicitly.
+- Pair ordered results with stable work IDs before filtering. When one agent consumes another's selected result, include both its stable ID and actual data in the downstream prompt. Treat recoverable `null` as missing coverage and report it.
+- Bound fan-out, loops, retries, agents, concurrency, time, and token spend to the task.
+- Use `log()` for new code; `console` is compatibility-only.
+- Write plain JavaScript without imports or filesystem modules. Pass nondeterminism through `args`; `Date.now()`, `Math.random()`, and no-argument `new Date()` are unavailable.

--- a/skills/workflow-authoring/examples/adversarial-verification.js
+++ b/skills/workflow-authoring/examples/adversarial-verification.js
@@ -1,0 +1,63 @@
+export const meta = {
+  name: "adversarial_verification",
+  description: "Produce claims and challenge them in separate skeptical contexts",
+  phases: [{ title: "Produce" }, { title: "Verify" }],
+};
+
+// ADAPT: validate and bound topics; define the evidence standard and schemas.
+const topics =
+  args && Array.isArray(args.topics) ? args.topics : [{ id: "sample", topic: "Verify one sample claim" }];
+const rubric = args && typeof args.rubric === "string" ? args.rubric : "Evidence is direct and sufficient";
+const productionSchema = {
+  type: "object",
+  properties: {
+    claim: { type: "string" },
+    evidence: { type: "array", items: { type: "string" } },
+  },
+  required: ["claim", "evidence"],
+};
+const verdictSchema = {
+  type: "object",
+  properties: { upheld: { type: "boolean" }, reason: { type: "string" } },
+  required: ["upheld", "reason"],
+};
+
+phase("Produce");
+const productions = await parallel(
+  topics.map((topic, index) => () =>
+    agent(`Develop a claim and cite its evidence.\n\n${JSON.stringify(topic)}`, {
+      label: `produce:${index}:${String(topic.id)}`,
+      schema: productionSchema,
+    }),
+  ),
+);
+const producerFailures = topics.flatMap((topic, index) =>
+  productions[index] === null ? [String(topic.id)] : [],
+);
+const reviewable = topics.flatMap((topic, index) =>
+  productions[index] === null ? [] : [{ topic, production: productions[index] }],
+);
+
+phase("Verify");
+// INVARIANT: each skeptic is a fresh agent call, never the producer reviewing itself.
+const verdicts = await parallel(
+  reviewable.map(({ topic, production }, index) => () =>
+    agent(
+      `Act as a skeptic. Try to refute this production under the rubric.\nRubric: ${rubric}\nProduction: ${JSON.stringify(production)}`,
+      { label: `skeptic:${index}:${String(topic.id)}`, schema: verdictSchema },
+    ),
+  ),
+);
+const skepticFailures = reviewable.flatMap(({ topic }, index) =>
+  verdicts[index] === null ? [String(topic.id)] : [],
+);
+
+return {
+  reviewed: reviewable.flatMap(({ topic, production }, index) =>
+    verdicts[index] === null
+      ? []
+      : [{ id: String(topic.id), production, verdict: verdicts[index] }],
+  ),
+  failed: { producers: producerFailures, skeptics: skepticFailures },
+  complete: producerFailures.length === 0 && skepticFailures.length === 0,
+};

--- a/skills/workflow-authoring/examples/bounded-semantic-retry.js
+++ b/skills/workflow-authoring/examples/bounded-semantic-retry.js
@@ -1,0 +1,56 @@
+export const meta = {
+  name: "bounded_semantic_retry",
+  description: "Separate recoverable transport retries from a visible bounded semantic attempt ledger",
+  phases: [{ title: "Attempt" }],
+};
+
+// ADAPT: define task-owned acceptance, prompts, bounds, and structured result fields.
+const maxSemanticAttempts =
+  args && Number.isInteger(args.maxSemanticAttempts) ? Math.max(1, Math.min(args.maxSemanticAttempts, 5)) : 3;
+const transportRetries =
+  args && Number.isInteger(args.transportRetries) ? Math.max(0, Math.min(args.transportRetries, 3)) : 0;
+const resultSchema = {
+  type: "object",
+  properties: {
+    accepted: { type: "boolean" },
+    answer: { type: "string" },
+    feedback: { type: "string" },
+  },
+  required: ["accepted", "answer", "feedback"],
+};
+const attempts = [];
+let feedback = "";
+let acceptedResult = null;
+
+phase("Attempt");
+for (let attempt = 1; attempt <= maxSemanticAttempts; attempt++) {
+  const result = await agent(
+    `Produce an acceptable answer.${feedback ? ` Address this prior feedback: ${feedback}` : ""}`,
+    {
+      label: `semantic-attempt:${attempt}`,
+      schema: resultSchema,
+      // Runtime retries repeat this same logical call after recoverable execution failures.
+      retries: transportRetries,
+    },
+  );
+  if (result === null) {
+    attempts.push({ attempt, status: "missing", result: null });
+    feedback = "The previous logical attempt produced no usable coverage.";
+    continue;
+  }
+  const status = result.accepted ? "accepted" : "rejected";
+  attempts.push({ attempt, status, result });
+  if (result.accepted) {
+    acceptedResult = result;
+    break;
+  }
+  feedback = result.feedback;
+}
+
+// INVARIANT: semantic exhaustion is returned visibly; it is not presented as success or thrown away.
+return {
+  ok: acceptedResult !== null,
+  exhausted: acceptedResult === null && attempts.length === maxSemanticAttempts,
+  result: acceptedResult,
+  attempts,
+};

--- a/skills/workflow-authoring/examples/classify-and-act.js
+++ b/skills/workflow-authoring/examples/classify-and-act.js
@@ -1,0 +1,67 @@
+export const meta = {
+  name: "classify_and_act",
+  description: "Classify bounded work before routing each item to an appropriate actor",
+  phases: [{ title: "Classify" }, { title: "Act" }],
+};
+
+// ADAPT: validate and bound items, categories, prompts, and schemas for the task.
+const items =
+  args && Array.isArray(args.items) ? args.items : [{ id: "sample", task: "Classify one sample item" }];
+const categories = ["direct", "parallel", "iterative"];
+const instructionsByCategory = {
+  direct: "Handle directly in one focused pass.",
+  parallel: "Divide independent parts, account for each part, then combine them.",
+  iterative: "Work in bounded rounds and stop when the task-specific condition is met.",
+};
+const classificationSchema = {
+  type: "object",
+  properties: {
+    category: { type: "string", enum: categories },
+    reason: { type: "string" },
+  },
+  required: ["category", "reason"],
+};
+const actionSchema = {
+  type: "object",
+  properties: { outcome: { type: "string" } },
+  required: ["outcome"],
+};
+
+phase("Classify");
+const classifications = await parallel(
+  items.map((item, index) => () =>
+    agent(`Classify this item as ${categories.join(", ")}.\n\n${JSON.stringify(item)}`, {
+      label: `classify:${index}:${String(item.id)}`,
+      schema: classificationSchema,
+    }),
+  ),
+);
+const failedClassification = items.flatMap((item, index) =>
+  classifications[index] === null ? [String(item.id)] : [],
+);
+const routed = items.flatMap((item, index) =>
+  classifications[index] === null ? [] : [{ item, classification: classifications[index] }],
+);
+
+// INVARIANT: no routed action starts until the complete classification set exists.
+phase("Act");
+const actions = await parallel(
+  routed.map(({ item, classification }, index) => () =>
+    agent(
+      `${instructionsByCategory[classification.category]}\n\n${JSON.stringify(item)}`,
+      { label: `act:${index}:${String(item.id)}`, schema: actionSchema },
+    ),
+  ),
+);
+const failedAction = routed.flatMap(({ item }, index) => (actions[index] === null ? [String(item.id)] : []));
+
+// INVARIANT: retain identities for failures in either stage.
+return {
+  handled: routed.flatMap(({ item, classification }, index) =>
+    actions[index] === null
+      ? []
+      : [{ id: String(item.id), category: classification.category, result: actions[index] }],
+  ),
+  failed: { classification: failedClassification, action: failedAction },
+  complete: failedClassification.length === 0 && failedAction.length === 0,
+};

--- a/skills/workflow-authoring/examples/fan-out-and-synthesize.js
+++ b/skills/workflow-authoring/examples/fan-out-and-synthesize.js
@@ -1,0 +1,47 @@
+export const meta = {
+  name: "fan_out_and_synthesize",
+  description: "Run bounded independent work, retain a complete coverage ledger, then synthesize",
+  phases: [{ title: "Fan out" }, { title: "Synthesize" }],
+};
+
+// ADAPT: validate and bound args.work for the task before invoking this workflow.
+const work = args && Array.isArray(args.work) ? args.work : [];
+
+phase("Fan out");
+const fanOutResults = await parallel(
+  work.map((unit, index) => () =>
+    agent(
+      `Complete this independent work unit. Return only evidence relevant to it.\n\n${JSON.stringify(unit)}`,
+      // INVARIANT: index plus a stable task-owned id keeps labels unique.
+      { label: `fanout:${index}:${String(unit.id)}` },
+    ),
+  ),
+);
+
+// INVARIANT: preserve every intended identity before filtering or synthesis.
+const ledger = work.map((unit, index) => ({
+  id: String(unit.id),
+  status: fanOutResults[index] === null ? "failed" : "complete",
+  result: fanOutResults[index],
+}));
+
+phase("Synthesize");
+const synthesis = await agent(
+  `Synthesize the complete fan-out ledger below. Distinguish covered work from failed/missing coverage; do not invent results.\n\n${JSON.stringify(ledger)}`,
+  {
+    label: "synthesize-complete-set",
+    // ADAPT: keep the schema small and aligned with downstream field access.
+    schema: {
+      type: "object",
+      properties: {
+        summary: { type: "string" },
+        coveredIds: { type: "array", items: { type: "string" } },
+        failedIds: { type: "array", items: { type: "string" } },
+      },
+      required: ["summary", "coveredIds", "failedIds"],
+    },
+  },
+);
+
+// INVARIANT: return plain serializable data, including missing-coverage identities.
+return { ledger, synthesis };

--- a/skills/workflow-authoring/examples/generate-and-filter.js
+++ b/skills/workflow-authoring/examples/generate-and-filter.js
@@ -1,0 +1,68 @@
+export const meta = {
+  name: "generate_and_filter",
+  description: "Generate divergent candidates, deterministically deduplicate, then apply a rubric",
+  phases: [{ title: "Generate" }, { title: "Filter" }],
+};
+
+// ADAPT: choose the topic, rubric, candidate schema, and a task-appropriate batch bound.
+const topic = args && typeof args.topic === "string" ? args.topic : "candidate ideas";
+const rubric = args && typeof args.rubric === "string" ? args.rubric : "Distinct and fit for purpose";
+const batchCount = args && Number.isInteger(args.batches) ? Math.max(1, Math.min(args.batches, 8)) : 3;
+const maxCandidates =
+  args && Number.isInteger(args.maxCandidates) ? Math.max(1, Math.min(args.maxCandidates, 64)) : 24;
+const generationSchema = {
+  type: "object",
+  properties: { candidates: { type: "array", items: { type: "string" } } },
+  required: ["candidates"],
+};
+const filterSchema = {
+  type: "object",
+  properties: { keep: { type: "boolean" }, reason: { type: "string" } },
+  required: ["keep", "reason"],
+};
+
+phase("Generate");
+const batches = await parallel(
+  Array.from({ length: batchCount }, (_, index) => () =>
+    agent(`Generate divergent candidates for ${topic}. Seek a distinct angle for batch ${index + 1}.`, {
+      label: `generate:${index + 1}`,
+      schema: generationSchema,
+    }),
+  ),
+);
+const failedBatches = batches.flatMap((batch, index) => (batch === null ? [index + 1] : []));
+
+// INVARIANT: JavaScript performs stable, normalized first-wins deduplication before filter calls.
+const seen = new Set();
+const deduplicated = [];
+for (const batch of batches) {
+  for (const candidate of batch?.candidates ?? []) {
+    const key = candidate.trim().toLowerCase();
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      deduplicated.push(candidate);
+    }
+  }
+}
+const candidates = deduplicated.slice(0, maxCandidates);
+const omitted = deduplicated.slice(maxCandidates);
+
+phase("Filter");
+const verdicts = await parallel(
+  candidates.map((candidate, index) => () =>
+    agent(`Apply this rubric: ${rubric}\nCandidate: ${candidate}`, {
+      label: `filter:${index + 1}`,
+      schema: filterSchema,
+    }),
+  ),
+);
+const failedFilters = candidates.flatMap((candidate, index) => (verdicts[index] === null ? [candidate] : []));
+
+return {
+  candidates,
+  omitted,
+  survivors: candidates.filter((_, index) => verdicts[index]?.keep),
+  rejected: candidates.filter((_, index) => verdicts[index] !== null && !verdicts[index].keep),
+  failed: { batches: failedBatches, filters: failedFilters },
+  complete: failedBatches.length === 0 && failedFilters.length === 0,
+};

--- a/skills/workflow-authoring/examples/loop-until-done.js
+++ b/skills/workflow-authoring/examples/loop-until-done.js
@@ -1,0 +1,68 @@
+export const meta = {
+  name: "loop_until_done",
+  description: "Discover unknown-cardinality findings until repeated successful rounds are dry",
+  phases: [{ title: "Discover" }],
+};
+
+// ADAPT: choose the target, stable identity field, schema, dry-round rule, and maximum bound.
+const target = args && typeof args.target === "string" ? args.target : "new findings";
+const maxRounds = args && Number.isInteger(args.maxRounds) ? Math.max(1, Math.min(args.maxRounds, 20)) : 6;
+const consecutiveDry = 2;
+const roundSchema = {
+  type: "object",
+  properties: {
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { id: { type: "string" }, detail: { type: "string" } },
+        required: ["id", "detail"],
+      },
+    },
+  },
+  required: ["findings"],
+};
+const failedRounds = [];
+const knownIds = new Set();
+const findings = [];
+let dryRounds = 0;
+let roundsRun = 0;
+
+phase("Discover");
+while (roundsRun < maxRounds && dryRounds < consecutiveDry) {
+  const roundNumber = roundsRun + 1;
+  const response = await agent(
+    `Find ${target}. Return only findings not represented by these stable IDs: ${JSON.stringify([...knownIds])}`,
+    { label: `discover:${roundNumber}`, schema: roundSchema },
+  );
+  roundsRun++;
+  if (response === null) {
+    // INVARIANT: missing coverage is not evidence that a round was dry or part of a dry streak.
+    failedRounds.push(roundNumber);
+    dryRounds = 0;
+    continue;
+  }
+
+  const fresh = [];
+  for (const finding of response.findings) {
+    if (!knownIds.has(finding.id)) {
+      knownIds.add(finding.id);
+      fresh.push(finding);
+    }
+  }
+  if (fresh.length === 0) dryRounds++;
+  else {
+    dryRounds = 0;
+    findings.push(...fresh);
+  }
+}
+
+// INVARIANT: stable IDs, consecutive successful dry rounds, and maxRounds bound exploration.
+const termination = dryRounds >= consecutiveDry ? "dry" : "max-rounds";
+return {
+  findings,
+  failedRounds,
+  roundsRun,
+  termination,
+  complete: failedRounds.length === 0 && termination === "dry",
+};

--- a/skills/workflow-authoring/examples/phased-budgets.js
+++ b/skills/workflow-authoring/examples/phased-budgets.js
@@ -1,0 +1,75 @@
+export const meta = {
+  name: "phased_budgets",
+  description: "Bound noisy work with named phase budgets and report shared token spending truthfully",
+  phases: [{ title: "Explore" }, { title: "Deliver" }],
+};
+
+// ADAPT: validate the work, choose phase budgets, prompts, schemas, and invocation-level tokenBudget.
+const work = args && Array.isArray(args.work) ? args.work.slice(0, 8) : [{ id: "sample" }];
+const phaseBudget =
+  args && Number.isFinite(args.phaseBudget) ? Math.max(1, Math.min(args.phaseBudget, 100000)) : 2000;
+const resultSchema = {
+  type: "object",
+  properties: { summary: { type: "string" } },
+  required: ["summary"],
+};
+const phases = [];
+
+phase("Explore", { budget: phaseBudget });
+const exploreStart = budget.spent();
+const explored = [];
+const exploreMissing = [];
+const exploreAttempted = work.map((item) => String(item.id));
+for (let index = 0; index < work.length; index++) {
+  const item = work[index];
+  const id = String(item.id);
+  try {
+    const result = await agent(`Explore this bounded work item: ${JSON.stringify(item)}`, {
+      label: `explore:${index}:${id}`,
+      schema: resultSchema,
+    });
+    if (result === null) exploreMissing.push(id);
+    else explored.push({ id, index, result });
+  } catch (error) {
+    if (!error || error.code !== "TOKEN_BUDGET_EXHAUSTED") throw error;
+    // INVARIANT: the soft gate blocks this and later calls; retain every intended identity as missing coverage.
+    exploreMissing.push(...work.slice(index).map((remaining) => String(remaining.id)));
+    break;
+  }
+}
+phases.push({
+  title: "Explore",
+  startSpent: exploreStart,
+  endSpent: budget.spent(),
+  attempted: exploreAttempted,
+  missing: exploreMissing,
+});
+
+phase("Deliver");
+const deliverStart = budget.spent();
+const delivered = [];
+const deliverMissing = [];
+for (const item of explored) {
+  const result = await agent(`Turn this exploration into a deliverable: ${JSON.stringify(item.result)}`, {
+    label: `deliver:${item.index}:${item.id}`,
+    schema: resultSchema,
+  });
+  if (result === null) deliverMissing.push(item.id);
+  else delivered.push({ id: item.id, result });
+}
+phases.push({
+  title: "Deliver",
+  startSpent: deliverStart,
+  endSpent: budget.spent(),
+  attempted: explored.map((item) => item.id),
+  missing: deliverMissing,
+});
+
+// INVARIANT: phase and total budgets are soft pre-call gates; completed in-flight work may overshoot a limit.
+return {
+  phases,
+  delivered,
+  totalSpent: budget.spent(),
+  remaining: budget.remaining(),
+  complete: exploreMissing.length === 0 && deliverMissing.length === 0,
+};

--- a/skills/workflow-authoring/examples/saved-nested-workflows.js
+++ b/skills/workflow-authoring/examples/saved-nested-workflows.js
@@ -1,0 +1,44 @@
+export const meta = {
+  name: "saved_nested_workflows",
+  description: "Run bounded jobs sequentially through one context-supplied installed workflow",
+  phases: [{ title: "Prepare" }, { title: "Run saved workflow" }],
+};
+
+// ADAPT: accept only a saved workflow name supplied in context; never guess an installed name.
+const savedWorkflowName = args && typeof args.savedWorkflowName === "string" ? args.savedWorkflowName : null;
+if (!savedWorkflowName) throw new Error("args.savedWorkflowName must be supplied by context");
+const jobs = args && Array.isArray(args.jobs) ? args.jobs.slice(0, 8) : [{ id: "sample" }];
+const preparationSchema = {
+  type: "object",
+  properties: { ready: { type: "boolean" } },
+  required: ["ready"],
+};
+
+phase("Prepare");
+const preparation = await agent(`Check ${jobs.length} bounded nested jobs for readiness.`, {
+  label: "prepare-nested-jobs",
+  schema: preparationSchema,
+});
+const preparationMissing = preparation === null;
+
+phase("Run saved workflow");
+const nested = [];
+if (preparationMissing || !preparation.ready) {
+  for (const job of jobs) nested.push({ id: String(job.id), status: "missing", result: null });
+}
+for (const job of preparationMissing || !preparation.ready ? [] : jobs) {
+  const id = String(job.id);
+  // INVARIANT: await each nested run before starting the next; workflow() permits only one nested level.
+  const result = await workflow(savedWorkflowName, job);
+  const missing = result === null || (typeof result === "object" && result !== null && result.result === null);
+  nested.push({ id, status: missing ? "missing" : "complete", result });
+}
+const missing = nested.filter((entry) => entry.status === "missing").map((entry) => entry.id);
+
+// INVARIANT: nested runs share parent agent/concurrency/token limits, accounting, and store state.
+return {
+  preparation: { status: preparationMissing ? "missing" : "complete", result: preparation },
+  nested,
+  missing,
+  complete: !preparationMissing && missing.length === 0,
+};

--- a/skills/workflow-authoring/examples/structured-output.js
+++ b/skills/workflow-authoring/examples/structured-output.js
@@ -1,0 +1,37 @@
+export const meta = {
+  name: "structured_output",
+  description: "Validate agent output with a plain JSON Schema before JavaScript consumes fields",
+  phases: [{ title: "Extract" }],
+};
+
+// ADAPT: validate and bound work, then keep the schema as small as downstream JavaScript needs.
+const work = args && Array.isArray(args.work) ? args.work.slice(0, 8) : [{ id: "sample" }];
+const outputSchema = {
+  type: "object",
+  properties: {
+    summary: { type: "string" },
+    confidence: { type: "number", minimum: 0, maximum: 1 },
+  },
+  required: ["summary", "confidence"],
+};
+const outputs = [];
+const missing = [];
+
+phase("Extract");
+for (let index = 0; index < work.length; index++) {
+  const item = work[index];
+  const id = String(item.id);
+  const result = await agent(`Summarize this item: ${JSON.stringify(item)}`, {
+    label: `structured:${index}:${id}`,
+    schema: outputSchema,
+  });
+  if (result === null) {
+    missing.push(id);
+    outputs.push({ id, status: "missing", summary: null });
+    continue;
+  }
+  // INVARIANT: field access happens only after schema validation guarantees this shape.
+  outputs.push({ id, status: "complete", summary: result.summary.toUpperCase(), confidence: result.confidence });
+}
+
+return { outputs, missing, complete: missing.length === 0 };

--- a/skills/workflow-authoring/examples/tournament.js
+++ b/skills/workflow-authoring/examples/tournament.js
@@ -1,0 +1,81 @@
+export const meta = {
+  name: "pairwise_tournament",
+  description: "Create bounded contenders and choose among them through pairwise judgments",
+  phases: [{ title: "Compete" }, { title: "Judge" }],
+};
+
+// ADAPT: choose the task, pairwise rubric, schemas, and a suitable contender bound.
+const task = args && typeof args.task === "string" ? args.task : "Propose a candidate";
+const rubric = args && typeof args.rubric === "string" ? args.rubric : "Prefer the better task fit";
+const contenderCount = args && Number.isInteger(args.contenders)
+  ? Math.max(2, Math.min(args.contenders, 8))
+  : 4;
+const contenderSchema = {
+  type: "object",
+  properties: { candidate: { type: "string" }, rationale: { type: "string" } },
+  required: ["candidate", "rationale"],
+};
+const judgeSchema = {
+  type: "object",
+  properties: { winnerIndex: { type: "integer", enum: [0, 1] }, reason: { type: "string" } },
+  required: ["winnerIndex", "reason"],
+};
+
+phase("Compete");
+const attempts = await parallel(
+  Array.from({ length: contenderCount }, (_, index) => () =>
+    agent(`${task}\nAttempt a distinct approach as contender ${index + 1}.`, {
+      label: `contender:${index + 1}`,
+      schema: contenderSchema,
+    }),
+  ),
+);
+const failedContenders = attempts.flatMap((attempt, index) => (attempt === null ? [index + 1] : []));
+let round = attempts.flatMap((attempt, index) =>
+  attempt === null ? [] : [{ id: `contender-${index + 1}`, attempt }],
+);
+const failedMatches = [];
+const bracket = [];
+
+phase("Judge");
+// INVARIANT: JavaScript owns the bounded bracket; agents only judge one pair at a time.
+let roundNumber = 1;
+while (round.length > 1) {
+  const matches = [];
+  for (let index = 0; index < round.length; index += 2) {
+    const match = { left: round[index], right: round[index + 1] ?? null, match: index / 2 + 1 };
+    matches.push(match);
+    bracket.push({
+      round: roundNumber,
+      match: match.match,
+      leftId: match.left.id,
+      rightId: match.right?.id ?? null,
+    });
+  }
+  const judgments = await parallel(
+    matches.map(({ left, right, match }) => () =>
+      right === null
+        ? Promise.resolve({ winnerIndex: 0, reason: "bye" })
+        : agent(
+            `Choose index 0 or 1 under this rubric: ${rubric}\nCandidate 0: ${JSON.stringify(left.attempt)}\nCandidate 1: ${JSON.stringify(right.attempt)}`,
+            { label: `judge:${roundNumber}:${match}`, schema: judgeSchema },
+          ),
+    ),
+  );
+  round = matches.flatMap(({ left, right, match }, index) => {
+    const judgment = judgments[index];
+    if (judgment === null) {
+      failedMatches.push(`round-${roundNumber}-match-${match}`);
+      return [];
+    }
+    return [judgment.winnerIndex === 1 && right !== null ? right : left];
+  });
+  roundNumber++;
+}
+
+return {
+  winner: failedMatches.length === 0 ? (round[0] ?? null) : null,
+  bracket,
+  failed: { contenders: failedContenders, matches: failedMatches },
+  complete: failedContenders.length === 0 && failedMatches.length === 0 && round.length === 1,
+};

--- a/skills/workflow-authoring/examples/validated-gate.js
+++ b/skills/workflow-authoring/examples/validated-gate.js
@@ -1,0 +1,63 @@
+export const meta = {
+  name: "validated_gate",
+  description: "Use validator feedback to steer bounded structured attempts through gate()",
+  phases: [{ title: "Validate" }],
+};
+
+// ADAPT: replace the task, structured fields, and task-owned acceptance policy.
+const task = args && typeof args.task === "string" ? args.task : "Produce an acceptable answer.";
+const maxAttempts =
+  args && Number.isInteger(args.maxAttempts) ? Math.max(1, Math.min(args.maxAttempts, 5)) : 3;
+const resultSchema = {
+  type: "object",
+  properties: {
+    acceptable: { type: "boolean" },
+    answer: { type: "string" },
+    feedback: { type: "string" },
+  },
+  required: ["acceptable", "answer", "feedback"],
+};
+const ledger = [];
+
+phase("Validate");
+const outcome = await gate(
+  async (feedback, attempt) => {
+    // gate() supplies undefined feedback initially and a zero-based attempt index.
+    const value = await agent(
+      `${task}${feedback ? ` Address this validator feedback: ${feedback}` : ""}`,
+      {
+        label: `gate-attempt:${attempt + 1}`,
+        schema: resultSchema,
+      },
+    );
+    ledger.push({
+      attempt: attempt + 1,
+      feedbackReceived: feedback ?? null,
+      accepted: false,
+      validatorFeedback: null,
+      value,
+    });
+    return value;
+  },
+  (value) => {
+    // The validator must return an object. A bare boolean is never an accepting verdict.
+    const ok = value !== null && value.acceptable === true && value.answer.trim().length > 0;
+    const feedback =
+      value === null
+        ? "The previous attempt returned no usable result."
+        : value.feedback.trim() || "The answer did not satisfy the acceptance policy.";
+    const entry = ledger[ledger.length - 1];
+    entry.accepted = ok;
+    entry.validatorFeedback = ok ? null : feedback;
+    return ok ? { ok: true } : { ok: false, feedback };
+  },
+  { attempts: maxAttempts },
+);
+
+// INVARIANT: return gate exhaustion explicitly together with every attempt and feedback handoff.
+return {
+  ok: outcome.ok,
+  value: outcome.value,
+  attempts: outcome.attempts,
+  ledger,
+};

--- a/skills/workflow-authoring/references/capabilities.md
+++ b/skills/workflow-authoring/references/capabilities.md
@@ -2,7 +2,7 @@
 # Workflow capability index
 
 Contract format: `1.0.0`<br>
-Contract content / skill / extension: `3.0.0`
+Contract content / skill / extension: `3.2.2`
 
 This compact generated index covers supported runtime globals and workflow-tool inputs. For constraints, compatibility behavior, internal boundaries, and dynamic-reference ownership, follow the [exhaustive generated facts](capability-details.md).
 
@@ -34,7 +34,7 @@ This compact generated index covers supported runtime globals and workflow-tool 
 | maxAgents | workflow-tool-input | `maxAgents?: number = 1000` | — |
 | concurrency | workflow-tool-input | `concurrency?: number` | — |
 | agentRetries | workflow-tool-input | `agentRetries?: number = configured value or 0` | — |
-| agentTimeoutMs | workflow-tool-input | `agentTimeoutMs?: number = configured value or unbounded` | — |
-| tokenBudget | workflow-tool-input | `tokenBudget?: number = unlimited` | — |
+| agentTimeoutMs | workflow-tool-input | `agentTimeoutMs?: number = configured default or unbounded` | — |
+| tokenBudget | workflow-tool-input | `tokenBudget?: number = configured default or unlimited` | — |
 | resumeFromRunId | workflow-tool-input | `resumeFromRunId?: string` | — |
 <!-- END GENERATED SUPPORTED WORKFLOW CAPABILITIES -->

--- a/skills/workflow-authoring/references/capabilities.md
+++ b/skills/workflow-authoring/references/capabilities.md
@@ -1,0 +1,40 @@
+<!-- GENERATED from WORKFLOW_CAPABILITY_CONTRACT; do not edit by hand. -->
+# Workflow capability index
+
+Contract format: `1.0.0`<br>
+Contract content / skill / extension: `3.0.0`
+
+This compact generated index covers supported runtime globals and workflow-tool inputs. For constraints, compatibility behavior, internal boundaries, and dynamic-reference ownership, follow the [exhaustive generated facts](capability-details.md).
+
+## Supported capability index
+
+<!-- BEGIN GENERATED SUPPORTED WORKFLOW CAPABILITIES -->
+| Name | Classification | Signature | Options and defaults |
+| --- | --- | --- | --- |
+| agent | runtime-global | `agent(prompt, options?) => Promise<string \| structured value \| null>` | `label`: string (optional; default: derived from phase and call count)<br>`phase`: string (optional; default: current phase)<br>`schema`: plain JSON Schema (optional)<br>`model`: string (optional)<br>`tier`: string (optional)<br>`isolation`: "worktree" (optional)<br>`agentType`: string (optional)<br>`timeoutMs`: number \| null (optional; default: run timeout; null disables)<br>`retries`: number (optional; default: run retry count) |
+| parallel | runtime-global | `parallel(thunks) => Promise<Array<unknown \| null>>` | — |
+| pipeline | runtime-global | `pipeline(items, ...stages) => Promise<Array<unknown \| null>>` | — |
+| workflow | runtime-global | `workflow(savedName, childArgs?) => Promise<unknown>` | — |
+| verify | runtime-global | `verify(item: unknown, options?: { reviewers?: number; threshold?: number; lens?: string \| string[] }) => Promise<{ real: boolean; realCount: number; total: number; votes: Array<{ real: boolean; reason?: string }> }>` | `reviewers`: number (optional; default: 2)<br>`threshold`: number (optional; default: 0.5)<br>`lens`: string \| string[] (optional) |
+| judgePanel | runtime-global | `judgePanel(attempts: unknown[], options?: { judges?: number; rubric?: string }) => Promise<{ index: number; attempt: unknown; score: number; judgments: Array<{ score: number; reason?: string }> } \| undefined>` | `judges`: number (optional; default: 3)<br>`rubric`: string (optional; default: "overall quality and correctness") |
+| loopUntilDry | runtime-global | `loopUntilDry(options: { round: (roundIndex: number) => unknown[] \| Promise<unknown[]>; key?: (item: unknown) => string; consecutiveEmpty?: number; maxRounds?: number }) => Promise<unknown[]>` | `round`: (roundIndex: number) => unknown[] \| Promise<unknown[]> (required)<br>`key`: (item: unknown) => string (optional; default: JSON.stringify)<br>`consecutiveEmpty`: number (optional; default: 2)<br>`maxRounds`: number (optional; default: 50) |
+| completenessCheck | runtime-global | `completenessCheck(taskArgs: unknown, results: unknown) => Promise<{ complete: boolean; missing?: string[] } \| null>` | — |
+| retry | runtime-global | `retry(thunk: (attempt: number) => unknown \| Promise<unknown>, options?: { attempts?: number; until?: (result: unknown) => boolean }) => Promise<unknown>` | `attempts`: number (optional; default: 3)<br>`until`: (result: unknown) => boolean (optional; default: accept first result when omitted) |
+| gate | runtime-global | `gate(thunk: (feedback: string \| undefined, attempt: number) => unknown \| Promise<unknown>, validator: (value: unknown) => { ok: boolean; feedback?: string } \| Promise<{ ok: boolean; feedback?: string }>, options?: { attempts?: number }) => Promise<{ ok: boolean; value: unknown; attempts: number }>` | `attempts`: number (optional; default: 3) |
+| checkpoint | runtime-global | `checkpoint(prompt, options?) => Promise<unknown>` | `default`: unknown (optional; default: true when no UI and omitted)<br>`headless`: "default" \| "abort" (optional; default: "default")<br>`kind`: "confirm" \| "input" \| "select" (optional; default: "confirm")<br>`choices`: string[] (optional)<br>`timeoutMs`: number (optional) |
+| log | runtime-global | `log(message) => void` | — |
+| phase | runtime-global | `phase(title, options?) => void` | `budget`: number (optional) |
+| args | runtime-global | `args: unknown` | — |
+| cwd | runtime-global | `cwd: string` | — |
+| process | runtime-global | `process: { cwd(): string }` | — |
+| budget | runtime-global | `budget: { total, spent(), remaining() }` | — |
+| script | workflow-tool-input | `script: string` | — |
+| args | workflow-tool-input | `args?: unknown` | — |
+| background | workflow-tool-input | `background?: boolean = true` | — |
+| maxAgents | workflow-tool-input | `maxAgents?: number = 1000` | — |
+| concurrency | workflow-tool-input | `concurrency?: number` | — |
+| agentRetries | workflow-tool-input | `agentRetries?: number = configured value or 0` | — |
+| agentTimeoutMs | workflow-tool-input | `agentTimeoutMs?: number = configured value or unbounded` | — |
+| tokenBudget | workflow-tool-input | `tokenBudget?: number = unlimited` | — |
+| resumeFromRunId | workflow-tool-input | `resumeFromRunId?: string` | — |
+<!-- END GENERATED SUPPORTED WORKFLOW CAPABILITIES -->

--- a/skills/workflow-authoring/references/capability-details.md
+++ b/skills/workflow-authoring/references/capability-details.md
@@ -1,0 +1,348 @@
+<!-- GENERATED from WORKFLOW_CAPABILITY_CONTRACT; do not edit by hand. -->
+# Exhaustive workflow capability facts
+
+Contract format: `1.0.0`<br>
+Contract content / skill / extension: `3.0.0`
+
+Every exact fact below is projected from the installed extension's capability contract. Explanatory judgment belongs in the hand-written references next to this file.
+
+<a id="agent"></a>
+## agent
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `agent(prompt, options?) => Promise<string \| structured value \| null>`
+- Option shape: `agent-options`
+- `label`: string (optional; default: derived from phase and call count)
+- `phase`: string (optional; default: current phase)
+- `schema`: plain JSON Schema (optional)
+- `model`: string (optional; highest-priority exact model selector)
+- `tier`: string (optional; configured route name; dynamic reference: model-routes)
+- `isolation`: "worktree" (optional)
+- `agentType`: string (optional; must come from provided context; dynamic reference: agent-types)
+- `timeoutMs`: number | null (optional; default: run timeout; null disables)
+- `retries`: number (optional; default: run retry count; finite values are floored and clamped to 0..3)
+- Constraint: recoverable failures return null after retries; nonrecoverable failures throw
+- Constraint: schema noncompliance after bounded structured-output repair is nonrecoverable and bypasses agent retries
+- Constraint: per-agent retries override invocation retries; retries are floored and clamped to 0..3
+- Constraint: resume replays only the longest unchanged prefix; the first miss and every later call execute live
+- Constraint: selector priority is explicit model > agentType model > tier > phase model > metadata model > implicit medium > session default
+- Constraint: if the selected model or route is unavailable, execution falls directly to the session default rather than trying lower-priority selectors
+- Constraint: worktree isolation is best-effort; failure logs that isolation was ignored and continues without an isolated working directory
+
+<a id="parallel"></a>
+## parallel
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `parallel(thunks) => Promise<Array<unknown \| null>>`
+- Constraint: requires functions rather than promises
+- Constraint: result order matches input order
+- Constraint: recoverable thunk failures become null; nonrecoverable failures throw
+
+<a id="pipeline"></a>
+## pipeline
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `pipeline(items, ...stages) => Promise<Array<unknown \| null>>`
+- Constraint: items run concurrently while stages per item run sequentially
+- Constraint: each stage receives previousValue, originalItem, and zero-based index
+- Constraint: a null stage result is passed to the next stage; authors must guard missing coverage explicitly
+- Constraint: recoverable stage failures become null; nonrecoverable failures throw
+
+<a id="workflow"></a>
+## workflow
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `workflow(savedName, childArgs?) => Promise<unknown>`
+- Constraint: one nested level
+- Constraint: shares limiter, counters, token accounting, and store
+- Constraint: nested workflows do not reuse the parent resume journal
+
+<a id="verify"></a>
+## verify
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `verify(item: unknown, options?: { reviewers?: number; threshold?: number; lens?: string \| string[] }) => Promise<{ real: boolean; realCount: number; total: number; votes: Array<{ real: boolean; reason?: string }> }>`
+- Option shape: `verify-options`
+- `reviewers`: number (optional; default: 2; authors should provide a finite integer; runtime clamps below 1)
+- `threshold`: number (optional; default: 0.5)
+- `lens`: string | string[] (optional)
+- Constraint: reviewer failures are omitted; successful votes form the denominator in realCount / total
+- Constraint: threshold comparison is inclusive and real is false when no reviewer succeeds
+- Constraint: multiple lenses cycle across reviewers
+
+<a id="judgepanel"></a>
+## judgePanel
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `judgePanel(attempts: unknown[], options?: { judges?: number; rubric?: string }) => Promise<{ index: number; attempt: unknown; score: number; judgments: Array<{ score: number; reason?: string }> } \| undefined>`
+- Option shape: `judge-panel-options`
+- `judges`: number (optional; default: 3; authors should provide a finite integer; runtime clamps below 1)
+- `rubric`: string (optional; default: "overall quality and correctness")
+- Constraint: failed judgments are omitted and each candidate score averages successful judgments only
+- Constraint: a candidate with no successful judgments scores 0
+- Constraint: highest mean score wins with stable input index as the tie-break; empty input returns undefined
+
+<a id="loopuntildry"></a>
+## loopUntilDry
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `loopUntilDry(options: { round: (roundIndex: number) => unknown[] \| Promise<unknown[]>; key?: (item: unknown) => string; consecutiveEmpty?: number; maxRounds?: number }) => Promise<unknown[]>`
+- Option shape: `loop-until-dry-options`
+- `round`: (roundIndex: number) => unknown[] | Promise<unknown[]> (required)
+- `key`: (item: unknown) => string (optional; default: JSON.stringify)
+- `consecutiveEmpty`: number (optional; default: 2; authors should provide a finite integer; runtime clamps below 1)
+- `maxRounds`: number (optional; default: 50; authors should provide a finite positive integer)
+- Constraint: roundIndex is zero-based; null, non-array, or duplicate-only round results count as empty
+- Constraint: token-budget or agent-limit capacity exhaustion returns the accumulated partial array instead of throwing
+- Constraint: the returned array does not report whether termination came from dryness, maxRounds, or capacity exhaustion
+- Constraint: authors must retain failed-round identity and truthful termination state outside the helper
+
+<a id="completenesscheck"></a>
+## completenessCheck
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `completenessCheck(taskArgs: unknown, results: unknown) => Promise<{ complete: boolean; missing?: string[] } \| null>`
+- Constraint: only the first 4,000 characters of serialized result evidence are sent to the critic
+- Constraint: missing is optional and recoverable critic failure returns null
+- Constraint: large evidence sets must be chunked or summarized before relying on the advisory verdict
+
+<a id="retry"></a>
+## retry
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `retry(thunk: (attempt: number) => unknown \| Promise<unknown>, options?: { attempts?: number; until?: (result: unknown) => boolean }) => Promise<unknown>`
+- Option shape: `retry-options`
+- `attempts`: number (optional; default: 3; authors must provide a finite integer; runtime clamps values below 1 to 1)
+- `until`: (result: unknown) => boolean (optional; default: accept first result when omitted; must be synchronous; use gate for asynchronous validation)
+- Constraint: attempt is zero-based and attempts counts total thunk calls
+- Constraint: until is synchronous; returning a Promise is truthy and accepts the first result
+- Constraint: omitting until accepts the first result regardless of attempts
+- Constraint: stops when until(result) is true; exhaustion returns only the last result without attempt metadata
+- Constraint: authors must supply a finite attempts bound when overriding the default
+
+<a id="gate"></a>
+## gate
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `gate(thunk: (feedback: string \| undefined, attempt: number) => unknown \| Promise<unknown>, validator: (value: unknown) => { ok: boolean; feedback?: string } \| Promise<{ ok: boolean; feedback?: string }>, options?: { attempts?: number }) => Promise<{ ok: boolean; value: unknown; attempts: number }>`
+- Option shape: `gate-options`
+- `attempts`: number (optional; default: 3; authors must provide a finite integer; runtime clamps values below 1 to 1)
+- Constraint: feedback is undefined on the first thunk call and then receives the previous validator feedback string
+- Constraint: attempt is zero-based for the thunk while the returned attempts count is one-based
+- Constraint: a value is accepted when the validator returns an object with a truthy ok property; a bare boolean is not accepted
+- Constraint: exhaustion returns ok false with the last value and the bounded attempts count
+- Constraint: authors must supply a finite attempts bound when overriding the default
+
+<a id="checkpoint"></a>
+## checkpoint
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `checkpoint(prompt, options?) => Promise<unknown>`
+- Option shape: `checkpoint-options`
+- `default`: unknown (optional; default: true when no UI and omitted)
+- `headless`: "default" | "abort" (optional; default: "default")
+- `kind`: "confirm" | "input" | "select" (optional; default: "confirm")
+- `choices`: string[] (optional)
+- `timeoutMs`: number (optional)
+- Constraint: foreground confirm and headless behavior are implemented; input/select/timeout are declared-only
+- Constraint: consumes one agent slot and no tokens
+- Constraint: journaled answers replay only within an unchanged resume prefix
+
+<a id="log"></a>
+## log
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `log(message) => void`
+
+<a id="phase"></a>
+## phase
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `phase(title, options?) => void`
+- Option shape: `phase-options`
+- `budget`: number (optional; positive soft pre-call token gate)
+- Constraint: phase budgets are soft pre-call gates
+
+<a id="args"></a>
+## args
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `args: unknown`
+
+<a id="cwd"></a>
+## cwd
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `cwd: string`
+
+<a id="process"></a>
+## process
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `process: { cwd(): string }`
+
+<a id="budget"></a>
+## budget
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `budget: { total, spent(), remaining() }`
+- Constraint: frozen view over shared soft token accounting
+- Constraint: spend accrues after agents finish, so in-flight work can overshoot
+- Constraint: nested workflows share the same accounting
+
+<a id="console"></a>
+## console
+
+- Classification: `runtime-global`
+- Support: `compatibility`
+- Signature: `console: { log, info, warn, error }`
+- Constraint: new workflows should use log()
+
+<a id="tool-input-script"></a>
+## script
+
+- Classification: `workflow-tool-input`
+- Support: `supported`
+- Signature: `script: string`
+- Constraint: required raw JavaScript workflow source
+
+<a id="tool-input-args"></a>
+## args
+
+- Classification: `workflow-tool-input`
+- Support: `supported`
+- Signature: `args?: unknown`
+
+<a id="tool-input-background"></a>
+## background
+
+- Classification: `workflow-tool-input`
+- Support: `supported`
+- Signature: `background?: boolean = true`
+- Constraint: background workflows are headless; use background false when checkpoint must show foreground confirmation
+
+<a id="tool-input-maxagents"></a>
+## maxAgents
+
+- Classification: `workflow-tool-input`
+- Support: `supported`
+- Signature: `maxAgents?: number = 1000`
+- Constraint: default, not a hard product maximum
+
+<a id="tool-input-concurrency"></a>
+## concurrency
+
+- Classification: `workflow-tool-input`
+- Support: `supported`
+- Signature: `concurrency?: number`
+- Constraint: runtime clamps to 1..16
+
+<a id="tool-input-agentretries"></a>
+## agentRetries
+
+- Classification: `workflow-tool-input`
+- Support: `supported`
+- Signature: `agentRetries?: number = configured value or 0`
+- Constraint: floored and clamped to 0..3
+
+<a id="tool-input-agenttimeoutms"></a>
+## agentTimeoutMs
+
+- Classification: `workflow-tool-input`
+- Support: `supported`
+- Signature: `agentTimeoutMs?: number = configured value or unbounded`
+
+<a id="tool-input-tokenbudget"></a>
+## tokenBudget
+
+- Classification: `workflow-tool-input`
+- Support: `supported`
+- Signature: `tokenBudget?: number = unlimited`
+- Constraint: soft pre-call gate; in-flight work can overshoot
+
+<a id="tool-input-resumefromrunid"></a>
+## resumeFromRunId
+
+- Classification: `workflow-tool-input`
+- Support: `supported`
+- Signature: `resumeFromRunId?: string`
+- Constraint: resumes a prior incomplete run with an edited script
+- Constraint: unchanged positional agent calls replay from cache until the first changed or inserted call
+- Constraint: always runs in the background
+
+<a id="metadata"></a>
+## export const meta
+
+- Classification: `script-contract`
+- Support: `supported`
+- Signature: `export const meta = { name: string, description: string, phases?: Array<{ title: string; detail?: string; model?: string }>, model?: string }`
+- Constraint: must be the first statement
+- Constraint: name and description must be nonblank strings
+- Constraint: metadata must use literal values; expressions such as string concatenation and template interpolation are rejected
+- Constraint: the meta declaration is the only legal export because the remaining body executes inside an async function
+
+<a id="return-value"></a>
+## workflow return value
+
+- Classification: `script-contract`
+- Support: `supported`
+- Signature: `return JSON-serializable data`
+- Constraint: do not return functions, promises, cyclic objects, BigInt, or runtime handles
+
+<a id="determinism"></a>
+## deterministic script execution
+
+- Classification: `script-contract`
+- Support: `supported`
+- Signature: —
+- Constraint: Date.now(), Math.random(), and no-argument new Date() are unavailable
+- Constraint: pass timestamps and randomness through args
+
+<a id="compatibility"></a>
+## whole-script Markdown fence stripping
+
+- Classification: `compatibility-behavior`
+- Support: `compatibility`
+- Signature: —
+- Constraint: accepted for compatibility but not recommended
+
+<a id="model-routes"></a>
+## model routes
+
+- Classification: `dynamic-reference`
+- Support: `supported`
+- Signature: —
+- Constraint: live values must not be copied into static contract data
+- Dynamic reference owner: `model-tier-config`
+- Item shape: `{ name: string; description?: string }`
+- Future lookup connection: `loadModelTierConfig`
+- Live values are intentionally absent from this static reference.
+
+<a id="agent-types"></a>
+## agent types
+
+- Classification: `dynamic-reference`
+- Support: `supported`
+- Signature: —
+- Constraint: live values must not be copied into static contract data
+- Dynamic reference owner: `agent-registry`
+- Item shape: `{ name: string; description?: string }`
+- Future lookup connection: `loadAgentRegistry`
+- Live values are intentionally absent from this static reference.

--- a/skills/workflow-authoring/references/capability-details.md
+++ b/skills/workflow-authoring/references/capability-details.md
@@ -2,7 +2,7 @@
 # Exhaustive workflow capability facts
 
 Contract format: `1.0.0`<br>
-Contract content / skill / extension: `3.0.0`
+Contract content / skill / extension: `3.2.2`
 
 Every exact fact below is projected from the installed extension's capability contract. Explanatory judgment belongs in the hand-written references next to this file.
 
@@ -267,14 +267,14 @@ Every exact fact below is projected from the installed extension's capability co
 
 - Classification: `workflow-tool-input`
 - Support: `supported`
-- Signature: `agentTimeoutMs?: number = configured value or unbounded`
+- Signature: `agentTimeoutMs?: number = configured default or unbounded`
 
 <a id="tool-input-tokenbudget"></a>
 ## tokenBudget
 
 - Classification: `workflow-tool-input`
 - Support: `supported`
-- Signature: `tokenBudget?: number = unlimited`
+- Signature: `tokenBudget?: number = configured default or unlimited`
 - Constraint: soft pre-call gate; in-flight work can overshoot
 
 <a id="tool-input-resumefromrunid"></a>

--- a/skills/workflow-authoring/references/common-helpers.md
+++ b/skills/workflow-authoring/references/common-helpers.md
@@ -1,0 +1,4 @@
+# Common helper index
+
+- Read [quality helpers](quality-helpers.md) for `verify()` or `judgePanel()`.
+- Read the [retry helper](retry-helper.md) for `retry()`.

--- a/skills/workflow-authoring/references/debugging.md
+++ b/skills/workflow-authoring/references/debugging.md
@@ -1,0 +1,27 @@
+# Workflow debugging map
+
+Start from the symptom, then reproduce through the real workflow runtime with deterministic fake agents.
+
+| Symptom | Likely authoring cause | Check |
+| --- | --- | --- |
+| Parser says metadata is missing | `export const meta` is not the first statement or is nonliteral | [runtime](runtime.md#script-envelope) |
+| `parallel()` rejects input | Promises were passed instead of thunks | [runtime](runtime.md#topology) |
+| Synthesis starts early | Fan-out was not awaited as one complete result set | [pattern selection](pattern-selection.md#fan-out-and-synthesize) |
+| Coverage silently disappears | `null` results were filtered before IDs were ledgered | [lifecycle](lifecycle.md#retry-and-recoverable-failure) |
+| Wrong model is used | A higher-priority selector overrides the expected route | [registry ownership](registry-ownership.md#priority) |
+| Unknown `agentType` log | A live registry name was guessed or is unavailable | [registry ownership](registry-ownership.md#agent-types) |
+| Budget exceeds the number shown | The budget is a soft pre-call gate and work was in flight | [lifecycle](lifecycle.md#bounds-and-budget) |
+| Later calls rerun on resume | An earlier call missed or changed, ending the replayable prefix | [lifecycle](lifecycle.md#resume) |
+| Nested workflow fails | Nesting exceeded one level or shared limits were exhausted | [lifecycle](lifecycle.md#nesting-and-shared-state) |
+| Checkpoint does not show a form | Input/select/timeout behavior is declared-only | [lifecycle](lifecycle.md#checkpoints) |
+| Returned result cannot cross boundary | It contains a function, promise, cycle, `BigInt`, or runtime object | [lifecycle](lifecycle.md#serialization) |
+| `Date.now()`/randomness is rejected | Resume requires deterministic call structure | [lifecycle](lifecycle.md#resume) |
+
+## Debugging procedure
+
+1. Reduce to the smallest script that preserves metadata, labels, work IDs, and the failing topology.
+2. Replace provider calls with deterministic, schema-aware fake agents.
+3. Record call order, labels, phases, prompts, results, and `null` entries.
+4. When the failure turns on a disputed signature or default, compare it with the compact [capability index](capabilities.md); follow its exhaustive-facts pointer only when needed.
+5. Separate runtime defects from unsupported authoring assumptions and compatibility-only behavior.
+6. Fix only the demonstrated authoring issue; do not rely on known out-of-scope gaps in nested persistence, resume accounting, checkpoint forms/timeouts, metadata validation, or budget overshoot.

--- a/skills/workflow-authoring/references/focused-recipes.md
+++ b/skills/workflow-authoring/references/focused-recipes.md
@@ -1,0 +1,11 @@
+# Focused recipes
+
+Read only the recipe matching the concern. Change task prompts, schemas, bounds, and context-supplied inputs; preserve the listed contract.
+
+| Concern | Preserve when adapting | Tested recipe |
+| --- | --- | --- |
+| Phased budgets | Phase and run budgets are soft pre-call gates; active work can overshoot. Report shared spend and bound calls independently. | [Phased budgets](../examples/phased-budgets.js) |
+| Saved workflows | Use a context-supplied name, await jobs sequentially, nest one level, and treat shared limits, counters, tokens, limiter, and store as parent capacity. | [Saved nested workflows](../examples/saved-nested-workflows.js) |
+| Semantic retry | Separate it from recoverable runtime retries. Use a new unique label per bounded attempt and return the attempt ledger plus exhausted outcome. | [Bounded semantic retry](../examples/bounded-semantic-retry.js) |
+| Validator feedback | Follow the exact `gate()` callbacks in [specialized helpers](specialized-helpers.md). Return the gate outcome and attempt ledger so feedback and exhaustion remain visible. | [Validated gate](../examples/validated-gate.js) |
+| Structured fields | Pass a small plain JSON Schema before reading fields. Ledger recoverable `null`; treat exhausted schema repair as a nonrecoverable failure. | [Structured output](../examples/structured-output.js) |

--- a/skills/workflow-authoring/references/helpers.md
+++ b/skills/workflow-authoring/references/helpers.md
@@ -1,0 +1,9 @@
+# Helper reference index
+
+Use a helper only when it expresses the task's policy. Preserve candidate or work identity outside helper results that may omit failed agents.
+
+- Read [quality helpers](quality-helpers.md) for `verify()` or `judgePanel()`.
+- Read the [retry helper](retry-helper.md) for `retry()`.
+- Read [specialized helpers](specialized-helpers.md) for `completenessCheck()`, `loopUntilDry()`, `gate()`, or `checkpoint()`.
+
+Runtime agent retries repeat recoverable execution failures; helper attempts are new semantic calls. Bound both layers and ledger exhaustion.

--- a/skills/workflow-authoring/references/lifecycle.md
+++ b/skills/workflow-authoring/references/lifecycle.md
@@ -1,0 +1,33 @@
+# Lifecycle, limits, and resume
+
+## Bounds and budget
+
+Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script.
+
+Enter a phase budget with `phase("Name", { budget: N })`; phase metadata does not carry budgets. `N` is a token allowance, not a call or round count: size it for the intended agent work instead of copying a small iteration limit. Token and phase budgets are soft pre-call gates. Spend lands after agents finish, so concurrent work can overshoot. A phase budget gates later calls in that phase; it neither reserves tokens nor cancels active calls. `budget.spent()` and `budget.remaining()` include nested work.
+
+## Checkpoints
+
+A checkpoint consumes an agent slot but no tokens. A workflow invocation is backgrounded by default, and background workflows are headless: they cannot display checkpoint confirmation. Use `background: false` when a checkpoint must reach the foreground host confirmation interface. Without a UI, a checkpoint returns the declared default (or `true` when omitted) unless `headless: "abort"` is selected. Confirm is implemented. Input, select, and timeout fields are declared for compatibility/future behavior but are not authoring promises.
+
+Checkpoint answers are journaled and can replay during an unchanged resume prefix. Do not describe checkpoints as guaranteed arbitrary forms or as remote steering.
+
+## Retry and recoverable failure
+
+Recoverable execution failures retry according to the per-agent option or invocation-time tool input, then return `null`. Nonrecoverable failures throw without becoming `null`. The logical `retry()` combinator is separate: it performs new agent calls and returns its last result when exhausted unless the script records and handles that outcome.
+
+Always retain `{ id, status, result }` or an equivalent ledger for each intended work unit. Filtering `null` before recording identity turns an execution failure into invisible missing coverage.
+
+## Resume
+
+Resume replays only the longest unchanged prefix of journaled calls. Once one call is new, changed, or unusable, that call and all later calls execute live. Stable lexical call ordering, prompts, labels, routing options, and inputs therefore matter. Retry chains can cascade after an upstream miss. Nested workflows do not reuse the parent's resume journal.
+
+The runtime blocks common accidental nondeterminism, but this is not a security boundary. Pass timestamps, randomness, and external decisions through `args`.
+
+## Nesting and shared state
+
+`workflow(savedName, childArgs)` runs sequentially inline, allows one nested level, and shares limiter, counters, token accounting, and shared store with the parent. It is not independent capacity. Use only a saved-workflow name provided by context; do not guess registry entries or pass raw scripts as a new authoring pattern even where compatibility behavior accepts them.
+
+## Serialization
+
+The workflow's explicit return value crosses the tool boundary. Keep it JSON-serializable and preserve coverage ledgers in the returned data. Structured agent schemas must be plain JSON Schema. Schema success guarantees the downstream field shape expected by JavaScript; without a schema, treat output as text or `null`.

--- a/skills/workflow-authoring/references/lifecycle.md
+++ b/skills/workflow-authoring/references/lifecycle.md
@@ -2,7 +2,7 @@
 
 ## Bounds and budget
 
-Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script.
+Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script. An omitted `agentTimeoutMs` uses the configured `defaultAgentTimeoutMs` and is otherwise unbounded. An omitted `tokenBudget` uses the configured `defaultTokenBudget` and is otherwise unlimited.
 
 Enter a phase budget with `phase("Name", { budget: N })`; phase metadata does not carry budgets. `N` is a token allowance, not a call or round count: size it for the intended agent work instead of copying a small iteration limit. Token and phase budgets are soft pre-call gates. Spend lands after agents finish, so concurrent work can overshoot. A phase budget gates later calls in that phase; it neither reserves tokens nor cancels active calls. `budget.spent()` and `budget.remaining()` include nested work.
 

--- a/skills/workflow-authoring/references/pattern-selection.md
+++ b/skills/workflow-authoring/references/pattern-selection.md
@@ -1,0 +1,15 @@
+# Pattern selection
+
+Choose from data dependencies, then read only the matching example. JavaScript owns enumeration, identity, ordering, deduplication, bounds, stopping, brackets, and failure ledgers. Agents own semantic work.
+
+<a id="fan-out-and-synthesize"></a>
+| Dependency shape | Pattern | Preserve when adapting | Example |
+| --- | --- | --- | --- |
+| Heterogeneous items need different handling | Classify and act | Finish all classification before routed action; ledger classification and action failures by item ID | [Adapt](../examples/classify-and-act.js) |
+| Independent work needs whole-set judgment | Fan out and synthesize | Pass thunks; await the full set; give synthesis every intended ID, including `null` | [Adapt](../examples/fan-out-and-synthesize.js) |
+| Claims need skeptical checks | Adversarial verification | Use separate producer and skeptic calls; start skepticism after production; ledger both failures | [Adapt](../examples/adversarial-verification.js) |
+| Exploration should diverge before one rubric | Generate and filter | Finish generation; deterministically deduplicate and bound candidates before filter calls | [Adapt](../examples/generate-and-filter.js) |
+| Pairwise comparison beats absolute scoring | Tournament | Let JavaScript run the bounded bracket and byes; agents compare one pair; ledger match failures | [Adapt](../examples/tournament.js) |
+| Work cardinality is unknown | Loop until done | Deduplicate by stable key; count only successful empty rounds as dry; cap rounds; retain failed rounds | [Adapt](../examples/loop-until-done.js) |
+
+For every pattern, validate and bound input before fan-out, use stable IDs and unique labels, preserve missing coverage, and return plain JSON data. Combine patterns only when the task has both dependency shapes. Direct work needs no orchestration.

--- a/skills/workflow-authoring/references/quality-helpers.md
+++ b/skills/workflow-authoring/references/quality-helpers.md
@@ -1,0 +1,8 @@
+# Verify and judge
+
+Keep work IDs outside helper results that may omit failed agents.
+
+| Call | Contract |
+| --- | --- |
+| `verify(item, { reviewers: number, threshold: number, lens: string | string[] })` | Defaults: 2 reviewers, inclusive `0.5`, one lens or a cycled array. Returns `{ real, realCount, total, votes }`. Failed reviewers are omitted; successful votes are the denominator; zero survivors means `real: false`. |
+| `judgePanel(attempts, { judges: number, rubric: string })` | Defaults: 3 judges and `"overall quality and correctness"`. Failed judgments are omitted. Returns the highest mean `{ index, attempt, score, judgments }`; input order wins ties; empty input returns `undefined`. |

--- a/skills/workflow-authoring/references/registry-ownership.md
+++ b/skills/workflow-authoring/references/registry-ownership.md
@@ -1,0 +1,15 @@
+# Dynamic registry ownership
+
+Model routes and agent types are dynamic references. Their shape and owner are documented, but available names depend on active user/project configuration and are intentionally absent from static skill files.
+
+## Model routes
+
+The model-tier configuration owns route names. Standard routes are `small`, `medium`, and `big`; use another route only when its name and purpose are supplied in context. A route is selected with `tier`. An exact user-requested model is selected with `model`.
+
+## Agent types
+
+The agent registry owns agent-type names and their bound instructions, tools, model, and isolation policy. Use `agentType` only when context supplies both its name and purpose. Do not infer an agent type from a role-like label.
+
+## Priority
+
+Routing priority is explicit `model` > `agentType` model > `tier` > phase model > metadata model > implicit `medium` > session default. Higher priority means selection, not "try this then fall back to the next selector." If the selected model or route is unavailable, execution falls directly to the session default; it does not try lower-priority selectors. Avoid specifying competing selectors unless deliberately overriding a lower-priority default.

--- a/skills/workflow-authoring/references/retry-helper.md
+++ b/skills/workflow-authoring/references/retry-helper.md
@@ -1,0 +1,5 @@
+# Retry
+
+`retry(thunk, { attempts, until })` takes exactly these 2 arguments; `until` belongs in the options object. It calls `thunk(attempt)` with a zero-based index and defaults to 3 attempts. `until` is synchronous—a Promise or omitted predicate accepts the first result. Exhaustion returns only the last result, so keep an attempt ledger.
+
+Always `await retry()`. A thunk containing `await` must be `async`; await `agent()` before adding its resolved value to the ledger. Runtime retries repeat recoverable execution failures; helper attempts are new semantic calls. Bound both layers and ledger exhaustion.

--- a/skills/workflow-authoring/references/review.md
+++ b/skills/workflow-authoring/references/review.md
@@ -1,0 +1,43 @@
+# Workflow review checklist
+
+Review author-visible behavior, not formatting preferences. When behavior depends on a quality or control combinator, consult only its exact [quality](quality-helpers.md) or [specialized](specialized-helpers.md) helper contract before correcting the script.
+
+## Envelope and contract
+
+- Is literal `export const meta` the first statement, with a short unique name and useful description?
+- Are only used phases declared, and does each named phase begin at the intended boundary?
+- Does the script call at least one agent and explicitly return JSON-serializable data?
+- Are imports and nondeterministic APIs absent?
+
+## Topology and identity
+
+- Does topology match dependencies: thunks for independent parallel work, stages for per-item pipelines, barriers before whole-set synthesis?
+- Is cardinality bounded before fan-out?
+- Is every agent label short and unique?
+- Are stable work-unit IDs retained beside ordered results?
+- Are failed/null identities recorded before any filtering?
+
+## Data and routing
+
+- Does JavaScript consume structured fields only after a small plain JSON Schema guarantees them?
+- Does synthesis receive complete coverage and failure ledgers?
+- Are `model`, `tier`, and `agentType` used according to selector priority?
+- Did every nonstandard route or agent type come from context with a name and purpose?
+
+## Lifecycle
+
+- Are runtime retries and semantic retries separately bounded?
+- Are loops, agents, concurrency, timeout, and token spend bounded appropriately?
+- Are budget claims honest about soft gates and in-flight overshoot?
+- Are checkpoints limited to implemented confirmation/headless behavior?
+- Does nesting stay one level and account for shared limits/store?
+- Would lexical call order remain stable under resume?
+
+## Compatibility and publication
+
+- Does new code use `log()` rather than compatibility-only `console`?
+- Is compatibility behavior clearly distinguished from supported authoring behavior and VM substrate?
+- Do package, skill, and generated contract versions match?
+- Do all relative links resolve within the publishable package?
+
+Use [lifecycle](lifecycle.md) for lifecycle reasoning. Open the compact [capability index](capabilities.md) only when the review turns on a disputed signature, default, support boundary, or installed version; follow its exhaustive-facts pointer only when the index is insufficient.

--- a/skills/workflow-authoring/references/runtime.md
+++ b/skills/workflow-authoring/references/runtime.md
@@ -1,0 +1,27 @@
+# Runtime authoring
+
+Use this page for routine scripts. Open the generated capability index only when a signature, default, support boundary, or installed-version fact is missing here.
+
+## Script envelope
+
+Start with the only legal export: `export const meta = { name, description, phases?: [{ title, detail?, model? }] }`. Values are nonblank literals; declare only used phases and call `phase()` before each phase's work. The remaining body already runs inside an async function: write helpers as ordinary declarations; `export default` and other exports are invalid. Return the result explicitly.
+
+The runtime supplies `agent`, `parallel`, `pipeline`, `workflow`, quality/control helpers, `phase`, `log`, `args`, `cwd`, restricted `process.cwd()`, and `budget`. Imports, `require()`, filesystem modules, `Date.now()`, `Math.random()`, and no-argument `new Date()` are unavailable. The Node VM realm is implementation substrate, not a security boundary or public API.
+
+## Topology
+
+- `parallel()` takes thunks, runs independent work, and preserves input order. Await the whole array before whole-set synthesis.
+- `pipeline()` runs stages sequentially per item while items proceed concurrently. Each stage receives `(previousValue, originalItem, index)` and forwards `null` to the next stage, so guard missing coverage first.
+- `workflow(name, childArgs?)` runs a context-supplied saved workflow. Nesting is one level and shares limits, counters, tokens, and store.
+
+## Data and failure
+
+Call `agent(prompt, { label, schema? })`; it returns text, a schema-validated value, or recoverable `null`. Nonrecoverable limit, validation, and budget failures throw. Record each intended work ID before filtering. A `null` means missing coverage, never a negative finding.
+
+When JavaScript reads fields, pass a small plain JSON Schema. Schema noncompliance after repair throws and bypasses agent retries. Catch it only to return an explicit incomplete outcome without reading missing fields. Return objects, arrays, strings, numbers, booleans, and `null`—not functions, promises, cycles, `BigInt`, or runtime handles.
+
+## Routing and support
+
+Selector priority is explicit `model` > `agentType` model > `tier` > phase model > metadata model > implicit `medium` > session default. An unavailable selected route falls directly to the session default. Use exact `model`, nonstandard `tier`, or `agentType` only when context supplies its name and purpose. Worktree isolation is best-effort. See [registry ownership](registry-ownership.md).
+
+Generated entries marked `supported` are authoring API. `console` and whole-script Markdown fences are compatibility-only. VM realm facilities are internal. Active model routes and agent types are dynamic. Use `log()` in new scripts.

--- a/skills/workflow-authoring/references/specialized-helpers.md
+++ b/skills/workflow-authoring/references/specialized-helpers.md
@@ -1,0 +1,19 @@
+# Specialized helpers
+
+Preserve candidate or work identity outside helper results that may omit failed agents.
+
+## Quality
+
+| Helper | Authoring contract |
+| --- | --- |
+| `completenessCheck(args, results)` | Returns `{ complete, missing? }` or recoverable `null`. The critic sees only the first 4,000 serialized characters, so chunk or summarize larger evidence. Treat the verdict as advisory. |
+| `loopUntilDry({ round, key, consecutiveEmpty, maxRounds })` | `round(index)` is zero-based. Defaults: `JSON.stringify` key, two dry rounds, 50 rounds. Null, non-array, and duplicate-only rounds are dry. Token-budget or agent-limit exhaustion returns the partial array without a termination reason; keep failed-round identity and stopping state outside the helper. |
+
+## Control
+
+| Helper | Authoring contract |
+| --- | --- |
+| `gate(thunk, validator, { attempts })` | Calls `thunk(feedback, attempt)` with initial `undefined` feedback and a zero-based attempt. `validator(value)` returns `{ ok, feedback? }`, synchronously or asynchronously; a bare boolean is not accepted. Three attempts by default. Returns `{ ok, value, attempts }`, including the last value on exhaustion. See [validated gate](../examples/validated-gate.js). |
+| `checkpoint(prompt, options?)` | Journals a human/default decision. Only foreground confirm and documented headless behavior work; input, select, and timeout are declared-only. |
+
+Always `await gate()`. A thunk containing `await` must itself be declared `async`; await `agent()` before adding its resolved value to a ledger. Runtime agent retries repeat recoverable execution failures; helper attempts are new semantic calls. Bound both layers and ledger exhaustion.

--- a/skills/workflow-authoring/references/versions.md
+++ b/skills/workflow-authoring/references/versions.md
@@ -1,0 +1,13 @@
+# Version compatibility
+
+The installed package, capability-contract content, and this skill must describe the same extension version. Read the version line generated at the top of [capabilities](capabilities.md); the skill's frontmatter version and package version must match it.
+
+`present-at` means a capability is confirmed in the recorded version. It is an honest baseline, not a claim about the first historical release that introduced the capability. The contract format has its own version because descriptor shape can evolve separately from extension content.
+
+When copying a workflow between installations:
+
+1. Check the destination's generated version and exact capability facts.
+2. Re-check every supported global, option, and constraint used by the script.
+3. Treat compatibility entries as preservation aids, not portable recommendations.
+4. Re-resolve dynamic model routes and agent types from destination context; static docs intentionally contain no live entries.
+5. Prefer runtime behavior when prose and execution disagree, and report the documentation mismatch rather than changing behavior during an authoring fix.

--- a/src/accept-workflow-guidance.ts
+++ b/src/accept-workflow-guidance.ts
@@ -1,0 +1,71 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { WORKFLOW_AUTHORING_FROZEN_FILES } from "./workflow-authoring-coverage.js";
+
+const COVERAGE_MANIFEST_PATH = "src/workflow-authoring-coverage.ts";
+
+/** A reviewed frozen-guidance hash transition recorded in the coverage manifest. */
+export interface WorkflowGuidanceAcceptance {
+  path: string;
+  previousSha256: string;
+  sha256: string;
+  changed: boolean;
+}
+
+function sha256(source: string): string {
+  return createHash("sha256").update(source).digest("hex");
+}
+
+function manifestEntry(path: string, hash: string): string {
+  return `    path: ${JSON.stringify(path)},\n    sha256: ${JSON.stringify(hash)},`;
+}
+
+/**
+ * Accepts reviewed changes to explicitly named frozen workflow-authoring files.
+ *
+ * Throws before writing when no path is supplied, a path is not frozen, a file
+ * is missing, or the coverage manifest no longer contains the expected entry.
+ */
+export function acceptWorkflowGuidance(root: string, requestedPaths: readonly string[]): WorkflowGuidanceAcceptance[] {
+  if (requestedPaths.length === 0) {
+    throw new Error("Pass at least one frozen workflow-authoring path to accept.");
+  }
+
+  const frozenByPath: ReadonlyMap<string, (typeof WORKFLOW_AUTHORING_FROZEN_FILES)[number]> = new Map(
+    WORKFLOW_AUTHORING_FROZEN_FILES.map((entry) => [entry.path, entry]),
+  );
+  const paths = [...new Set(requestedPaths.map((path) => path.replace(/^\.\//, "")))];
+  const entries = paths.map((path) => {
+    const frozen = frozenByPath.get(path);
+    if (frozen === undefined) {
+      throw new Error(`${path} is not a frozen workflow-authoring guidance file.`);
+    }
+    const absolute = join(root, path);
+    if (!existsSync(absolute)) {
+      throw new Error(`Frozen workflow-authoring guidance file is missing: ${path}.`);
+    }
+    return {
+      path,
+      previousSha256: frozen.sha256,
+      sha256: sha256(readFileSync(absolute, "utf8")),
+    };
+  });
+
+  const manifestPath = join(root, COVERAGE_MANIFEST_PATH);
+  const originalManifest = readFileSync(manifestPath, "utf8");
+  let nextManifest = originalManifest;
+  for (const entry of entries) {
+    const previous = manifestEntry(entry.path, entry.previousSha256);
+    if (!nextManifest.includes(previous)) {
+      throw new Error(`Coverage manifest does not contain the expected frozen entry for ${entry.path}.`);
+    }
+    nextManifest = nextManifest.replace(previous, manifestEntry(entry.path, entry.sha256));
+  }
+
+  if (nextManifest !== originalManifest) {
+    writeFileSync(manifestPath, nextManifest);
+  }
+
+  return entries.map((entry) => ({ ...entry, changed: entry.previousSha256 !== entry.sha256 }));
+}

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,77 @@
+/** Classifies a workflow capability by its runtime and documentation role. */
+export enum CapabilityClassification {
+  RUNTIME_GLOBAL = "runtime-global",
+  WORKFLOW_TOOL_INPUT = "workflow-tool-input",
+  SCRIPT_CONTRACT = "script-contract",
+  COMPATIBILITY_BEHAVIOR = "compatibility-behavior",
+  INTERNAL_SUBSTRATE = "internal-substrate",
+  DYNAMIC_REFERENCE = "dynamic-reference",
+}
+
+/** Declares whether workflow authors should use a capability. */
+export enum CapabilitySupport {
+  SUPPORTED = "supported",
+  COMPATIBILITY = "compatibility",
+  INTERNAL = "internal",
+}
+
+/** Identifies the model-visible surface responsible for discovery. */
+export enum DiscoveryPlacement {
+  COMPACT_GUIDANCE = "compact-guidance",
+  WORKFLOW_AUTHORING_SKILL = "workflow-authoring-skill",
+  NONE = "none",
+}
+
+/** Names the subsystem that owns a capability's behavior. */
+export enum CapabilityOrigin {
+  PROJECT = "project",
+  TOOL_ADAPTER = "tool-adapter",
+  VM_REALM = "vm-realm",
+  LIVE_CONFIGURATION = "live-configuration",
+}
+
+/** Severity carried by capability-alignment diagnostics. */
+export enum DiagnosticSeverity {
+  ERROR = "error",
+  WARNING = "warning",
+  INFORMATION = "information",
+}
+
+/** Optional model-comprehension scenario groups. */
+export enum ComprehensionSuite {
+  QUICK = "quick",
+  FULL = "full",
+  COVERAGE = "coverage",
+}
+
+/** Authoring operation exercised by a comprehension scenario. */
+export enum ComprehensionTaskKind {
+  WRITE = "write",
+  EDIT = "edit",
+  REVIEW = "review",
+  DEBUG = "debug",
+}
+
+/** Whether authoring guidance may be optimized against behavioral evidence or must remain frozen. */
+export enum WorkflowAuthoringProtection {
+  BEHAVIORALLY_COVERED = "behaviorally-covered",
+  GUIDANCE_FROZEN = "guidance-frozen",
+}
+
+/** Machine-readable release-gate failure and warning domains. */
+export enum WorkflowReleaseDiagnosticCode {
+  INCOMPATIBLE_VERSION = "INCOMPATIBLE_VERSION",
+  MISSING_BEHAVIOR_EVIDENCE = "MISSING_BEHAVIOR_EVIDENCE",
+  UNRESOLVED_BEHAVIOR_EVIDENCE = "UNRESOLVED_BEHAVIOR_EVIDENCE",
+  BROKEN_CONTRACT_REFERENCE = "BROKEN_CONTRACT_REFERENCE",
+  MISSING_PACKAGE_RESOURCE = "MISSING_PACKAGE_RESOURCE",
+  BROKEN_PACKAGE_LINK = "BROKEN_PACKAGE_LINK",
+  STALE_GENERATED_SURFACE = "STALE_GENERATED_SURFACE",
+  TOOL_INPUT_MISMATCH = "TOOL_INPUT_MISMATCH",
+  RUNTIME_CONSTRAINT_DISAGREEMENT = "RUNTIME_CONSTRAINT_DISAGREEMENT",
+  NON_CONTRACTUAL_PROSE_DRIFT = "NON_CONTRACTUAL_PROSE_DRIFT",
+  MISSING_AUTHORING_COVERAGE = "MISSING_AUTHORING_COVERAGE",
+  UNPROTECTED_AUTHORING_GUIDANCE = "UNPROTECTED_AUTHORING_GUIDANCE",
+  PROTECTED_GUIDANCE_DRIFT = "PROTECTED_GUIDANCE_DRIFT",
+  UNKNOWN_COMPREHENSION_SCENARIO = "UNKNOWN_COMPREHENSION_SCENARIO",
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,6 +2,32 @@
  * Workflow-specific error types.
  */
 
+/** Dependency-neutral diagnostic payload retained by capability contract failures. */
+export interface CapabilityErrorDiagnostic {
+  code: string;
+  severity: "error" | "warning" | "information";
+  subject: string;
+  message: string;
+}
+
+/** Dependency-neutral skill-loading payload retained by generation failures. */
+export interface ModelGenerationSkillLoadingEvidence {
+  discovered: boolean;
+  loaded: boolean;
+  toolCalls: Array<{ tool: string; path?: string }>;
+}
+
+/** Dependency-neutral provider-usage payload retained by generation failures. */
+export interface ModelGenerationTokenUsage {
+  input: number;
+  output: number;
+  total: number;
+  cost: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+/** Stable runtime and persistence failure codes exposed to callers and UI surfaces. */
 export enum WorkflowErrorCode {
   /** Agent exceeded timeout. */
   AGENT_TIMEOUT = "AGENT_TIMEOUT",
@@ -31,6 +57,7 @@ export enum WorkflowErrorCode {
   UNKNOWN = "UNKNOWN",
 }
 
+/** Classified workflow failure with recoverability and optional agent/provider context. */
 export class WorkflowError extends Error {
   readonly code: WorkflowErrorCode;
   readonly recoverable: boolean;
@@ -54,10 +81,40 @@ export class WorkflowError extends Error {
   }
 }
 
+/** Contract failure that retains every definition or assembly diagnostic. */
+export class WorkflowCapabilityContractError extends Error {
+  readonly diagnostics: readonly CapabilityErrorDiagnostic[];
+
+  constructor(message: string, diagnostics: readonly CapabilityErrorDiagnostic[]) {
+    super(message);
+    this.name = "WorkflowCapabilityContractError";
+    this.diagnostics = diagnostics;
+  }
+}
+
+/** Generation failure that retains loading and token evidence for diagnosis. */
+export class ModelGenerationError extends Error {
+  readonly skillLoadingEvidence: ModelGenerationSkillLoadingEvidence;
+  readonly tokenUsage: ModelGenerationTokenUsage;
+
+  constructor(
+    message: string,
+    skillLoadingEvidence: ModelGenerationSkillLoadingEvidence,
+    tokenUsage: ModelGenerationTokenUsage,
+  ) {
+    super(message);
+    this.name = "ModelGenerationError";
+    this.skillLoadingEvidence = skillLoadingEvidence;
+    this.tokenUsage = tokenUsage;
+  }
+}
+
+/** Narrow an unknown failure to WorkflowError. */
 export function isWorkflowError(error: unknown): error is WorkflowError {
   return error instanceof WorkflowError;
 }
 
+/** Report whether an unknown failure is a provider usage-limit checkpoint condition. */
 export function isProviderUsageLimit(error: unknown): error is WorkflowError {
   return isWorkflowError(error) && error.code === WorkflowErrorCode.PROVIDER_USAGE_LIMIT;
 }
@@ -85,11 +142,13 @@ export function classifyProviderLimit(text: string | undefined): { matched: bool
   return { matched: true, resetHint: reset?.[0]?.trim() };
 }
 
+/** Recognize abort-like Error messages without assuming a provider-specific class. */
 export function isAbortError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   return /\babort(?:ed)?\b/i.test(error.message);
 }
 
+/** Recognize timeout-like errors by name or message. */
 export function isTimeoutError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   return /\btimeout\b/i.test(error.message) || error.name === "TimeoutError";

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,31 @@ export type {
   WorkflowRunResult,
 } from "./workflow.js";
 export { parseWorkflowScript, runWorkflow } from "./workflow.js";
+export type {
+  AlignmentEvidence,
+  CapabilityDescriptor,
+  CapabilityDiagnostic,
+  DynamicReferenceDescriptor,
+  OptionDescriptor,
+  OptionShape,
+  PresentAtVersion,
+  RuntimeBindingAssembly,
+  StaticCapabilityFact,
+  WorkflowCapabilityContract,
+  WorkflowCapabilityDefinition,
+  WorkflowRuntimeImplementations,
+} from "./workflow-capability-contract.js";
+export {
+  CapabilityClassification,
+  CapabilityOrigin,
+  CapabilitySupport,
+  DiagnosticSeverity,
+  DiscoveryPlacement,
+  defineWorkflowCapabilityContract,
+  WORKFLOW_CAPABILITY_CONTRACT,
+  WORKFLOW_CAPABILITY_DEFINITION,
+  WorkflowCapabilityContractError,
+} from "./workflow-capability-contract.js";
 export { registerWorkflowCommands } from "./workflow-commands.js";
 export type {
   WorkflowControlInput,

--- a/src/structured-output.ts
+++ b/src/structured-output.ts
@@ -1,4 +1,4 @@
-import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { defineTool } from "@earendil-works/pi-coding-agent";
 import type { Static, TSchema } from "typebox";
 
 export interface StructuredOutputCapture<T = unknown> {
@@ -23,7 +23,7 @@ export function createStructuredOutputTool<TSchemaDef extends TSchema>({
   schema,
   capture,
   name = "structured_output",
-}: StructuredOutputToolOptions<TSchemaDef>): ToolDefinition<TSchemaDef, Static<TSchemaDef>> {
+}: StructuredOutputToolOptions<TSchemaDef>): ReturnType<typeof defineTool<TSchemaDef, Static<TSchemaDef>>> {
   return defineTool({
     name,
     label: "Structured Output",

--- a/src/workflow-authoring-coverage.ts
+++ b/src/workflow-authoring-coverage.ts
@@ -33,7 +33,7 @@ export const WORKFLOW_COMPREHENSION_SCENARIO_IDS = COMPREHENSION_SCENARIOS.map((
 export const WORKFLOW_AUTHORING_FROZEN_FILES = [
   {
     path: "skills/workflow-authoring/SKILL.md",
-    sha256: "0bb3989248403a5103a88079cc42c86ac9f7e57b75d2958eb5e3f37b03c6ebd8",
+    sha256: "06c4ab576c56c5e90a4d2e0e0375f38967fbecd5ad7452083024dd5a8eebb8a3",
   },
   {
     path: "skills/workflow-authoring/references/runtime.md",
@@ -49,7 +49,7 @@ export const WORKFLOW_AUTHORING_FROZEN_FILES = [
   },
   {
     path: "skills/workflow-authoring/references/lifecycle.md",
-    sha256: "4fdb7cabcace254aebe3ae74f82cb7a4622edd6e15c56cc05915f80f52ccdc0d",
+    sha256: "e2f187a7b633beef0ca257e6782f72a140fc06b37a58aac423432d36d1dc19ee",
   },
   {
     path: "skills/workflow-authoring/references/pattern-selection.md",

--- a/src/workflow-authoring-coverage.ts
+++ b/src/workflow-authoring-coverage.ts
@@ -29,7 +29,7 @@ export interface WorkflowAuthoringCoverageEntry {
 /** Scenario identifiers that release checks may accept as provider-backed evidence. */
 export const WORKFLOW_COMPREHENSION_SCENARIO_IDS = COMPREHENSION_SCENARIOS.map(({ id }) => id);
 
-/** Complete mixed guidance files that remain immutable inside autoresearch. */
+/** Mixed guidance files that require explicit acceptance while behavioral coverage remains partial. */
 export const WORKFLOW_AUTHORING_FROZEN_FILES = [
   {
     path: "skills/workflow-authoring/SKILL.md",

--- a/src/workflow-authoring-coverage.ts
+++ b/src/workflow-authoring-coverage.ts
@@ -1,0 +1,486 @@
+import {
+  CapabilityClassification,
+  CapabilitySupport,
+  DiscoveryPlacement,
+  WorkflowAuthoringProtection,
+} from "./enums.js";
+import { WORKFLOW_CAPABILITY_DEFINITION } from "./workflow-capability-contract.js";
+import { COMPREHENSION_SCENARIOS } from "./workflow-comprehension.js";
+
+/** Exact installed guidance location retained for an authoring surface without model evidence. */
+export interface ProtectedGuidanceSurface {
+  path: string;
+  anchor?: string;
+  requiredText?: string;
+}
+
+/** Evidence and optimization policy for one stable workflow authoring surface. */
+export interface WorkflowAuthoringCoverageEntry {
+  id: string;
+  kind: string;
+  reference: { path: string; anchor?: string };
+  example?: string;
+  behaviorEvidence: readonly string[];
+  comprehensionScenarios: readonly string[];
+  protection: WorkflowAuthoringProtection;
+  protectedGuidance: readonly ProtectedGuidanceSurface[];
+}
+
+/** Scenario identifiers that release checks may accept as provider-backed evidence. */
+export const WORKFLOW_COMPREHENSION_SCENARIO_IDS = COMPREHENSION_SCENARIOS.map(({ id }) => id);
+
+/** Complete mixed guidance files that remain immutable inside autoresearch. */
+export const WORKFLOW_AUTHORING_FROZEN_FILES = [
+  {
+    path: "skills/workflow-authoring/SKILL.md",
+    sha256: "0bb3989248403a5103a88079cc42c86ac9f7e57b75d2958eb5e3f37b03c6ebd8",
+  },
+  {
+    path: "skills/workflow-authoring/references/runtime.md",
+    sha256: "14f1c4496c523d2e37316a7c96041a22630a65d342d08fdd77aeca2d325e22a3",
+  },
+  {
+    path: "skills/workflow-authoring/references/helpers.md",
+    sha256: "1c8d253649f00412511f17ffc08c6156797b99de72ae037e14f2ea92ac33a11e",
+  },
+  {
+    path: "skills/workflow-authoring/references/specialized-helpers.md",
+    sha256: "7597c94bbacea885697fb2d05a96ed9ec39403ca6d3a94547bf8ce5e233b2c76",
+  },
+  {
+    path: "skills/workflow-authoring/references/lifecycle.md",
+    sha256: "4fdb7cabcace254aebe3ae74f82cb7a4622edd6e15c56cc05915f80f52ccdc0d",
+  },
+  {
+    path: "skills/workflow-authoring/references/pattern-selection.md",
+    sha256: "923988a1b4d506a7b330bf5e4b8ab47cf8456edcfe6674b5d8d8848264633c3d",
+  },
+  {
+    path: "skills/workflow-authoring/references/focused-recipes.md",
+    sha256: "30906054232f67029e31f71b3b093f9949f6de9116e4381f433009c401f2c5c7",
+  },
+  {
+    path: "skills/workflow-authoring/references/registry-ownership.md",
+    sha256: "daf324448be16732c6796fd6359d1b1b842fa550ed616a6154f556d6ec1ef0b9",
+  },
+  {
+    path: "skills/workflow-authoring/references/review.md",
+    sha256: "2bd97acb87a8f6e9514892cdf5c431305b3d8952ba9761c1c203c217b08c9e7d",
+  },
+  {
+    path: "skills/workflow-authoring/references/debugging.md",
+    sha256: "2938e635f5856f2934e42c9cc3b7035a66d53176f4ab2beadfeabb9abf42e6cc",
+  },
+  {
+    path: "skills/workflow-authoring/examples/classify-and-act.js",
+    sha256: "23d0d9f37ee8648cd29ca526b0b23cf55bd3ac57efd02e1b93e227bcd0c18603",
+  },
+  {
+    path: "skills/workflow-authoring/examples/tournament.js",
+    sha256: "3a90bd3055c5e38e13fd8d7447173fc2e6a141fbc33b9bcc8a84723b7ab9d2e6",
+  },
+  {
+    path: "skills/workflow-authoring/examples/validated-gate.js",
+    sha256: "1cb4b3941ae61ebd1e12ada899f7d04678fe858a307c7fabc408603a4b9ba889",
+  },
+] as const;
+
+const RUNTIME_PATH = "skills/workflow-authoring/references/runtime.md";
+const SPECIALIZED_HELPERS_PATH = "skills/workflow-authoring/references/specialized-helpers.md";
+const LIFECYCLE_PATH = "skills/workflow-authoring/references/lifecycle.md";
+const PATTERN_PATH = "skills/workflow-authoring/references/pattern-selection.md";
+const RECIPE_PATH = "skills/workflow-authoring/references/focused-recipes.md";
+const SKILL_PATH = "skills/workflow-authoring/SKILL.md";
+const WRITE_EDIT_ROUTE: ProtectedGuidanceSurface = {
+  path: SKILL_PATH,
+  requiredText:
+    "- **Write or edit:** start with [runtime](references/runtime.md). Add [pattern selection](references/pattern-selection.md) for topology, [lifecycle](references/lifecycle.md) for limits or resume, and [focused recipes](references/focused-recipes.md) for the matching concern.",
+};
+const HELPER_ROUTE: ProtectedGuidanceSurface = {
+  path: SKILL_PATH,
+  requiredText:
+    "- **Helper task:** read [quality helpers](references/quality-helpers.md) only for `verify` or `judgePanel`, the [retry helper](references/retry-helper.md) only for `retry`, and [specialized helpers](references/specialized-helpers.md) only for `completenessCheck`, `loopUntilDry`, `gate`, or `checkpoint`.",
+};
+const ROUTING_ROUTE: ProtectedGuidanceSurface = {
+  path: SKILL_PATH,
+  requiredText:
+    "- **Routing:** read [registry ownership](references/registry-ownership.md) before using `model`, `tier`, phase models, or `agentType`; use environment-specific names only when context supplies them.",
+};
+
+const CAPABILITY_SCENARIOS: Readonly<Record<string, readonly string[]>> = {
+  "workflow.runtime.agent": WORKFLOW_COMPREHENSION_SCENARIO_IDS,
+  "workflow.runtime.parallel": [
+    "quick-write",
+    "full-write",
+    "coverage-fan-out-synthesize",
+    "coverage-generate-filter",
+    "coverage-judge-panel",
+  ],
+  "workflow.runtime.workflow": ["full-edit"],
+  "workflow.runtime.verify": ["full-review"],
+  "workflow.runtime.judgePanel": ["coverage-judge-panel"],
+  "workflow.runtime.retry": ["full-retry"],
+  "workflow.runtime.phase": ["full-edit"],
+  "workflow.script.metadata": WORKFLOW_COMPREHENSION_SCENARIO_IDS,
+  "workflow.script.return-value": WORKFLOW_COMPREHENSION_SCENARIO_IDS,
+};
+
+const FROZEN_GUIDANCE_BY_CAPABILITY: Readonly<Record<string, readonly ProtectedGuidanceSurface[]>> = {
+  "workflow.runtime.pipeline": [
+    {
+      path: RUNTIME_PATH,
+      requiredText:
+        "`pipeline()` runs stages sequentially per item while items proceed concurrently. Each stage receives `(previousValue, originalItem, index)` and forwards `null` to the next stage, so guard missing coverage first.",
+    },
+  ],
+  "workflow.runtime.loopUntilDry": [
+    {
+      path: SPECIALIZED_HELPERS_PATH,
+      requiredText:
+        "`loopUntilDry({ round, key, consecutiveEmpty, maxRounds })` | `round(index)` is zero-based. Defaults: `JSON.stringify` key, two dry rounds, 50 rounds. Null, non-array, and duplicate-only rounds are dry. Token-budget or agent-limit exhaustion returns the partial array without a termination reason; keep failed-round identity and stopping state outside the helper.",
+    },
+  ],
+  "workflow.runtime.completenessCheck": [
+    {
+      path: SPECIALIZED_HELPERS_PATH,
+      requiredText:
+        "`completenessCheck(args, results)` | Returns `{ complete, missing? }` or recoverable `null`. The critic sees only the first 4,000 serialized characters, so chunk or summarize larger evidence. Treat the verdict as advisory.",
+    },
+  ],
+  "workflow.runtime.gate": [
+    {
+      path: SPECIALIZED_HELPERS_PATH,
+      requiredText:
+        "`gate(thunk, validator, { attempts })` | Calls `thunk(feedback, attempt)` with initial `undefined` feedback and a zero-based attempt. `validator(value)` returns `{ ok, feedback? }`, synchronously or asynchronously; a bare boolean is not accepted. Three attempts by default. Returns `{ ok, value, attempts }`, including the last value on exhaustion.",
+    },
+  ],
+  "workflow.runtime.checkpoint": [
+    {
+      path: SPECIALIZED_HELPERS_PATH,
+      requiredText:
+        "`checkpoint(prompt, options?)` | Journals a human/default decision. Only foreground confirm and documented headless behavior work; input, select, and timeout are declared-only.",
+    },
+    {
+      path: LIFECYCLE_PATH,
+      requiredText:
+        "A workflow invocation is backgrounded by default, and background workflows are headless: they cannot display checkpoint confirmation.",
+    },
+  ],
+  "workflow.runtime.log": [
+    { path: SKILL_PATH, requiredText: "Use `log()` for new code; `console` is compatibility-only." },
+  ],
+  "workflow.runtime.args": [
+    {
+      path: RUNTIME_PATH,
+      requiredText:
+        "The runtime supplies `agent`, `parallel`, `pipeline`, `workflow`, quality/control helpers, `phase`, `log`, `args`, `cwd`, restricted `process.cwd()`, and `budget`.",
+    },
+  ],
+  "workflow.runtime.cwd": [
+    {
+      path: RUNTIME_PATH,
+      requiredText:
+        "The runtime supplies `agent`, `parallel`, `pipeline`, `workflow`, quality/control helpers, `phase`, `log`, `args`, `cwd`, restricted `process.cwd()`, and `budget`.",
+    },
+  ],
+  "workflow.runtime.process": [
+    {
+      path: RUNTIME_PATH,
+      requiredText:
+        "The runtime supplies `agent`, `parallel`, `pipeline`, `workflow`, quality/control helpers, `phase`, `log`, `args`, `cwd`, restricted `process.cwd()`, and `budget`.",
+    },
+  ],
+  "workflow.runtime.budget": [
+    {
+      path: LIFECYCLE_PATH,
+      requiredText:
+        "Token and phase budgets are soft pre-call gates. Spend lands after agents finish, so concurrent work can overshoot.",
+    },
+  ],
+  "workflow.runtime.console": [
+    { path: SKILL_PATH, requiredText: "Use `log()` for new code; `console` is compatibility-only." },
+  ],
+  "workflow.tool-input.script": [{ path: RUNTIME_PATH, anchor: "script-envelope" }],
+  "workflow.tool-input.args": [
+    {
+      path: LIFECYCLE_PATH,
+      requiredText: "Pass timestamps, randomness, and external decisions through `args`.",
+    },
+  ],
+  "workflow.tool-input.background": [
+    {
+      path: LIFECYCLE_PATH,
+      requiredText:
+        "A workflow invocation is backgrounded by default, and background workflows are headless: they cannot display checkpoint confirmation.",
+    },
+  ],
+  "workflow.tool-input.maxAgents": [
+    {
+      path: LIFECYCLE_PATH,
+      requiredText:
+        "Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script.",
+    },
+  ],
+  "workflow.tool-input.concurrency": [
+    {
+      path: LIFECYCLE_PATH,
+      requiredText:
+        "Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script.",
+    },
+  ],
+  "workflow.tool-input.agentRetries": [
+    {
+      path: LIFECYCLE_PATH,
+      requiredText:
+        "Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script.",
+    },
+  ],
+  "workflow.tool-input.agentTimeoutMs": [
+    {
+      path: LIFECYCLE_PATH,
+      requiredText:
+        "Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script.",
+    },
+  ],
+  "workflow.tool-input.tokenBudget": [
+    {
+      path: LIFECYCLE_PATH,
+      requiredText:
+        "Token and phase budgets are soft pre-call gates. Spend lands after agents finish, so concurrent work can overshoot.",
+    },
+  ],
+  "workflow.tool-input.resumeFromRunId": [
+    {
+      path: LIFECYCLE_PATH,
+      requiredText:
+        "Resume replays only the longest unchanged prefix of journaled calls. Once one call is new, changed, or unusable, that call and all later calls execute live.",
+    },
+  ],
+  "workflow.script.determinism": [
+    {
+      path: SKILL_PATH,
+      requiredText:
+        "Write plain JavaScript without imports or filesystem modules. Pass nondeterminism through `args`; `Date.now()`, `Math.random()`, and no-argument `new Date()` are unavailable.",
+    },
+  ],
+  "workflow.compat.markdown-fences": [
+    {
+      path: RUNTIME_PATH,
+      requiredText:
+        "Generated entries marked `supported` are authoring API. `console` and whole-script Markdown fences are compatibility-only.",
+    },
+  ],
+  "workflow.dynamic.model-routes": [
+    {
+      path: RUNTIME_PATH,
+      requiredText:
+        "Use exact `model`, nonstandard `tier`, or `agentType` only when context supplies its name and purpose.",
+    },
+  ],
+  "workflow.dynamic.agent-types": [
+    {
+      path: RUNTIME_PATH,
+      requiredText:
+        "Use exact `model`, nonstandard `tier`, or `agentType` only when context supplies its name and purpose.",
+    },
+  ],
+};
+
+/** Stable orchestration-pattern identifiers covered by the authoring inventory. */
+export const WORKFLOW_AUTHORING_PATTERN_IDS = [
+  "workflow.pattern.classify-and-act",
+  "workflow.pattern.fan-out-and-synthesize",
+  "workflow.pattern.adversarial-verification",
+  "workflow.pattern.generate-and-filter",
+  "workflow.pattern.tournament",
+  "workflow.pattern.loop-until-done",
+] as const;
+
+/** Stable focused-recipe identifiers covered by the authoring inventory. */
+export const WORKFLOW_AUTHORING_RECIPE_IDS = [
+  "workflow.recipe.phased-budgets",
+  "workflow.recipe.saved-nested-workflows",
+  "workflow.recipe.bounded-semantic-retry",
+  "workflow.recipe.validator-feedback",
+  "workflow.recipe.structured-output",
+] as const;
+
+const PATTERN_COVERAGE: readonly WorkflowAuthoringCoverageEntry[] = [
+  {
+    id: "workflow.pattern.classify-and-act",
+    kind: "pattern",
+    reference: { path: PATTERN_PATH },
+    example: "skills/workflow-authoring/examples/classify-and-act.js",
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts"],
+    comprehensionScenarios: [],
+    protection: WorkflowAuthoringProtection.GUIDANCE_FROZEN,
+    protectedGuidance: [
+      WRITE_EDIT_ROUTE,
+      {
+        path: PATTERN_PATH,
+        requiredText:
+          "| Heterogeneous items need different handling | Classify and act | Finish all classification before routed action; ledger classification and action failures by item ID | [Adapt](../examples/classify-and-act.js) |",
+      },
+    ],
+  },
+  {
+    id: "workflow.pattern.fan-out-and-synthesize",
+    kind: "pattern",
+    reference: { path: PATTERN_PATH, anchor: "fan-out-and-synthesize" },
+    example: "skills/workflow-authoring/examples/fan-out-and-synthesize.js",
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts", "tests/workflow-comprehension.test.ts"],
+    comprehensionScenarios: ["coverage-fan-out-synthesize"],
+    protection: WorkflowAuthoringProtection.BEHAVIORALLY_COVERED,
+    protectedGuidance: [],
+  },
+  {
+    id: "workflow.pattern.adversarial-verification",
+    kind: "pattern",
+    reference: { path: PATTERN_PATH },
+    example: "skills/workflow-authoring/examples/adversarial-verification.js",
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts", "tests/workflow-comprehension.test.ts"],
+    comprehensionScenarios: ["full-review"],
+    protection: WorkflowAuthoringProtection.BEHAVIORALLY_COVERED,
+    protectedGuidance: [],
+  },
+  {
+    id: "workflow.pattern.generate-and-filter",
+    kind: "pattern",
+    reference: { path: PATTERN_PATH },
+    example: "skills/workflow-authoring/examples/generate-and-filter.js",
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts", "tests/workflow-comprehension.test.ts"],
+    comprehensionScenarios: ["coverage-generate-filter"],
+    protection: WorkflowAuthoringProtection.BEHAVIORALLY_COVERED,
+    protectedGuidance: [],
+  },
+  {
+    id: "workflow.pattern.tournament",
+    kind: "pattern",
+    reference: { path: PATTERN_PATH },
+    example: "skills/workflow-authoring/examples/tournament.js",
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts"],
+    comprehensionScenarios: [],
+    protection: WorkflowAuthoringProtection.GUIDANCE_FROZEN,
+    protectedGuidance: [
+      WRITE_EDIT_ROUTE,
+      {
+        path: PATTERN_PATH,
+        requiredText:
+          "| Pairwise comparison beats absolute scoring | Tournament | Let JavaScript run the bounded bracket and byes; agents compare one pair; ledger match failures | [Adapt](../examples/tournament.js) |",
+      },
+    ],
+  },
+  {
+    id: "workflow.pattern.loop-until-done",
+    kind: "pattern",
+    reference: { path: PATTERN_PATH },
+    example: "skills/workflow-authoring/examples/loop-until-done.js",
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts", "tests/workflow-comprehension.test.ts"],
+    comprehensionScenarios: ["full-loop"],
+    protection: WorkflowAuthoringProtection.BEHAVIORALLY_COVERED,
+    protectedGuidance: [],
+  },
+];
+
+const RECIPE_COVERAGE: readonly WorkflowAuthoringCoverageEntry[] = [
+  {
+    id: "workflow.recipe.phased-budgets",
+    kind: "recipe",
+    reference: { path: RECIPE_PATH },
+    example: "skills/workflow-authoring/examples/phased-budgets.js",
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts", "tests/workflow-comprehension.test.ts"],
+    comprehensionScenarios: ["full-edit"],
+    protection: WorkflowAuthoringProtection.BEHAVIORALLY_COVERED,
+    protectedGuidance: [],
+  },
+  {
+    id: "workflow.recipe.saved-nested-workflows",
+    kind: "recipe",
+    reference: { path: RECIPE_PATH },
+    example: "skills/workflow-authoring/examples/saved-nested-workflows.js",
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts", "tests/workflow-comprehension.test.ts"],
+    comprehensionScenarios: ["full-edit"],
+    protection: WorkflowAuthoringProtection.BEHAVIORALLY_COVERED,
+    protectedGuidance: [],
+  },
+  {
+    id: "workflow.recipe.bounded-semantic-retry",
+    kind: "recipe",
+    reference: { path: RECIPE_PATH },
+    example: "skills/workflow-authoring/examples/bounded-semantic-retry.js",
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts", "tests/workflow-comprehension.test.ts"],
+    comprehensionScenarios: ["full-retry"],
+    protection: WorkflowAuthoringProtection.BEHAVIORALLY_COVERED,
+    protectedGuidance: [],
+  },
+  {
+    id: "workflow.recipe.validator-feedback",
+    kind: "recipe",
+    reference: { path: RECIPE_PATH },
+    example: "skills/workflow-authoring/examples/validated-gate.js",
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts"],
+    comprehensionScenarios: [],
+    protection: WorkflowAuthoringProtection.GUIDANCE_FROZEN,
+    protectedGuidance: [
+      WRITE_EDIT_ROUTE,
+      {
+        path: RECIPE_PATH,
+        requiredText:
+          "| Validator feedback | Follow the exact `gate()` callbacks in [specialized helpers](specialized-helpers.md). Return the gate outcome and attempt ledger so feedback and exhaustion remain visible. | [Validated gate](../examples/validated-gate.js) |",
+      },
+    ],
+  },
+  {
+    id: "workflow.recipe.structured-output",
+    kind: "recipe",
+    reference: { path: RECIPE_PATH },
+    example: "skills/workflow-authoring/examples/structured-output.js",
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts", "tests/workflow-comprehension.test.ts"],
+    comprehensionScenarios: ["full-write", "full-debug", "full-loop", "full-retry"],
+    protection: WorkflowAuthoringProtection.BEHAVIORALLY_COVERED,
+    protectedGuidance: [],
+  },
+];
+
+const HELPER_CAPABILITY_IDS = new Set([
+  "workflow.runtime.verify",
+  "workflow.runtime.judgePanel",
+  "workflow.runtime.completenessCheck",
+  "workflow.runtime.loopUntilDry",
+  "workflow.runtime.retry",
+  "workflow.runtime.gate",
+  "workflow.runtime.checkpoint",
+]);
+
+const CONTRACT_COVERAGE: readonly WorkflowAuthoringCoverageEntry[] = WORKFLOW_CAPABILITY_DEFINITION.capabilities
+  .filter(({ discovery, support }) => discovery !== DiscoveryPlacement.NONE && support !== CapabilitySupport.INTERNAL)
+  .map((capability) => {
+    const comprehensionScenarios = CAPABILITY_SCENARIOS[capability.id] ?? [];
+    const frozenGuidance = FROZEN_GUIDANCE_BY_CAPABILITY[capability.id] ?? [];
+    const route =
+      capability.classification === CapabilityClassification.DYNAMIC_REFERENCE
+        ? ROUTING_ROUTE
+        : HELPER_CAPABILITY_IDS.has(capability.id)
+          ? HELPER_ROUTE
+          : WRITE_EDIT_ROUTE;
+    const protectedGuidance = comprehensionScenarios.length > 0 ? [] : [...frozenGuidance, route];
+    return {
+      id: capability.id,
+      kind: capability.classification,
+      reference: capability.staticReference ?? { path: "skills/workflow-authoring/references/capabilities.md" },
+      behaviorEvidence: capability.behaviorEvidence,
+      comprehensionScenarios,
+      protection:
+        comprehensionScenarios.length > 0
+          ? WorkflowAuthoringProtection.BEHAVIORALLY_COVERED
+          : WorkflowAuthoringProtection.GUIDANCE_FROZEN,
+      protectedGuidance,
+    };
+  });
+
+/** Complete release-gated inventory of behavioral coverage and frozen authoring guidance. */
+export const WORKFLOW_AUTHORING_COVERAGE: readonly WorkflowAuthoringCoverageEntry[] = [
+  ...CONTRACT_COVERAGE,
+  ...PATTERN_COVERAGE,
+  ...RECIPE_COVERAGE,
+];

--- a/src/workflow-authoring-reference.ts
+++ b/src/workflow-authoring-reference.ts
@@ -1,0 +1,186 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  CapabilityClassification,
+  CapabilitySupport,
+  type OptionDescriptor,
+  type StaticCapabilityFact,
+  WORKFLOW_CAPABILITY_CONTRACT,
+} from "./workflow-capability-contract.js";
+
+const GENERATED_MARKER = "<!-- GENERATED from WORKFLOW_CAPABILITY_CONTRACT; do not edit by hand. -->";
+const TABLE_START = "<!-- BEGIN GENERATED SUPPORTED WORKFLOW CAPABILITIES -->";
+const TABLE_END = "<!-- END GENERATED SUPPORTED WORKFLOW CAPABILITIES -->";
+
+/** Package-relative compact capability index generated from the contract. */
+export const CAPABILITY_INDEX_PATH = "skills/workflow-authoring/references/capabilities.md";
+
+/** Package-relative exhaustive generated capability reference. */
+export const CAPABILITY_DETAIL_PATH = "skills/workflow-authoring/references/capability-details.md";
+
+/** Documents that embed the byte-identical supported-capability table. */
+export const CAPABILITY_TABLE_PUBLICATION_PATHS = [
+  CAPABILITY_INDEX_PATH,
+  "README.md",
+  "docs/workflow-authoring.md",
+] as const;
+/** All generated capability publication surfaces checked for drift. */
+export const CAPABILITY_PUBLICATION_PATHS = [...CAPABILITY_TABLE_PUBLICATION_PATHS, CAPABILITY_DETAIL_PATH] as const;
+
+function escapeTable(value: string): string {
+  return value.replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function display(value: string | null): string {
+  return value === null ? "—" : `\`${escapeTable(value)}\``;
+}
+
+function optionText(option: OptionDescriptor): string {
+  const required = option.optional ? "optional" : "required";
+  const defaultValue = option.default === null ? "" : `; default: ${option.default}`;
+  const constraints = option.constraints.length === 0 ? "" : `; ${option.constraints.join("; ")}`;
+  const dynamic = option.dynamicReference === null ? "" : `; dynamic reference: ${option.dynamicReference}`;
+  return `- \`${option.name}\`: ${option.type} (${required}${defaultValue}${constraints}${dynamic})`;
+}
+
+function compactOptions(fact: StaticCapabilityFact): string {
+  if (!fact.options) return "—";
+  return fact.options.options
+    .map((option) => {
+      const optionality = option.optional ? "optional" : "required";
+      const defaultValue = option.default === null ? "" : `; default: ${option.default}`;
+      return `\`${escapeTable(option.name)}\`: ${escapeTable(option.type)} (${optionality}${escapeTable(defaultValue)})`;
+    })
+    .join("<br>");
+}
+
+function publishedFacts(): readonly StaticCapabilityFact[] {
+  return WORKFLOW_CAPABILITY_CONTRACT.projectStaticReferenceFacts().filter(
+    (fact) =>
+      fact.support === CapabilitySupport.SUPPORTED &&
+      (fact.classification === CapabilityClassification.RUNTIME_GLOBAL ||
+        fact.classification === CapabilityClassification.WORKFLOW_TOOL_INPUT),
+  );
+}
+
+/** The byte-identical generated block embedded in every public documentation surface. */
+export function renderSupportedCapabilityTable(): string {
+  const rows = publishedFacts().map(
+    (fact) =>
+      `| ${escapeTable(fact.label)} | ${fact.classification} | ${display(fact.signature)} | ${compactOptions(fact)} |`,
+  );
+  return `${TABLE_START}
+| Name | Classification | Signature | Options and defaults |
+| --- | --- | --- | --- |
+${rows.join("\n")}
+${TABLE_END}`;
+}
+
+function replaceSupportedCapabilityTable(document: string): string | null {
+  const start = document.indexOf(TABLE_START);
+  const end = document.indexOf(TABLE_END, start + TABLE_START.length);
+  if (start < 0 || end < 0 || document.indexOf(TABLE_START, start + TABLE_START.length) >= 0) return null;
+  const after = end + TABLE_END.length;
+  return `${document.slice(0, start)}${renderSupportedCapabilityTable()}${document.slice(after)}`;
+}
+
+/** Regenerates only contract-owned content, preserving hand-written prose around marked blocks. */
+export function writeWorkflowCapabilityPublications(root: string): void {
+  for (const path of CAPABILITY_TABLE_PUBLICATION_PATHS) {
+    const absolutePath = join(root, path);
+    if (path === CAPABILITY_INDEX_PATH) {
+      writeFileSync(absolutePath, renderWorkflowCapabilityReference());
+      continue;
+    }
+    const source = readFileSync(absolutePath, "utf8");
+    const refreshed = replaceSupportedCapabilityTable(source);
+    if (refreshed === null) throw new Error(`Missing or duplicate generated capability-table anchors in ${path}.`);
+    writeFileSync(absolutePath, refreshed);
+  }
+  writeFileSync(join(root, CAPABILITY_DETAIL_PATH), renderWorkflowCapabilityDetails());
+}
+
+/** Returns every stale surface in stable publication order. Overrides are useful to CI callers and tests. */
+export function checkWorkflowCapabilityPublications(
+  root: string,
+  overrides: Readonly<Partial<Record<(typeof CAPABILITY_PUBLICATION_PATHS)[number], string>>> = {},
+): string[] {
+  const stale: string[] = [];
+  for (const path of CAPABILITY_TABLE_PUBLICATION_PATHS) {
+    const actual = overrides[path] ?? readFileSync(join(root, path), "utf8");
+    if (path === CAPABILITY_INDEX_PATH) {
+      if (actual !== renderWorkflowCapabilityReference()) stale.push(path);
+      continue;
+    }
+    const refreshed = replaceSupportedCapabilityTable(actual);
+    if (refreshed === null || refreshed !== actual) stale.push(path);
+  }
+  const details = overrides[CAPABILITY_DETAIL_PATH] ?? readFileSync(join(root, CAPABILITY_DETAIL_PATH), "utf8");
+  if (details !== renderWorkflowCapabilityDetails()) stale.push(CAPABILITY_DETAIL_PATH);
+  return stale;
+}
+
+function anchorFor(fact: StaticCapabilityFact): string {
+  const anchor = fact.reference?.split("#")[1];
+  if (!anchor) throw new Error(`Static capability fact ${fact.id} has no reference anchor.`);
+  return anchor;
+}
+
+function detail(fact: StaticCapabilityFact): string {
+  const lines = [
+    `<a id="${anchorFor(fact)}"></a>`,
+    `## ${fact.label}`,
+    "",
+    `- Classification: \`${fact.classification}\``,
+    `- Support: \`${fact.support}\``,
+    `- Signature: ${display(fact.signature)}`,
+  ];
+  if (fact.options) {
+    lines.push(`- Option shape: \`${fact.options.id}\``, ...fact.options.options.map(optionText));
+  }
+  if (fact.constraints.length > 0) lines.push(...fact.constraints.map((constraint) => `- Constraint: ${constraint}`));
+  if (fact.dynamicReference) {
+    lines.push(
+      `- Dynamic reference owner: \`${fact.dynamicReference.owner}\``,
+      `- Item shape: \`${fact.dynamicReference.itemShape}\``,
+      `- Future lookup connection: \`${fact.dynamicReference.connection}\``,
+      "- Live values are intentionally absent from this static reference.",
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+/** Compact generated entrypoint for ordinary exact-name and signature lookup. */
+/** Render the compact index that routes exact lookups to exhaustive details. */
+export function renderWorkflowCapabilityReference(): string {
+  const { definition } = WORKFLOW_CAPABILITY_CONTRACT;
+  return `${GENERATED_MARKER}
+# Workflow capability index
+
+Contract format: \`${definition.versions.format.version}\`<br>
+Contract content / skill / extension: \`${definition.versions.content.version}\`
+
+This compact generated index covers supported runtime globals and workflow-tool inputs. For constraints, compatibility behavior, internal boundaries, and dynamic-reference ownership, follow the [exhaustive generated facts](capability-details.md).
+
+## Supported capability index
+
+${renderSupportedCapabilityTable()}
+`;
+}
+
+/** Exhaustive generated fact projection and stable anchor owner. */
+/** Render exhaustive static facts while leaving live catalogues as dynamic references. */
+export function renderWorkflowCapabilityDetails(): string {
+  const { definition } = WORKFLOW_CAPABILITY_CONTRACT;
+  const facts = WORKFLOW_CAPABILITY_CONTRACT.projectStaticReferenceFacts();
+
+  return `${GENERATED_MARKER}
+# Exhaustive workflow capability facts
+
+Contract format: \`${definition.versions.format.version}\`<br>
+Contract content / skill / extension: \`${definition.versions.content.version}\`
+
+Every exact fact below is projected from the installed extension's capability contract. Explanatory judgment belongs in the hand-written references next to this file.
+
+${facts.map(detail).join("\n")}`;
+}

--- a/src/workflow-capability-contract.ts
+++ b/src/workflow-capability-contract.ts
@@ -1,0 +1,800 @@
+import packageJson from "../package.json" with { type: "json" };
+import {
+  CapabilityClassification,
+  CapabilityOrigin,
+  CapabilitySupport,
+  DiagnosticSeverity,
+  DiscoveryPlacement,
+} from "./enums.js";
+import { WorkflowCapabilityContractError } from "./errors.js";
+
+/** Re-exported capability domains used by contract consumers. */
+export {
+  CapabilityClassification,
+  CapabilityOrigin,
+  CapabilitySupport,
+  DiagnosticSeverity,
+  DiscoveryPlacement,
+} from "./enums.js";
+
+/** Version marker for behavior present at or after a release. */
+export interface PresentAtVersion {
+  kind: "present-at";
+  version: string;
+}
+
+/** One named option and the facts safe to publish about it. */
+export interface OptionDescriptor {
+  name: string;
+  type: string;
+  optional: boolean;
+  default: string | null;
+  constraints: readonly string[];
+  dynamicReference: "model-routes" | "agent-types" | null;
+}
+
+/** Reusable option group referenced by capability descriptors. */
+export interface OptionShape {
+  id:
+    | "agent-options"
+    | "checkpoint-options"
+    | "phase-options"
+    | "verify-options"
+    | "judge-panel-options"
+    | "loop-until-dry-options"
+    | "retry-options"
+    | "gate-options";
+  options: readonly OptionDescriptor[];
+}
+
+/** Authoritative declaration of one workflow capability and its evidence. */
+export interface CapabilityDescriptor {
+  id: `workflow.${string}`;
+  label: string;
+  classification: CapabilityClassification;
+  support: CapabilitySupport;
+  discovery: DiscoveryPlacement;
+  origin: CapabilityOrigin;
+  lifecycle: PresentAtVersion;
+  signature: string | null;
+  optionShape: OptionShape["id"] | null;
+  constraints: readonly string[];
+  enforcementOwner: string;
+  runtimeBinding: { global: string; implementation: string; allowsUndefined?: true } | null;
+  behaviorEvidence: readonly string[];
+  staticReference: { path: string; anchor: string } | null;
+  dynamicReference: "model-routes" | "agent-types" | null;
+}
+
+/** Ownership and item shape for a live catalogue that static docs must not embed. */
+export interface DynamicReferenceDescriptor {
+  id: "model-routes" | "agent-types";
+  owner: "model-tier-config" | "agent-registry";
+  itemShape: string;
+  connection: string;
+  items?: never;
+}
+
+/** Versioned plain-data source for runtime assembly and generated documentation. */
+export interface WorkflowCapabilityDefinition {
+  versions: {
+    extension: string;
+    format: PresentAtVersion;
+    content: PresentAtVersion;
+  };
+  optionShapes: readonly OptionShape[];
+  capabilities: readonly CapabilityDescriptor[];
+  dynamicReferences: readonly DynamicReferenceDescriptor[];
+}
+
+/** Machine-readable disagreement between the contract and an observed surface. */
+export interface CapabilityDiagnostic {
+  code:
+    | "MISSING_RUNTIME_IMPLEMENTATION"
+    | "UNDECLARED_RUNTIME_IMPLEMENTATION"
+    | "DECLARED_GLOBAL_UNOBSERVED"
+    | "OBSERVED_GLOBAL_UNDECLARED"
+    | "INVALID_CAPABILITY_DEFINITION";
+  severity: DiagnosticSeverity;
+  subject: string;
+  message: string;
+}
+
+/** Re-exported contract failure type retained for existing consumers. */
+export { WorkflowCapabilityContractError } from "./errors.js";
+
+/** Runtime globals assembled from declared implementations plus non-fatal diagnostics. */
+export interface RuntimeBindingAssembly {
+  globals: Readonly<Record<string, unknown>>;
+  diagnostics: readonly CapabilityDiagnostic[];
+}
+
+/** Project-owned implementations required to assemble the workflow VM context. */
+export interface WorkflowRuntimeImplementations {
+  agent: unknown;
+  parallel: unknown;
+  pipeline: unknown;
+  workflow: unknown;
+  verify: unknown;
+  judgePanel: unknown;
+  loopUntilDry: unknown;
+  completenessCheck: unknown;
+  retry: unknown;
+  gate: unknown;
+  checkpoint: unknown;
+  log: unknown;
+  phase: unknown;
+  args: unknown;
+  cwd: unknown;
+  process: unknown;
+  budget: unknown;
+  console: unknown;
+}
+
+/** Exact static projection of one capability for generated references. */
+export interface StaticCapabilityFact {
+  id: string;
+  label: string;
+  classification: CapabilityClassification;
+  support: CapabilitySupport;
+  signature: string | null;
+  options: OptionShape | null;
+  constraints: readonly string[];
+  reference: string | null;
+  dynamicReference: DynamicReferenceDescriptor | null;
+}
+
+/** Runtime implementations or observed globals used for drift diagnostics. */
+export interface AlignmentEvidence {
+  suppliedImplementations?: Readonly<Record<string, unknown>>;
+  observedProjectGlobals?: readonly string[];
+}
+
+/** Validated capability contract with runtime, publication, and alignment projections. */
+export interface WorkflowCapabilityContract {
+  readonly definition: WorkflowCapabilityDefinition;
+  assembleRuntimeBindings(implementations: Readonly<Record<string, unknown>>): RuntimeBindingAssembly;
+  projectStaticReferenceFacts(): readonly StaticCapabilityFact[];
+  diagnoseAlignment(evidence: AlignmentEvidence): readonly CapabilityDiagnostic[];
+}
+
+const REFERENCE_PATH = "skills/workflow-authoring/references/capability-details.md";
+const PRESENT_AT: PresentAtVersion = { kind: "present-at", version: packageJson.version };
+const noOptions = [] as const;
+
+const option = (
+  name: string,
+  type: string,
+  optional: boolean,
+  defaultValue: string | null = null,
+  constraints: readonly string[] = noOptions,
+  dynamicReference: OptionDescriptor["dynamicReference"] = null,
+): OptionDescriptor => ({ name, type, optional, default: defaultValue, constraints, dynamicReference });
+
+const AGENT_OPTIONS: OptionShape = {
+  id: "agent-options",
+  options: [
+    option("label", "string", true, "derived from phase and call count"),
+    option("phase", "string", true, "current phase"),
+    option("schema", "plain JSON Schema", true),
+    option("model", "string", true, null, ["highest-priority exact model selector"]),
+    option("tier", "string", true, null, ["configured route name"], "model-routes"),
+    option("isolation", '"worktree"', true),
+    option("agentType", "string", true, null, ["must come from provided context"], "agent-types"),
+    option("timeoutMs", "number | null", true, "run timeout; null disables"),
+    option("retries", "number", true, "run retry count", ["finite values are floored and clamped to 0..3"]),
+  ],
+};
+const CHECKPOINT_OPTIONS: OptionShape = {
+  id: "checkpoint-options",
+  options: [
+    option("default", "unknown", true, "true when no UI and omitted"),
+    option("headless", '"default" | "abort"', true, '"default"'),
+    option("kind", '"confirm" | "input" | "select"', true, '"confirm"'),
+    option("choices", "string[]", true),
+    option("timeoutMs", "number", true),
+  ],
+};
+const PHASE_OPTIONS: OptionShape = {
+  id: "phase-options",
+  options: [option("budget", "number", true, null, ["positive soft pre-call token gate"])],
+};
+const VERIFY_OPTIONS: OptionShape = {
+  id: "verify-options",
+  options: [
+    option("reviewers", "number", true, "2", ["authors should provide a finite integer; runtime clamps below 1"]),
+    option("threshold", "number", true, "0.5"),
+    option("lens", "string | string[]", true),
+  ],
+};
+const JUDGE_PANEL_OPTIONS: OptionShape = {
+  id: "judge-panel-options",
+  options: [
+    option("judges", "number", true, "3", ["authors should provide a finite integer; runtime clamps below 1"]),
+    option("rubric", "string", true, '"overall quality and correctness"'),
+  ],
+};
+const LOOP_UNTIL_DRY_OPTIONS: OptionShape = {
+  id: "loop-until-dry-options",
+  options: [
+    option("round", "(roundIndex: number) => unknown[] | Promise<unknown[]>", false),
+    option("key", "(item: unknown) => string", true, "JSON.stringify"),
+    option("consecutiveEmpty", "number", true, "2", [
+      "authors should provide a finite integer; runtime clamps below 1",
+    ]),
+    option("maxRounds", "number", true, "50", ["authors should provide a finite positive integer"]),
+  ],
+};
+const RETRY_OPTIONS: OptionShape = {
+  id: "retry-options",
+  options: [
+    option("attempts", "number", true, "3", [
+      "authors must provide a finite integer; runtime clamps values below 1 to 1",
+    ]),
+    option("until", "(result: unknown) => boolean", true, "accept first result when omitted", [
+      "must be synchronous; use gate for asynchronous validation",
+    ]),
+  ],
+};
+const GATE_OPTIONS: OptionShape = {
+  id: "gate-options",
+  options: [
+    option("attempts", "number", true, "3", [
+      "authors must provide a finite integer; runtime clamps values below 1 to 1",
+    ]),
+  ],
+};
+
+interface RuntimeDescriptorOptions {
+  signature?: string;
+  discovery?: DiscoveryPlacement;
+  support?: CapabilitySupport;
+  optionShape?: OptionShape["id"];
+  constraints?: readonly string[];
+  evidence?: readonly string[];
+  allowsUndefined?: true;
+}
+
+const runtimeGlobal = (name: string, options: RuntimeDescriptorOptions = {}): CapabilityDescriptor => ({
+  id: `workflow.runtime.${name}`,
+  label: name,
+  classification: CapabilityClassification.RUNTIME_GLOBAL,
+  support: options.support ?? CapabilitySupport.SUPPORTED,
+  discovery: options.discovery ?? DiscoveryPlacement.COMPACT_GUIDANCE,
+  origin: CapabilityOrigin.PROJECT,
+  lifecycle: PRESENT_AT,
+  signature: options.signature ?? name,
+  optionShape: options.optionShape ?? null,
+  constraints: options.constraints ?? noOptions,
+  enforcementOwner: "runWorkflow context assembly",
+  runtimeBinding: {
+    global: name,
+    implementation: name,
+    ...(options.allowsUndefined ? { allowsUndefined: true as const } : {}),
+  },
+  behaviorEvidence: options.evidence ?? ["tests/workflow-runtime.test.ts"],
+  staticReference: { path: REFERENCE_PATH, anchor: name.toLowerCase() },
+  dynamicReference: null,
+});
+
+const toolInput = (
+  name: string,
+  signature: string,
+  constraints: readonly string[] = noOptions,
+): CapabilityDescriptor => ({
+  id: `workflow.tool-input.${name}`,
+  label: name,
+  classification: CapabilityClassification.WORKFLOW_TOOL_INPUT,
+  support: CapabilitySupport.SUPPORTED,
+  discovery: DiscoveryPlacement.COMPACT_GUIDANCE,
+  origin: CapabilityOrigin.TOOL_ADAPTER,
+  lifecycle: PRESENT_AT,
+  signature,
+  optionShape: null,
+  constraints,
+  enforcementOwner: "workflowToolSchema and createWorkflowTool",
+  runtimeBinding: null,
+  behaviorEvidence: ["tests/workflow-tool.test.ts"],
+  staticReference: { path: REFERENCE_PATH, anchor: `tool-input-${name.toLowerCase()}` },
+  dynamicReference: null,
+});
+
+const capabilities: readonly CapabilityDescriptor[] = [
+  runtimeGlobal("agent", {
+    signature: "agent(prompt, options?) => Promise<string | structured value | null>",
+    optionShape: "agent-options",
+    constraints: [
+      "recoverable failures return null after retries; nonrecoverable failures throw",
+      "schema noncompliance after bounded structured-output repair is nonrecoverable and bypasses agent retries",
+      "per-agent retries override invocation retries; retries are floored and clamped to 0..3",
+      "resume replays only the longest unchanged prefix; the first miss and every later call execute live",
+      "selector priority is explicit model > agentType model > tier > phase model > metadata model > implicit medium > session default",
+      "if the selected model or route is unavailable, execution falls directly to the session default rather than trying lower-priority selectors",
+      "worktree isolation is best-effort; failure logs that isolation was ignored and continues without an isolated working directory",
+    ],
+    evidence: ["tests/workflow-runtime.test.ts", "tests/agent-registry.test.ts", "tests/structured-output.test.ts"],
+  }),
+  runtimeGlobal("parallel", {
+    signature: "parallel(thunks) => Promise<Array<unknown | null>>",
+    constraints: [
+      "requires functions rather than promises",
+      "result order matches input order",
+      "recoverable thunk failures become null; nonrecoverable failures throw",
+    ],
+  }),
+  runtimeGlobal("pipeline", {
+    signature: "pipeline(items, ...stages) => Promise<Array<unknown | null>>",
+    constraints: [
+      "items run concurrently while stages per item run sequentially",
+      "each stage receives previousValue, originalItem, and zero-based index",
+      "a null stage result is passed to the next stage; authors must guard missing coverage explicitly",
+      "recoverable stage failures become null; nonrecoverable failures throw",
+    ],
+  }),
+  runtimeGlobal("workflow", {
+    signature: "workflow(savedName, childArgs?) => Promise<unknown>",
+    constraints: [
+      "one nested level",
+      "shares limiter, counters, token accounting, and store",
+      "nested workflows do not reuse the parent resume journal",
+    ],
+    evidence: ["tests/workflow-saved.test.ts", "tests/shared-store.test.ts"],
+  }),
+  runtimeGlobal("verify", {
+    signature:
+      "verify(item: unknown, options?: { reviewers?: number; threshold?: number; lens?: string | string[] }) => Promise<{ real: boolean; realCount: number; total: number; votes: Array<{ real: boolean; reason?: string }> }>",
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    optionShape: "verify-options",
+    constraints: [
+      "reviewer failures are omitted; successful votes form the denominator in realCount / total",
+      "threshold comparison is inclusive and real is false when no reviewer succeeds",
+      "multiple lenses cycle across reviewers",
+    ],
+    evidence: ["tests/quality-stdlib.test.ts"],
+  }),
+  runtimeGlobal("judgePanel", {
+    signature:
+      "judgePanel(attempts: unknown[], options?: { judges?: number; rubric?: string }) => Promise<{ index: number; attempt: unknown; score: number; judgments: Array<{ score: number; reason?: string }> } | undefined>",
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    optionShape: "judge-panel-options",
+    constraints: [
+      "failed judgments are omitted and each candidate score averages successful judgments only",
+      "a candidate with no successful judgments scores 0",
+      "highest mean score wins with stable input index as the tie-break; empty input returns undefined",
+    ],
+    evidence: ["tests/quality-stdlib.test.ts"],
+  }),
+  runtimeGlobal("loopUntilDry", {
+    signature:
+      "loopUntilDry(options: { round: (roundIndex: number) => unknown[] | Promise<unknown[]>; key?: (item: unknown) => string; consecutiveEmpty?: number; maxRounds?: number }) => Promise<unknown[]>",
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    optionShape: "loop-until-dry-options",
+    constraints: [
+      "roundIndex is zero-based; null, non-array, or duplicate-only round results count as empty",
+      "token-budget or agent-limit capacity exhaustion returns the accumulated partial array instead of throwing",
+      "the returned array does not report whether termination came from dryness, maxRounds, or capacity exhaustion",
+      "authors must retain failed-round identity and truthful termination state outside the helper",
+    ],
+    evidence: ["tests/quality-stdlib.test.ts"],
+  }),
+  runtimeGlobal("completenessCheck", {
+    signature:
+      "completenessCheck(taskArgs: unknown, results: unknown) => Promise<{ complete: boolean; missing?: string[] } | null>",
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    constraints: [
+      "only the first 4,000 characters of serialized result evidence are sent to the critic",
+      "missing is optional and recoverable critic failure returns null",
+      "large evidence sets must be chunked or summarized before relying on the advisory verdict",
+    ],
+    evidence: ["tests/quality-stdlib.test.ts"],
+  }),
+  runtimeGlobal("retry", {
+    signature:
+      "retry(thunk: (attempt: number) => unknown | Promise<unknown>, options?: { attempts?: number; until?: (result: unknown) => boolean }) => Promise<unknown>",
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    optionShape: "retry-options",
+    constraints: [
+      "attempt is zero-based and attempts counts total thunk calls",
+      "until is synchronous; returning a Promise is truthy and accepts the first result",
+      "omitting until accepts the first result regardless of attempts",
+      "stops when until(result) is true; exhaustion returns only the last result without attempt metadata",
+      "authors must supply a finite attempts bound when overriding the default",
+    ],
+    evidence: ["tests/quality-stdlib.test.ts"],
+  }),
+  runtimeGlobal("gate", {
+    signature:
+      "gate(thunk: (feedback: string | undefined, attempt: number) => unknown | Promise<unknown>, validator: (value: unknown) => { ok: boolean; feedback?: string } | Promise<{ ok: boolean; feedback?: string }>, options?: { attempts?: number }) => Promise<{ ok: boolean; value: unknown; attempts: number }>",
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    optionShape: "gate-options",
+    constraints: [
+      "feedback is undefined on the first thunk call and then receives the previous validator feedback string",
+      "attempt is zero-based for the thunk while the returned attempts count is one-based",
+      "a value is accepted when the validator returns an object with a truthy ok property; a bare boolean is not accepted",
+      "exhaustion returns ok false with the last value and the bounded attempts count",
+      "authors must supply a finite attempts bound when overriding the default",
+    ],
+    evidence: ["tests/quality-stdlib.test.ts"],
+  }),
+  runtimeGlobal("checkpoint", {
+    signature: "checkpoint(prompt, options?) => Promise<unknown>",
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    optionShape: "checkpoint-options",
+    constraints: [
+      "foreground confirm and headless behavior are implemented; input/select/timeout are declared-only",
+      "consumes one agent slot and no tokens",
+      "journaled answers replay only within an unchanged resume prefix",
+    ],
+    evidence: ["tests/checkpoint.test.ts"],
+  }),
+  runtimeGlobal("log", { signature: "log(message) => void" }),
+  runtimeGlobal("phase", {
+    signature: "phase(title, options?) => void",
+    optionShape: "phase-options",
+    constraints: ["phase budgets are soft pre-call gates"],
+  }),
+  runtimeGlobal("args", { signature: "args: unknown", allowsUndefined: true }),
+  runtimeGlobal("cwd", { signature: "cwd: string" }),
+  runtimeGlobal("process", { signature: "process: { cwd(): string }" }),
+  runtimeGlobal("budget", {
+    signature: "budget: { total, spent(), remaining() }",
+    constraints: [
+      "frozen view over shared soft token accounting",
+      "spend accrues after agents finish, so in-flight work can overshoot",
+      "nested workflows share the same accounting",
+    ],
+  }),
+  runtimeGlobal("console", {
+    signature: "console: { log, info, warn, error }",
+    support: CapabilitySupport.COMPATIBILITY,
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    constraints: ["new workflows should use log()"],
+  }),
+  toolInput("script", "script: string", ["required raw JavaScript workflow source"]),
+  toolInput("args", "args?: unknown"),
+  toolInput("background", "background?: boolean = true", [
+    "background workflows are headless; use background false when checkpoint must show foreground confirmation",
+  ]),
+  toolInput("maxAgents", "maxAgents?: number = 1000", ["default, not a hard product maximum"]),
+  toolInput("concurrency", "concurrency?: number", ["runtime clamps to 1..16"]),
+  toolInput("agentRetries", "agentRetries?: number = configured value or 0", ["floored and clamped to 0..3"]),
+  toolInput("agentTimeoutMs", "agentTimeoutMs?: number = configured value or unbounded"),
+  toolInput("tokenBudget", "tokenBudget?: number = unlimited", ["soft pre-call gate; in-flight work can overshoot"]),
+  toolInput("resumeFromRunId", "resumeFromRunId?: string", [
+    "resumes a prior incomplete run with an edited script",
+    "unchanged positional agent calls replay from cache until the first changed or inserted call",
+    "always runs in the background",
+  ]),
+  {
+    id: "workflow.script.metadata",
+    label: "export const meta",
+    classification: CapabilityClassification.SCRIPT_CONTRACT,
+    support: CapabilitySupport.SUPPORTED,
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    origin: CapabilityOrigin.PROJECT,
+    lifecycle: PRESENT_AT,
+    signature:
+      "export const meta = { name: string, description: string, phases?: Array<{ title: string; detail?: string; model?: string }>, model?: string }",
+    optionShape: null,
+    constraints: [
+      "must be the first statement",
+      "name and description must be nonblank strings",
+      "metadata must use literal values; expressions such as string concatenation and template interpolation are rejected",
+      "the meta declaration is the only legal export because the remaining body executes inside an async function",
+    ],
+    enforcementOwner: "parseWorkflowScript",
+    runtimeBinding: null,
+    behaviorEvidence: ["tests/workflow-parser.test.ts"],
+    staticReference: { path: REFERENCE_PATH, anchor: "metadata" },
+    dynamicReference: null,
+  },
+  {
+    id: "workflow.script.return-value",
+    label: "workflow return value",
+    classification: CapabilityClassification.SCRIPT_CONTRACT,
+    support: CapabilitySupport.SUPPORTED,
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    origin: CapabilityOrigin.PROJECT,
+    lifecycle: PRESENT_AT,
+    signature: "return JSON-serializable data",
+    optionShape: null,
+    constraints: ["do not return functions, promises, cyclic objects, BigInt, or runtime handles"],
+    enforcementOwner: "workflow tool result boundary",
+    runtimeBinding: null,
+    behaviorEvidence: ["tests/workflow-authoring-skill.test.ts", "tests/workflow-tool.test.ts"],
+    staticReference: { path: REFERENCE_PATH, anchor: "return-value" },
+    dynamicReference: null,
+  },
+  {
+    id: "workflow.script.determinism",
+    label: "deterministic script execution",
+    classification: CapabilityClassification.SCRIPT_CONTRACT,
+    support: CapabilitySupport.SUPPORTED,
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    origin: CapabilityOrigin.PROJECT,
+    lifecycle: PRESENT_AT,
+    signature: null,
+    optionShape: null,
+    constraints: [
+      "Date.now(), Math.random(), and no-argument new Date() are unavailable",
+      "pass timestamps and randomness through args",
+    ],
+    enforcementOwner: "parseWorkflowScript and VM determinism prelude",
+    runtimeBinding: null,
+    behaviorEvidence: ["tests/workflow-parser.test.ts", "tests/workflow-runtime.test.ts"],
+    staticReference: { path: REFERENCE_PATH, anchor: "determinism" },
+    dynamicReference: null,
+  },
+  {
+    id: "workflow.compat.markdown-fences",
+    label: "whole-script Markdown fence stripping",
+    classification: CapabilityClassification.COMPATIBILITY_BEHAVIOR,
+    support: CapabilitySupport.COMPATIBILITY,
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    origin: CapabilityOrigin.TOOL_ADAPTER,
+    lifecycle: PRESENT_AT,
+    signature: null,
+    optionShape: null,
+    constraints: ["accepted for compatibility but not recommended"],
+    enforcementOwner: "normalizeWorkflowScript",
+    runtimeBinding: null,
+    behaviorEvidence: ["tests/workflow-tool.test.ts"],
+    staticReference: { path: REFERENCE_PATH, anchor: "compatibility" },
+    dynamicReference: null,
+  },
+  {
+    id: "workflow.vm.realm-substrate",
+    label: "VM realm JavaScript substrate",
+    classification: CapabilityClassification.INTERNAL_SUBSTRATE,
+    support: CapabilitySupport.INTERNAL,
+    discovery: DiscoveryPlacement.NONE,
+    origin: CapabilityOrigin.VM_REALM,
+    lifecycle: PRESENT_AT,
+    signature: null,
+    optionShape: null,
+    constraints: ["Node-version-dependent globals are not project-owned workflow API", "VM is not a security sandbox"],
+    enforcementOwner: "node:vm",
+    runtimeBinding: null,
+    behaviorEvidence: ["tests/workflow-runtime.test.ts"],
+    staticReference: null,
+    dynamicReference: null,
+  },
+  {
+    id: "workflow.dynamic.model-routes",
+    label: "model routes",
+    classification: CapabilityClassification.DYNAMIC_REFERENCE,
+    support: CapabilitySupport.SUPPORTED,
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    origin: CapabilityOrigin.LIVE_CONFIGURATION,
+    lifecycle: PRESENT_AT,
+    signature: null,
+    optionShape: null,
+    constraints: ["live values must not be copied into static contract data"],
+    enforcementOwner: "model-tier-config",
+    runtimeBinding: null,
+    behaviorEvidence: ["tests/workflows-models-command.test.ts"],
+    staticReference: { path: REFERENCE_PATH, anchor: "model-routes" },
+    dynamicReference: "model-routes",
+  },
+  {
+    id: "workflow.dynamic.agent-types",
+    label: "agent types",
+    classification: CapabilityClassification.DYNAMIC_REFERENCE,
+    support: CapabilitySupport.SUPPORTED,
+    discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
+    origin: CapabilityOrigin.LIVE_CONFIGURATION,
+    lifecycle: PRESENT_AT,
+    signature: null,
+    optionShape: null,
+    constraints: ["live values must not be copied into static contract data"],
+    enforcementOwner: "agent-registry",
+    runtimeBinding: null,
+    behaviorEvidence: ["tests/agent-registry.test.ts"],
+    staticReference: { path: REFERENCE_PATH, anchor: "agent-types" },
+    dynamicReference: "agent-types",
+  },
+];
+
+/** Authoritative versioned inventory used by runtime assembly and every static projection. */
+export const WORKFLOW_CAPABILITY_DEFINITION: WorkflowCapabilityDefinition = {
+  versions: {
+    extension: packageJson.version,
+    format: { kind: "present-at", version: "1.0.0" },
+    content: PRESENT_AT,
+  },
+  optionShapes: [
+    AGENT_OPTIONS,
+    CHECKPOINT_OPTIONS,
+    PHASE_OPTIONS,
+    VERIFY_OPTIONS,
+    JUDGE_PANEL_OPTIONS,
+    LOOP_UNTIL_DRY_OPTIONS,
+    RETRY_OPTIONS,
+    GATE_OPTIONS,
+  ],
+  capabilities,
+  dynamicReferences: [
+    {
+      id: "model-routes",
+      owner: "model-tier-config",
+      itemShape: "{ name: string; description?: string }",
+      connection: "loadModelTierConfig",
+    },
+    {
+      id: "agent-types",
+      owner: "agent-registry",
+      itemShape: "{ name: string; description?: string }",
+      connection: "loadAgentRegistry",
+    },
+  ],
+};
+
+/** Validate and freeze a definition, throwing with diagnostics when its identities or references conflict. */
+export function defineWorkflowCapabilityContract(definition: WorkflowCapabilityDefinition): WorkflowCapabilityContract {
+  deepFreeze(definition);
+  const definitionDiagnostics = validateDefinition(definition);
+  if (definitionDiagnostics.length > 0) {
+    throw new WorkflowCapabilityContractError("invalid workflow capability definition", definitionDiagnostics);
+  }
+
+  const optionShapes = new Map(definition.optionShapes.map((shape) => [shape.id, shape]));
+  const dynamicReferences = new Map(definition.dynamicReferences.map((reference) => [reference.id, reference]));
+  const bindings = definition.capabilities.flatMap((capability) =>
+    capability.runtimeBinding ? [{ ...capability.runtimeBinding }] : [],
+  );
+  const implementations = new Set(bindings.map((binding) => binding.implementation));
+  const globals = new Set(bindings.map((binding) => binding.global));
+
+  const diagnoseAlignment = (evidence: AlignmentEvidence): readonly CapabilityDiagnostic[] => {
+    const diagnostics: CapabilityDiagnostic[] = [];
+    if (evidence.suppliedImplementations) {
+      for (const binding of bindings) {
+        if (
+          !Object.hasOwn(evidence.suppliedImplementations, binding.implementation) ||
+          (evidence.suppliedImplementations[binding.implementation] === undefined && !binding.allowsUndefined)
+        ) {
+          diagnostics.push({
+            code: "MISSING_RUNTIME_IMPLEMENTATION",
+            severity: DiagnosticSeverity.ERROR,
+            subject: binding.implementation,
+            message: `Declared workflow global "${binding.global}" has no supplied implementation "${binding.implementation}".`,
+          });
+        }
+      }
+      for (const name of Object.keys(evidence.suppliedImplementations)) {
+        if (!implementations.has(name)) {
+          diagnostics.push({
+            code: "UNDECLARED_RUNTIME_IMPLEMENTATION",
+            severity: DiagnosticSeverity.WARNING,
+            subject: name,
+            message: `Supplied runtime implementation "${name}" is undeclared and was ignored.`,
+          });
+        }
+      }
+    }
+    if (evidence.observedProjectGlobals) {
+      const observed = new Set(evidence.observedProjectGlobals);
+      for (const name of globals) {
+        if (!observed.has(name)) {
+          diagnostics.push({
+            code: "DECLARED_GLOBAL_UNOBSERVED",
+            severity: DiagnosticSeverity.ERROR,
+            subject: name,
+            message: `Declared workflow global "${name}" was not observed in the assembled context.`,
+          });
+        }
+      }
+      for (const name of observed) {
+        if (!globals.has(name)) {
+          diagnostics.push({
+            code: "OBSERVED_GLOBAL_UNDECLARED",
+            severity: DiagnosticSeverity.ERROR,
+            subject: name,
+            message: `Observed project-owned workflow global "${name}" is undeclared.`,
+          });
+        }
+      }
+    }
+    return diagnostics;
+  };
+
+  return {
+    definition,
+    assembleRuntimeBindings(supplied) {
+      const diagnostics = diagnoseAlignment({ suppliedImplementations: supplied });
+      const missing = diagnostics.filter((diagnostic) => diagnostic.code === "MISSING_RUNTIME_IMPLEMENTATION");
+      if (missing.length > 0) {
+        throw new WorkflowCapabilityContractError(
+          `missing declared runtime implementation: ${missing.map((diagnostic) => diagnostic.subject).join(", ")}`,
+          diagnostics,
+        );
+      }
+      const assembled: Record<string, unknown> = {};
+      for (const binding of bindings) assembled[binding.global] = supplied[binding.implementation];
+      return { globals: assembled, diagnostics };
+    },
+    projectStaticReferenceFacts() {
+      return definition.capabilities
+        .filter((capability) => capability.staticReference !== null)
+        .map((capability) => ({
+          id: capability.id,
+          label: capability.label,
+          classification: capability.classification,
+          support: capability.support,
+          signature: capability.signature,
+          options: capability.optionShape ? (optionShapes.get(capability.optionShape) ?? null) : null,
+          constraints: capability.constraints,
+          reference: capability.staticReference
+            ? `${capability.staticReference.path}#${capability.staticReference.anchor}`
+            : null,
+          dynamicReference: capability.dynamicReference
+            ? (dynamicReferences.get(capability.dynamicReference) ?? null)
+            : null,
+        }));
+    },
+    diagnoseAlignment,
+  };
+}
+
+function validateDefinition(definition: WorkflowCapabilityDefinition): CapabilityDiagnostic[] {
+  const diagnostics: CapabilityDiagnostic[] = [];
+  const ids = new Set<string>();
+  const globals = new Set<string>();
+  const runtimeImplementations = new Set<string>();
+  const optionShapes = new Set<string>();
+  const dynamicReferences = new Set<string>();
+  const invalid = (subject: string, message: string) =>
+    diagnostics.push({ code: "INVALID_CAPABILITY_DEFINITION", severity: DiagnosticSeverity.ERROR, subject, message });
+  for (const shape of definition.optionShapes) {
+    if (optionShapes.has(shape.id)) invalid(shape.id, `Duplicate option shape "${shape.id}".`);
+    optionShapes.add(shape.id);
+  }
+  for (const reference of definition.dynamicReferences) {
+    if (dynamicReferences.has(reference.id)) invalid(reference.id, `Duplicate dynamic reference "${reference.id}".`);
+    dynamicReferences.add(reference.id);
+  }
+  for (const capability of definition.capabilities) {
+    if (ids.has(capability.id)) invalid(capability.id, `Duplicate capability id "${capability.id}".`);
+    ids.add(capability.id);
+    if (capability.classification === CapabilityClassification.RUNTIME_GLOBAL && !capability.runtimeBinding) {
+      invalid(capability.id, "Runtime-global capabilities require a runtime binding.");
+    }
+    if (capability.runtimeBinding) {
+      if (globals.has(capability.runtimeBinding.global)) {
+        invalid(capability.runtimeBinding.global, `Duplicate runtime global "${capability.runtimeBinding.global}".`);
+      }
+      globals.add(capability.runtimeBinding.global);
+      if (runtimeImplementations.has(capability.runtimeBinding.implementation)) {
+        invalid(
+          capability.runtimeBinding.implementation,
+          `Duplicate runtime implementation identity "${capability.runtimeBinding.implementation}".`,
+        );
+      }
+      runtimeImplementations.add(capability.runtimeBinding.implementation);
+      if (
+        capability.classification !== CapabilityClassification.RUNTIME_GLOBAL ||
+        capability.origin !== CapabilityOrigin.PROJECT
+      ) {
+        invalid(capability.id, "Runtime bindings require runtime-global classification and project origin.");
+      }
+    }
+    if (capability.optionShape && !optionShapes.has(capability.optionShape)) {
+      invalid(capability.id, `Unknown option shape "${capability.optionShape}".`);
+    }
+    if (capability.dynamicReference && !dynamicReferences.has(capability.dynamicReference)) {
+      invalid(capability.id, `Unknown dynamic reference "${capability.dynamicReference}".`);
+    }
+  }
+  return diagnostics;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const nested of Object.values(value)) deepFreeze(nested);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+/** Installed validated workflow capability contract. */
+export const WORKFLOW_CAPABILITY_CONTRACT = defineWorkflowCapabilityContract(WORKFLOW_CAPABILITY_DEFINITION);

--- a/src/workflow-capability-contract.ts
+++ b/src/workflow-capability-contract.ts
@@ -458,8 +458,10 @@ const capabilities: readonly CapabilityDescriptor[] = [
   toolInput("maxAgents", "maxAgents?: number = 1000", ["default, not a hard product maximum"]),
   toolInput("concurrency", "concurrency?: number", ["runtime clamps to 1..16"]),
   toolInput("agentRetries", "agentRetries?: number = configured value or 0", ["floored and clamped to 0..3"]),
-  toolInput("agentTimeoutMs", "agentTimeoutMs?: number = configured value or unbounded"),
-  toolInput("tokenBudget", "tokenBudget?: number = unlimited", ["soft pre-call gate; in-flight work can overshoot"]),
+  toolInput("agentTimeoutMs", "agentTimeoutMs?: number = configured default or unbounded"),
+  toolInput("tokenBudget", "tokenBudget?: number = configured default or unlimited", [
+    "soft pre-call gate; in-flight work can overshoot",
+  ]),
   toolInput("resumeFromRunId", "resumeFromRunId?: string", [
     "resumes a prior incomplete run with an edited script",
     "unchanged positional agent calls replay from cache until the first changed or inserted call",

--- a/src/workflow-comprehension.ts
+++ b/src/workflow-comprehension.ts
@@ -1,0 +1,1677 @@
+import { setImmediate as pause } from "node:timers/promises";
+import { isDeepStrictEqual } from "node:util";
+import type { ModelThinkingLevel } from "@earendil-works/pi-ai";
+import type { TSchema } from "typebox";
+import type { AgentRunOptions } from "./agent.js";
+import { ComprehensionSuite, ComprehensionTaskKind } from "./enums.js";
+import { ModelGenerationError, WorkflowError, WorkflowErrorCode } from "./errors.js";
+import { parseWorkflowScript, runWorkflow, type WorkflowRuntimeEvent } from "./workflow.js";
+
+/** Re-exported scenario groups and authoring operations used by the optional comprehension CLI. */
+export { ComprehensionSuite, ComprehensionTaskKind } from "./enums.js";
+
+/** Prompt and expected authoring branch for one optional model scenario. */
+export interface ComprehensionScenario {
+  id: string;
+  suite: ComprehensionSuite;
+  kind: ComprehensionTaskKind;
+  prompt: string;
+}
+
+const ENVELOPE =
+  "Return one complete plain-JavaScript workflow. It must start with export const meta, call agent() at least once, use unique labels, and explicitly return JSON-serializable data. Do not use imports.";
+
+/** Stable quick, core, and coverage scenarios available to provider and replay runs. */
+export const COMPREHENSION_SCENARIOS: readonly ComprehensionScenario[] = [
+  {
+    id: "quick-write",
+    suite: ComprehensionSuite.QUICK,
+    kind: ComprehensionTaskKind.WRITE,
+    prompt: `${ENVELOPE}\nWrite a small workflow that asks two independent agents to summarize alpha and beta concurrently, then returns both labeled results. Consult any installed skill that applies before authoring.`,
+  },
+  {
+    id: "full-write",
+    suite: ComprehensionSuite.FULL,
+    kind: ComprehensionTaskKind.WRITE,
+    prompt: `${ENVELOPE}\nWrite a fan-out workflow for work units alpha and beta. Use common authoring with parallel calls and require structured output from each agent before JavaScript reads fields. The deterministic beta agent may fail, so return completed data and a missing-work ledger that preserves beta by identity. Consult any installed skill that applies.`,
+  },
+  {
+    id: "full-edit",
+    suite: ComprehensionSuite.FULL,
+    kind: ComprehensionTaskKind.EDIT,
+    prompt: `${ENVELOPE}\nEdit the workflow below. It must declare and enter a phase with a positive phase budget, ask one preparation agent, then invoke the saved workflow named child-workflow sequentially for alpha and beta with workflow( and return both child results. Consult any installed skill that applies.\n\nCurrent workflow:\nexport const meta = { name: "nested", description: "broken" }\nreturn await workflow("child-workflow", { id: "alpha" })`,
+  },
+  {
+    id: "full-review",
+    suite: ComprehensionSuite.FULL,
+    kind: ComprehensionTaskKind.REVIEW,
+    prompt: `${ENVELOPE}\nReview and correct the workflow below. The corrected workflow must adversarially verify an agent-produced claim with exactly three reviewers, an inclusive threshold of 0.6, and source/logic lenses cycled across reviewers. One deterministic reviewer may fail. Return the claim plus the helper's complete verdict unchanged so successful-vote counts and missing review coverage remain visible. Consult any installed skill that applies.\n\nCurrent workflow:\nexport const meta = { name: "review", description: "broken" }\nconst claim = await agent("claim")\nreturn claim`,
+  },
+  {
+    id: "full-debug",
+    suite: ComprehensionSuite.FULL,
+    kind: ComprehensionTaskKind.DEBUG,
+    prompt: `${ENVELOPE}\nDebug and correct the workflow below. Use a bounded control helper (retry or gate), with at most three attempts. Require structured agent output with the fields acceptable (boolean) and answer (string), retry when acceptable is false, and return the accepted agent result plus attempt outcome. The deterministic first result is unacceptable and the next is acceptable. Consult any installed skill that applies.\n\nCurrent workflow:\nexport const meta = { name: "debug", description: "broken" }\nwhile (true) await agent("try")`,
+  },
+  {
+    id: "full-loop",
+    suite: ComprehensionSuite.FULL,
+    kind: ComprehensionTaskKind.WRITE,
+    prompt: `${ENVELOPE}\nWrite a bounded discovery workflow that stops after two consecutive successful dry rounds, with at most five rounds. Each round must call one uniquely labeled agent with structured output containing a findings array of { id, evidence }. The deterministic agent responses provide one alpha finding, then a recoverable failure, then two empty successes. Derive findings, failures, and stopping state from the actual agent return values; do not hard-code the announced sequence. A failed round must not count as dry. Return deduplicated findings, failed-round identity, a truthful termination reason, and complete: false whenever any round failed. Consult any installed skill that applies.`,
+  },
+  {
+    id: "full-retry",
+    suite: ComprehensionSuite.FULL,
+    kind: ComprehensionTaskKind.DEBUG,
+    prompt: `${ENVELOPE}\nWrite a workflow using retry() with at most three total attempts. The thunk receives a zero-based attempt index and must call one uniquely labeled structured agent per attempt for { acceptable: boolean, answer: string }. Use a synchronous null-safe acceptance predicate. The deterministic first result is unacceptable and the second is acceptable. Return the accepted agent result, an explicit exhausted boolean, and a ledger containing every attempt result. Consult any installed skill that applies.`,
+  },
+  {
+    id: "coverage-fan-out-synthesize",
+    suite: ComprehensionSuite.COVERAGE,
+    kind: ComprehensionTaskKind.WRITE,
+    prompt: `${ENVELOPE}\nWrite a fan-out-and-synthesize workflow for two independent research briefs identified as climate and transport. Run both structured research agents concurrently and wait for the complete result set before synthesis. The deterministic transport agent may fail recoverably. Then call exactly one structured synthesis agent with both intended brief identities, the actual climate result, and transport represented as missing rather than omitted. Return the contributor coverage ledger and the actual synthesis result. Consult any installed skill that applies.`,
+  },
+  {
+    id: "coverage-generate-filter",
+    suite: ComprehensionSuite.COVERAGE,
+    kind: ComprehensionTaskKind.WRITE,
+    prompt: `${ENVELOPE}\nWrite a generate-and-filter workflow. Run exactly two structured generator agents concurrently; each returns candidate objects with id and proposal fields, and the deterministic outputs contain one duplicate id. After all generation finishes, use JavaScript to deduplicate by id and cap the retained set at three before calling one uniquely labeled structured filter agent per retained candidate. Return the actual generator outputs, retained candidate identities, accepted filter results, and any filter failures. Consult any installed skill that applies.`,
+  },
+  {
+    id: "coverage-judge-panel",
+    suite: ComprehensionSuite.COVERAGE,
+    kind: ComprehensionTaskKind.REVIEW,
+    prompt: `${ENVELOPE}\nWrite a workflow that produces exactly two structured candidate attempts concurrently, then passes the actual attempts to judgePanel() with exactly three judges and a concrete correctness rubric. One deterministic judgment may fail recoverably. Return both produced attempts and the helper's winning result unchanged, including its index, attempt, mean score, and surviving judgments. Consult any installed skill that applies.`,
+  },
+];
+
+/** Skill discovery and read calls observed while the parent model authored a workflow. */
+export interface SkillLoadingEvidence {
+  discovered: boolean;
+  loaded: boolean;
+  toolCalls: Array<{ tool: string; path?: string }>;
+}
+
+/** Provider-reported usage attached to one generated workflow. */
+export interface ComprehensionTokenUsage {
+  input: number;
+  output: number;
+  total: number;
+  cost: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+/** Workflow source and generation evidence supplied to the deterministic replay seam. */
+export interface ModelGeneration {
+  workflow: string;
+  skillLoadingEvidence: SkillLoadingEvidence;
+  tokenUsage: ComprehensionTokenUsage;
+}
+
+/** Re-exported generation failure that retains loading and usage evidence. */
+export { ModelGenerationError } from "./errors.js";
+
+interface RuntimeCall {
+  index: number;
+  completedIndex: number | null;
+  label: string;
+  prompt: string;
+  phase: string | null;
+  structured: boolean;
+  scenarioRole: "generator" | "filter" | null;
+  status: "returned" | "null";
+  result: unknown;
+}
+
+type RuntimeEvent = WorkflowRuntimeEvent & { index: number };
+
+interface ScenarioFixtureState {
+  attempt: number;
+}
+
+interface GeneratorFixtureValue {
+  value: unknown;
+  consumed: number;
+}
+
+interface ScenarioAgentRequest {
+  prompt: string;
+  label: string;
+  schema: unknown;
+}
+
+type ScenarioAgentResponse = { status: "returned"; result: unknown } | { status: "null"; message: string };
+
+type ScenarioAgentFixture = (request: ScenarioAgentRequest, state: ScenarioFixtureState) => ScenarioAgentResponse;
+
+const ordinaryAgentFixture: ScenarioAgentFixture = ({ prompt, label, schema }) => ({
+  status: "returned",
+  result: schema ? sampleSchema(schema, label || "agent") : `result:${label || prompt}`,
+});
+
+function resolveWriteTaskIdentity(label: string, prompt: string): string | undefined {
+  return resolveIdentity(label, prompt, ["alpha", "beta"]);
+}
+
+function resolveIdentity(label: string, prompt: string, identities: readonly string[]): string | undefined {
+  const labelIdentities = identities.filter((identity) => new RegExp(`\\b${identity}\\b`, "i").test(label));
+  if (labelIdentities.length === 1) {
+    return labelIdentities[0];
+  }
+  return identities
+    .map((identity) => ({ identity, position: prompt.search(new RegExp(`\\b${identity}\\b`, "i")) }))
+    .filter(({ position }) => position >= 0)
+    .sort((left, right) => left.position - right.position)[0]?.identity;
+}
+
+function resolveExclusiveIdentity(label: string, prompt: string, identities: readonly string[]): string | undefined {
+  const labelIdentities = identities.filter((identity) => new RegExp(`\\b${identity}\\b`, "i").test(label));
+  if (labelIdentities.length === 1) return labelIdentities[0];
+  const promptIdentities = identities.filter((identity) => new RegExp(`\\b${identity}\\b`, "i").test(prompt));
+  return promptIdentities.length === 1 ? promptIdentities[0] : undefined;
+}
+
+function resolveGenerateFilterIdentity(
+  label: string,
+  prompt: string,
+  identities: readonly string[],
+): string | undefined {
+  const labelIdentity = resolveExclusiveIdentity(label, "", identities);
+  if (labelIdentity) {
+    return labelIdentity;
+  }
+  const candidateIdentities = jsonValuesInText(prompt)
+    .flatMap((value) => generatedCandidatesFromResult(value) ?? [])
+    .flatMap(({ id }) => (typeof id === "string" && identities.includes(id) ? [id] : []));
+  if (new Set(candidateIdentities).size === 1) {
+    return candidateIdentities[0];
+  }
+  return resolveIdentity(label, prompt, identities);
+}
+
+const fullWriteAgentFixture: ScenarioAgentFixture = (request) => {
+  const taskIdentity = resolveWriteTaskIdentity(request.label, request.prompt);
+  if (taskIdentity === "beta") {
+    return { status: "null", message: "deterministic beta failure" };
+  }
+  return {
+    status: "returned",
+    result: request.schema
+      ? sampleSchema(request.schema, request.label || "agent", taskIdentity)
+      : `result:${request.label || request.prompt}`,
+  };
+};
+
+const SCENARIO_AGENT_FIXTURES: Readonly<Record<string, ScenarioAgentFixture>> = {
+  "quick-write": ordinaryAgentFixture,
+  "full-write": fullWriteAgentFixture,
+  "full-edit": ordinaryAgentFixture,
+  "full-review": (request) => {
+    const reviewerMatch = /^verify (\d+)$/.exec(request.label);
+    if (!reviewerMatch) {
+      return ordinaryAgentFixture(request, { attempt: 0 });
+    }
+    const reviewer = Number(reviewerMatch[1]);
+    if (reviewer === 3) {
+      return { status: "null", message: "deterministic reviewer failure" };
+    }
+    return {
+      status: "returned",
+      result: { real: reviewer === 1, reason: `reviewer-${reviewer}` },
+    };
+  },
+  "full-debug": (request, state) => {
+    state.attempt++;
+    const attemptIdentity = request.label || `attempt-${state.attempt}`;
+    return {
+      status: "returned",
+      result: {
+        acceptable: state.attempt > 1,
+        answer: state.attempt > 1 ? `accepted:${attemptIdentity}` : `invalid:${attemptIdentity}`,
+        feedback: state.attempt > 1 ? "" : "add concrete detail",
+      },
+    };
+  },
+  "full-loop": (request, state) => {
+    state.attempt++;
+    if (state.attempt === 2) {
+      return { status: "null", message: "deterministic discovery round failure" };
+    }
+    return {
+      status: "returned",
+      result: {
+        findings: state.attempt === 1 ? [{ id: "alpha", evidence: `evidence:${request.label}` }] : [],
+      },
+    };
+  },
+  "full-retry": (request, state) => {
+    state.attempt++;
+    return {
+      status: "returned",
+      result: {
+        acceptable: state.attempt > 1,
+        answer: state.attempt > 1 ? `accepted:${request.label}` : `invalid:${request.label}`,
+      },
+    };
+  },
+  "coverage-fan-out-synthesize": (request) => {
+    const identity = resolveExclusiveIdentity(request.label, request.prompt, ["climate", "transport"]);
+    if (identity === undefined) {
+      return {
+        status: "returned",
+        result: {
+          summary: "synthesis:climate-with-transport-missing",
+          coveredIds: ["climate"],
+          missingIds: ["transport"],
+        },
+      };
+    }
+    if (identity === "transport") {
+      return { status: "null", message: "deterministic transport failure" };
+    }
+    return {
+      status: "returned",
+      result: request.schema
+        ? sampleSchema(request.schema, request.label || "research", identity)
+        : { id: identity ?? "climate", finding: `finding:${request.label}` },
+    };
+  },
+  "coverage-generate-filter": (request, state) => {
+    if (isGenerateFilterGeneratorSchema(request.schema)) {
+      state.attempt++;
+      const candidates =
+        state.attempt === 1
+          ? [
+              { id: "signal-a", proposal: "proposal:signal-a" },
+              { id: "shared", proposal: "proposal:shared:first" },
+            ]
+          : [
+              { id: "shared", proposal: "proposal:shared:duplicate" },
+              { id: "signal-b", proposal: "proposal:signal-b" },
+              { id: "signal-c", proposal: "proposal:signal-c" },
+            ];
+      return {
+        status: "returned",
+        result: createGeneratorResult(request.schema, candidates, request.label),
+      };
+    }
+    const identity = resolveGenerateFilterIdentity(request.label, request.prompt, [
+      "signal-a",
+      "shared",
+      "signal-b",
+      "signal-c",
+    ]);
+    if (identity === "signal-b") {
+      return { status: "null", message: "deterministic filter failure for signal-b" };
+    }
+    return {
+      status: "returned",
+      result: createFilterDecisionResult(request.schema, identity ?? "unknown", identity === "signal-a"),
+    };
+  },
+  "coverage-judge-panel": (request, state) => {
+    const judgeMatch = /^judge (\d+)\.(\d+)$/.exec(request.label);
+    if (judgeMatch) {
+      const attempt = Number(judgeMatch[1]);
+      const judge = Number(judgeMatch[2]);
+      if (attempt === 2 && judge === 3) {
+        return { status: "null", message: "deterministic judge 2.3 failure" };
+      }
+      const scores = attempt === 1 ? [0.4, 0.5, 0.3] : [0.9, 0.8, 0.7];
+      return {
+        status: "returned",
+        result: { score: scores[judge - 1], reason: `judge:${attempt}.${judge}` },
+      };
+    }
+    state.attempt++;
+    const identity = state.attempt === 1 ? "draft-a" : "draft-b";
+    return {
+      status: "returned",
+      result: { id: identity, answer: `answer:${identity}` },
+    };
+  },
+};
+
+/** Exact requested and resolved model settings recorded for reproducible comparison. */
+export interface ComprehensionModelSelection {
+  requested: string;
+  resolved: string;
+  thinkingLevel: ModelThinkingLevel | null;
+}
+
+type ComprehensionFailureStage = "generation" | "parse" | "runtime" | "assertion";
+
+/** Versioned evidence from one generated workflow executed against its scenario contract. */
+export interface ComprehensionEvidence {
+  formatVersion: 2;
+  provider: string;
+  modelSelection: ComprehensionModelSelection;
+  extensionVersion: string;
+  contractVersions: { format: string; content: string };
+  skillVersion: string;
+  task: { id: string; suite: ComprehensionSuite; kind: ComprehensionTaskKind; prompt: string };
+  generatedWorkflow: string | null;
+  skillLoadingEvidence: SkillLoadingEvidence;
+  tokenUsage: ComprehensionTokenUsage | null;
+  runtime: {
+    calls: RuntimeCall[];
+    events: RuntimeEvent[];
+    topology: { maxConcurrent: number; phases: string[] };
+    failures: Array<{
+      callIndex: number;
+      label: string;
+      message: string;
+      errorCode: string | null;
+      recoverable: boolean | null;
+    }>;
+    result: unknown;
+    assertions: Array<{ name: string; passed: boolean; details: string }>;
+  };
+  passed: boolean;
+  failure: { stage: ComprehensionFailureStage; message: string; stack?: string } | null;
+}
+
+interface RunComprehensionScenarioBaseOptions {
+  scenario: ComprehensionScenario;
+  provider: string;
+  extensionVersion: string;
+  contractVersions: { format: string; content: string };
+  skillVersion: string;
+  generate: (scenario: ComprehensionScenario) => Promise<ModelGeneration>;
+}
+
+/** Dependencies and version facts needed to generate and execute one comprehension scenario. */
+export type RunComprehensionScenarioOptions = RunComprehensionScenarioBaseOptions &
+  (
+    | { modelSelection: ComprehensionModelSelection; model?: never }
+    | {
+        /** @deprecated Use modelSelection. Retained for provider-free callers created before evidence format 2. */
+        model: string;
+        modelSelection?: never;
+      }
+  );
+
+/** Select scenarios in stable declaration order for one suite. */
+export function selectComprehensionScenarios(
+  suite: ComprehensionSuite | `${ComprehensionSuite}`,
+): readonly ComprehensionScenario[] {
+  return COMPREHENSION_SCENARIOS.filter((scenario) => scenario.suite === suite);
+}
+
+/** Generate, parse, execute, and behaviorally score one scenario without making scoring-stage provider calls. */
+export async function runComprehensionScenario(
+  options: RunComprehensionScenarioOptions,
+): Promise<ComprehensionEvidence> {
+  const evidence = emptyEvidence(options);
+  let generation: ModelGeneration;
+  try {
+    generation = await options.generate(options.scenario);
+    evidence.generatedWorkflow = generation.workflow;
+    evidence.skillLoadingEvidence = generation.skillLoadingEvidence;
+    evidence.tokenUsage = generation.tokenUsage;
+  } catch (error) {
+    if (error instanceof ModelGenerationError) {
+      evidence.skillLoadingEvidence = error.skillLoadingEvidence;
+      evidence.tokenUsage = error.tokenUsage;
+    }
+    evidence.failure = failure("generation", error);
+    return evidence;
+  }
+
+  try {
+    parseWorkflowScript(generation.workflow);
+  } catch (error) {
+    evidence.failure = failure("parse", error);
+    return evidence;
+  }
+
+  const calls: RuntimeCall[] = [];
+  const events: RuntimeEvent[] = [];
+  const runtimeFailures: ComprehensionEvidence["runtime"]["failures"] = [];
+  let timelineIndex = 0;
+  let active = 0;
+  let maxConcurrent = 0;
+  const fixtureState: ScenarioFixtureState = { attempt: 0 };
+  try {
+    const result = await runWorkflow(generation.workflow, {
+      persistLogs: false,
+      args: { work: [{ id: "alpha" }, { id: "beta" }], phaseBudget: 100 },
+      loadSavedWorkflow: () =>
+        `export const meta = { name: "comprehension_child", description: "deterministic child" }\nconst value = await agent("child:" + args.id, { label: "child:" + args.id })\nreturn { id: args.id, value }`,
+      onRuntimeEvent: (event) => events.push({ ...event, index: timelineIndex++ }),
+      onAgentStart: ({ label, phase, prompt }) => {
+        calls.push({
+          index: timelineIndex++,
+          completedIndex: null,
+          label,
+          prompt,
+          phase: phase ?? null,
+          structured: false,
+          scenarioRole: null,
+          status: "returned",
+          result: null,
+        });
+      },
+      onAgentEnd: ({ label, error, errorCode, recoverable }) => {
+        const call = [...calls].reverse().find((candidate) => candidate.label === label);
+        const completedIndex = timelineIndex++;
+        if (call) {
+          call.completedIndex = completedIndex;
+        }
+        if (!error) {
+          return;
+        }
+        runtimeFailures.push({
+          callIndex: call?.index ?? -1,
+          label,
+          message: error,
+          errorCode: errorCode ?? null,
+          recoverable: recoverable ?? null,
+        });
+      },
+      agent: {
+        async run(prompt: string, agentOptions: AgentRunOptions<TSchema> = {}): Promise<unknown> {
+          const call = [...calls].reverse().find(({ label }) => label === agentOptions.label && label !== "");
+          if (call) {
+            call.structured = agentOptions.schema !== undefined;
+            if (options.scenario.id === "coverage-generate-filter") {
+              call.scenarioRole = isGenerateFilterGeneratorSchema(agentOptions.schema) ? "generator" : "filter";
+            }
+          }
+          active++;
+          maxConcurrent = Math.max(maxConcurrent, active);
+          await pause();
+          active--;
+          const fixture = SCENARIO_AGENT_FIXTURES[options.scenario.id];
+          if (!fixture) {
+            throw new Error(`No deterministic fixture for scenario ${options.scenario.id}`);
+          }
+          const response = fixture(
+            {
+              prompt,
+              label: agentOptions.label ?? "",
+              schema: agentOptions.schema,
+            },
+            fixtureState,
+          );
+          if (response.status === "null") {
+            if (call) {
+              call.status = "null";
+            }
+            throw new WorkflowError(response.message, WorkflowErrorCode.AGENT_EXECUTION_ERROR, {
+              recoverable: true,
+              agentLabel: agentOptions.label,
+            });
+          }
+          if (call) {
+            call.result = serializable(response.result);
+          }
+          return response.result;
+        },
+      },
+    });
+    evidence.runtime.calls = calls;
+    evidence.runtime.events = events;
+    evidence.runtime.topology = { maxConcurrent, phases: [...result.phases] };
+    evidence.runtime.failures = runtimeFailures;
+    evidence.runtime.result = serializable(result.result);
+  } catch (error) {
+    evidence.runtime.calls = calls;
+    evidence.runtime.events = events;
+    evidence.runtime.topology.maxConcurrent = maxConcurrent;
+    evidence.failure = failure("runtime", error);
+    return evidence;
+  }
+
+  const assertions = assertScenario(options.scenario, generation.skillLoadingEvidence, evidence.runtime);
+  evidence.runtime.assertions = assertions;
+  evidence.passed = assertions.every(({ passed }) => passed);
+  if (!evidence.passed) {
+    evidence.failure = {
+      stage: "assertion",
+      message: assertions
+        .filter(({ passed }) => !passed)
+        .map(({ details }) => details)
+        .join("; "),
+    };
+  }
+  return evidence;
+}
+
+function emptyEvidence(options: RunComprehensionScenarioOptions): ComprehensionEvidence {
+  return {
+    formatVersion: 2,
+    provider: options.provider,
+    modelSelection: normalizeModelSelection(options),
+    extensionVersion: options.extensionVersion,
+    contractVersions: options.contractVersions,
+    skillVersion: options.skillVersion,
+    task: {
+      id: options.scenario.id,
+      suite: options.scenario.suite,
+      kind: options.scenario.kind,
+      prompt: options.scenario.prompt,
+    },
+    generatedWorkflow: null,
+    skillLoadingEvidence: { discovered: false, loaded: false, toolCalls: [] },
+    tokenUsage: null,
+    runtime: {
+      calls: [],
+      events: [],
+      topology: { maxConcurrent: 0, phases: [] },
+      failures: [],
+      result: null,
+      assertions: [],
+    },
+    passed: false,
+    failure: null,
+  };
+}
+
+function normalizeModelSelection(options: RunComprehensionScenarioOptions): ComprehensionModelSelection {
+  if (options.modelSelection) {
+    return options.modelSelection;
+  }
+  if (options.model) {
+    return { requested: options.model, resolved: options.model, thinkingLevel: null };
+  }
+  throw new Error("modelSelection is required");
+}
+
+function assertScenario(
+  scenario: ComprehensionScenario,
+  skillLoadingEvidence: SkillLoadingEvidence,
+  runtime: ComprehensionEvidence["runtime"],
+): Array<{ name: string; passed: boolean; details: string }> {
+  const assertions: Array<{ name: string; passed: boolean; details: string }> = [];
+  assertions.push({
+    name: "skill:loaded",
+    passed: skillLoadingEvidence.discovered && skillLoadingEvidence.loaded,
+    details: "model must discover and load the applicable installed skill",
+  });
+  assertions.push({
+    name: "runtime:calls",
+    passed: runtime.calls.length > 0,
+    details: "real runtime must observe at least one deterministic agent call",
+  });
+  const labels = runtime.calls.map(({ label }) => label);
+  assertions.push({
+    name: "labels:unique",
+    passed: labels.every((label) => label.trim().length > 0) && new Set(labels).size === labels.length,
+    details: "every agent call must use a unique nonblank label",
+  });
+  if (scenario.id === "quick-write" || scenario.id === "full-write") {
+    assertions.push({
+      name: "topology:parallel",
+      passed: runtime.topology.maxConcurrent > 1,
+      details: "write scenario must execute independent calls concurrently",
+    });
+  }
+  if (scenario.id === "quick-write") {
+    const taskCalls = ["alpha", "beta"].map((workId) => findTaskCall(runtime.calls, workId));
+    assertions.push({
+      name: "labels:unique-task-calls",
+      passed:
+        taskCalls.every((call) => call !== undefined && call.label.trim() !== "") &&
+        new Set(taskCalls.map((call) => call?.label)).size === taskCalls.length,
+      details: "quick-write task calls must use distinct nonblank labels",
+    });
+    for (const [index, workId] of ["alpha", "beta"].entries()) {
+      const call = taskCalls[index];
+      assertions.push({
+        name: `result:${workId}-returned`,
+        passed: call !== undefined && containsTaskResult(runtime.result, workId, call.result),
+        details: `quick-write must return the ${workId} agent result associated with ${workId}`,
+      });
+    }
+  }
+  if (scenario.id === "full-write") {
+    const alphaCall = findTaskCall(runtime.calls, "alpha");
+    const betaCall = findTaskCall(runtime.calls, "beta");
+    assertions.push({
+      name: "structured-output:task-calls",
+      passed: alphaCall?.structured === true && betaCall?.structured === true,
+      details: "full-write must execute both alpha and beta with schema-validated output",
+    });
+    assertions.push({
+      name: "coverage:completed-alpha",
+      passed:
+        alphaCall !== undefined &&
+        containsInNamedField(runtime.result, /complet|success|done/i, (value) =>
+          containsTaskResultEvidence(value, "alpha", alphaCall.result),
+        ),
+      details: "full-write must preserve the successful alpha result in completed data",
+    });
+    assertions.push({
+      name: "coverage:missing-beta",
+      passed:
+        betaCall !== undefined &&
+        betaCall.status === "null" &&
+        runtime.failures.some(({ callIndex }) => callIndex === betaCall.index) &&
+        containsInNamedField(runtime.result, /miss|fail|error|unavailable/i, (value) =>
+          containsIdentity(value, "beta"),
+        ),
+      details: "full-write must preserve failed beta by identity in a missing-work collection",
+    });
+  }
+  if (scenario.id === "coverage-fan-out-synthesize") {
+    const contributorCalls = runtime.calls.filter(
+      ({ label, prompt }) => resolveExclusiveIdentity(label, prompt, ["climate", "transport"]) !== undefined,
+    );
+    const synthesisCalls = runtime.calls.filter((call) => !contributorCalls.includes(call));
+    const synthesisCall = synthesisCalls[0];
+    const climateCall = contributorCalls.find(
+      ({ label, prompt }) => resolveExclusiveIdentity(label, prompt, ["climate", "transport"]) === "climate",
+    );
+    const transportCall = contributorCalls.find(
+      ({ label, prompt }) => resolveExclusiveIdentity(label, prompt, ["climate", "transport"]) === "transport",
+    );
+    assertions.push({
+      name: "synthesis:complete-fan-out",
+      passed:
+        contributorCalls.length === 2 &&
+        runtime.topology.maxConcurrent > 1 &&
+        climateCall?.structured === true &&
+        transportCall?.structured === true &&
+        transportCall.status === "null" &&
+        runtime.failures.some(({ callIndex }) => callIndex === transportCall.index),
+      details:
+        "fan-out-and-synthesize must run both structured contributors concurrently and preserve failure evidence",
+    });
+    assertions.push({
+      name: "synthesis:complete-input",
+      passed:
+        synthesisCalls.length === 1 &&
+        synthesisCall?.structured === true &&
+        climateCall !== undefined &&
+        promptContainsResultOrSingleFieldProjection(synthesisCall.prompt, climateCall.result) &&
+        /\btransport\b/i.test(synthesisCall.prompt) &&
+        /miss|null|fail|unavailable/i.test(synthesisCall.prompt),
+      details:
+        "synthesis must start from the complete intended coverage, including the climate result and missing transport identity",
+    });
+    assertions.push({
+      name: "synthesis:returned-provenance",
+      passed:
+        synthesisCall !== undefined &&
+        climateCall !== undefined &&
+        containsValue(runtime.result, synthesisCall.result) &&
+        containsInNamedField(
+          runtime.result,
+          /contribut|coverage|ledger/i,
+          (value) =>
+            containsIdentity(value, "climate") &&
+            containsIdentity(value, "transport") &&
+            containsMissingCoverage(value, "transport"),
+        ),
+      details:
+        "fan-out-and-synthesize must return the actual synthesis and a contributor ledger with missing transport coverage",
+    });
+  }
+  if (scenario.id === "coverage-generate-filter") {
+    const generatorCalls = runtime.calls.filter(({ scenarioRole }) => scenarioRole === "generator");
+    const filterCalls = runtime.calls.filter(({ scenarioRole }) => scenarioRole === "filter");
+    const generatedCandidates = generatorCalls.flatMap(({ result }) => generatedCandidatesFromResult(result) ?? []);
+    const retainedCandidates: Array<Record<string, unknown>> = [];
+    const seenCandidateIds = new Set<string>();
+    for (const candidate of generatedCandidates) {
+      if (typeof candidate.id !== "string" || seenCandidateIds.has(candidate.id)) continue;
+      seenCandidateIds.add(candidate.id);
+      if (retainedCandidates.length < 3) retainedCandidates.push(candidate);
+    }
+    const filterCallsById = new Map(
+      retainedCandidates.map((candidate) => [
+        candidate.id,
+        filterCalls.filter(({ prompt }) => promptContainsCandidate(prompt, candidate)),
+      ]),
+    );
+    assertions.push({
+      name: "filter:generation-barrier",
+      passed:
+        generatorCalls.length === 2 &&
+        generatorCalls.every(({ structured }) => structured) &&
+        runtime.topology.maxConcurrent > 1 &&
+        generatorCalls.every(({ completedIndex }) => completedIndex !== null) &&
+        filterCalls.every(
+          ({ index }) =>
+            index > Math.max(...generatorCalls.map(({ completedIndex }) => completedIndex ?? Number.POSITIVE_INFINITY)),
+        ),
+      details: "generate-and-filter must finish exactly two concurrent structured generators before filtering",
+    });
+    assertions.push({
+      name: "filter:deduplicated-bounded-input",
+      passed:
+        retainedCandidates.length > 0 &&
+        retainedCandidates.length <= 3 &&
+        generatedCandidates.length > seenCandidateIds.size &&
+        filterCalls.length === retainedCandidates.length &&
+        filterCalls.every(({ structured }) => structured) &&
+        retainedCandidates.every((candidate) => {
+          const calls = filterCallsById.get(candidate.id) ?? [];
+          return calls.length === 1 && promptContainsCandidate(calls[0]?.prompt ?? "", candidate);
+        }),
+      details:
+        "generate-and-filter must deduplicate by candidate id, cap at three, and filter each retained candidate once",
+    });
+    const acceptedCalls = filterCalls.filter(({ result }) => filterDecisionIsAccepted(result));
+    const failedFilters = filterCalls.filter(({ status }) => status === "null");
+    const generatorOutputsReturned = containsInNamedField(runtime.result, /generat|output|batch/i, (value) =>
+      generatedCandidates.every((candidate) => containsCandidateProjection(value, candidate)),
+    );
+    assertions.push({
+      name: "filter:returned-provenance",
+      passed:
+        generatorOutputsReturned &&
+        retainedCandidates.every(
+          ({ id }) =>
+            typeof id === "string" &&
+            containsInNamedField(runtime.result, /retain|candidate.?id/i, (value) => containsIdentity(value, id)),
+        ) &&
+        acceptedCalls.every((call) => {
+          const identity = resolveGenerateFilterIdentity(
+            call.label,
+            call.prompt,
+            retainedCandidates.flatMap(({ id }) => (typeof id === "string" ? [id] : [])),
+          );
+          return (
+            identity !== undefined &&
+            containsInNamedField(runtime.result, /accept|pass|selected/i, (value) =>
+              containsIdentity(value, identity),
+            ) &&
+            containsFilterDecisionEvidence(runtime.result, call.result, identity)
+          );
+        }) &&
+        failedFilters.every((call) => {
+          const identity = resolveGenerateFilterIdentity(
+            call.label,
+            call.prompt,
+            retainedCandidates.flatMap(({ id }) => (typeof id === "string" ? [id] : [])),
+          );
+          return (
+            identity !== undefined &&
+            runtime.failures.some(({ callIndex }) => callIndex === call.index) &&
+            containsInNamedField(runtime.result, /fail|miss|error/i, (value) => containsIdentity(value, identity))
+          );
+        }) &&
+        (failedFilters.length > 0 ||
+          containsInNamedField(runtime.result, /fail|miss|error/i, (value) => Array.isArray(value) || isRecord(value))),
+      details:
+        "generate-and-filter must return actual generation, retained identities, accepted decisions, and failed filter identity",
+    });
+  }
+  if (scenario.id === "coverage-judge-panel") {
+    const qualityStart = runtime.events.find(
+      (event) => event.type === "quality" && event.stage === "start" && event.helper === "judgePanel",
+    );
+    const qualityEnd = runtime.events.find(
+      (event) => event.type === "quality" && event.stage === "end" && event.helper === "judgePanel",
+    );
+    const judgmentCalls =
+      qualityStart && qualityEnd
+        ? runtime.calls.filter(({ index }) => qualityStart.index < index && index < qualityEnd.index)
+        : [];
+    const candidateCalls = runtime.calls.filter((call) => !judgmentCalls.includes(call));
+    const judgedAttempts = candidateCalls.map((candidate, index) =>
+      judgedAttemptFromPrompt(
+        judgmentCalls.find(({ label }) => label.startsWith(`judge ${index + 1}.`))?.prompt ?? "",
+        candidate.result,
+      ),
+    );
+    const judgmentsByCandidate = candidateCalls.map((_candidate, index) =>
+      judgmentCalls.filter(({ label }) => label.startsWith(`judge ${index + 1}.`)),
+    );
+    assertions.push({
+      name: "judge-panel:executed",
+      passed:
+        qualityStart !== undefined &&
+        qualityEnd !== undefined &&
+        candidateCalls.length === 2 &&
+        candidateCalls.every(({ structured }) => structured) &&
+        runtime.topology.maxConcurrent > 1,
+      details:
+        "judge-panel scenario must produce exactly two structured candidates concurrently and execute judgePanel",
+    });
+    assertions.push({
+      name: "judge-panel:numeric-judges",
+      passed:
+        judgmentCalls.length === 6 &&
+        judgmentCalls.every(({ structured, prompt }) => structured && /correct|valid|accur/i.test(prompt)) &&
+        judgmentsByCandidate.every(
+          (calls, index) =>
+            calls.length === 3 &&
+            judgedAttempts[index] !== undefined &&
+            containsResultProjection(judgedAttempts[index], candidateCalls[index]?.result),
+        ) &&
+        judgmentCalls.filter(({ status }) => status === "null").length === 1,
+      details:
+        "judgePanel must run exactly three structured correctness judges per produced candidate and retain one recoverable failure",
+    });
+    const scoredCandidates = judgmentsByCandidate.map((calls, index) => {
+      const surviving = calls.filter(({ status }) => status === "returned");
+      const scores = surviving.map(({ result }) =>
+        isRecord(result) && typeof result.score === "number" ? result.score : 0,
+      );
+      return {
+        index,
+        attempt: judgedAttempts[index],
+        score: scores.length > 0 ? scores.reduce((sum, score) => sum + score, 0) / scores.length : 0,
+        judgments: surviving.map(({ result }) => result),
+      };
+    });
+    const expectedWinner = scoredCandidates.reduce<(typeof scoredCandidates)[number] | undefined>(
+      (best, candidate) =>
+        !best || candidate.score > best.score || (candidate.score === best.score && candidate.index < best.index)
+          ? candidate
+          : best,
+      undefined,
+    );
+    assertions.push({
+      name: "judge-panel:returned-winner",
+      passed:
+        expectedWinner !== undefined &&
+        candidateCalls.every(({ result }) => containsResultProjection(runtime.result, result)) &&
+        containsValue(runtime.result, expectedWinner),
+      details: "judge-panel scenario must return both produced candidates and the helper's unchanged winning result",
+    });
+  }
+  if (scenario.id === "full-edit") {
+    const childStarts = runtime.events.filter(
+      (event): event is RuntimeEvent & { type: "workflow"; stage: "start" } =>
+        event.type === "workflow" && event.stage === "start",
+    );
+    const childEnds = runtime.events.filter(
+      (event): event is RuntimeEvent & { type: "workflow"; stage: "end" } =>
+        event.type === "workflow" && event.stage === "end",
+    );
+    const alphaStart = childStarts.find((event) => isRecord(event.args) && event.args.id === "alpha");
+    const alphaEnd = childEnds.find((event) => isRecord(event.args) && event.args.id === "alpha");
+    const betaStart = childStarts.find((event) => isRecord(event.args) && event.args.id === "beta");
+    const betaEnd = childEnds.find((event) => isRecord(event.args) && event.args.id === "beta");
+    const preparationCalls = alphaStart ? runtime.calls.filter(({ index }) => index < alphaStart.index) : [];
+    const preparation = preparationCalls[0];
+    const alphaCall = callWithin(runtime.calls, alphaStart, alphaEnd);
+    const betaCall = callWithin(runtime.calls, betaStart, betaEnd);
+    assertions.push({
+      name: "preparation:executed",
+      passed: preparationCalls.length === 1,
+      details: "edit scenario must execute exactly one preparation agent before saved children",
+    });
+    assertions.push({
+      name: "nesting:executed",
+      passed: alphaStart !== undefined && betaStart !== undefined,
+      details: "saved child workflow must execute for alpha and beta",
+    });
+    assertions.push({
+      name: "nesting:sequential",
+      passed: alphaEnd !== undefined && betaStart !== undefined && alphaEnd.index < betaStart.index,
+      details: "saved child workflows must execute sequentially in alpha then beta order",
+    });
+    assertions.push({
+      name: "nesting:returned-results",
+      passed:
+        alphaCall !== undefined &&
+        betaCall !== undefined &&
+        containsValue(runtime.result, alphaCall.result) &&
+        containsValue(runtime.result, betaCall.result),
+      details: "edit scenario must return data from both saved child workflows",
+    });
+    assertions.push({
+      name: "phase:entered",
+      passed:
+        preparation !== undefined &&
+        runtime.events.some(
+          (event) =>
+            event.type === "phase" && event.budget !== null && event.budget > 0 && event.index < preparation.index,
+        ),
+      details: "edit scenario must enter a positive-budget phase before preparation",
+    });
+  }
+  if (scenario.id === "full-review") {
+    const qualityStart = runtime.events.find((event) => event.type === "quality" && event.stage === "start");
+    const qualityEnd = runtime.events.find((event) => event.type === "quality" && event.stage === "end");
+    const claimCall = qualityStart ? runtime.calls.filter(({ index }) => index < qualityStart.index).at(-1) : undefined;
+    const qualityCalls =
+      qualityStart && qualityEnd
+        ? runtime.calls.filter(({ index }) => qualityStart.index < index && index < qualityEnd.index)
+        : [];
+    const successfulQualityCalls = qualityCalls.filter(({ status }) => status === "returned");
+    const expectedVerdict = {
+      real: false,
+      realCount: 1,
+      total: 2,
+      votes: successfulQualityCalls.map(({ result }) => result),
+    };
+    assertions.push({
+      name: "quality:executed",
+      passed:
+        claimCall !== undefined &&
+        qualityCalls.length === 3 &&
+        qualityCalls.every(({ prompt }) => promptContainsResultOrSingleFieldProjection(prompt, claimCall.result)),
+      details: "quality helper must run exactly three adversarial reviewers over the produced claim",
+    });
+    assertions.push({
+      name: "quality:verify-contract",
+      passed:
+        qualityCalls.length === 3 &&
+        /\bFocus lens:[^\n]*\bsource\b/i.test(qualityCalls[0]?.prompt ?? "") &&
+        /\bFocus lens:[^\n]*\blogic(?:al)?\b/i.test(qualityCalls[1]?.prompt ?? "") &&
+        /\bFocus lens:[^\n]*\bsource\b/i.test(qualityCalls[2]?.prompt ?? "") &&
+        qualityCalls[2]?.status === "null" &&
+        containsValue(runtime.result, expectedVerdict),
+      details: "review scenario must use the documented verify options and return its survivor-based verdict unchanged",
+    });
+    assertions.push({
+      name: "review:returned-outcome",
+      passed:
+        claimCall !== undefined &&
+        containsResultOrSingleFieldProjection(runtime.result, claimCall.result) &&
+        successfulQualityCalls.length === 2 &&
+        successfulQualityCalls.every(({ result }) => containsValue(runtime.result, result)),
+      details: "review scenario must return the produced claim and successful quality-helper votes",
+    });
+  }
+  if (scenario.id === "full-debug") {
+    const attempts = runtime.events.filter((event) => event.type === "control-attempt");
+    const firstAttemptCall = attempts[0]
+      ? runtime.calls.filter(({ index }) => index < attempts[0].index).at(-1)
+      : undefined;
+    const acceptedEvent = attempts.at(-1);
+    const acceptedCall = acceptedEvent
+      ? runtime.calls.filter(({ index }) => index < acceptedEvent.index).at(-1)
+      : undefined;
+    assertions.push({
+      name: "control:retried",
+      passed:
+        attempts.length >= 2 &&
+        attempts.length <= 3 &&
+        attempts[0]?.accepted === false &&
+        acceptedEvent?.accepted === true,
+      details: "bounded control helper must reject the first result and accept within two or three attempts",
+    });
+    assertions.push({
+      name: "control:structured-validity",
+      passed:
+        firstAttemptCall?.structured === true &&
+        acceptedCall?.structured === true &&
+        isRecord(firstAttemptCall.result) &&
+        firstAttemptCall.result.acceptable === false &&
+        isRecord(acceptedCall.result) &&
+        acceptedCall.result.acceptable === true,
+      details: "debug scenario must gate the scenario-owned structured validity signal",
+    });
+    assertions.push({
+      name: "debug:returned-outcome",
+      passed:
+        acceptedCall !== undefined &&
+        containsNamedResultProjection(runtime.result, acceptedCall.result, ["acceptable", "answer"]),
+      details: "debug scenario must return the accepted agent result rather than fabricate success",
+    });
+  }
+  if (scenario.id === "full-loop") {
+    const firstCall = runtime.calls[0];
+    const failedCall = runtime.calls.find(({ status }) => status === "null");
+    const firstFinding =
+      isRecord(firstCall?.result) && Array.isArray(firstCall.result.findings)
+        ? firstCall.result.findings[0]
+        : undefined;
+    assertions.push({
+      name: "loop:successful-dry-stopping",
+      passed:
+        runtime.calls.length === 4 &&
+        runtime.calls.every(({ structured }) => structured) &&
+        failedCall === runtime.calls[1],
+      details: "loop scenario must ignore the failed round for dryness and stop after two later successful dry rounds",
+    });
+    assertions.push({
+      name: "loop:coverage-ledger",
+      passed:
+        firstFinding !== undefined &&
+        containsValue(runtime.result, firstFinding) &&
+        failedCall !== undefined &&
+        containsInNamedField(runtime.result, /fail|miss|error/i, (value) =>
+          containsRoundIdentity(value, failedCall.label, runtime.calls.indexOf(failedCall)),
+        ),
+      details: "loop scenario must return the alpha finding and preserve the failed round by identity",
+    });
+    assertions.push({
+      name: "loop:truthful-termination",
+      passed:
+        containsInNamedField(runtime.result, /complete/i, (value) => value === false) &&
+        containsInNamedField(runtime.result, /termin|reason|status/i, (value) => typeof value === "string"),
+      details: "loop scenario must return a termination reason and must not claim complete after a failed round",
+    });
+  }
+  if (scenario.id === "full-retry") {
+    const controlAttempts = runtime.events.filter(
+      (event): event is RuntimeEvent & { type: "control-attempt" } =>
+        event.type === "control-attempt" && event.helper === "retry",
+    );
+    const firstCall = runtime.calls[0];
+    const acceptedCall = runtime.calls[1];
+    assertions.push({
+      name: "retry:exact-control-contract",
+      passed:
+        runtime.calls.length === 2 &&
+        controlAttempts.length === 2 &&
+        controlAttempts[0]?.accepted === false &&
+        controlAttempts[1]?.accepted === true &&
+        firstCall?.structured === true &&
+        acceptedCall?.structured === true,
+      details: "retry scenario must use synchronous false-then-true acceptance over exactly two structured attempts",
+    });
+    assertions.push({
+      name: "retry:returned-ledger",
+      passed:
+        firstCall !== undefined &&
+        acceptedCall !== undefined &&
+        containsInNamedField(
+          runtime.result,
+          /attempt|ledger|history/i,
+          (value) =>
+            containsResultProjection(value, firstCall.result) && containsResultProjection(value, acceptedCall.result),
+        ) &&
+        containsValue(runtime.result, acceptedCall.result) &&
+        containsInNamedField(runtime.result, /exhaust/i, (value) => value === false),
+      details: "retry scenario must return every attempt, the accepted result, and explicit non-exhaustion",
+    });
+  }
+  return assertions;
+}
+
+function sampleSchema(schema: unknown, label: string, taskIdentity?: string): unknown {
+  if (isRecord(schema) && schema.type === "object") {
+    const properties = isRecord(schema.properties) ? schema.properties : {};
+    return Object.fromEntries(
+      Object.entries(properties).map(([key, value]) => [key, sampleProperty(key, value, label, taskIdentity)]),
+    );
+  }
+  return sampleProperty("value", schema, label, taskIdentity);
+}
+
+function sampleProperty(key: string, schema: unknown, label: string, taskIdentity?: string): unknown {
+  if (isRecord(schema) && Object.hasOwn(schema, "const")) {
+    return schema.const;
+  }
+  if (isRecord(schema) && Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
+  const type = isRecord(schema) ? schema.type : undefined;
+  if (type === "string" && taskIdentity && /(?:^id$|id$|identity|work.?unit|^unit$)/i.test(key)) {
+    return taskIdentity;
+  }
+  if (type === "boolean") {
+    return true;
+  }
+  if (type === "number" || type === "integer") {
+    return 1;
+  }
+  if (type === "array") {
+    return [];
+  }
+  if (type === "object") {
+    return sampleSchema(schema, label, taskIdentity);
+  }
+  return `${key}:${label}`;
+}
+
+function callWithin(
+  calls: RuntimeCall[],
+  start: RuntimeEvent | undefined,
+  end: RuntimeEvent | undefined,
+): RuntimeCall | undefined {
+  if (!start || !end) {
+    return undefined;
+  }
+  return calls.find(({ index }) => start.index < index && index < end.index);
+}
+
+function findTaskCall(calls: RuntimeCall[], workId: string): RuntimeCall | undefined {
+  return calls.find(({ label, prompt }) => resolveWriteTaskIdentity(label, prompt) === workId);
+}
+
+function containsInNamedField(
+  container: unknown,
+  fieldPattern: RegExp,
+  predicate: (value: unknown) => boolean,
+): boolean {
+  if (Array.isArray(container)) {
+    return container.some((value) => containsInNamedField(value, fieldPattern, predicate));
+  }
+  if (!isRecord(container)) {
+    return false;
+  }
+  for (const [key, value] of Object.entries(container)) {
+    if (fieldPattern.test(key) && predicate(value)) {
+      return true;
+    }
+    if (containsInNamedField(value, fieldPattern, predicate)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function containsIdentity(container: unknown, identity: string): boolean {
+  if (typeof container === "string") {
+    return container.toLowerCase() === identity.toLowerCase();
+  }
+  if (Array.isArray(container)) {
+    return container.some((value) => containsIdentity(value, identity));
+  }
+  if (!isRecord(container)) {
+    return false;
+  }
+  return Object.entries(container).some(
+    ([key, value]) => key.toLowerCase() === identity.toLowerCase() || containsIdentity(value, identity),
+  );
+}
+
+function containsRoundIdentity(container: unknown, label: string, zeroBasedIndex: number): boolean {
+  if (typeof container === "number") {
+    return container === zeroBasedIndex || container === zeroBasedIndex + 1;
+  }
+  if (typeof container === "string") {
+    const normalized = container.toLowerCase();
+    return (
+      normalized === label.toLowerCase() ||
+      normalized === String(zeroBasedIndex) ||
+      normalized === String(zeroBasedIndex + 1) ||
+      new RegExp(`\\bround[-_: ]?${zeroBasedIndex + 1}\\b`, "i").test(container)
+    );
+  }
+  if (Array.isArray(container)) {
+    return container.some((value) => containsRoundIdentity(value, label, zeroBasedIndex));
+  }
+  return (
+    isRecord(container) &&
+    Object.entries(container).some(
+      ([key, value]) =>
+        containsRoundIdentity(key, label, zeroBasedIndex) || containsRoundIdentity(value, label, zeroBasedIndex),
+    )
+  );
+}
+
+function containsTaskResult(container: unknown, workId: string, expected: unknown): boolean {
+  if (Array.isArray(container)) {
+    return container.some((value) => containsTaskResult(value, workId, expected));
+  }
+  if (!isRecord(container)) {
+    return false;
+  }
+  for (const [key, value] of Object.entries(container)) {
+    if (new RegExp(`\\b${workId}\\b`, "i").test(key) && containsValue(value, expected)) {
+      return true;
+    }
+  }
+  const values = Object.values(container);
+  if (
+    values.some((value) => typeof value === "string" && value.toLowerCase() === workId.toLowerCase()) &&
+    values.some((value) => containsValue(value, expected))
+  ) {
+    return true;
+  }
+  return values.some((value) => containsTaskResult(value, workId, expected));
+}
+
+function containsTaskResultEvidence(container: unknown, identity: string, expected: unknown): boolean {
+  if (isDeepStrictEqual(container, expected)) {
+    return true;
+  }
+  if (Array.isArray(container)) {
+    return container.some((value) => containsTaskResultEvidence(value, identity, expected));
+  }
+  if (!isRecord(container)) {
+    return false;
+  }
+  if (isRecord(expected) && containsIdentity(container, identity)) {
+    const producedPayload = Object.entries(expected).filter(
+      ([, value]) =>
+        typeof value !== "boolean" &&
+        !(typeof value === "string" && value.toLowerCase() === identity.toLowerCase()) &&
+        !(Array.isArray(value) && value.length === 0),
+    );
+    if (producedPayload.some(([, value]) => containsValue(container, value))) {
+      return true;
+    }
+  }
+  return Object.values(container).some((value) => containsTaskResultEvidence(value, identity, expected));
+}
+
+function containsNamedResultProjection(container: unknown, expected: unknown, keys: string[]): boolean {
+  if (Array.isArray(container)) {
+    return container.some((value) => containsNamedResultProjection(value, expected, keys));
+  }
+  if (!isRecord(container) || !isRecord(expected)) return false;
+  if (
+    keys.every(
+      (key) =>
+        Object.hasOwn(expected, key) &&
+        Object.hasOwn(container, key) &&
+        isDeepStrictEqual(container[key], expected[key]),
+    )
+  ) {
+    return true;
+  }
+  return Object.values(container).some((value) => containsNamedResultProjection(value, expected, keys));
+}
+
+function containsResultProjection(container: unknown, expected: unknown): boolean {
+  if (isDeepStrictEqual(container, expected)) return true;
+  if (Array.isArray(container)) {
+    return container.some((value) => containsResultProjection(value, expected));
+  }
+  if (!isRecord(container)) return false;
+  if (isRecord(expected)) {
+    const expectedEntries = Object.entries(expected);
+    if (
+      expectedEntries.length > 0 &&
+      expectedEntries.every(([key, value]) => Object.hasOwn(container, key) && isDeepStrictEqual(container[key], value))
+    ) {
+      return true;
+    }
+  }
+  return Object.values(container).some((value) => containsResultProjection(value, expected));
+}
+
+function containsValue(container: unknown, expected: unknown): boolean {
+  if (isDeepStrictEqual(container, expected)) {
+    return true;
+  }
+  if (Array.isArray(container)) {
+    return container.some((value) => containsValue(value, expected));
+  }
+  return isRecord(container) && Object.values(container).some((value) => containsValue(value, expected));
+}
+
+function promptContainsValue(prompt: string, value: unknown): boolean {
+  if (typeof value === "string") {
+    return prompt.includes(value);
+  }
+  const serialized = JSON.stringify(value);
+  return serialized !== undefined && prompt.includes(serialized);
+}
+
+function promptContainsCandidate(prompt: string, candidate: Record<string, unknown>): boolean {
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.proposal === "string" &&
+    prompt.includes(candidate.id) &&
+    prompt.includes(candidate.proposal)
+  );
+}
+
+function isIdentityKey(key: string): boolean {
+  return /^(?:id|candidate.?id)$/i.test(key);
+}
+
+function isDecisionBooleanKey(key: string): boolean {
+  return /^(?:accept|accepted|pass|passed|selected)$/i.test(key);
+}
+
+function isDecisionExplanationKey(key: string): boolean {
+  return /^(?:reason|rationale|explanation)$/i.test(key);
+}
+
+function hasDecisionProperties(properties: Record<string, unknown>): boolean {
+  return Object.keys(properties).some(
+    (key) => isDecisionBooleanKey(key) || isDecisionExplanationKey(key) || /^(?:decision|verdict|score)$/i.test(key),
+  );
+}
+
+function schemaLiteralOr(schema: unknown, fallback: unknown): unknown {
+  if (isRecord(schema) && Object.hasOwn(schema, "const")) {
+    return schema.const;
+  }
+  if (isRecord(schema) && Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
+  return fallback;
+}
+
+function isCandidateSchema(schema: unknown): boolean {
+  if (!isRecord(schema) || schema.type !== "object") {
+    return false;
+  }
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  return Object.hasOwn(properties, "id") && Object.hasOwn(properties, "proposal") && !hasDecisionProperties(properties);
+}
+
+function schemaContainsCandidate(schema: unknown): boolean {
+  if (isCandidateSchema(schema)) {
+    return true;
+  }
+  if (!isRecord(schema)) {
+    return false;
+  }
+  if (
+    (Object.hasOwn(schema, "const") && generatedCandidatesFromResult(schema.const) !== null) ||
+    (Array.isArray(schema.enum) && generatedCandidatesFromResult(schema.enum) !== null)
+  ) {
+    return true;
+  }
+  if (schema.type === "array") {
+    const prefixItems = Array.isArray(schema.prefixItems) ? schema.prefixItems : [];
+    return (
+      prefixItems.some((itemSchema) => schemaContainsCandidate(itemSchema)) ||
+      (schema.items !== false && (schema.items === undefined || schemaContainsCandidate(schema.items)))
+    );
+  }
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  return Object.values(properties).some((propertySchema) => schemaContainsCandidate(propertySchema));
+}
+
+function isGenerateFilterGeneratorSchema(schema: unknown): boolean {
+  if (!isRecord(schema)) {
+    return false;
+  }
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  if (hasDecisionProperties(properties)) {
+    return false;
+  }
+  return schemaContainsCandidate(schema);
+}
+
+function candidateFromSchema(
+  schema: unknown,
+  candidate: Record<string, unknown>,
+  label: string,
+): Record<string, unknown> {
+  const sampled = sampleSchema(schema, label, typeof candidate.id === "string" ? candidate.id : undefined);
+  if (!isRecord(sampled)) {
+    return candidate;
+  }
+  const properties = isRecord(schema) && isRecord(schema.properties) ? schema.properties : {};
+  return {
+    ...sampled,
+    id: schemaLiteralOr(properties.id, candidate.id),
+    proposal: schemaLiteralOr(properties.proposal, candidate.proposal),
+  };
+}
+
+function fillGeneratorSchema(
+  schema: unknown,
+  candidates: Array<Record<string, unknown>>,
+  label: string,
+): GeneratorFixtureValue {
+  if (isRecord(schema) && Object.hasOwn(schema, "const")) {
+    return {
+      value: schema.const,
+      consumed: generatedCandidatesFromResult(schema.const)?.length ?? 0,
+    };
+  }
+  if (isCandidateSchema(schema)) {
+    const candidate = candidates[0] ?? { id: "signal-a", proposal: "proposal:signal-a" };
+    return { value: candidateFromSchema(schema, candidate, label), consumed: 1 };
+  }
+  if (!isRecord(schema)) {
+    return { value: candidates, consumed: candidates.length };
+  }
+  if (schema.type === "array") {
+    const prefixItems = Array.isArray(schema.prefixItems) ? schema.prefixItems : [];
+    const prefixed = prefixItems.map((itemSchema, index) => {
+      const candidate = candidates[index] ?? { id: `signal-${index + 1}`, proposal: `proposal:signal-${index + 1}` };
+      return candidateFromSchema(itemSchema, candidate, label);
+    });
+    if (schema.items === false) {
+      return { value: prefixed, consumed: prefixed.length };
+    }
+    const enumeratedItems =
+      isRecord(schema.items) && Array.isArray(schema.items.enum)
+        ? generatedCandidatesFromResult(schema.items.enum)
+        : null;
+    if (enumeratedItems) {
+      const maxItems =
+        typeof schema.maxItems === "number" && Number.isFinite(schema.maxItems)
+          ? Math.max(0, Math.floor(schema.maxItems))
+          : enumeratedItems.length + prefixed.length;
+      const selected = enumeratedItems.slice(0, Math.max(0, maxItems - prefixed.length));
+      return { value: [...prefixed, ...selected], consumed: prefixed.length + selected.length };
+    }
+    const remaining = candidates.slice(prefixed.length);
+    return {
+      value: [...prefixed, ...remaining.map((candidate) => candidateFromSchema(schema.items, candidate, label))],
+      consumed: prefixed.length + remaining.length,
+    };
+  }
+  const sampled = sampleSchema(schema, label);
+  if (!isRecord(sampled)) {
+    return { value: sampled, consumed: 0 };
+  }
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  let consumed = 0;
+  for (const [key, propertySchema] of Object.entries(properties)) {
+    if (!schemaContainsCandidate(propertySchema)) {
+      continue;
+    }
+    const nested = fillGeneratorSchema(propertySchema, candidates.slice(consumed), label);
+    sampled[key] = nested.value;
+    consumed += nested.consumed;
+  }
+  return { value: sampled, consumed };
+}
+
+function createGeneratorResult(schema: unknown, candidates: Array<Record<string, unknown>>, label: string): unknown {
+  if (isCandidateSchema(schema)) {
+    const duplicate = candidates.find(({ id }) => id === "shared") ?? candidates[0];
+    return duplicate ? candidateFromSchema(schema, duplicate, label) : sampleSchema(schema, label);
+  }
+  return fillGeneratorSchema(schema, candidates, label).value;
+}
+
+function generatedCandidatesFromResult(result: unknown): Array<Record<string, unknown>> | null {
+  const candidates: Array<Record<string, unknown>> = [];
+  const collect = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        collect(item);
+      }
+      return;
+    }
+    if (!isRecord(value)) {
+      return;
+    }
+    if (typeof value.id === "string" && typeof value.proposal === "string") {
+      candidates.push(value);
+      return;
+    }
+    for (const nested of Object.values(value)) {
+      collect(nested);
+    }
+  };
+  collect(result);
+  return candidates.length > 0 ? candidates : null;
+}
+
+function fillFilterDecisionSchema(schema: unknown, identity: string, accepted: boolean, label: string): unknown {
+  if (!isRecord(schema) || schema.type !== "object") {
+    return sampleSchema(schema, label, identity);
+  }
+  const sampled = sampleSchema(schema, label, identity);
+  if (!isRecord(sampled)) {
+    return sampled;
+  }
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  for (const [key, propertySchema] of Object.entries(properties)) {
+    if (isIdentityKey(key)) {
+      sampled[key] = schemaLiteralOr(propertySchema, identity);
+    } else if (key === "proposal") {
+      sampled[key] = schemaLiteralOr(propertySchema, `proposal:${identity}`);
+    } else if (isDecisionBooleanKey(key)) {
+      sampled[key] = schemaLiteralOr(propertySchema, accepted);
+    } else if (isDecisionExplanationKey(key)) {
+      sampled[key] = schemaLiteralOr(propertySchema, `filter:${identity}`);
+    } else if (isRecord(propertySchema) && propertySchema.type === "object") {
+      sampled[key] = fillFilterDecisionSchema(propertySchema, identity, accepted, label);
+    }
+  }
+  return sampled;
+}
+
+function createFilterDecisionResult(schema: unknown, identity: string, accepted: boolean): unknown {
+  const result = fillFilterDecisionSchema(schema, identity, accepted, `filter:${identity}`);
+  if (isRecord(result) && Object.keys(result).length > 0) {
+    return result;
+  }
+  return { id: identity, accepted, reason: `filter:${identity}` };
+}
+
+function filterDecisionIsAccepted(result: unknown): boolean {
+  if (Array.isArray(result)) {
+    return result.some((value) => filterDecisionIsAccepted(value));
+  }
+  if (!isRecord(result)) {
+    return false;
+  }
+  return Object.entries(result).some(
+    ([key, value]) =>
+      (isDecisionBooleanKey(key) && value === true) ||
+      ((!isDecisionBooleanKey(key) || value !== false) && filterDecisionIsAccepted(value)),
+  );
+}
+
+function containsCandidateProjection(container: unknown, candidate: Record<string, unknown>): boolean {
+  return containsNamedResultProjection(container, candidate, ["id", "proposal"]);
+}
+
+function decisionPayloadValues(result: unknown): unknown[] {
+  if (Array.isArray(result)) {
+    return result.flatMap((value) => decisionPayloadValues(value));
+  }
+  if (!isRecord(result)) {
+    return [];
+  }
+  return Object.entries(result).flatMap(([key, value]) => {
+    if (isDecisionExplanationKey(key)) {
+      return [value];
+    }
+    return decisionPayloadValues(value);
+  });
+}
+
+function containsFilterDecisionEvidence(container: unknown, result: unknown, identity: string): boolean {
+  if (containsResultProjection(container, result)) {
+    return true;
+  }
+  if (!containsIdentity(container, identity)) {
+    return false;
+  }
+  return decisionPayloadValues(result).every((value) => containsValue(container, value));
+}
+
+function singleFieldProjection(value: unknown): unknown[] {
+  if (!isRecord(value)) return [];
+  const values = Object.values(value);
+  return values.length === 1 ? values : [];
+}
+
+function jsonValuesInText(text: string): unknown[] {
+  const values: unknown[] = [];
+  for (let start = 0; start < text.length; start++) {
+    if (text[start] !== "{" && text[start] !== "[") {
+      continue;
+    }
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let end = start; end < text.length; end++) {
+      const character = text[end];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (character === "\\") {
+          escaped = true;
+        } else if (character === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (character === '"') {
+        inString = true;
+      } else if (character === "{" || character === "[") {
+        depth++;
+      } else if (character === "}" || character === "]") {
+        depth--;
+        if (depth === 0) {
+          try {
+            const parsed: unknown = JSON.parse(text.slice(start, end + 1));
+            values.push(parsed);
+          } catch {
+            // Continue scanning other balanced JSON candidates in the prompt.
+          }
+          start = end;
+          break;
+        }
+      }
+    }
+  }
+  return values;
+}
+
+function promptContainsJsonProjection(prompt: string, result: unknown): boolean {
+  return promptContainsValue(prompt, result) || jsonValuesInText(prompt).some((value) => containsValue(value, result));
+}
+
+function promptContainsResultOrSingleFieldProjection(prompt: string, result: unknown): boolean {
+  return (
+    promptContainsJsonProjection(prompt, result) ||
+    singleFieldProjection(result).some((value) => promptContainsJsonProjection(prompt, value))
+  );
+}
+
+function containsMissingCoverage(container: unknown, identity: string): boolean {
+  if (Array.isArray(container)) {
+    return container.some((value) => containsMissingCoverage(value, identity));
+  }
+  if (!isRecord(container)) {
+    return false;
+  }
+  if (containsIdentity(container, identity)) {
+    const missing = Object.entries(container).some(([key, value]) => {
+      if (/^(?:missing|failed|unavailable)$/i.test(key)) {
+        return value === true || containsIdentity(value, identity);
+      }
+      if (/^status$/i.test(key)) {
+        return typeof value === "string" && /miss|fail|unavailable/i.test(value);
+      }
+      if (/^(?:result|value|data)$/i.test(key)) {
+        return value === null;
+      }
+      if (/^missing.*ids?$/i.test(key)) {
+        return containsIdentity(value, identity);
+      }
+      return false;
+    });
+    if (missing) {
+      return true;
+    }
+  }
+  return Object.values(container).some((value) => containsMissingCoverage(value, identity));
+}
+
+function judgedAttemptFromPrompt(prompt: string, candidateResult: unknown): unknown {
+  return jsonValuesInText(prompt).find((value) => containsResultProjection(value, candidateResult));
+}
+
+function containsResultOrSingleFieldProjection(container: unknown, result: unknown): boolean {
+  return (
+    containsValue(container, result) || singleFieldProjection(result).some((value) => containsValue(container, value))
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function serializable(value: unknown): unknown {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function failure(stage: Exclude<ComprehensionFailureStage, "assertion">, error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    stage,
+    message,
+    ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+  };
+}

--- a/src/workflow-comprehension.ts
+++ b/src/workflow-comprehension.ts
@@ -1115,11 +1115,7 @@ function sampleProperty(key: string, schema: unknown, label: string, taskIdentit
   return `${key}:${label}`;
 }
 
-function callWithin(
-  calls: RuntimeCall[],
-  start: RuntimeEvent | undefined,
-  end: RuntimeEvent | undefined,
-): RuntimeCall | undefined {
+function callWithin(calls: RuntimeCall[], start?: RuntimeEvent, end?: RuntimeEvent): RuntimeCall | undefined {
   if (!start || !end) {
     return undefined;
   }

--- a/src/workflow-context-measurement.ts
+++ b/src/workflow-context-measurement.ts
@@ -1,0 +1,226 @@
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { createWorkflowTool } from "./workflow-tool.js";
+
+/** Package-relative generated context-measurement artifact. */
+export const WORKFLOW_CONTEXT_MEASUREMENT_PATH = "docs/workflow-context-surfaces.json";
+const ROOT = join(import.meta.dirname, "..");
+const SKILL_ROOT = "skills/workflow-authoring";
+const SKILL_PATH = `${SKILL_ROOT}/SKILL.md`;
+
+/** Canonical task profiles used for stable byte-based on-demand context measurements. */
+export const WORKFLOW_AUTHORING_PROFILES = [
+  {
+    name: "write",
+    files: [
+      SKILL_PATH,
+      `${SKILL_ROOT}/references/runtime.md`,
+      `${SKILL_ROOT}/references/pattern-selection.md`,
+      `${SKILL_ROOT}/references/focused-recipes.md`,
+      `${SKILL_ROOT}/examples/fan-out-and-synthesize.js`,
+      `${SKILL_ROOT}/examples/structured-output.js`,
+    ],
+  },
+  {
+    name: "edit",
+    files: [
+      SKILL_PATH,
+      `${SKILL_ROOT}/references/runtime.md`,
+      `${SKILL_ROOT}/references/lifecycle.md`,
+      `${SKILL_ROOT}/references/focused-recipes.md`,
+      `${SKILL_ROOT}/examples/phased-budgets.js`,
+      `${SKILL_ROOT}/examples/saved-nested-workflows.js`,
+    ],
+  },
+  {
+    name: "review",
+    files: [
+      SKILL_PATH,
+      `${SKILL_ROOT}/references/runtime.md`,
+      `${SKILL_ROOT}/references/review.md`,
+      `${SKILL_ROOT}/references/quality-helpers.md`,
+      `${SKILL_ROOT}/examples/adversarial-verification.js`,
+    ],
+  },
+  {
+    name: "debug",
+    files: [
+      SKILL_PATH,
+      `${SKILL_ROOT}/references/runtime.md`,
+      `${SKILL_ROOT}/references/debugging.md`,
+      `${SKILL_ROOT}/references/specialized-helpers.md`,
+      `${SKILL_ROOT}/examples/validated-gate.js`,
+    ],
+  },
+  {
+    name: "loop",
+    files: [
+      SKILL_PATH,
+      `${SKILL_ROOT}/references/runtime.md`,
+      `${SKILL_ROOT}/references/pattern-selection.md`,
+      `${SKILL_ROOT}/references/lifecycle.md`,
+      `${SKILL_ROOT}/references/focused-recipes.md`,
+      `${SKILL_ROOT}/examples/loop-until-done.js`,
+      `${SKILL_ROOT}/examples/structured-output.js`,
+    ],
+  },
+  {
+    name: "retry",
+    files: [
+      SKILL_PATH,
+      `${SKILL_ROOT}/references/runtime.md`,
+      `${SKILL_ROOT}/references/retry-helper.md`,
+      `${SKILL_ROOT}/references/focused-recipes.md`,
+      `${SKILL_ROOT}/examples/bounded-semantic-retry.js`,
+      `${SKILL_ROOT}/examples/structured-output.js`,
+    ],
+  },
+] as const;
+
+interface ByteSurface {
+  serialization: string;
+  bytes: number;
+}
+
+/** Versioned byte measurements for always-on, discovery, corpus, and representative authoring surfaces. */
+export interface WorkflowContextMeasurement {
+  formatVersion: 2;
+  encoding: "utf8";
+  sources: ["src/workflow-tool.ts", "skills/workflow-authoring"];
+  surfaces: {
+    permanentWorkflowPrompt: ByteSurface;
+    providerVisibleWorkflowToolDefinition: ByteSurface;
+    workflowAuthoringSkillDiscovery: ByteSurface;
+    ordinaryWorkflowOwnedAlwaysOn: ByteSurface;
+    workflowAuthoringSkillCorpus: ByteSurface & { files: number };
+    representativeAuthoringProfiles: {
+      serialization: "sum of UTF-8 bytes for each profile's declared package-relative files";
+      medianBytes: number;
+      profiles: Array<{ name: string; files: string[]; bytes: number }>;
+    };
+  };
+}
+
+function bytes(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function fileBytes(root: string, path: string): number {
+  return bytes(readFileSync(join(root, path), "utf8"));
+}
+
+function skillFiles(root: string): string[] {
+  const absoluteRoot = join(root, SKILL_ROOT);
+  const pending = [absoluteRoot];
+  const files: string[] = [];
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    if (!directory) continue;
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const absolute = join(directory, entry.name);
+      if (entry.isDirectory()) pending.push(absolute);
+      else if (entry.isFile()) files.push(relative(root, absolute).replaceAll("\\", "/"));
+    }
+  }
+  return files.sort();
+}
+
+function skillDiscoveryEntry(root: string): string {
+  const skill = readFileSync(join(root, SKILL_PATH), "utf8");
+  const name = /^name:\s*(.+)$/m.exec(skill)?.[1]?.trim();
+  const description = /^description:\s*(.+)$/m.exec(skill)?.[1]?.trim();
+  if (!name || !description) throw new Error(`${SKILL_PATH} must declare name and description`);
+  return [
+    "<skill>",
+    `  <name>${name}</name>`,
+    `  <description>${description}</description>`,
+    `  <location>${SKILL_PATH}</location>`,
+    "</skill>",
+  ].join("\n");
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = sorted.length / 2;
+  return sorted.length % 2 === 0
+    ? ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2
+    : (sorted[Math.floor(middle)] ?? 0);
+}
+
+/** Measures permanent, discovery, corpus, and canonical on-demand workflow context surfaces. */
+export function measureWorkflowContextSurfaces(root: string = ROOT): WorkflowContextMeasurement {
+  const tool = createWorkflowTool();
+  const permanentWorkflowPrompt = [
+    `- workflow: ${tool.promptSnippet}`,
+    ...(tool.promptGuidelines ?? []).map((guideline) => `- ${guideline}`),
+  ].join("\n");
+  const providerVisibleWorkflowToolDefinition = JSON.stringify({
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.parameters,
+  });
+  const discoveryEntry = skillDiscoveryEntry(root);
+  const corpusFiles = skillFiles(root);
+  const corpusBytes = corpusFiles.reduce((sum, path) => sum + fileBytes(root, path), 0);
+  const profiles = WORKFLOW_AUTHORING_PROFILES.map((profile) => ({
+    name: profile.name,
+    files: [...profile.files],
+    bytes: profile.files.reduce((sum, path) => sum + fileBytes(root, path), 0),
+  }));
+  const promptBytes = bytes(permanentWorkflowPrompt);
+  const toolBytes = bytes(providerVisibleWorkflowToolDefinition);
+  const discoveryBytes = bytes(discoveryEntry);
+
+  return {
+    formatVersion: 2,
+    encoding: "utf8",
+    sources: ["src/workflow-tool.ts", "skills/workflow-authoring"],
+    surfaces: {
+      permanentWorkflowPrompt: {
+        serialization: "UTF-8 bytes of LF-joined Pi prompt lines",
+        bytes: promptBytes,
+      },
+      providerVisibleWorkflowToolDefinition: {
+        serialization: "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
+        bytes: toolBytes,
+      },
+      workflowAuthoringSkillDiscovery: {
+        serialization: "UTF-8 bytes of normalized Pi skill XML with package-relative location",
+        bytes: discoveryBytes,
+      },
+      ordinaryWorkflowOwnedAlwaysOn: {
+        serialization:
+          "sum of permanent prompt, provider-visible tool definition, and normalized skill discovery bytes",
+        bytes: promptBytes + toolBytes + discoveryBytes,
+      },
+      workflowAuthoringSkillCorpus: {
+        serialization: "sum of UTF-8 bytes for every file under skills/workflow-authoring",
+        files: corpusFiles.length,
+        bytes: corpusBytes,
+      },
+      representativeAuthoringProfiles: {
+        serialization: "sum of UTF-8 bytes for each profile's declared package-relative files",
+        medianBytes: median(profiles.map(({ bytes: profileBytes }) => profileBytes)),
+        profiles,
+      },
+    },
+  };
+}
+
+/** Render the current measurement as deterministic formatted JSON. */
+export function renderWorkflowContextMeasurement(): string {
+  return `${JSON.stringify(measureWorkflowContextSurfaces(), null, 2)}\n`;
+}
+
+/** Write the generated measurement under root and return the measured values. */
+export function writeWorkflowContextMeasurement(root: string): WorkflowContextMeasurement {
+  const measurement = measureWorkflowContextSurfaces(root);
+  writeFileSync(join(root, WORKFLOW_CONTEXT_MEASUREMENT_PATH), `${JSON.stringify(measurement, null, 2)}\n`);
+  return measurement;
+}
+
+/** Report whether committed or supplied measurement JSON matches current package bytes. */
+export function checkWorkflowContextMeasurement(root: string, actual?: string): boolean {
+  const committed = actual ?? readFileSync(join(root, WORKFLOW_CONTEXT_MEASUREMENT_PATH), "utf8");
+  return committed === `${JSON.stringify(measureWorkflowContextSurfaces(root), null, 2)}\n`;
+}

--- a/src/workflow-delivery-choice.ts
+++ b/src/workflow-delivery-choice.ts
@@ -1,0 +1,69 @@
+/** One model-facing timing decision for invoking the workflow tool. */
+export interface WorkflowDeliveryChoiceScenario {
+  id: string;
+  prompt: string;
+  expectedBackground: boolean;
+}
+
+/** Pure scoring result for one captured workflow tool invocation. */
+export interface WorkflowDeliveryChoiceEvaluation {
+  passed: boolean;
+  resolvedBackground: boolean | null;
+  assertions: Array<{ name: string; passed: boolean; details: string }>;
+}
+
+/** Focused #89 scenarios for default background delivery versus same-turn use. */
+export const WORKFLOW_DELIVERY_CHOICE_SCENARIOS: readonly WorkflowDeliveryChoiceScenario[] = [
+  {
+    id: "background-delivery",
+    prompt:
+      "Run a workflow to audit the repository from several independent angles. I do not need the result in this turn; let it be delivered back later so I can keep working.",
+    expectedBackground: true,
+  },
+  {
+    id: "inline-result",
+    prompt:
+      "Run a workflow to compare the two proposed designs, then use its result in your answer in this same turn. I am waiting for the result before you respond.",
+    expectedBackground: false,
+  },
+];
+
+/** Score captured workflow arguments without executing the submitted workflow. */
+export function evaluateWorkflowDeliveryChoice(
+  scenario: WorkflowDeliveryChoiceScenario,
+  value: unknown,
+): WorkflowDeliveryChoiceEvaluation {
+  const input = isRecord(value) ? value : null;
+  const hasScript = typeof input?.script === "string" && input.script.trim().length > 0;
+  const validBackground = input !== null && (input.background === undefined || typeof input.background === "boolean");
+  const resolvedBackground = validBackground ? (typeof input.background === "boolean" ? input.background : true) : null;
+  const timingMatches = resolvedBackground === scenario.expectedBackground;
+  const assertions = [
+    {
+      name: "workflow:called-with-script",
+      passed: hasScript,
+      details: "the model must invoke the real workflow tool shape with a nonblank script",
+    },
+    {
+      name: "background:valid-type",
+      passed: validBackground,
+      details: "background must be omitted for its true default or supplied as a boolean",
+    },
+    {
+      name: "background:matches-user-timing",
+      passed: timingMatches,
+      details: scenario.expectedBackground
+        ? "later delivery should use the default background run"
+        : "same-turn use should pass background: false",
+    },
+  ];
+  return {
+    passed: assertions.every(({ passed }) => passed),
+    resolvedBackground,
+    assertions,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/workflow-release-gate.ts
+++ b/src/workflow-release-gate.ts
@@ -254,7 +254,7 @@ function validateAuthoringCoverage(
       );
       continue;
     }
-    const drifted = entry.protectedGuidance.some(({ path, anchor, requiredText }) => {
+    const drifted = entry.protectedGuidance.find(({ path, anchor, requiredText }) => {
       const absolute = join(root, path);
       if (!existsSync(absolute) && guidanceOverrides[path] === undefined) return true;
       const source = guidanceOverrides[path] ?? readFileSync(absolute, "utf8");
@@ -264,11 +264,26 @@ function validateAuthoringCoverage(
       );
     });
     if (drifted) {
+      const absolute = join(root, drifted.path);
+      const source =
+        !existsSync(absolute) && guidanceOverrides[drifted.path] === undefined
+          ? null
+          : (guidanceOverrides[drifted.path] ?? readFileSync(absolute, "utf8"));
+      const failedChecks: string[] = [];
+      if (source === null) {
+        failedChecks.push("protected file");
+      }
+      if (source !== null && drifted.anchor !== undefined && !anchorExists(source, drifted.anchor)) {
+        failedChecks.push("required anchor");
+      }
+      if (source !== null && drifted.requiredText !== undefined && !source.includes(drifted.requiredText)) {
+        failedChecks.push("required text");
+      }
       diagnostics.push(
         diagnostic(
           WorkflowReleaseDiagnosticCode.PROTECTED_GUIDANCE_DRIFT,
           entry.id,
-          `Guidance-frozen authoring surface ${entry.id} changed without provider-backed comprehension coverage.`,
+          `Protected guidance for ${entry.id} no longer matches the ${failedChecks.join(" and ")} in ${drifted.path}. Restore it to undo an accidental change. For an intentional change, inspect the coverage manifest and relevant behavioral/provider evidence before deliberately updating the corresponding anchor/text in src/workflow-authoring-coverage.ts. See CONTRIBUTING.md#protected-workflow-authoring-guidance.`,
         ),
       );
     }
@@ -287,7 +302,7 @@ function validateFrozenGuidanceFiles(
         diagnostic(
           WorkflowReleaseDiagnosticCode.PROTECTED_GUIDANCE_DRIFT,
           path,
-          `Frozen workflow authoring guidance file is missing: ${path}.`,
+          `Protected workflow-authoring file is missing: ${path}. Restore an accidental deletion. An intentional removal requires review of the coverage manifest and relevant behavioral/provider evidence, followed by deliberate updates to authoring coverage and package resources. See CONTRIBUTING.md#protected-workflow-authoring-guidance.`,
         ),
       ];
     }
@@ -298,7 +313,7 @@ function validateFrozenGuidanceFiles(
           diagnostic(
             WorkflowReleaseDiagnosticCode.PROTECTED_GUIDANCE_DRIFT,
             path,
-            `Mixed workflow authoring guidance changed without reviewed coverage protection: ${path}.`,
+            `Protected workflow-authoring file changed: ${path}. Its SHA-256 is a deliberate anti-overfitting and manual-review gate. Revert accidental changes. For an intentional reviewed change, inspect the coverage manifest and relevant behavioral/provider evidence, recompute the exact SHA-256, and manually update the matching sha256 in WORKFLOW_AUTHORING_FROZEN_FILES (src/workflow-authoring-coverage.ts). See CONTRIBUTING.md#protected-workflow-authoring-guidance.`,
           ),
         ];
   });

--- a/src/workflow-release-gate.ts
+++ b/src/workflow-release-gate.ts
@@ -1,0 +1,514 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, normalize, relative } from "node:path";
+import packageJson from "../package.json" with { type: "json" };
+import {
+  CapabilityClassification,
+  CapabilitySupport,
+  DiscoveryPlacement,
+  WorkflowAuthoringProtection,
+  WorkflowReleaseDiagnosticCode,
+} from "./enums.js";
+import {
+  WORKFLOW_AUTHORING_COVERAGE,
+  WORKFLOW_AUTHORING_FROZEN_FILES,
+  WORKFLOW_AUTHORING_PATTERN_IDS,
+  WORKFLOW_AUTHORING_RECIPE_IDS,
+  WORKFLOW_COMPREHENSION_SCENARIO_IDS,
+  type WorkflowAuthoringCoverageEntry,
+} from "./workflow-authoring-coverage.js";
+import {
+  type CAPABILITY_PUBLICATION_PATHS,
+  checkWorkflowCapabilityPublications,
+} from "./workflow-authoring-reference.js";
+import { WORKFLOW_CAPABILITY_DEFINITION, type WorkflowCapabilityDefinition } from "./workflow-capability-contract.js";
+import { checkWorkflowContextMeasurement, WORKFLOW_CONTEXT_MEASUREMENT_PATH } from "./workflow-context-measurement.js";
+import { createWorkflowTool } from "./workflow-tool.js";
+
+/** Re-exported stable diagnostic codes for release automation. */
+export { WorkflowReleaseDiagnosticCode } from "./enums.js";
+
+/** One actionable release alignment error or warning. */
+export interface WorkflowReleaseDiagnostic {
+  code: WorkflowReleaseDiagnosticCode;
+  severity: "error" | "warning";
+  subject: string;
+  message: string;
+}
+
+type PublicationPath = (typeof CAPABILITY_PUBLICATION_PATHS)[number];
+
+/** Inputs and test overrides for the model-free workflow release gate. */
+export interface WorkflowReleaseCheckOptions {
+  root: string;
+  definition?: WorkflowCapabilityDefinition;
+  extensionVersion?: string;
+  skillVersion?: string;
+  publishableFiles: readonly string[];
+  publicationOverrides?: Readonly<Partial<Record<PublicationPath, string>>>;
+  contextMeasurement?: string;
+  guidanceBaseline?: string;
+  authoringCoverage?: readonly WorkflowAuthoringCoverageEntry[];
+  guidanceOverrides?: Readonly<Record<string, string>>;
+}
+
+const SKILL_ROOT = "skills/workflow-authoring";
+/** Package-relative generated hash baseline for compact and detailed guidance. */
+export const WORKFLOW_GUIDANCE_BASELINE_PATH = "docs/workflow-guidance-baseline.json";
+const FOCUSED_REFERENCES = [
+  "capabilities",
+  "capability-details",
+  "runtime",
+  "helpers",
+  "common-helpers",
+  "quality-helpers",
+  "retry-helper",
+  "specialized-helpers",
+  "lifecycle",
+  "versions",
+  "pattern-selection",
+  "focused-recipes",
+  "registry-ownership",
+  "review",
+  "debugging",
+] as const;
+const PATTERNS = [
+  "classify-and-act",
+  "fan-out-and-synthesize",
+  "adversarial-verification",
+  "generate-and-filter",
+  "tournament",
+  "loop-until-done",
+] as const;
+const RECIPES = ["phased-budgets", "saved-nested-workflows", "bounded-semantic-retry", "structured-output"] as const;
+
+/** Skill files that must be present in the publishable npm package. */
+export const REQUIRED_WORKFLOW_PACKAGE_RESOURCES = [
+  `${SKILL_ROOT}/SKILL.md`,
+  ...FOCUSED_REFERENCES.map((name) => `${SKILL_ROOT}/references/${name}.md`),
+  ...PATTERNS.map((name) => `${SKILL_ROOT}/examples/${name}.js`),
+  ...RECIPES.map((name) => `${SKILL_ROOT}/examples/${name}.js`),
+] as const;
+
+function diagnostic(
+  code: WorkflowReleaseDiagnosticCode,
+  subject: string,
+  message: string,
+  severity: WorkflowReleaseDiagnostic["severity"] = "error",
+): WorkflowReleaseDiagnostic {
+  return { code, severity, subject, message };
+}
+
+function skillVersion(root: string): string | null {
+  const skill = readFileSync(join(root, SKILL_ROOT, "SKILL.md"), "utf8");
+  return /^\s{2}version:\s*["']?([^"'\s]+)["']?\s*$/m.exec(skill)?.[1] ?? null;
+}
+
+function anchorExists(markdown: string, anchor: string): boolean {
+  if (markdown.includes(`<a id="${anchor}"></a>`)) return true;
+  return markdown
+    .split("\n")
+    .filter((line) => /^#{1,6} /.test(line))
+    .map((line) =>
+      line
+        .replace(/^#{1,6} /, "")
+        .toLowerCase()
+        .replace(/[^a-z0-9 -]/g, "")
+        .trim()
+        .replace(/ +/g, "-"),
+    )
+    .includes(anchor);
+}
+
+function validateVersions(
+  definition: WorkflowCapabilityDefinition,
+  extensionVersion: string,
+  installedSkillVersion: string | null,
+): WorkflowReleaseDiagnostic[] {
+  const diagnostics: WorkflowReleaseDiagnostic[] = [];
+  const versions: Array<[string, string | null]> = [
+    ["contract extension", definition.versions.extension],
+    ["contract content", definition.versions.content.version],
+    ["installed skill", installedSkillVersion],
+  ];
+  for (const [subject, actual] of versions) {
+    if (actual !== extensionVersion) {
+      diagnostics.push(
+        diagnostic(
+          WorkflowReleaseDiagnosticCode.INCOMPATIBLE_VERSION,
+          subject,
+          `${subject} version ${actual ?? "<missing>"} must match extension version ${extensionVersion}.`,
+        ),
+      );
+    }
+  }
+  if (definition.versions.format.kind !== "present-at" || !/^1(?:\.|$)/.test(definition.versions.format.version)) {
+    diagnostics.push(
+      diagnostic(
+        WorkflowReleaseDiagnosticCode.INCOMPATIBLE_VERSION,
+        "contract format",
+        `Contract format ${definition.versions.format.version} is incompatible with supported format major 1.`,
+      ),
+    );
+  }
+  return diagnostics;
+}
+
+function validateCapabilityLinks(root: string, definition: WorkflowCapabilityDefinition): WorkflowReleaseDiagnostic[] {
+  const diagnostics: WorkflowReleaseDiagnostic[] = [];
+  for (const capability of definition.capabilities) {
+    if (
+      capability.support === CapabilitySupport.SUPPORTED &&
+      capability.discovery !== DiscoveryPlacement.NONE &&
+      capability.behaviorEvidence.length === 0
+    ) {
+      diagnostics.push(
+        diagnostic(
+          WorkflowReleaseDiagnosticCode.MISSING_BEHAVIOR_EVIDENCE,
+          capability.id,
+          `Advertised capability ${capability.id} has no behavior-test evidence.`,
+        ),
+      );
+    }
+    for (const evidence of capability.behaviorEvidence) {
+      if (!existsSync(join(root, evidence))) {
+        diagnostics.push(
+          diagnostic(
+            WorkflowReleaseDiagnosticCode.UNRESOLVED_BEHAVIOR_EVIDENCE,
+            evidence,
+            `Capability ${capability.id} references missing behavior test ${evidence}.`,
+          ),
+        );
+      }
+    }
+    if (capability.staticReference) {
+      const { path, anchor } = capability.staticReference;
+      const absolute = join(root, path);
+      const subject = `${path}#${anchor}`;
+      if (!existsSync(absolute) || !anchorExists(readFileSync(absolute, "utf8"), anchor)) {
+        diagnostics.push(
+          diagnostic(
+            WorkflowReleaseDiagnosticCode.BROKEN_CONTRACT_REFERENCE,
+            subject,
+            `Capability ${capability.id} references unresolved installed documentation ${subject}.`,
+          ),
+        );
+      }
+    }
+  }
+  return diagnostics;
+}
+
+function validateAuthoringCoverage(
+  root: string,
+  definition: WorkflowCapabilityDefinition,
+  coverage: readonly WorkflowAuthoringCoverageEntry[],
+  guidanceOverrides: Readonly<Record<string, string>> = {},
+): WorkflowReleaseDiagnostic[] {
+  const expectedIds = [
+    ...definition.capabilities
+      .filter(
+        ({ discovery, support }) => discovery !== DiscoveryPlacement.NONE && support !== CapabilitySupport.INTERNAL,
+      )
+      .map(({ id }) => id),
+    ...WORKFLOW_AUTHORING_PATTERN_IDS,
+    ...WORKFLOW_AUTHORING_RECIPE_IDS,
+  ];
+  const observed = new Set(coverage.map(({ id }) => id));
+  const diagnostics = expectedIds
+    .filter((id) => !observed.has(id))
+    .map((id) =>
+      diagnostic(
+        WorkflowReleaseDiagnosticCode.MISSING_AUTHORING_COVERAGE,
+        id,
+        `Stable workflow authoring surface ${id} is absent from the capability coverage manifest.`,
+      ),
+    );
+
+  const knownScenarioIds = new Set(WORKFLOW_COMPREHENSION_SCENARIO_IDS);
+  for (const entry of coverage.filter(
+    ({ protection }) => protection === WorkflowAuthoringProtection.BEHAVIORALLY_COVERED,
+  )) {
+    if (
+      entry.comprehensionScenarios.length === 0 ||
+      entry.comprehensionScenarios.some((scenarioId) => !knownScenarioIds.has(scenarioId))
+    ) {
+      diagnostics.push(
+        diagnostic(
+          WorkflowReleaseDiagnosticCode.UNKNOWN_COMPREHENSION_SCENARIO,
+          entry.id,
+          `Behaviorally covered authoring surface ${entry.id} references a missing comprehension scenario.`,
+        ),
+      );
+    }
+  }
+
+  for (const entry of coverage.filter(({ protection }) => protection === WorkflowAuthoringProtection.GUIDANCE_FROZEN)) {
+    if (entry.protectedGuidance.length === 0) {
+      diagnostics.push(
+        diagnostic(
+          WorkflowReleaseDiagnosticCode.UNPROTECTED_AUTHORING_GUIDANCE,
+          entry.id,
+          `Untested authoring surface ${entry.id} has no frozen guidance or routing pointer.`,
+        ),
+      );
+      continue;
+    }
+    const drifted = entry.protectedGuidance.some(({ path, anchor, requiredText }) => {
+      const absolute = join(root, path);
+      if (!existsSync(absolute) && guidanceOverrides[path] === undefined) return true;
+      const source = guidanceOverrides[path] ?? readFileSync(absolute, "utf8");
+      return (
+        (anchor !== undefined && !anchorExists(source, anchor)) ||
+        (requiredText !== undefined && !source.includes(requiredText))
+      );
+    });
+    if (drifted) {
+      diagnostics.push(
+        diagnostic(
+          WorkflowReleaseDiagnosticCode.PROTECTED_GUIDANCE_DRIFT,
+          entry.id,
+          `Guidance-frozen authoring surface ${entry.id} changed without provider-backed comprehension coverage.`,
+        ),
+      );
+    }
+  }
+  return diagnostics;
+}
+
+function validateFrozenGuidanceFiles(
+  root: string,
+  guidanceOverrides: Readonly<Record<string, string>> = {},
+): WorkflowReleaseDiagnostic[] {
+  return WORKFLOW_AUTHORING_FROZEN_FILES.flatMap(({ path, sha256: expected }) => {
+    const absolute = join(root, path);
+    if (!existsSync(absolute) && guidanceOverrides[path] === undefined) {
+      return [
+        diagnostic(
+          WorkflowReleaseDiagnosticCode.PROTECTED_GUIDANCE_DRIFT,
+          path,
+          `Frozen workflow authoring guidance file is missing: ${path}.`,
+        ),
+      ];
+    }
+    const source = guidanceOverrides[path] ?? readFileSync(absolute, "utf8");
+    return sha256(source) === expected
+      ? []
+      : [
+          diagnostic(
+            WorkflowReleaseDiagnosticCode.PROTECTED_GUIDANCE_DRIFT,
+            path,
+            `Mixed workflow authoring guidance changed without reviewed coverage protection: ${path}.`,
+          ),
+        ];
+  });
+}
+
+function validateToolInputs(definition: WorkflowCapabilityDefinition): WorkflowReleaseDiagnostic[] {
+  const { parameters } = createWorkflowTool();
+  const properties: Record<string, unknown> =
+    isRecord(parameters) && isRecord(parameters.properties) ? parameters.properties : {};
+  const observed = new Set(Object.keys(properties));
+  const declared = new Set(
+    definition.capabilities
+      .filter((capability) => capability.classification === CapabilityClassification.WORKFLOW_TOOL_INPUT)
+      .map((capability) => capability.label),
+  );
+  const diagnostics: WorkflowReleaseDiagnostic[] = [];
+  for (const name of declared) {
+    if (!observed.has(name)) {
+      diagnostics.push(
+        diagnostic(
+          WorkflowReleaseDiagnosticCode.TOOL_INPUT_MISMATCH,
+          name,
+          `Declared workflow-tool input ${name} is absent from the runtime schema.`,
+        ),
+      );
+    }
+  }
+  for (const name of observed) {
+    if (!declared.has(name)) {
+      diagnostics.push(
+        diagnostic(
+          WorkflowReleaseDiagnosticCode.TOOL_INPUT_MISMATCH,
+          name,
+          `Runtime schema exposes undeclared workflow-tool input ${name}.`,
+        ),
+      );
+    }
+  }
+
+  const tokenBudget = definition.capabilities.find(
+    (capability) =>
+      capability.classification === CapabilityClassification.WORKFLOW_TOOL_INPUT && capability.label === "tokenBudget",
+  );
+  const tokenBudgetSchema = properties.tokenBudget;
+  const observedTokenBudget =
+    isRecord(tokenBudgetSchema) && typeof tokenBudgetSchema.description === "string"
+      ? tokenBudgetSchema.description
+      : "";
+  const contractCallsSoft = tokenBudget?.constraints.some((constraint) => /soft/i.test(constraint)) ?? false;
+  const contractCallsHard = tokenBudget?.constraints.some((constraint) => /hard/i.test(constraint)) ?? false;
+  const proseCallsSoft = /soft/i.test(observedTokenBudget);
+  const proseCallsHard = /hard/i.test(observedTokenBudget);
+  if ((contractCallsSoft && proseCallsHard) || (contractCallsHard && proseCallsSoft)) {
+    diagnostics.push(
+      diagnostic(
+        WorkflowReleaseDiagnosticCode.RUNTIME_CONSTRAINT_DISAGREEMENT,
+        "tokenBudget",
+        `Contract constraints and provider-visible tool prose disagree about whether tokenBudget is a soft or hard gate. Contract: ${tokenBudget?.constraints.join("; ")}. Tool prose: ${observedTokenBudget}`,
+      ),
+    );
+  }
+  return diagnostics;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/** Render deterministic hashes for provider-visible and on-demand guidance surfaces. */
+export function renderWorkflowGuidanceBaseline(root: string): string {
+  const tool = createWorkflowTool();
+  const compact = JSON.stringify({
+    description: tool.description,
+    parameters: tool.parameters,
+    promptSnippet: tool.promptSnippet,
+    promptGuidelines: tool.promptGuidelines,
+  });
+  const detailedPaths = [
+    `${SKILL_ROOT}/SKILL.md`,
+    ...FOCUSED_REFERENCES.filter((name) => name !== "capabilities" && name !== "capability-details").map(
+      (name) => `${SKILL_ROOT}/references/${name}.md`,
+    ),
+  ];
+  const detailed = detailedPaths.map((path) => `${path}\n${readFileSync(join(root, path), "utf8")}`).join("\n");
+  return `${JSON.stringify(
+    {
+      formatVersion: 1,
+      algorithm: "sha256",
+      surfaces: {
+        compactGuidance: sha256(compact),
+        detailedProse: sha256(detailed),
+      },
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+/** Refresh the committed guidance hash baseline under root. */
+export function writeWorkflowGuidanceBaseline(root: string): void {
+  writeFileSync(join(root, WORKFLOW_GUIDANCE_BASELINE_PATH), renderWorkflowGuidanceBaseline(root));
+}
+
+function validateGuidanceBaseline(root: string, actual?: string): WorkflowReleaseDiagnostic[] {
+  const committed = actual ?? readFileSync(join(root, WORKFLOW_GUIDANCE_BASELINE_PATH), "utf8");
+  if (committed === renderWorkflowGuidanceBaseline(root)) return [];
+  return [
+    diagnostic(
+      WorkflowReleaseDiagnosticCode.NON_CONTRACTUAL_PROSE_DRIFT,
+      WORKFLOW_GUIDANCE_BASELINE_PATH,
+      `Compact guidance or detailed hand-written prose changed; review intent and refresh ${WORKFLOW_GUIDANCE_BASELINE_PATH} if intentional.`,
+      "warning",
+    ),
+  ];
+}
+
+function validatePackage(root: string, publishableFiles: readonly string[]): WorkflowReleaseDiagnostic[] {
+  const diagnostics: WorkflowReleaseDiagnostic[] = [];
+  const files = new Set(publishableFiles);
+  for (const resource of REQUIRED_WORKFLOW_PACKAGE_RESOURCES) {
+    if (!files.has(resource)) {
+      diagnostics.push(
+        diagnostic(
+          WorkflowReleaseDiagnosticCode.MISSING_PACKAGE_RESOURCE,
+          resource,
+          `Publishable package omitted required workflow resource ${resource}.`,
+        ),
+      );
+    }
+  }
+
+  for (const sourcePath of publishableFiles.filter(
+    (path) => path.startsWith(`${SKILL_ROOT}/`) && path.endsWith(".md"),
+  )) {
+    const source = readFileSync(join(root, sourcePath), "utf8");
+    for (const match of source.matchAll(/\[[^\]]+\]\(([^)#]+)(?:#([^)]+))?\)/g)) {
+      const target = normalize(join(dirname(sourcePath), match[1]));
+      const anchor = match[2];
+      const outsidePackage = relative(".", target).startsWith("..");
+      const targetMissing = !files.has(target);
+      const targetSource = !targetMissing && anchor ? readFileSync(join(root, target), "utf8") : null;
+      if (outsidePackage || targetMissing || (anchor && targetSource !== null && !anchorExists(targetSource, anchor))) {
+        const subject = `${sourcePath} -> ${target}${anchor ? `#${anchor}` : ""}`;
+        diagnostics.push(
+          diagnostic(
+            WorkflowReleaseDiagnosticCode.BROKEN_PACKAGE_LINK,
+            subject,
+            `Packaged workflow skill link does not resolve: ${subject}.`,
+          ),
+        );
+      }
+    }
+  }
+  return diagnostics;
+}
+
+/** Parse publishable paths from `npm pack --dry-run --json` without trusting external JSON shapes. */
+export function parseNpmPackFilePaths(output: string): string[] {
+  const parsed: unknown = JSON.parse(output);
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  const first = parsed[0];
+  if (!isRecord(first) || !Array.isArray(first.files)) {
+    return [];
+  }
+  return first.files.flatMap((file: unknown) => (isRecord(file) && typeof file.path === "string" ? [file.path] : []));
+}
+
+/** Return every model-free contract, package, documentation, and guidance alignment diagnostic. */
+export function checkWorkflowRelease(options: WorkflowReleaseCheckOptions): WorkflowReleaseDiagnostic[] {
+  const definition = options.definition ?? WORKFLOW_CAPABILITY_DEFINITION;
+  const extensionVersion = options.extensionVersion ?? packageJson.version;
+  const installedSkillVersion = options.skillVersion ?? skillVersion(options.root);
+  const diagnostics = [
+    ...validateVersions(definition, extensionVersion, installedSkillVersion),
+    ...validateCapabilityLinks(options.root, definition),
+    ...validateAuthoringCoverage(
+      options.root,
+      definition,
+      options.authoringCoverage ?? WORKFLOW_AUTHORING_COVERAGE,
+      options.guidanceOverrides,
+    ),
+    ...validateFrozenGuidanceFiles(options.root, options.guidanceOverrides),
+    ...validateToolInputs(definition),
+    ...validatePackage(options.root, options.publishableFiles),
+    ...validateGuidanceBaseline(options.root, options.guidanceBaseline),
+  ];
+
+  for (const path of checkWorkflowCapabilityPublications(options.root, options.publicationOverrides)) {
+    diagnostics.push(
+      diagnostic(
+        WorkflowReleaseDiagnosticCode.STALE_GENERATED_SURFACE,
+        path,
+        `Generated workflow capability publication is stale: ${path}.`,
+      ),
+    );
+  }
+  if (!checkWorkflowContextMeasurement(options.root, options.contextMeasurement)) {
+    diagnostics.push(
+      diagnostic(
+        WorkflowReleaseDiagnosticCode.STALE_GENERATED_SURFACE,
+        WORKFLOW_CONTEXT_MEASUREMENT_PATH,
+        `Generated workflow context measurement is stale: ${WORKFLOW_CONTEXT_MEASUREMENT_PATH}.`,
+      ),
+    );
+  }
+  return diagnostics;
+}

--- a/src/workflow-release-gate.ts
+++ b/src/workflow-release-gate.ts
@@ -313,7 +313,7 @@ function validateFrozenGuidanceFiles(
           diagnostic(
             WorkflowReleaseDiagnosticCode.PROTECTED_GUIDANCE_DRIFT,
             path,
-            `Protected workflow-authoring file changed: ${path}. Its SHA-256 is a deliberate anti-overfitting and manual-review gate. Revert accidental changes. For an intentional reviewed change, inspect the coverage manifest and relevant behavioral/provider evidence, recompute the exact SHA-256, and manually update the matching sha256 in WORKFLOW_AUTHORING_FROZEN_FILES (src/workflow-authoring-coverage.ts). See CONTRIBUTING.md#protected-workflow-authoring-guidance.`,
+            `Protected workflow-authoring file changed: ${path}. Its SHA-256 is an explicit review checkpoint for guidance with partial behavioral coverage. Revert accidental changes. For an intentional change, inspect the coverage manifest and relevant behavioral tests, plus provider evidence when needed, then run npm run guidance:accept -- ${path}. This updates the matching sha256 in WORKFLOW_AUTHORING_FROZEN_FILES (src/workflow-authoring-coverage.ts). See CONTRIBUTING.md#protected-workflow-authoring-guidance.`,
           ),
         ];
   });

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -1,7 +1,6 @@
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { listAgentTypes, loadAgentRegistry } from "./agent-registry.js";
 import {
   createToolUpdateWorkflowDisplay,
   createWorkflowSnapshot,
@@ -19,115 +18,23 @@ import { WorkflowManager } from "./workflow-manager.js";
 import { createWorkflowStorage, type WorkflowStorage } from "./workflow-saved.js";
 import { loadWorkflowSettings } from "./workflow-settings.js";
 
-/**
- * Model routing guideline for workflow authors.
- * Tells the LLM about opts.tier (small/medium/big) for runtime-enforced
- * model selection, and opts.model for an exact provider/id override.
- *
- * This string is injected into the workflow tool's promptGuidelines and
- * therefore appears in the LLM's system prompt for every workflow execution.
- */
-export function modelRoutingGuideline(): string {
-  return [
-    "For workflow, the user configures per-tier models (/workflows-models), so TAG EVERY agent with opts.tier by role so those models are actually used.",
-    "opts.tier accepts 'small', 'medium', or 'big' and is enforced at runtime.",
-    "Small tier: lightweight exploration/search/inventory agents.",
-    "Medium tier: balanced analysis agents.",
-    "Big tier: synthesis/judgment/decision agents spanning the full context.",
-    "An agent with no opts.tier and no opts.model falls back to the user's medium tier; do not rely on that — tag agents explicitly so small/big are used where they fit.",
-    "Use opts.model only when the user names a specific model; pass that exact provider/id. opts.model always takes precedence over opts.tier.",
-    "Exact model specs may include Pi CLI-style thinking suffixes such as openai-codex/gpt-5.5:xhigh or anthropic/claude-fable-5:max when the user requests a specific effort level.",
-  ].join(" ");
-}
-
-/**
- * Tells the LLM which named subagent definitions (agentType) are available, so
- * it can route an agent() to a reusable role that binds tools+model+prompt.
- * Returns undefined when no definitions are registered (nothing to advertise).
- */
-export function agentTypeGuideline(cwd: string = process.cwd()): string | undefined {
-  let types: Array<{ name: string; description?: string }>;
-  try {
-    types = listAgentTypes(loadAgentRegistry(cwd));
-  } catch {
-    return undefined;
-  }
-  if (!types.length) return undefined;
-  const list = types.map((t) => (t.description ? `${t.name} (${t.description})` : t.name)).join(", ");
-  return `For workflow, opts.agentType routes an agent to a named definition that binds its tools, model, and role prompt. Available agentTypes: ${list}. An explicit opts.model still overrides the definition's model.`;
-}
-
-/**
- * The single ALWAYS-ON guideline rendered into the system prompt every turn.
- * It is a pure gate: it tells the model when the tool is in scope and, crucially,
- * that it should NOT reach for the tool otherwise. The how-to mechanics live in
- * {@link workflowHowToGuidelines} and are folded into the tool's static
- * `description` (see {@link createWorkflowTool}), not into this always-on line.
- *
- * The line is balanced on purpose: a task-shape positive ("this is the kind of
- * work the tool is for") so the model recognizes a good fit even when the user
- * phrases it off-keyword, PLUS the explicit-opt-in gate and the "do not call it
- * otherwise" negative so it doesn't self-trigger (#88). The "offer with a rough
- * cost" keeps a non-forcing path open for a task that fits but wasn't opted into.
- */
+/** The single always-on gate that authorizes workflow use without forcing it. */
 export const WORKFLOW_GATE_GUIDELINE =
   "The `workflow` tool runs multi-agent orchestration — it fans decomposable work out across subagents, and fits tasks shaped like: repo-wide inspection, independent parallel research/checks, multi-perspective review, or fan-out/fan-in synthesis. ONLY call it when the user explicitly opts in — via the workflow trigger word, `/workflows run`, or their own words (e.g. 'run a workflow', 'fan this out', '并行审一遍'). For any other task — even one that would clearly benefit — do not call it; you may briefly offer it (with a rough cost) as an option instead.";
-
-/**
- * The how-to guidance for actually WRITING a workflow script. These lines are
- * folded into the tool's static `description` (see {@link createWorkflowTool}),
- * NOT into the always-on `promptGuidelines` and NOT re-injected into the armed
- * turn's message.
- *
- * A tool description is the right home for this "manual": it is visible to the
- * model whenever it considers or calls the tool — regardless of which path armed
- * the turn, and even on the natural-language opt-ins that the gate line blesses
- * but that never trip the literal keyword arm — and it is a static, prefix-
- * cacheable part of the tool definition rather than per-turn behavioral priming.
- * That fixes both the "armed off-keyword ⇒ no mechanics ⇒ lower-quality script"
- * gap and the ~1.4KB-per-armed-turn re-injection (worse for `/effort` users).
- *
- * Keeping it out of `promptGuidelines` still shrinks the always-on prompt (#88
- * self-priming) — this array is the how-to only, never the always-on gate. Note
- * the description now carries this weight in the tool DEFINITION budget; trimming
- * the how-to text itself is a separate concern (#65 / contract-concision work),
- * not this change's job.
- */
-export function workflowHowToGuidelines(cwd: string = process.cwd()): string[] {
-  return [
-    "For workflow, always pass one raw JavaScript string in the required script parameter; do not include Markdown fences or prose around the script.",
-    "For workflow, the script's first statement must be `export const meta = { name: 'short_snake_case', description: 'non-empty human description', phases: [{ title: 'Phase name' }] }`; meta.name and meta.description are required non-empty strings.",
-    "For workflow, write plain JavaScript after the meta export. Do not use TypeScript syntax, imports, require(), fs, Date.now(), Math.random(), or new Date().",
-    "For workflow, available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), args, cwd, process.cwd(), and budget. Every workflow must call agent() at least once; do not use workflow only to declare phases or return a static object.",
-    "For workflow, prefer the built-in quality helpers when they fit (each is built on agent()/parallel() and returns plain data): verify(item, {reviewers, threshold, lens}) for adversarial fact-checking; judgePanel(attempts, {judges, rubric}) to score N candidates and return the best; loopUntilDry({round, key, consecutiveEmpty}) to keep finding until rounds stop yielding new items; completenessCheck(args, results) as a final 'what's missing' critic.",
-    "For workflow, when meta.phases declares more than one phase, call phase('Exact Title') at the start of each phase's work (or set opts.phase on each agent) so every agent groups under the correct phase; never declare a phase you don't switch into — a declared phase with no agents shows as 0/0 and any agent you forgot to move stays in the previous phase.",
-    "For workflow, do not set tokenBudget or agentTimeoutMs unless the user explicitly asks to cap spend or time; runs are unbounded unless settings.json sets defaults (defaultTokenBudget, defaultAgentTimeoutMs).",
-    "For workflow, to bound spend: pass tokenBudget for a hard run-wide cap; carve a per-phase ceiling with phase('Name', {budget: N}) (that phase throws at its sub-budget without touching the run total — wrap its work in try/catch so later phases proceed); use retry(thunk, {attempts, until}) for bounded retry, and gate(thunk, validator, {attempts}) when a validator's feedback should steer the next attempt. To degrade gracefully, branch on budget.remaining() to skip optional rounds or choose a lighter tier.",
-    "For workflow, prefer it for decomposable work: repository inspection, independent research/checks, multi-perspective review, or fan-out/fan-in synthesis. Do not use it for a single quick file read/edit or when ordinary tools are enough.",
-    "For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.",
-    "For workflow, pipeline(items, ...stages) runs each item through stages sequentially, while different items may run concurrently. Each stage receives (previousValue, originalItem, index).",
-    "For workflow, every agent() call should include a unique short label option, 2-5 words, such as { label: 'repo inventory' } or { label: 'source modules' }; unique labels make live status and error reporting readable.",
-    "For workflow, use low concurrency and agentRetries for unstable provider/transport fan-out runs; retries apply only to recoverable agent failures and still require explicit null handling after exhaustion.",
-    "For workflow, failed agent(), parallel(), or pipeline() branches return null and log the failure unless the workflow is aborted. Check for nulls before synthesizing conclusions.",
-    "For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.",
-    "For workflow, the default quality shape for fan-out work is finder -> verify -> merge: run one agent per angle or work-unit (in parallel), pass each candidate finding through verify() and drop the unconfirmed, then a single synthesis agent that de-duplicates, ranks by confidence/severity, and caps the output. If nothing survives verification, return an empty result and say so rather than padding.",
-    "For workflow, give each subagent a substantive, self-contained task: do not spawn an agent just to read one file or run one command, and do not use one agent only to check on another. Prefer fewer, higher-level agents over many trivial micro-tasks.",
-    "For workflow, if agent() needs machine-readable output, pass a plain JSON Schema via opts.schema; agent() will return the validated object. Use JSON Schema syntax, not TypeScript or TypeBox constructors.",
-    modelRoutingGuideline(),
-    agentTypeGuideline(cwd),
-    "For workflow, do not assume the parent assistant has repository code context inside subagents; include enough task context and relevant paths in each agent prompt.",
-    "For workflow, runs are background by default: the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when the run finishes. Pass background: false only when you must use the result inline in this same turn (it will block).",
-    "For workflow, you may call `await workflow('saved-name', argsObject)` to run a saved workflow inline and use its result; nesting is one level deep only, and the global 16-concurrent / 1000-total caps hold across the nesting.",
-  ].filter((g): g is string => typeof g === "string" && g.length > 0);
-}
 
 const workflowToolSchema = Type.Object({
   script: Type.String({
     description: [
       "Required raw JavaScript workflow script, with no Markdown fences.",
-      "First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }",
-      "Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, and budget. The workflow must call agent() at least once.",
-      "parallel() requires functions, not promises: await parallel(items.map(item => () => agent(...))).",
+      "First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description' }. Add phases: [{ title: 'Phase' }] only when the workflow has named phases, and declare only phases it will use. With multiple phases, call phase('Exact Title') before each phase's work or set `phase` in the agent options.",
+      "Use `await workflow(savedName, childArgs)` to run a saved workflow inline; nesting is limited to one level and shares the parent run's concurrency, agent, and token limits.",
+      "Optional quality helpers include verify(), judgePanel(), loopUntilDry(), and completenessCheck().",
+      "Optional control helpers include retry() and gate(); budget exposes total, spent(), and remaining(), and phase('Name', { budget: N }) sets a phase token limit.",
+      "The optional `agentType` option selects a named user or project definition that can bind tools, a model, and role instructions; use it only when its name and purpose are provided in context. Its bound model overrides `tier`; an explicit `model` overrides both.",
+      "Use plain JavaScript only; imports, require(), filesystem modules, Date.now(), Math.random(), and new Date() are unavailable.",
+      "Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, cwd, process.cwd(), and budget. The workflow must call agent() at least once.",
+      "parallel() requires functions, not promises, and returns results in input order: await parallel(items.map(item => () => agent(...))).",
+      "pipeline(items, ...stages) runs stages sequentially for each item while items proceed concurrently; each stage receives (previousValue, originalItem, index).",
     ].join(" "),
   }),
   args: Type.Optional(
@@ -141,7 +48,8 @@ const workflowToolSchema = Type.Object({
   ),
   maxAgents: Type.Optional(
     Type.Number({
-      description: "Maximum number of agents allowed in this run. Default: 1000.",
+      description:
+        "Maximum number of agents allowed in this run. Default: 1000; this is a safety ceiling, not a target. Set a lower limit for dynamic or exploratory fan-out, and reserve large fan-outs for explicit user intent.",
     }),
   ),
   concurrency: Type.Optional(
@@ -159,13 +67,13 @@ const workflowToolSchema = Type.Object({
   agentTimeoutMs: Type.Optional(
     Type.Number({
       description:
-        "Timeout per agent in milliseconds. Omit for no hard timeout by default. Set only when the user asks to bound time.",
+        "Timeout per agent in milliseconds. Omit to use configured `defaultAgentTimeoutMs`; without one, there is no hard timeout. Set only when the user asks to bound time.",
     }),
   ),
   tokenBudget: Type.Optional(
     Type.Number({
       description:
-        "Hard total-token budget for the whole run. Once spent reaches it, further agent() calls fail and the run stops. Omit for no limit. Set it when the user asks to cap spend.",
+        "Soft pre-call token gate for the whole run. Once recorded spend reaches it, further agent() calls fail; concurrent in-flight work can overshoot. Omit to use configured `defaultTokenBudget`; without one, the run is unlimited. Set it only when the user asks to bound spend.",
     }),
   ),
   resumeFromRunId: Type.Optional(
@@ -223,39 +131,10 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
   return defineTool({
     name: "workflow",
     label: "Workflow",
-    // The how-to "manual" lives here, in the static tool description, so the
-    // model has the mechanics whenever it considers/calls the tool — on every
-    // arming path AND on off-keyword natural-language opt-ins that never trip the
-    // literal keyword arm. This is a cacheable part of the tool definition, not
-    // per-turn priming (that's why it's here and not appended to the armed
-    // message; see workflowHowToGuidelines / buildArmedWorkflowPrompt). It grows
-    // the tool-DEFINITION budget; trimming the how-to itself is separate work
-    // (#65 / contract-concision), not this change's job.
-    //
-    // CAVEAT: the off-keyword natural-language path only sees this description if
-    // the host keeps the `workflow` tool in its default active tool set. The
-    // arming paths add the tool on arm (installWorkflowKeywordArming's setActiveTools),
-    // but a bare natural-language opt-in with no arm relies on the tool already
-    // being active in the host's config — keep `workflow` default-active so the
-    // gate line's "fan this out" promise (mechanics available) holds.
-    description: [
-      "Execute a deterministic JavaScript workflow that orchestrates multiple subagents with agent(), parallel(), and pipeline().",
-      "script is required raw JavaScript. It must start with export const meta = { name, description, phases? } and must call agent() at least once.",
-      "",
-      "How to write the script:",
-      ...workflowHowToGuidelines(cwd).map((g) => `- ${g}`),
-    ].join("\n"),
+    description:
+      "Run a JavaScript workflow that delegates work to subagents with agent(), optionally composing calls with parallel() and pipeline().",
     promptSnippet:
-      "Run a deterministic JavaScript workflow. Required script header: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }.",
-    // Lazy accessor: the SDK re-reads definition.promptGuidelines on every
-    // tool-registry refresh. This is ALWAYS-ON weight (rendered into the system
-    // prompt every turn), so it is deliberately a single gate line — see #65
-    // (always-on prompt budget) and #88 (self-priming: a wall of "For workflow, …"
-    // how-to text nudges the model toward the tool even when it wasn't asked for).
-    // The ~20 how-to lines that used to live here now live in the tool's static
-    // `description` (see above / workflowHowToGuidelines), so the model has the
-    // mechanics whenever it looks at the tool — without paying the always-on cost
-    // or the per-armed-turn re-injection.
+      "Delegate substantive independent or staged work to subagents with a JavaScript workflow, optionally composing agent calls with parallel(), pipeline(), or both",
     get promptGuidelines() {
       return [WORKFLOW_GATE_GUIDELINE];
     },

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -5,7 +5,7 @@ import type { Node } from "acorn";
 import { parse } from "acorn";
 import type { TSchema } from "typebox";
 import type { AgentUsage } from "./agent.js";
-import { WorkflowAgent, type WorkflowAgentOptions } from "./agent.js";
+import { type AgentRunOptions, WorkflowAgent, type WorkflowAgentOptions } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import {
   type AgentDefinition,
@@ -19,6 +19,7 @@ import { WorkflowError, WorkflowErrorCode, wrapError } from "./errors.js";
 import { createWorkflowLogger } from "./logger.js";
 import { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.js";
 import { createAgentStoreTools, SharedStore } from "./shared-store.js";
+import { WORKFLOW_CAPABILITY_CONTRACT, type WorkflowRuntimeImplementations } from "./workflow-capability-contract.js";
 import { createWorktree, removeWorktree, type Worktree } from "./worktree.js";
 
 /**
@@ -84,9 +85,21 @@ export interface SharedRuntime {
   depth: number;
 }
 
+/** Runtime instrumentation for workflow boundaries, quality helpers, and control attempts. */
+export type WorkflowRuntimeEvent =
+  | { type: "phase"; title: string; budget: number | null }
+  | { type: "workflow"; stage: "start" | "end"; name: string; args: unknown }
+  | { type: "quality"; stage: "start" | "end"; helper: "verify" | "judgePanel" | "completenessCheck" }
+  | { type: "control-attempt"; helper: "retry" | "gate"; attempt: number; accepted: boolean };
+
+/** Minimal injected agent surface used by the workflow runtime and deterministic tests. */
+export interface WorkflowAgentRunner {
+  run(prompt: string, options?: AgentRunOptions<TSchema>): Promise<unknown>;
+}
+
 export interface WorkflowRunOptions extends WorkflowAgentOptions {
   args?: unknown;
-  agent?: Pick<WorkflowAgent, "run">;
+  agent?: WorkflowAgentRunner;
   /** The session's main model (provider/id), shown in /workflows for default agents. */
   mainModel?: string;
   /**
@@ -133,6 +146,8 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   confirm?: (promptText: string, options: CheckpointOptions) => Promise<unknown>;
   onLog?: (message: string) => void;
   onPhase?: (title: string) => void;
+  /** Runtime behavior trace used by diagnostics and comprehension evidence. */
+  onRuntimeEvent?: (event: WorkflowRuntimeEvent) => void;
   onAgentStart?: (event: { label: string; phase?: string; prompt: string; model?: string }) => void;
   onAgentEnd?: (event: {
     label: string;
@@ -352,6 +367,11 @@ export async function runWorkflow<T = unknown>(
       state.phaseBudgets.set(title, { budget: phaseOptions.budget, startSpent: shared.spent, warned: false });
     }
     options.onPhase?.(title);
+    options.onRuntimeEvent?.({
+      type: "phase",
+      title,
+      budget: typeof phaseOptions?.budget === "number" && phaseOptions.budget > 0 ? phaseOptions.budget : null,
+    });
   };
 
   const budget = Object.freeze({
@@ -726,6 +746,8 @@ export async function runWorkflow<T = unknown>(
     }
     const resolved = options.loadSavedWorkflow?.(String(nameOrScript));
     const childScript = resolved ?? String(nameOrScript);
+    const workflowName = String(nameOrScript);
+    options.onRuntimeEvent?.({ type: "workflow", stage: "start", name: workflowName, args: childArgs });
     shared.depth++;
     try {
       const child = await runWorkflow(childScript, {
@@ -743,6 +765,7 @@ export async function runWorkflow<T = unknown>(
       return child.result;
     } finally {
       shared.depth--;
+      options.onRuntimeEvent?.({ type: "workflow", stage: "end", name: workflowName, args: childArgs });
     }
   };
 
@@ -759,6 +782,7 @@ export async function runWorkflow<T = unknown>(
     item: unknown,
     opts: { reviewers?: number; threshold?: number; lens?: string | string[] } = {},
   ) => {
+    options.onRuntimeEvent?.({ type: "quality", stage: "start", helper: "verify" });
     const reviewers = Math.max(1, opts.reviewers ?? 2);
     const threshold = opts.threshold ?? 0.5;
     const lenses = opts.lens ? (Array.isArray(opts.lens) ? opts.lens : [opts.lens]) : [];
@@ -776,7 +800,14 @@ export async function runWorkflow<T = unknown>(
       )
     ).filter(Boolean) as Array<{ real?: boolean; reason?: string }>;
     const realCount = votes.filter((v) => v?.real).length;
-    return { real: votes.length > 0 && realCount / votes.length >= threshold, realCount, total: votes.length, votes };
+    const verdict = {
+      real: votes.length > 0 && realCount / votes.length >= threshold,
+      realCount,
+      total: votes.length,
+      votes,
+    };
+    options.onRuntimeEvent?.({ type: "quality", stage: "end", helper: "verify" });
+    return verdict;
   };
 
   const JUDGE_SCHEMA = {
@@ -785,6 +816,7 @@ export async function runWorkflow<T = unknown>(
     required: ["score"],
   };
   const judgePanel = async (attempts: unknown[], opts: { judges?: number; rubric?: string } = {}) => {
+    options.onRuntimeEvent?.({ type: "quality", stage: "start", helper: "judgePanel" });
     const judges = Math.max(1, opts.judges ?? 3);
     const rubric = opts.rubric ?? "overall quality and correctness";
     const scored = (
@@ -814,6 +846,7 @@ export async function runWorkflow<T = unknown>(
     // Highest mean score; stable tie-break by input index.
     let best = scored[0];
     for (const s of scored) if (s.score > best.score || (s.score === best.score && s.index < best.index)) best = s;
+    options.onRuntimeEvent?.({ type: "quality", stage: "end", helper: "judgePanel" });
     return best;
   };
 
@@ -860,11 +893,15 @@ export async function runWorkflow<T = unknown>(
     properties: { complete: { type: "boolean" }, missing: { type: "array", items: { type: "string" } } },
     required: ["complete"],
   };
-  const completenessCheck = (taskArgs: unknown, results: unknown) =>
-    agent(
+  const completenessCheck = async (taskArgs: unknown, results: unknown) => {
+    options.onRuntimeEvent?.({ type: "quality", stage: "start", helper: "completenessCheck" });
+    const verdict = await agent(
       `Given the task and the results gathered so far, list what is still MISSING (modalities not covered, claims unverified, gaps). Be specific and concise.\n\nTask:\n${JSON.stringify(taskArgs)}\n\nResults so far:\n${JSON.stringify(results).slice(0, 4000)}`,
       { label: "completeness critic", schema: COMPLETENESS_SCHEMA },
     );
+    options.onRuntimeEvent?.({ type: "quality", stage: "end", helper: "completenessCheck" });
+    return verdict;
+  };
 
   // Thin bounded-retry / validation-gate combinators. Sugar over the for-loop +
   // agent() pattern, but each attempt is a real agent() call so it auto-journals
@@ -879,7 +916,9 @@ export async function runWorkflow<T = unknown>(
     let last: unknown;
     for (let i = 0; i < attempts; i++) {
       last = await thunk(i);
-      if (!opts.until || opts.until(last)) return last;
+      const accepted = !opts.until || opts.until(last);
+      options.onRuntimeEvent?.({ type: "control-attempt", helper: "retry", attempt: i + 1, accepted });
+      if (accepted) return last;
     }
     return last; // attempts exhausted — return the last result (caller inspects it)
   };
@@ -894,7 +933,9 @@ export async function runWorkflow<T = unknown>(
     for (let i = 0; i < attempts; i++) {
       last = await thunk(feedback, i);
       const verdict = await validator(last);
-      if (verdict?.ok) return { ok: true, value: last, attempts: i + 1 };
+      const accepted = Boolean(verdict?.ok);
+      options.onRuntimeEvent?.({ type: "control-attempt", helper: "gate", attempt: i + 1, accepted });
+      if (accepted) return { ok: true, value: last, attempts: i + 1 };
       feedback = verdict?.feedback; // fed into the next attempt
     }
     return { ok: false, value: last, attempts };
@@ -938,7 +979,7 @@ export async function runWorkflow<T = unknown>(
     return reply;
   };
 
-  const context = vm.createContext({
+  const runtimeImplementations = {
     agent,
     parallel,
     pipeline,
@@ -962,6 +1003,12 @@ export async function runWorkflow<T = unknown>(
       warn: (m: unknown) => log(`[warn] ${String(m)}`),
       error: (m: unknown) => log(`[error] ${String(m)}`),
     },
+  } satisfies WorkflowRuntimeImplementations;
+  const { globals: projectGlobals, diagnostics: bindingDiagnostics } =
+    WORKFLOW_CAPABILITY_CONTRACT.assembleRuntimeBindings(runtimeImplementations);
+  for (const diagnostic of bindingDiagnostics) logger.warn(diagnostic.message);
+  const context = vm.createContext({
+    ...projectGlobals,
     // Object/Array/JSON/Math/Date/Promise/Set/Map/etc. come from the vm realm
     // itself — we deliberately do NOT inject host built-ins, whose .constructor
     // would be the host Function (a determinism-guard bypass). Math/Date are

--- a/tests/accept-workflow-guidance.test.ts
+++ b/tests/accept-workflow-guidance.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { acceptWorkflowGuidance } from "../src/accept-workflow-guidance.js";
+import { WORKFLOW_AUTHORING_FROZEN_FILES } from "../src/workflow-authoring-coverage.js";
+
+const ROOT = join(import.meta.dirname, "..");
+const MANIFEST_PATH = "src/workflow-authoring-coverage.ts";
+const REVIEWED_GUIDANCE = "reviewed guidance\n";
+const REVIEWED_GUIDANCE_SHA256 = "9cfddc2c9df03bc3982e49cf7c29b91901e55473716626333a7ca9c6d9ea036e";
+
+function createFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "workflow-guidance-accept-"));
+  const manifest = join(root, MANIFEST_PATH);
+  mkdirSync(dirname(manifest), { recursive: true });
+  writeFileSync(manifest, readFileSync(join(ROOT, MANIFEST_PATH), "utf8"));
+  return root;
+}
+
+function writeGuidance(root: string, path: string, source: string): void {
+  const absolute = join(root, path);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, source);
+}
+
+test("accepts only explicitly named frozen workflow guidance", () => {
+  const root = createFixture();
+  const accepted = WORKFLOW_AUTHORING_FROZEN_FILES[0];
+  const untouched = WORKFLOW_AUTHORING_FROZEN_FILES[1];
+  try {
+    writeGuidance(root, accepted.path, REVIEWED_GUIDANCE);
+    writeGuidance(root, untouched.path, "also changed but not accepted\n");
+
+    const result = acceptWorkflowGuidance(root, [accepted.path]);
+
+    assert.deepEqual(result, [
+      {
+        path: accepted.path,
+        previousSha256: accepted.sha256,
+        sha256: REVIEWED_GUIDANCE_SHA256,
+        changed: true,
+      },
+    ]);
+    const manifest = readFileSync(join(root, MANIFEST_PATH), "utf8");
+    assert.match(manifest, new RegExp(`path: "${accepted.path}"[\\s\\S]*?sha256: "${REVIEWED_GUIDANCE_SHA256}"`));
+    assert.match(manifest, new RegExp(`path: "${untouched.path}"[\\s\\S]*?sha256: "${untouched.sha256}"`));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rejects an unknown guidance path without changing the manifest", () => {
+  const root = createFixture();
+  const before = readFileSync(join(root, MANIFEST_PATH), "utf8");
+  try {
+    assert.throws(
+      () => acceptWorkflowGuidance(root, ["skills/workflow-authoring/references/not-frozen.md"]),
+      /not a frozen workflow-authoring guidance file/i,
+    );
+    assert.equal(readFileSync(join(root, MANIFEST_PATH), "utf8"), before);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("requires at least one explicit guidance path", () => {
+  const root = createFixture();
+  try {
+    assert.throws(() => acceptWorkflowGuidance(root, []), /pass at least one frozen workflow-authoring path/i);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/enums.test.ts
+++ b/tests/enums.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CapabilityClassification,
+  CapabilityOrigin,
+  CapabilitySupport,
+  ComprehensionSuite,
+  ComprehensionTaskKind,
+  DiagnosticSeverity,
+  DiscoveryPlacement,
+  WorkflowAuthoringProtection,
+  WorkflowReleaseDiagnosticCode,
+} from "../src/enums.js";
+
+test("workflow enums preserve their evidence and release wire values", () => {
+  assert.deepEqual(Object.values(CapabilityClassification), [
+    "runtime-global",
+    "workflow-tool-input",
+    "script-contract",
+    "compatibility-behavior",
+    "internal-substrate",
+    "dynamic-reference",
+  ]);
+  assert.deepEqual(Object.values(CapabilitySupport), ["supported", "compatibility", "internal"]);
+  assert.deepEqual(Object.values(DiscoveryPlacement), ["compact-guidance", "workflow-authoring-skill", "none"]);
+  assert.deepEqual(Object.values(CapabilityOrigin), ["project", "tool-adapter", "vm-realm", "live-configuration"]);
+  assert.deepEqual(Object.values(DiagnosticSeverity), ["error", "warning", "information"]);
+  assert.deepEqual(Object.values(ComprehensionSuite), ["quick", "full", "coverage"]);
+  assert.deepEqual(Object.values(ComprehensionTaskKind), ["write", "edit", "review", "debug"]);
+  assert.deepEqual(Object.values(WorkflowAuthoringProtection), ["behaviorally-covered", "guidance-frozen"]);
+  assert.equal(WorkflowReleaseDiagnosticCode.MISSING_AUTHORING_COVERAGE, "MISSING_AUTHORING_COVERAGE");
+  assert.equal(WorkflowReleaseDiagnosticCode.PROTECTED_GUIDANCE_DRIFT, "PROTECTED_GUIDANCE_DRIFT");
+  assert.equal(WorkflowReleaseDiagnosticCode.UNKNOWN_COMPREHENSION_SCENARIO, "UNKNOWN_COMPREHENSION_SCENARIO");
+});

--- a/tests/quality-stdlib.test.ts
+++ b/tests/quality-stdlib.test.ts
@@ -35,6 +35,43 @@ return await verify('claim', { reviewers: 3, threshold: 0.75 })`;
   assert.equal(res.result.real, false);
 });
 
+test("verify(): options control lenses and successful votes form the denominator", async () => {
+  const prompts: string[] = [];
+  let call = 0;
+  const reviewers = {
+    async run(prompt: string) {
+      prompts.push(prompt);
+      call++;
+      if (call === 3) {
+        throw new Error("review unavailable");
+      }
+      return { real: call === 1, reason: `vote-${call}` };
+    },
+  };
+  const script = `export const meta = { name: 'verify_contract', description: 'exact verify contract' }
+return await verify('claim', { reviewers: 3, threshold: 0.5, lens: ['source', 'logic'] })`;
+  const res = await runWorkflow<{
+    real: boolean;
+    realCount: number;
+    total: number;
+    votes: Array<{ real: boolean; reason: string }>;
+  }>(script, { agent: reviewers, persistLogs: false });
+
+  assert.equal(res.result.real, true, "one of two successful votes meets the inclusive 0.5 threshold");
+  assert.equal(res.result.realCount, 1);
+  assert.equal(res.result.total, 2, "failed reviewers are omitted from the denominator");
+  assert.deepEqual(
+    Array.from(res.result.votes, ({ real, reason }) => ({ real, reason })),
+    [
+      { real: true, reason: "vote-1" },
+      { real: false, reason: "vote-2" },
+    ],
+  );
+  assert.match(prompts[0] ?? "", /Focus lens: source/);
+  assert.match(prompts[1] ?? "", /Focus lens: logic/);
+  assert.match(prompts[2] ?? "", /Focus lens: source/);
+});
+
 test("judgePanel(): picks the highest-mean-score attempt", async () => {
   const scorer = {
     async run(p: string, o: { schema?: unknown }) {
@@ -47,6 +84,32 @@ const r = await judgePanel(['lose one', 'WIN candidate', 'lose two'], { judges: 
 return { index: r.index, score: r.score }`;
   const res = await runWorkflow<{ index: number; score: number }>(script, { agent: scorer, persistLogs: false });
   assert.equal(res.result.index, 1, "the WIN candidate wins");
+});
+
+test("judgePanel(): returns the exact winner shape, stable ties, and undefined for empty input", async () => {
+  const prompts: string[] = [];
+  const scorer = {
+    async run(prompt: string) {
+      prompts.push(prompt);
+      return { score: 0.5, reason: "tie" };
+    },
+  };
+  const script = `export const meta = { name: 'judge_contract', description: 'exact judge contract' }
+const winner = await judgePanel(['first', 'second'], { judges: 2, rubric: 'source quality' })
+const empty = await judgePanel([])
+return { winner, empty: empty ?? null }`;
+  const res = await runWorkflow<{
+    winner: { index: number; attempt: string; score: number; judgments: Array<{ score: number }> };
+    empty: null;
+  }>(script, { agent: scorer, persistLogs: false });
+
+  assert.equal(prompts.length, 4);
+  assert.ok(prompts.every((prompt) => prompt.includes("source quality")));
+  assert.equal(res.result.winner.index, 0);
+  assert.equal(res.result.winner.attempt, "first");
+  assert.equal(res.result.winner.score, 0.5);
+  assert.equal(res.result.winner.judgments.length, 2);
+  assert.equal(res.result.empty, null);
 });
 
 test("loopUntilDry(): dedupes by key and stops after K empty rounds", async () => {
@@ -77,6 +140,32 @@ return out`;
   assert.deepEqual([...res.result], [1], "partial result returned, not an abort");
 });
 
+test("loopUntilDry(): returns indistinguishable partial data for capacity exhaustion", async () => {
+  for (const code of ["TOKEN_BUDGET_EXHAUSTED", "AGENT_LIMIT_EXCEEDED"]) {
+    const script = `export const meta = { name: 'loop_capacity', description: 'partial capacity result' }
+return await loopUntilDry({
+  round: (index) => {
+    if (index === 0) return [{ id: 'alpha' }]
+    throw { code: '${code}' }
+  },
+  maxRounds: 4,
+})`;
+    const res = await runWorkflow<Array<{ id: string }>>(script, { agent: yesAgent, persistLogs: false });
+    assert.deepEqual(
+      Array.from(res.result, ({ id }) => ({ id })),
+      [{ id: "alpha" }],
+    );
+  }
+
+  await assert.rejects(() =>
+    runWorkflow(
+      `export const meta = { name: 'loop_error', description: 'unrelated errors escape' }
+return await loopUntilDry({ round: () => { throw new Error('author bug') } })`,
+      { agent: yesAgent, persistLogs: false },
+    ),
+  );
+});
+
 test("completenessCheck(): returns the critic's structured verdict", async () => {
   const critic = {
     async run(_p: string, o: { schema?: unknown }) {
@@ -91,6 +180,35 @@ return await completenessCheck({ task: 1 }, [{ done: true }])`;
   });
   assert.equal(res.result.complete, false);
   assert.deepEqual([...res.result.missing], ["x"]);
+});
+
+test("completenessCheck(): truncates result evidence and can return null", async () => {
+  const prompts: string[] = [];
+  let calls = 0;
+  const critic = {
+    async run(prompt: string) {
+      prompts.push(prompt);
+      calls++;
+      if (calls === 2) {
+        throw new Error("critic unavailable");
+      }
+      return { complete: true };
+    },
+  };
+  const script = `export const meta = { name: 'critic_contract', description: 'exact critic contract' }
+const first = await completenessCheck({ taskMarker: 'TASK-TAIL' }, { head: '${"x".repeat(4100)}', tail: 'RESULT-TAIL' })
+const second = await completenessCheck({ taskMarker: 'TASK-TAIL' }, { small: true })
+return { first, second }`;
+  const res = await runWorkflow<{ first: { complete: boolean; missing?: string[] }; second: null }>(script, {
+    agent: critic,
+    persistLogs: false,
+  });
+
+  assert.equal(res.result.first.complete, true);
+  assert.equal(res.result.first.missing, undefined);
+  assert.equal(res.result.second, null);
+  assert.match(prompts[0] ?? "", /TASK-TAIL/);
+  assert.doesNotMatch(prompts[0] ?? "", /RESULT-TAIL/);
 });
 
 test("retry(): stops when until() is satisfied, else returns the last after exhausting", async () => {
@@ -110,6 +228,32 @@ return { ok, n, ex, m }`;
   assert.equal(res.result.m, 3);
 });
 
+test("retry(): uses zero-based attempts, accepts immediately without until, and does not await until", async () => {
+  const script = `export const meta = { name: 'retry_contract', description: 'exact retry contract' }
+const omittedSeen = []
+const omitted = await retry((attempt) => { omittedSeen.push(attempt); return attempt }, { attempts: 3 })
+const syncSeen = []
+const sync = await retry((attempt) => { syncSeen.push(attempt); return attempt }, { attempts: 3, until: value => value === 1 })
+const asyncSeen = []
+const asyncPredicate = await retry((attempt) => { asyncSeen.push(attempt); return attempt }, { attempts: 3, until: async () => false })
+return { omitted, omittedSeen, sync, syncSeen, asyncPredicate, asyncSeen }`;
+  const res = await runWorkflow<{
+    omitted: number;
+    omittedSeen: number[];
+    sync: number;
+    syncSeen: number[];
+    asyncPredicate: number;
+    asyncSeen: number[];
+  }>(script, { agent: yesAgent, persistLogs: false });
+
+  assert.equal(res.result.omitted, 0);
+  assert.deepEqual([...res.result.omittedSeen], [0]);
+  assert.equal(res.result.sync, 1);
+  assert.deepEqual([...res.result.syncSeen], [0, 1]);
+  assert.equal(res.result.asyncPredicate, 0, "a Promise is truthy because until is synchronous");
+  assert.deepEqual([...res.result.asyncSeen], [0]);
+});
+
 test("gate(): passes the validator and feeds feedback into the next attempt", async () => {
   const script = `export const meta = { name: 'g', description: 'gate' }
 const seen = []
@@ -118,8 +262,15 @@ const res = await gate(
   (r) => (r >= 1 ? { ok: true } : { ok: false, feedback: 'try higher' }),
   { attempts: 3 },
 )
-return { ok: res.ok, value: res.value, attempts: res.attempts, seen }`;
-  const res = await runWorkflow<{ ok: boolean; value: number; attempts: number; seen: string[] }>(script, {
+const legacyTruthy = await gate(() => 'legacy', () => ({ ok: 1 }), { attempts: 2 })
+return { ok: res.ok, value: res.value, attempts: res.attempts, seen, legacyTruthy }`;
+  const res = await runWorkflow<{
+    ok: boolean;
+    value: number;
+    attempts: number;
+    seen: string[];
+    legacyTruthy: { ok: boolean; value: string; attempts: number };
+  }>(script, {
     agent: yesAgent,
     persistLogs: false,
   });
@@ -127,4 +278,9 @@ return { ok: res.ok, value: res.value, attempts: res.attempts, seen }`;
   assert.equal(res.result.value, 1);
   assert.equal(res.result.attempts, 2);
   assert.deepEqual([...res.result.seen], ["none", "try higher"], "validator feedback is fed into the next attempt");
+  assert.deepEqual(
+    { ...res.result.legacyTruthy },
+    { ok: true, value: "legacy", attempts: 1 },
+    "legacy truthy validator verdicts remain accepted",
+  );
 });

--- a/tests/workflow-authoring-coverage.test.ts
+++ b/tests/workflow-authoring-coverage.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import test from "node:test";
+import { CapabilitySupport, DiscoveryPlacement, WorkflowAuthoringProtection } from "../src/enums.js";
+import {
+  WORKFLOW_AUTHORING_COVERAGE,
+  WORKFLOW_AUTHORING_PATTERN_IDS,
+  WORKFLOW_AUTHORING_RECIPE_IDS,
+  WORKFLOW_COMPREHENSION_SCENARIO_IDS,
+} from "../src/workflow-authoring-coverage.js";
+import { WORKFLOW_CAPABILITY_DEFINITION } from "../src/workflow-capability-contract.js";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+
+test("authoring coverage inventories every stable contract, pattern, and recipe exactly once", () => {
+  const expectedIds = [
+    ...WORKFLOW_CAPABILITY_DEFINITION.capabilities
+      .filter(
+        ({ discovery, support }) => discovery !== DiscoveryPlacement.NONE && support !== CapabilitySupport.INTERNAL,
+      )
+      .map(({ id }) => id),
+    ...WORKFLOW_AUTHORING_PATTERN_IDS,
+    ...WORKFLOW_AUTHORING_RECIPE_IDS,
+  ];
+  const observedIds = WORKFLOW_AUTHORING_COVERAGE.map(({ id }) => id);
+
+  assert.equal(new Set(observedIds).size, observedIds.length);
+  assert.deepEqual(new Set(observedIds), new Set(expectedIds));
+});
+
+test("covered entries resolve real scenarios and uncovered entries freeze installed guidance", () => {
+  const knownScenarios = new Set(WORKFLOW_COMPREHENSION_SCENARIO_IDS);
+  for (const entry of WORKFLOW_AUTHORING_COVERAGE) {
+    assert.equal(existsSync(`${ROOT}/${entry.reference.path}`), true, entry.id);
+    assert.equal(
+      entry.behaviorEvidence.every((path) => existsSync(`${ROOT}/${path}`)),
+      true,
+      entry.id,
+    );
+    if (entry.example) assert.equal(existsSync(`${ROOT}/${entry.example}`), true, entry.id);
+
+    if (entry.protection === WorkflowAuthoringProtection.BEHAVIORALLY_COVERED) {
+      assert.ok(entry.comprehensionScenarios.length > 0, entry.id);
+      assert.equal(
+        entry.comprehensionScenarios.every((id) => knownScenarios.has(id)),
+        true,
+        entry.id,
+      );
+    } else {
+      assert.deepEqual(entry.comprehensionScenarios, [], entry.id);
+      assert.ok(entry.protectedGuidance.length > 0, entry.id);
+    }
+  }
+});
+
+test("only the three agreed coverage scenarios unfreeze their named abilities", () => {
+  const scenariosById = new Map(
+    WORKFLOW_AUTHORING_COVERAGE.map(({ id, comprehensionScenarios }) => [id, comprehensionScenarios]),
+  );
+
+  assert.deepEqual(scenariosById.get("workflow.pattern.fan-out-and-synthesize"), ["coverage-fan-out-synthesize"]);
+  assert.deepEqual(scenariosById.get("workflow.pattern.generate-and-filter"), ["coverage-generate-filter"]);
+  assert.deepEqual(scenariosById.get("workflow.runtime.judgePanel"), ["coverage-judge-panel"]);
+  assert.deepEqual(scenariosById.get("workflow.pattern.classify-and-act"), []);
+  assert.deepEqual(scenariosById.get("workflow.pattern.tournament"), []);
+  assert.deepEqual(scenariosById.get("workflow.runtime.completenessCheck"), []);
+});

--- a/tests/workflow-authoring-skill.test.ts
+++ b/tests/workflow-authoring-skill.test.ts
@@ -180,6 +180,14 @@ test("generated capability index and exhaustive details are fresh and absent fro
   }
 });
 
+test("lifecycle guidance explains configured timeout and token-budget defaults", () => {
+  const lifecycle = readFileSync(join(ROOT, SKILL_ROOT, "references/lifecycle.md"), "utf8");
+
+  assert.match(lifecycle, /omitted `agentTimeoutMs`.*configured `defaultAgentTimeoutMs`.*otherwise.*unbounded/is);
+  assert.match(lifecycle, /omitted `tokenBudget`.*configured `defaultTokenBudget`.*otherwise.*unlimited/is);
+  assert.match(lifecycle, /soft pre-call gates.*concurrent work can overshoot/is);
+});
+
 test("generated facts cover the lifecycle constraints taught by the skill", () => {
   const facts = new Map(WORKFLOW_CAPABILITY_CONTRACT.projectStaticReferenceFacts().map((fact) => [fact.id, fact]));
   const exactFacts = [

--- a/tests/workflow-authoring-skill.test.ts
+++ b/tests/workflow-authoring-skill.test.ts
@@ -1,0 +1,862 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, normalize, relative } from "node:path";
+import test from "node:test";
+import packageJson from "../package.json" with { type: "json" };
+import { runWorkflow } from "../src/workflow.js";
+import {
+  CAPABILITY_TABLE_PUBLICATION_PATHS,
+  checkWorkflowCapabilityPublications,
+  renderSupportedCapabilityTable,
+  renderWorkflowCapabilityDetails,
+  renderWorkflowCapabilityReference,
+} from "../src/workflow-authoring-reference.js";
+import { WORKFLOW_CAPABILITY_CONTRACT } from "../src/workflow-capability-contract.js";
+import { parseNpmPackFilePaths } from "../src/workflow-release-gate.js";
+import { createWorkflowTool } from "../src/workflow-tool.js";
+
+const ROOT = join(import.meta.dirname, "..");
+const SKILL_ROOT = "skills/workflow-authoring";
+const REQUIRED_RESOURCES = [
+  `${SKILL_ROOT}/SKILL.md`,
+  `${SKILL_ROOT}/references/capabilities.md`,
+  `${SKILL_ROOT}/references/capability-details.md`,
+  `${SKILL_ROOT}/references/runtime.md`,
+  `${SKILL_ROOT}/references/helpers.md`,
+  `${SKILL_ROOT}/references/common-helpers.md`,
+  `${SKILL_ROOT}/references/quality-helpers.md`,
+  `${SKILL_ROOT}/references/retry-helper.md`,
+  `${SKILL_ROOT}/references/specialized-helpers.md`,
+  `${SKILL_ROOT}/references/lifecycle.md`,
+  `${SKILL_ROOT}/references/versions.md`,
+  `${SKILL_ROOT}/references/pattern-selection.md`,
+  `${SKILL_ROOT}/references/focused-recipes.md`,
+  `${SKILL_ROOT}/references/registry-ownership.md`,
+  `${SKILL_ROOT}/references/review.md`,
+  `${SKILL_ROOT}/references/debugging.md`,
+  `${SKILL_ROOT}/examples/classify-and-act.js`,
+  `${SKILL_ROOT}/examples/fan-out-and-synthesize.js`,
+  `${SKILL_ROOT}/examples/adversarial-verification.js`,
+  `${SKILL_ROOT}/examples/generate-and-filter.js`,
+  `${SKILL_ROOT}/examples/tournament.js`,
+  `${SKILL_ROOT}/examples/loop-until-done.js`,
+  `${SKILL_ROOT}/examples/phased-budgets.js`,
+  `${SKILL_ROOT}/examples/saved-nested-workflows.js`,
+  `${SKILL_ROOT}/examples/bounded-semantic-retry.js`,
+  `${SKILL_ROOT}/examples/validated-gate.js`,
+  `${SKILL_ROOT}/examples/structured-output.js`,
+] as const;
+
+function requiredSchemaFields(schema?: Record<string, unknown>): unknown[] {
+  return Array.isArray(schema?.required) ? Array.from(schema.required) : [];
+}
+
+function publishableFiles(): Set<string> {
+  const output = execFileSync("npm", ["pack", "--dry-run", "--json"], { cwd: ROOT, encoding: "utf8" });
+  return new Set(parseNpmPackFilePaths(output));
+}
+
+test("publishable Pi package discovers the workflow-authoring skill and all linked resources", () => {
+  assert.deepEqual(packageJson.pi.skills, [SKILL_ROOT]);
+  const files = publishableFiles();
+  for (const resource of REQUIRED_RESOURCES) assert.ok(files.has(resource), `publishable package omitted ${resource}`);
+
+  const skill = readFileSync(join(ROOT, SKILL_ROOT, "SKILL.md"), "utf8");
+  const description = /^description:\s*(.+)$/m.exec(skill)?.[1] ?? "";
+  for (const trigger of ["writing", "editing", "reviewing", "debugging"]) {
+    assert.match(description, new RegExp(`\\b${trigger}\\b`, "i"));
+  }
+  assert.match(description, /not (?:for )?(?:merely )?running an existing workflow/i);
+  assert.match(skill, new RegExp(`^  version: ["']?${packageJson.version.replaceAll(".", "\\.")}["']?$`, "m"));
+  assert.ok(skill.split("\n").length <= 80, "SKILL.md should remain a short progressive-disclosure router");
+
+  for (const sourcePath of REQUIRED_RESOURCES.filter((path) => path.endsWith(".md"))) {
+    const source = readFileSync(join(ROOT, sourcePath), "utf8");
+    for (const match of source.matchAll(/\[[^\]]+\]\(([^)#]+)(?:#([^)]+))?\)/g)) {
+      const target = normalize(join(dirname(sourcePath), match[1]));
+      assert.equal(
+        relative(".", target).startsWith(".."),
+        false,
+        `${sourcePath} links outside the package: ${match[1]}`,
+      );
+      assert.ok(files.has(target), `${sourcePath} has a broken packaged link to ${target}`);
+      if (match[2]) {
+        const targetSource = readFileSync(join(ROOT, target), "utf8");
+        const headingAnchors = targetSource
+          .split("\n")
+          .filter((line) => /^#{1,6} /.test(line))
+          .map((line) =>
+            line
+              .replace(/^#{1,6} /, "")
+              .toLowerCase()
+              .replace(/[^a-z0-9 -]/g, "")
+              .trim()
+              .replace(/ +/g, "-"),
+          );
+        assert.ok(
+          targetSource.includes(`<a id="${match[2]}"></a>`) || headingAnchors.includes(match[2]),
+          `${sourcePath} links to missing anchor ${target}#${match[2]}`,
+        );
+      }
+    }
+  }
+});
+
+test("always-read skill guidance preserves identity and payload across downstream agent calls", () => {
+  const skill = readFileSync(join(ROOT, SKILL_ROOT, "SKILL.md"), "utf8");
+
+  assert.match(
+    skill,
+    /when one agent consumes another's selected result, include both its stable ID and actual data in the downstream prompt/i,
+  );
+});
+
+test("one generated supported-capability table is fresh across skill, README, and website docs", () => {
+  assert.deepEqual(CAPABILITY_TABLE_PUBLICATION_PATHS, [
+    "skills/workflow-authoring/references/capabilities.md",
+    "README.md",
+    "docs/workflow-authoring.md",
+  ]);
+  assert.deepEqual(checkWorkflowCapabilityPublications(ROOT), []);
+
+  const generatedTable = renderSupportedCapabilityTable();
+  for (const path of CAPABILITY_TABLE_PUBLICATION_PATHS) {
+    const publication = readFileSync(join(ROOT, path), "utf8");
+    assert.equal(publication.split(generatedTable).length - 1, 1, `${path} must reuse the exact generated table once`);
+  }
+  assert.match(generatedTable, /agent\(prompt, options\?\)/);
+  assert.match(generatedTable, /label.*string.*optional.*derived from phase and call count/i);
+  assert.match(generatedTable, /background\?: boolean = true/);
+  assert.match(
+    readFileSync(join(ROOT, "README.md"), "utf8"),
+    /\[workflow authoring guide\]\(docs\/workflow-authoring\.md\)/,
+  );
+  assert.match(readFileSync(join(ROOT, "docs/workflow-authoring.md"), "utf8"), /^## Supported capabilities$/m);
+  assert.doesNotMatch(generatedTable, /console|VM realm|compatibility-behavior|internal-substrate/);
+  assert.doesNotMatch(generatedTable, /openai|gpt-|agentType catalogue|model route entries/i);
+
+  const installedReference = renderWorkflowCapabilityDetails();
+  for (const expectedMetadata of [
+    "Dynamic reference owner: `model-tier-config`",
+    "Item shape: `{ name: string; description?: string }`",
+    "Future lookup connection: `loadModelTierConfig`",
+    "Dynamic reference owner: `agent-registry`",
+    "Future lookup connection: `loadAgentRegistry`",
+  ]) {
+    assert.match(installedReference, new RegExp(expectedMetadata.replace(/[{}?]/g, "\\$&")));
+  }
+  assert.doesNotMatch(installedReference, /Dynamic reference.*items:/i);
+
+  const stale = checkWorkflowCapabilityPublications(ROOT, {
+    "README.md": readFileSync(join(ROOT, "README.md"), "utf8").replace("| agent |", "| stale-agent |"),
+    "docs/workflow-authoring.md": "missing generated anchors",
+  });
+  assert.deepEqual(stale, ["README.md", "docs/workflow-authoring.md"]);
+});
+
+test("generated capability index and exhaustive details are fresh and absent from permanent context surfaces", () => {
+  const index = readFileSync(join(ROOT, SKILL_ROOT, "references/capabilities.md"), "utf8");
+  const details = readFileSync(join(ROOT, SKILL_ROOT, "references/capability-details.md"), "utf8");
+  assert.equal(index, renderWorkflowCapabilityReference());
+  assert.equal(details, renderWorkflowCapabilityDetails());
+  assert.equal(index.split(renderSupportedCapabilityTable()).length - 1, 1);
+  assert.match(index, /exhaustive generated facts.*capability-details\.md/i);
+  assert.doesNotMatch(index, /<a id="agent"><\/a>/);
+  assert.match(details, /<a id="agent"><\/a>/);
+  assert.doesNotMatch(details, /BEGIN GENERATED SUPPORTED WORKFLOW CAPABILITIES/);
+  assert.ok(Buffer.byteLength(index, "utf8") < Buffer.byteLength(details, "utf8"));
+  for (const fact of WORKFLOW_CAPABILITY_CONTRACT.projectStaticReferenceFacts()) {
+    assert.equal(fact.reference?.split("#")[0], `${SKILL_ROOT}/references/capability-details.md`);
+  }
+
+  const tool = createWorkflowTool({ cwd: ROOT });
+  const permanentPrompt = JSON.stringify({ snippet: tool.promptSnippet, guidelines: tool.promptGuidelines });
+  const providerVisibleDefinition = JSON.stringify({ description: tool.description, parameters: tool.parameters });
+  for (const surface of [permanentPrompt, providerVisibleDefinition]) {
+    assert.doesNotMatch(surface, /generated from WORKFLOW_CAPABILITY_CONTRACT/i);
+    assert.doesNotMatch(surface, /Workflow capability reference|Supported capability index/i);
+    assert.doesNotMatch(surface, /skills\/workflow-authoring|references\/capabilities\.md/i);
+  }
+});
+
+test("generated facts cover the lifecycle constraints taught by the skill", () => {
+  const facts = new Map(WORKFLOW_CAPABILITY_CONTRACT.projectStaticReferenceFacts().map((fact) => [fact.id, fact]));
+  const exactFacts = [
+    "workflow.runtime.agent",
+    "workflow.runtime.workflow",
+    "workflow.runtime.retry",
+    "workflow.runtime.checkpoint",
+    "workflow.runtime.budget",
+    "workflow.script.return-value",
+    "workflow.script.determinism",
+  ]
+    .flatMap((id) => {
+      const fact = facts.get(id);
+      return fact ? [fact.signature ?? "", ...fact.constraints] : [];
+    })
+    .join(" ");
+
+  for (const requiredFact of [
+    /recoverable failures return null/i,
+    /selector priority/i,
+    /longest unchanged prefix/i,
+    /one nested level/i,
+    /exhaustion returns (?:only )?the last result/i,
+    /consumes one agent slot and no tokens/i,
+    /in-flight work can overshoot/i,
+    /JSON-serializable/i,
+    /Date\.now\(\).*Math\.random\(\)/i,
+  ]) {
+    assert.match(exactFacts, requiredFact);
+  }
+});
+
+test("generated gate facts expose exact callback, option, and result contracts", () => {
+  const gate = WORKFLOW_CAPABILITY_CONTRACT.projectStaticReferenceFacts().find(
+    (fact) => fact.id === "workflow.runtime.gate",
+  );
+
+  assert.ok(gate);
+  assert.equal(
+    gate.signature,
+    "gate(thunk: (feedback: string | undefined, attempt: number) => unknown | Promise<unknown>, validator: (value: unknown) => { ok: boolean; feedback?: string } | Promise<{ ok: boolean; feedback?: string }>, options?: { attempts?: number }) => Promise<{ ok: boolean; value: unknown; attempts: number }>",
+  );
+  assert.deepEqual(gate.options?.options, [
+    {
+      name: "attempts",
+      type: "number",
+      optional: true,
+      default: "3",
+      constraints: ["authors must provide a finite integer; runtime clamps values below 1 to 1"],
+      dynamicReference: null,
+    },
+  ]);
+  assert.match(gate.constraints.join(" "), /feedback is undefined.*first thunk call/i);
+  assert.match(gate.constraints.join(" "), /attempt is zero-based/i);
+  assert.match(gate.constraints.join(" "), /accepted when.*truthy ok.*bare boolean.*not accepted/i);
+
+  const helpers = readFileSync(join(ROOT, SKILL_ROOT, "references/specialized-helpers.md"), "utf8");
+  assert.match(helpers, /thunk.*feedback.*attempt/i);
+  assert.match(helpers, /zero-based/i);
+  assert.match(helpers, /validator.*value.*ok.*feedback/i);
+  assert.match(helpers, /bare boolean.*not accepted/i);
+
+  const recipes = readFileSync(join(ROOT, SKILL_ROOT, "references/focused-recipes.md"), "utf8");
+  assert.match(recipes, /\[Validated gate\]\(\.\.\/examples\/validated-gate\.js\)/);
+});
+
+test("generated helper facts expose exact callback, option, result, and failure contracts", () => {
+  const facts = new Map(WORKFLOW_CAPABILITY_CONTRACT.projectStaticReferenceFacts().map((fact) => [fact.id, fact]));
+  const verify = facts.get("workflow.runtime.verify");
+  const judgePanel = facts.get("workflow.runtime.judgePanel");
+  const loopUntilDry = facts.get("workflow.runtime.loopUntilDry");
+  const completenessCheck = facts.get("workflow.runtime.completenessCheck");
+  const retry = facts.get("workflow.runtime.retry");
+  const pipeline = facts.get("workflow.runtime.pipeline");
+  const agent = facts.get("workflow.runtime.agent");
+  const background = facts.get("workflow.tool-input.background");
+  const metadata = facts.get("workflow.script.metadata");
+
+  assert.match(verify?.signature ?? "", /reviewers.*threshold.*lens.*realCount.*votes/i);
+  assert.deepEqual(
+    verify?.options?.options.map(({ name, default: value }) => [name, value]),
+    [
+      ["reviewers", "2"],
+      ["threshold", "0.5"],
+      ["lens", null],
+    ],
+  );
+  assert.match(verify?.constraints.join(" ") ?? "", /successful votes.*denominator/i);
+
+  assert.match(judgePanel?.signature ?? "", /judges.*rubric.*index.*attempt.*score.*judgments.*undefined/i);
+  assert.deepEqual(
+    judgePanel?.options?.options.map(({ name, default: value }) => [name, value]),
+    [
+      ["judges", "3"],
+      ["rubric", '"overall quality and correctness"'],
+    ],
+  );
+  assert.match(judgePanel?.constraints.join(" ") ?? "", /stable.*input index.*tie/i);
+
+  assert.match(loopUntilDry?.signature ?? "", /round.*roundIndex.*key.*consecutiveEmpty.*maxRounds/i);
+  assert.deepEqual(
+    loopUntilDry?.options?.options.map(({ name, default: value }) => [name, value]),
+    [
+      ["round", null],
+      ["key", "JSON.stringify"],
+      ["consecutiveEmpty", "2"],
+      ["maxRounds", "50"],
+    ],
+  );
+  assert.match(loopUntilDry?.constraints.join(" ") ?? "", /capacity exhaustion.*partial array/i);
+  assert.match(loopUntilDry?.constraints.join(" ") ?? "", /does not report whether termination/i);
+
+  assert.match(completenessCheck?.signature ?? "", /complete: boolean.*missing\?: string\[\].*null/i);
+  assert.match(completenessCheck?.constraints.join(" ") ?? "", /4,000.*serialized result/i);
+
+  assert.match(retry?.signature ?? "", /attempt: number.*until.*boolean.*Promise<unknown>/i);
+  assert.deepEqual(
+    retry?.options?.options.map(({ name, default: value }) => [name, value]),
+    [
+      ["attempts", "3"],
+      ["until", "accept first result when omitted"],
+    ],
+  );
+  assert.match(retry?.constraints.join(" ") ?? "", /zero-based/i);
+  assert.match(retry?.constraints.join(" ") ?? "", /synchronous.*Promise.*first result/i);
+
+  assert.match(pipeline?.constraints.join(" ") ?? "", /null.*next stage/i);
+  assert.match(agent?.constraints.join(" ") ?? "", /schema noncompliance.*nonrecoverable/i);
+  assert.match(agent?.constraints.join(" ") ?? "", /selected.*unavailable.*session default/i);
+  assert.match(agent?.constraints.join(" ") ?? "", /worktree isolation.*best-effort/i);
+  assert.match(background?.constraints.join(" ") ?? "", /background workflows are headless/i);
+  assert.match(background?.constraints.join(" ") ?? "", /checkpoint.*foreground confirmation/i);
+  assert.match(metadata?.signature ?? "", /phases\?: Array<\{ title: string; detail\?: string; model\?: string \}>/);
+  assert.match(metadata?.constraints.join(" ") ?? "", /only legal export/i);
+  assert.match(metadata?.constraints.join(" ") ?? "", /literal.*string concatenation.*template interpolation/i);
+
+  const qualityHelpers = readFileSync(join(ROOT, SKILL_ROOT, "references/quality-helpers.md"), "utf8");
+  const retryHelper = readFileSync(join(ROOT, SKILL_ROOT, "references/retry-helper.md"), "utf8");
+  const specializedHelpers = readFileSync(join(ROOT, SKILL_ROOT, "references/specialized-helpers.md"), "utf8");
+  assert.match(qualityHelpers, /verify.*reviewers: number.*threshold: number.*lens: string/i);
+  assert.match(qualityHelpers, /judgePanel.*judges: number.*rubric: string/i);
+  assert.match(qualityHelpers, /successful votes.*denominator/i);
+  assert.match(specializedHelpers, /agent-limit exhaustion.*partial/i);
+  assert.match(retryHelper, /retry.*zero-based.*synchronous/i);
+  assert.match(retryHelper, /await retry/i);
+  assert.match(specializedHelpers, /await gate/i);
+  assert.match(retryHelper, /await.*agent.*resolved value.*ledger/i);
+  assert.match(specializedHelpers, /await.*agent.*resolved value.*ledger/i);
+  const runtime = readFileSync(join(ROOT, SKILL_ROOT, "references/runtime.md"), "utf8");
+  assert.match(runtime, /pipeline.*null.*next stage/i);
+  assert.match(runtime, /schema noncompliance.*throw/i);
+  assert.match(runtime, /phases.*\[\{.*title.*detail.*model/i);
+  assert.match(runtime, /only legal export.*meta/i);
+  assert.match(runtime, /export default.*other exports.*invalid/i);
+  assert.match(runtime, /agent\(prompt.*label.*schema/i);
+  const lifecycle = readFileSync(join(ROOT, SKILL_ROOT, "references/lifecycle.md"), "utf8");
+  assert.match(lifecycle, /background workflows are headless/i);
+  assert.match(lifecycle, /checkpoint.*foreground/i);
+});
+
+test("fan-out-and-synthesize example waits for the complete result set and preserves failures", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/fan-out-and-synthesize.js"), "utf8");
+  const work = [
+    { id: "alpha", task: "A" },
+    { id: "beta", task: "B" },
+    { id: "gamma", task: "C" },
+  ];
+  const finished = new Set<string>();
+  const labels: string[] = [];
+  let synthesisSawCompleteFanOut = false;
+
+  const result = await runWorkflow<{
+    ledger: Array<{ id: string; status: string; result: unknown }>;
+    synthesis: unknown;
+  }>(script, {
+    args: { work },
+    persistLogs: false,
+    onAgentStart: ({ label }) => labels.push(label),
+    agent: {
+      async run(prompt: string, options: { label?: string; schema?: unknown }) {
+        if (options.label === "synthesize-complete-set") {
+          synthesisSawCompleteFanOut = finished.size === work.length;
+          assert.match(prompt, /"id":"beta"/);
+          assert.match(prompt, /"status":"failed"/);
+          return { summary: "complete", coveredIds: ["alpha", "gamma"], failedIds: ["beta"] };
+        }
+        const id = options.label?.split(":").at(-1) ?? "unknown";
+        finished.add(id);
+        return id === "beta" ? "" : `result:${id}`;
+      },
+    },
+  });
+
+  assert.equal(synthesisSawCompleteFanOut, true);
+  assert.deepEqual(labels, ["fanout:0:alpha", "fanout:1:beta", "fanout:2:gamma", "synthesize-complete-set"]);
+  assert.equal(new Set(labels).size, labels.length, "all agent labels must be unique");
+  assert.deepEqual(
+    result.result.ledger.map(({ id, status, result: itemResult }) => ({ id, status, result: itemResult })),
+    [
+      { id: "alpha", status: "complete", result: "result:alpha" },
+      { id: "beta", status: "failed", result: null },
+      { id: "gamma", status: "complete", result: "result:gamma" },
+    ],
+  );
+  assert.doesNotThrow(() => JSON.stringify(result.result));
+});
+
+test("classify-and-act classifies the complete set before routed action", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/classify-and-act.js"), "utf8");
+  const labels: string[] = [];
+  const classified = new Set<string>();
+  let actionsStartedAfterClassification = true;
+
+  const result = await runWorkflow<{
+    handled: Array<{ id: string; category: string }>;
+    failed: { classification: string[]; action: string[] };
+  }>(script, {
+    args: { items: [{ id: "alpha" }, { id: "beta" }, { id: "gamma" }] },
+    persistLogs: false,
+    onAgentStart: ({ label }) => labels.push(label),
+    agent: {
+      async run(_prompt: string, options: { label?: string }) {
+        const label = options.label ?? "";
+        if (label.startsWith("classify:")) {
+          const id = label.split(":").at(-1) ?? "";
+          classified.add(id);
+          return id === "beta" ? null : { category: id === "alpha" ? "direct" : "iterative", reason: "fixture" };
+        }
+        actionsStartedAfterClassification &&= classified.size === 3;
+        return label.endsWith(":gamma") ? null : { outcome: "handled" };
+      },
+    },
+  });
+
+  assert.equal(actionsStartedAfterClassification, true);
+  assert.deepEqual(labels, ["classify:0:alpha", "classify:1:beta", "classify:2:gamma", "act:0:alpha", "act:1:gamma"]);
+  assert.deepEqual([...result.result.failed.classification], ["beta"]);
+  assert.deepEqual([...result.result.failed.action], ["gamma"]);
+  assert.deepEqual(
+    result.result.handled.map(({ id, category }) => ({ id, category })),
+    [{ id: "alpha", category: "direct" }],
+  );
+  assert.doesNotThrow(() => JSON.stringify(result.result));
+});
+
+test("adversarial verification uses separate producer and skeptic calls and retains failures", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/adversarial-verification.js"), "utf8");
+  const labels: string[] = [];
+  const finishedProducers = new Set<string>();
+  let skepticsStartedAfterProduction = true;
+
+  const result = await runWorkflow<{
+    failed: { producers: string[]; skeptics: string[] };
+  }>(script, {
+    args: { topics: [{ id: "alpha" }, { id: "beta" }] },
+    persistLogs: false,
+    onAgentStart: ({ label }) => labels.push(label),
+    agent: {
+      async run(prompt: string, options: { label?: string }) {
+        const label = options.label ?? "";
+        if (label.startsWith("produce:")) {
+          const id = label.split(":").at(-1) ?? "";
+          finishedProducers.add(id);
+          return id === "beta" ? null : { claim: "claim-alpha", evidence: ["source"] };
+        }
+        skepticsStartedAfterProduction &&= finishedProducers.size === 2;
+        assert.match(prompt, /claim-alpha/);
+        return null;
+      },
+    },
+  });
+
+  assert.equal(skepticsStartedAfterProduction, true);
+  assert.deepEqual(labels, ["produce:0:alpha", "produce:1:beta", "skeptic:0:alpha"]);
+  assert.equal(new Set(labels).size, labels.length);
+  assert.deepEqual([...result.result.failed.producers], ["beta"]);
+  assert.deepEqual([...result.result.failed.skeptics], ["alpha"]);
+  assert.doesNotThrow(() => JSON.stringify(result.result));
+});
+
+test("generate-and-filter deterministically deduplicates before rubric filtering", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/generate-and-filter.js"), "utf8");
+  const labels: string[] = [];
+  const filteredCandidates: string[] = [];
+
+  const result = await runWorkflow<{
+    candidates: string[];
+    survivors: string[];
+    failed: { batches: number[]; filters: string[] };
+  }>(script, {
+    args: { batches: 3, maxCandidates: 3, topic: "names", rubric: "clear" },
+    persistLogs: false,
+    onAgentStart: ({ label }) => labels.push(label),
+    agent: {
+      async run(prompt: string, options: { label?: string }) {
+        const label = options.label ?? "";
+        if (label === "generate:1") return { candidates: ["Alpha", " Beta "] };
+        if (label === "generate:2") return { candidates: [" alpha ", "Gamma"] };
+        if (label === "generate:3") return null;
+        const candidate = /Candidate: (.*)$/.exec(prompt)?.[1] ?? "";
+        filteredCandidates.push(candidate);
+        return candidate.trim() === "Beta" ? null : { keep: candidate === "Alpha", reason: "fixture" };
+      },
+    },
+  });
+
+  assert.deepEqual(filteredCandidates, ["Alpha", " Beta ", "Gamma"]);
+  assert.deepEqual([...result.result.candidates], ["Alpha", " Beta ", "Gamma"]);
+  assert.deepEqual([...result.result.survivors], ["Alpha"]);
+  assert.deepEqual([...result.result.failed.batches], [3]);
+  assert.deepEqual([...result.result.failed.filters], [" Beta "]);
+  assert.equal(new Set(labels).size, labels.length);
+  assert.doesNotThrow(() => JSON.stringify(result.result));
+});
+
+test("generate-and-filter bounds rubric calls after deterministic deduplication", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/generate-and-filter.js"), "utf8");
+  const filterLabels: string[] = [];
+  const result = await runWorkflow<{ candidates: string[]; omitted: string[] }>(script, {
+    args: { batches: 1, maxCandidates: 2 },
+    persistLogs: false,
+    agent: {
+      async run(_prompt: string, { label }: { label?: string }) {
+        if (label === "generate:1") return { candidates: ["Alpha", "alpha", "Beta", "Gamma"] };
+        filterLabels.push(label ?? "");
+        return { keep: true, reason: "fixture" };
+      },
+    },
+  });
+
+  assert.deepEqual([...result.result.candidates], ["Alpha", "Beta"]);
+  assert.deepEqual([...result.result.omitted], ["Gamma"]);
+  assert.deepEqual(filterLabels, ["filter:1", "filter:2"]);
+});
+
+test("tournament keeps a bounded bracket in JavaScript and agents judge only pairs", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/tournament.js"), "utf8");
+  const labels: string[] = [];
+  const judgePrompts: string[] = [];
+
+  const result = await runWorkflow<{
+    winner: { id: string } | null;
+    bracket: Array<{ round: number; match: number; leftId: string; rightId: string | null }>;
+    failed: { contenders: number[]; matches: string[] };
+  }>(script, {
+    args: { contenders: 4, task: "pick", rubric: "best" },
+    persistLogs: false,
+    onAgentStart: ({ label }) => labels.push(label),
+    agent: {
+      async run(prompt: string, options: { label?: string }) {
+        const label = options.label ?? "";
+        if (label.startsWith("contender:")) return { candidate: label, rationale: "fixture" };
+        judgePrompts.push(prompt);
+        return { winnerIndex: 0, reason: "fixture" };
+      },
+    },
+  });
+
+  assert.equal(judgePrompts.length, 3, "four contenders require exactly three pairwise judgments");
+  assert.ok(judgePrompts.every((prompt) => /Candidate 0:/.test(prompt) && /Candidate 1:/.test(prompt)));
+  assert.deepEqual(
+    Array.from(result.result.bracket, ({ leftId, rightId }) => [leftId, rightId]),
+    [
+      ["contender-1", "contender-2"],
+      ["contender-3", "contender-4"],
+      ["contender-1", "contender-3"],
+    ],
+  );
+  assert.equal(result.result.winner?.id, "contender-1");
+  assert.equal(new Set(labels).size, labels.length);
+  assert.doesNotThrow(() => JSON.stringify(result.result));
+
+  const failedResult = await runWorkflow<{
+    failed: { contenders: number[]; matches: string[] };
+  }>(script, {
+    args: { contenders: 3 },
+    persistLogs: false,
+    agent: {
+      async run(_prompt: string, { label }: { label?: string }) {
+        if (label === "contender:2") return null;
+        if (label?.startsWith("contender:")) return { candidate: label, rationale: "fixture" };
+        return null;
+      },
+    },
+  });
+  assert.deepEqual([...failedResult.result.failed.contenders], [2]);
+  assert.deepEqual([...failedResult.result.failed.matches], ["round-1-match-1"]);
+});
+
+test("tournament advances an odd contender by bye without an agent judgment", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/tournament.js"), "utf8");
+  const judgeLabels: string[] = [];
+  const result = await runWorkflow<{ bracket: Array<{ rightId: string | null }>; winner: { id: string } }>(script, {
+    args: { contenders: 3 },
+    persistLogs: false,
+    agent: {
+      async run(_prompt: string, { label }: { label?: string }) {
+        if (label?.startsWith("contender:")) return { candidate: label, rationale: "fixture" };
+        judgeLabels.push(label ?? "");
+        return { winnerIndex: 0, reason: "fixture" };
+      },
+    },
+  });
+
+  assert.deepEqual(judgeLabels, ["judge:1:1", "judge:2:1"]);
+  assert.equal(
+    result.result.bracket.some(({ rightId }) => rightId === null),
+    true,
+  );
+  assert.equal(result.result.winner.id, "contender-1");
+});
+
+test("loop-until-done uses stable identities, dry-round termination, and a maximum bound", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/loop-until-done.js"), "utf8");
+  const dryLabels: string[] = [];
+  const rounds = [
+    {
+      findings: [
+        { id: "alpha", detail: "first" },
+        { id: "alpha", detail: "same-round duplicate" },
+      ],
+    },
+    { findings: [{ id: "alpha", detail: "duplicate" }] },
+    { findings: [{ id: "beta", detail: "second" }] },
+    { findings: [] },
+    { findings: [] },
+  ];
+  const dryResult = await runWorkflow<{ findings: Array<{ id: string }>; failedRounds: number[] }>(script, {
+    args: { maxRounds: 10 },
+    persistLogs: false,
+    onAgentStart: ({ label }) => dryLabels.push(label),
+    agent: { run: async () => rounds.shift() ?? { findings: [{ id: "unexpected", detail: "too late" }] } },
+  });
+
+  assert.deepEqual(dryLabels, ["discover:1", "discover:2", "discover:3", "discover:4", "discover:5"]);
+  assert.deepEqual(
+    Array.from(dryResult.result.findings, ({ id }) => id),
+    ["alpha", "beta"],
+  );
+
+  const boundedLabels: string[] = [];
+  const boundedResult = await runWorkflow<{ complete: boolean; termination: string }>(script, {
+    args: { maxRounds: 3 },
+    persistLogs: false,
+    onAgentStart: ({ label }) => boundedLabels.push(label),
+    agent: {
+      run: async (_prompt: string, { label }: { label?: string }) => ({
+        findings: [{ id: label, detail: "new" }],
+      }),
+    },
+  });
+  assert.deepEqual(boundedLabels, ["discover:1", "discover:2", "discover:3"]);
+  assert.equal(boundedResult.result.complete, false);
+  assert.equal(boundedResult.result.termination, "max-rounds");
+
+  const failedResult = await runWorkflow<{ complete: boolean; failedRounds: number[]; termination: string }>(script, {
+    args: { maxRounds: 5 },
+    persistLogs: false,
+    agent: { run: async () => null },
+  });
+  assert.deepEqual([...failedResult.result.failedRounds], [1, 2, 3, 4, 5]);
+  assert.equal(failedResult.result.complete, false);
+  assert.equal(failedResult.result.termination, "max-rounds");
+  assert.equal(new Set(dryLabels).size, dryLabels.length);
+  assert.doesNotThrow(() => JSON.stringify(dryResult.result));
+});
+
+test("loop-until-done resets its consecutive dry streak after missing coverage", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/loop-until-done.js"), "utf8");
+  const labels: string[] = [];
+  const responses = [{ findings: [] }, null, { findings: [] }, { findings: [] }];
+  const result = await runWorkflow<{ complete: boolean; failedRounds: number[]; termination: string }>(script, {
+    args: { maxRounds: 5 },
+    persistLogs: false,
+    onAgentStart: ({ label }) => labels.push(label),
+    agent: {
+      run: async () => {
+        const response = responses.shift();
+        return response === undefined ? { findings: [{ id: "late", detail: "too late" }] } : response;
+      },
+    },
+  });
+
+  assert.deepEqual(labels, ["discover:1", "discover:2", "discover:3", "discover:4"]);
+  assert.deepEqual([...result.result.failedRounds], [2]);
+  assert.equal(result.result.termination, "dry");
+  assert.equal(result.result.complete, false);
+});
+
+test("phased-budget recipe reports soft-gate spending and bounds later calls", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/phased-budgets.js"), "utf8");
+  const labels: string[] = [];
+  const result = await runWorkflow<{
+    phases: Array<{ title: string; startSpent: number; endSpent: number; attempted: string[]; missing: string[] }>;
+    totalSpent: number;
+  }>(script, {
+    args: { phaseBudget: 10, work: [{ id: "alpha" }, { id: "beta" }, { id: "gamma" }] },
+    persistLogs: false,
+    onAgentStart: ({ label }) => labels.push(label),
+    agent: {
+      async run(_prompt: string, options: { label?: string; onUsage?: (usage: unknown) => void }) {
+        options.onUsage?.({ input: 10, output: 0, total: 10, cost: 0, cacheRead: 0, cacheWrite: 0 });
+        return options.label === "deliver:0:alpha" ? null : { summary: options.label ?? "" };
+      },
+    },
+  });
+
+  assert.deepEqual(labels, ["explore:0:alpha", "deliver:0:alpha"]);
+  assert.deepEqual(JSON.parse(JSON.stringify(result.result.phases[0])), {
+    title: "Explore",
+    startSpent: 0,
+    endSpent: 10,
+    attempted: ["alpha", "beta", "gamma"],
+    missing: ["beta", "gamma"],
+  });
+  assert.deepEqual(Array.from(result.result.phases[1]?.missing ?? []), ["alpha"]);
+  assert.equal(result.result.totalSpent, 20);
+  assert.doesNotThrow(() => JSON.stringify(result.result));
+});
+
+test("saved-workflow recipe runs context-supplied nested jobs sequentially at one level", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/saved-nested-workflows.js"), "utf8");
+  const child = `export const meta = { name: 'installed_child', description: 'fixture' }
+const result = await agent('child:' + args.id, { label: 'child:' + args.id })
+return { id: args.id, result }`;
+  const labels: string[] = [];
+  let active = 0;
+  let maxActive = 0;
+  const result = await runWorkflow<{
+    nested: Array<{ id: string; status: string; result: unknown }>;
+    missing: string[];
+  }>(script, {
+    args: { savedWorkflowName: "installed-child", jobs: [{ id: "alpha" }, { id: "beta" }] },
+    persistLogs: false,
+    loadSavedWorkflow: (name) => (name === "installed-child" ? child : undefined),
+    onAgentStart: ({ label }) => labels.push(label),
+    agent: {
+      async run(_prompt: string, { label }: { label?: string }) {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await Promise.resolve();
+        active--;
+        if (label === "child:beta") return null;
+        return label === "prepare-nested-jobs" ? { ready: true } : `result:${label}`;
+      },
+    },
+  });
+
+  assert.equal(maxActive, 1);
+  assert.deepEqual(labels, ["prepare-nested-jobs", "child:alpha", "child:beta"]);
+  assert.deepEqual(Array.from(result.result.missing), ["beta"]);
+  assert.deepEqual(
+    Array.from(result.result.nested, ({ id, status }) => ({ id, status })),
+    [
+      { id: "alpha", status: "complete" },
+      { id: "beta", status: "missing" },
+    ],
+  );
+  assert.doesNotThrow(() => JSON.stringify(result.result));
+});
+
+test("bounded-retry recipe separates transport retries and preserves every semantic attempt", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/bounded-semantic-retry.js"), "utf8");
+  const labels: string[] = [];
+  const result = await runWorkflow<{
+    ok: boolean;
+    exhausted: boolean;
+    attempts: Array<{ attempt: number; status: string; result: unknown }>;
+  }>(script, {
+    args: { maxSemanticAttempts: 3, transportRetries: 1 },
+    persistLogs: false,
+    onAgentStart: ({ label }) => labels.push(label),
+    agent: {
+      async run(_prompt: string, { label }: { label?: string }) {
+        if (label === "semantic-attempt:1") return null;
+        return { accepted: false, answer: `answer:${label}`, feedback: "try again" };
+      },
+    },
+  });
+
+  assert.deepEqual(labels, ["semantic-attempt:1", "semantic-attempt:2", "semantic-attempt:3"]);
+  assert.deepEqual(
+    Array.from(result.result.attempts, ({ attempt, status }) => ({ attempt, status })),
+    [
+      { attempt: 1, status: "missing" },
+      { attempt: 2, status: "rejected" },
+      { attempt: 3, status: "rejected" },
+    ],
+  );
+  assert.equal(result.result.ok, false);
+  assert.equal(result.result.exhausted, true);
+  assert.doesNotThrow(() => JSON.stringify(result.result));
+});
+
+test("validated-gate recipe uses exact callbacks and returns feedback-ledger evidence", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/validated-gate.js"), "utf8");
+  const labels: string[] = [];
+  const prompts: string[] = [];
+  const result = await runWorkflow<{
+    ok: boolean;
+    value: { acceptable: boolean; answer: string; feedback: string };
+    attempts: number;
+    ledger: Array<{
+      attempt: number;
+      feedbackReceived: string | null;
+      accepted: boolean;
+      validatorFeedback: string | null;
+    }>;
+  }>(script, {
+    args: { task: "Explain the contract", maxAttempts: 3 },
+    persistLogs: false,
+    onAgentStart: ({ label }) => labels.push(label),
+    agent: {
+      async run(prompt: string, { label, schema }: { label?: string; schema?: Record<string, unknown> }) {
+        prompts.push(prompt);
+        assert.deepEqual(requiredSchemaFields(schema), ["acceptable", "answer", "feedback"]);
+        if (label === "gate-attempt:1") {
+          return { acceptable: false, answer: "too short", feedback: "add concrete detail" };
+        }
+        return { acceptable: true, answer: "A concrete and complete answer", feedback: "" };
+      },
+    },
+  });
+
+  assert.deepEqual(labels, ["gate-attempt:1", "gate-attempt:2"]);
+  assert.match(prompts[1] ?? "", /add concrete detail/);
+  assert.equal(result.result.ok, true);
+  assert.equal(result.result.attempts, 2);
+  assert.equal(result.result.value.answer, "A concrete and complete answer");
+  assert.deepEqual(
+    Array.from(result.result.ledger, ({ attempt, feedbackReceived, accepted, validatorFeedback }) => ({
+      attempt,
+      feedbackReceived,
+      accepted,
+      validatorFeedback,
+    })),
+    [
+      {
+        attempt: 1,
+        feedbackReceived: null,
+        accepted: false,
+        validatorFeedback: "add concrete detail",
+      },
+      { attempt: 2, feedbackReceived: "add concrete detail", accepted: true, validatorFeedback: null },
+    ],
+  );
+  assert.doesNotThrow(() => JSON.stringify(result.result));
+});
+
+test("structured-output recipe requires schema validation before consuming fields", async () => {
+  const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/structured-output.js"), "utf8");
+  const labels: string[] = [];
+  const result = await runWorkflow<{
+    outputs: Array<{ id: string; status: string; summary: string | null }>;
+    missing: string[];
+  }>(script, {
+    args: { work: [{ id: "alpha" }, { id: "alpha" }, { id: "beta" }] },
+    persistLogs: false,
+    onAgentStart: ({ label }) => labels.push(label),
+    agent: {
+      async run(_prompt: string, { label, schema }: { label?: string; schema?: Record<string, unknown> }) {
+        assert.deepEqual(requiredSchemaFields(schema), ["summary", "confidence"]);
+        return label === "structured:2:beta" ? null : { summary: "validated", confidence: 0.8 };
+      },
+    },
+  });
+
+  assert.deepEqual(labels, ["structured:0:alpha", "structured:1:alpha", "structured:2:beta"]);
+  assert.equal(new Set(labels).size, labels.length);
+  assert.deepEqual(
+    Array.from(result.result.outputs, ({ id, status, summary }) => ({ id, status, summary })),
+    [
+      { id: "alpha", status: "complete", summary: "VALIDATED" },
+      { id: "alpha", status: "complete", summary: "VALIDATED" },
+      { id: "beta", status: "missing", summary: null },
+    ],
+  );
+  assert.deepEqual(Array.from(result.result.missing), ["beta"]);
+  assert.doesNotThrow(() => JSON.stringify(result.result));
+});

--- a/tests/workflow-capability-contract.test.ts
+++ b/tests/workflow-capability-contract.test.ts
@@ -90,6 +90,19 @@ test("capability definition inventories the settled runtime and invocation contr
   assert.equal(WORKFLOW_CAPABILITY_DEFINITION.versions.content.kind, "present-at");
 });
 
+test("tool-input contract records configured omission defaults and soft budget accounting", () => {
+  const agentTimeoutMs = WORKFLOW_CAPABILITY_DEFINITION.capabilities.find(
+    ({ id }) => id === "workflow.tool-input.agentTimeoutMs",
+  );
+  const tokenBudget = WORKFLOW_CAPABILITY_DEFINITION.capabilities.find(
+    ({ id }) => id === "workflow.tool-input.tokenBudget",
+  );
+
+  assert.equal(agentTimeoutMs?.signature, "agentTimeoutMs?: number = configured default or unbounded");
+  assert.equal(tokenBudget?.signature, "tokenBudget?: number = configured default or unlimited");
+  assert.deepEqual(tokenBudget?.constraints, ["soft pre-call gate; in-flight work can overshoot"]);
+});
+
 test("contract data is immutable after validation", () => {
   const firstCapability = WORKFLOW_CAPABILITY_DEFINITION.capabilities[0];
   assert.throws(() => Object.assign(firstCapability, { label: "mutated" }), TypeError);

--- a/tests/workflow-capability-contract.test.ts
+++ b/tests/workflow-capability-contract.test.ts
@@ -1,0 +1,325 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import vm from "node:vm";
+import { runWorkflow } from "../src/workflow.js";
+import {
+  CapabilityClassification,
+  CapabilityOrigin,
+  CapabilitySupport,
+  defineWorkflowCapabilityContract,
+  WORKFLOW_CAPABILITY_CONTRACT,
+  WORKFLOW_CAPABILITY_DEFINITION,
+  WorkflowCapabilityContractError,
+} from "../src/workflow-capability-contract.js";
+
+const EXPECTED_RUNTIME_GLOBALS = [
+  "agent",
+  "args",
+  "budget",
+  "checkpoint",
+  "completenessCheck",
+  "console",
+  "cwd",
+  "gate",
+  "judgePanel",
+  "log",
+  "loopUntilDry",
+  "parallel",
+  "phase",
+  "pipeline",
+  "process",
+  "retry",
+  "verify",
+  "workflow",
+] as const;
+
+const EXPECTED_TOOL_INPUTS = [
+  "agentRetries",
+  "agentTimeoutMs",
+  "args",
+  "background",
+  "concurrency",
+  "maxAgents",
+  "resumeFromRunId",
+  "script",
+  "tokenBudget",
+] as const;
+
+function implementations(): Record<string, unknown> {
+  return Object.fromEntries(EXPECTED_RUNTIME_GLOBALS.map((name) => [name, { name }]));
+}
+
+test("capability definition inventories the settled runtime and invocation contract", () => {
+  const runtimeGlobals = WORKFLOW_CAPABILITY_DEFINITION.capabilities
+    .filter((capability) => capability.classification === CapabilityClassification.RUNTIME_GLOBAL)
+    .map((capability) => capability.runtimeBinding?.global)
+    .sort();
+  const toolInputs = WORKFLOW_CAPABILITY_DEFINITION.capabilities
+    .filter((capability) => capability.classification === CapabilityClassification.WORKFLOW_TOOL_INPUT)
+    .map((capability) => capability.label)
+    .sort();
+
+  assert.deepEqual(runtimeGlobals, [...EXPECTED_RUNTIME_GLOBALS]);
+  assert.deepEqual(toolInputs, [...EXPECTED_TOOL_INPUTS]);
+  assert.deepEqual(WORKFLOW_CAPABILITY_DEFINITION.optionShapes.map((shape) => shape.id).sort(), [
+    "agent-options",
+    "checkpoint-options",
+    "gate-options",
+    "judge-panel-options",
+    "loop-until-dry-options",
+    "phase-options",
+    "retry-options",
+    "verify-options",
+  ]);
+  assert.ok(
+    WORKFLOW_CAPABILITY_DEFINITION.capabilities.some(
+      (capability) => capability.support === CapabilitySupport.COMPATIBILITY,
+    ),
+  );
+  assert.ok(
+    WORKFLOW_CAPABILITY_DEFINITION.capabilities.some((capability) => capability.origin === CapabilityOrigin.VM_REALM),
+  );
+  assert.deepEqual(
+    WORKFLOW_CAPABILITY_DEFINITION.dynamicReferences.map(({ id, owner, items }) => ({ id, owner, items })),
+    [
+      { id: "model-routes", owner: "model-tier-config", items: undefined },
+      { id: "agent-types", owner: "agent-registry", items: undefined },
+    ],
+  );
+  assert.equal(WORKFLOW_CAPABILITY_DEFINITION.versions.format.kind, "present-at");
+  assert.equal(WORKFLOW_CAPABILITY_DEFINITION.versions.content.kind, "present-at");
+});
+
+test("contract data is immutable after validation", () => {
+  const firstCapability = WORKFLOW_CAPABILITY_DEFINITION.capabilities[0];
+  assert.throws(() => Object.assign(firstCapability, { label: "mutated" }), TypeError);
+  assert.equal(WORKFLOW_CAPABILITY_DEFINITION.capabilities[0]?.label, "agent");
+});
+
+test("contract rejects malformed runtime and registry definitions", () => {
+  const missingBinding = {
+    ...WORKFLOW_CAPABILITY_DEFINITION,
+    capabilities: WORKFLOW_CAPABILITY_DEFINITION.capabilities.map((capability, index) =>
+      index === 0 ? { ...capability, runtimeBinding: null } : capability,
+    ),
+  };
+  assert.throws(
+    () => defineWorkflowCapabilityContract(missingBinding),
+    (error: unknown) =>
+      error instanceof WorkflowCapabilityContractError &&
+      error.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.code === "INVALID_CAPABILITY_DEFINITION" &&
+          diagnostic.message === "Runtime-global capabilities require a runtime binding.",
+      ),
+  );
+
+  const [firstOptionShape] = WORKFLOW_CAPABILITY_DEFINITION.optionShapes;
+  const [firstDynamicReference] = WORKFLOW_CAPABILITY_DEFINITION.dynamicReferences;
+  assert.ok(firstOptionShape);
+  assert.ok(firstDynamicReference);
+  const duplicateRegistries = {
+    ...WORKFLOW_CAPABILITY_DEFINITION,
+    optionShapes: [...WORKFLOW_CAPABILITY_DEFINITION.optionShapes, firstOptionShape],
+    dynamicReferences: [...WORKFLOW_CAPABILITY_DEFINITION.dynamicReferences, firstDynamicReference],
+  };
+  assert.throws(
+    () => defineWorkflowCapabilityContract(duplicateRegistries),
+    (error: unknown) =>
+      error instanceof WorkflowCapabilityContractError &&
+      error.diagnostics.filter((diagnostic) => diagnostic.code === "INVALID_CAPABILITY_DEFINITION").length === 2,
+  );
+
+  const duplicateImplementationIdentity = {
+    ...WORKFLOW_CAPABILITY_DEFINITION,
+    capabilities: WORKFLOW_CAPABILITY_DEFINITION.capabilities.map((capability, index) =>
+      index === 1 && capability.runtimeBinding
+        ? {
+            ...capability,
+            runtimeBinding: {
+              ...capability.runtimeBinding,
+              implementation: WORKFLOW_CAPABILITY_DEFINITION.capabilities[0]?.runtimeBinding?.implementation ?? "agent",
+            },
+          }
+        : capability,
+    ),
+  };
+  assert.throws(
+    () => defineWorkflowCapabilityContract(duplicateImplementationIdentity),
+    (error: unknown) =>
+      error instanceof WorkflowCapabilityContractError &&
+      error.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.code === "INVALID_CAPABILITY_DEFINITION" &&
+          diagnostic.subject === "agent" &&
+          diagnostic.message === 'Duplicate runtime implementation identity "agent".',
+      ),
+  );
+});
+
+test("runtime assembly preserves declared implementation identity", () => {
+  const supplied = implementations();
+  const assembled = WORKFLOW_CAPABILITY_CONTRACT.assembleRuntimeBindings(supplied);
+
+  assert.deepEqual(Object.keys(assembled.globals).sort(), [...EXPECTED_RUNTIME_GLOBALS]);
+  assert.deepEqual(assembled.diagnostics, []);
+  for (const name of EXPECTED_RUNTIME_GLOBALS) assert.equal(assembled.globals[name], supplied[name]);
+});
+
+test("static reference projection keeps live catalogue values out of contract data", () => {
+  const facts = WORKFLOW_CAPABILITY_CONTRACT.projectStaticReferenceFacts();
+  const modelRoutes = facts.find((fact) => fact.id === "workflow.dynamic.model-routes");
+  const agent = facts.find((fact) => fact.id === "workflow.runtime.agent");
+
+  assert.deepEqual(modelRoutes?.dynamicReference, {
+    id: "model-routes",
+    owner: "model-tier-config",
+    itemShape: "{ name: string; description?: string }",
+    connection: "loadModelTierConfig",
+  });
+  assert.equal(Object.hasOwn(modelRoutes?.dynamicReference ?? {}, "items"), false);
+  assert.equal(agent?.options?.id, "agent-options");
+  assert.deepEqual(
+    agent?.options?.options
+      .filter(({ dynamicReference }) => dynamicReference === "model-routes")
+      .map(({ name }) => name),
+    ["tier"],
+  );
+  assert.match(agent?.reference ?? "", /capability-details\.md#agent$/);
+});
+
+test("alignment diagnostics compare declared and observed project globals", () => {
+  assert.deepEqual(
+    WORKFLOW_CAPABILITY_CONTRACT.diagnoseAlignment({
+      observedProjectGlobals: EXPECTED_RUNTIME_GLOBALS.filter((name) => name !== "agent").concat("accidental"),
+    }),
+    [
+      {
+        code: "DECLARED_GLOBAL_UNOBSERVED",
+        severity: "error",
+        subject: "agent",
+        message: 'Declared workflow global "agent" was not observed in the assembled context.',
+      },
+      {
+        code: "OBSERVED_GLOBAL_UNDECLARED",
+        severity: "error",
+        subject: "accidental",
+        message: 'Observed project-owned workflow global "accidental" is undeclared.',
+      },
+    ],
+  );
+});
+
+test("runtime assembly refuses a missing implementation with a precise diagnostic", () => {
+  const supplied = implementations();
+  delete supplied.agent;
+
+  assert.throws(
+    () => WORKFLOW_CAPABILITY_CONTRACT.assembleRuntimeBindings(supplied),
+    (error: unknown) => {
+      assert.ok(error instanceof WorkflowCapabilityContractError);
+      assert.match(error.message, /missing declared runtime implementation: agent/);
+      assert.deepEqual(error.diagnostics, [
+        {
+          code: "MISSING_RUNTIME_IMPLEMENTATION",
+          severity: "error",
+          subject: "agent",
+          message: 'Declared workflow global "agent" has no supplied implementation "agent".',
+        },
+      ]);
+      return true;
+    },
+  );
+});
+
+test("runtime assembly treats an undefined required implementation as missing", () => {
+  const supplied = implementations();
+  supplied.agent = undefined;
+
+  assert.throws(
+    () => WORKFLOW_CAPABILITY_CONTRACT.assembleRuntimeBindings(supplied),
+    (error: unknown) => {
+      assert.ok(error instanceof WorkflowCapabilityContractError);
+      assert.match(error.message, /missing declared runtime implementation: agent/);
+      assert.deepEqual(error.diagnostics, [
+        {
+          code: "MISSING_RUNTIME_IMPLEMENTATION",
+          severity: "error",
+          subject: "agent",
+          message: 'Declared workflow global "agent" has no supplied implementation "agent".',
+        },
+      ]);
+      return true;
+    },
+  );
+});
+
+test("runtime assembly preserves undefined for the optional args runtime value", () => {
+  const supplied = implementations();
+  supplied.args = undefined;
+
+  const assembled = WORKFLOW_CAPABILITY_CONTRACT.assembleRuntimeBindings(supplied);
+
+  assert.equal(Object.hasOwn(assembled.globals, "args"), true);
+  assert.equal(assembled.globals.args, undefined);
+  assert.deepEqual(assembled.diagnostics, []);
+});
+
+test("runtime assembly reports and ignores an undeclared implementation", () => {
+  const supplied = { ...implementations(), accidental: { secret: true } };
+  const assembled = WORKFLOW_CAPABILITY_CONTRACT.assembleRuntimeBindings(supplied);
+
+  assert.equal(Object.hasOwn(assembled.globals, "accidental"), false);
+  assert.deepEqual(assembled.diagnostics, [
+    {
+      code: "UNDECLARED_RUNTIME_IMPLEMENTATION",
+      severity: "warning",
+      subject: "accidental",
+      message: 'Supplied runtime implementation "accidental" is undeclared and was ignored.',
+    },
+  ]);
+});
+
+test("runWorkflow exposes exactly the declared project-owned globals", async () => {
+  const result = await runWorkflow<{
+    allGlobals: string[];
+    substratePresent: boolean;
+    agentResult: string;
+    processMatchesCwd: boolean;
+    budgetWorks: boolean;
+  }>(
+    `export const meta = { name: 'observe_contract', description: 'observe project globals' }
+return {
+  allGlobals: Object.getOwnPropertyNames(globalThis).sort(),
+  substratePresent: typeof Array === 'function',
+  agentResult: await agent('proof', { label: 'proof' }),
+  processMatchesCwd: process.cwd() === cwd,
+  budgetWorks: budget.total === null && budget.spent() > 0 && budget.remaining() === Infinity,
+}`,
+    {
+      args: [...EXPECTED_RUNTIME_GLOBALS],
+      cwd: "/contract-cwd",
+      agent: {
+        async run() {
+          return "ok";
+        },
+      },
+      persistLogs: false,
+    },
+  );
+
+  const rawVmRealmGlobals: unknown = new vm.Script("Object.getOwnPropertyNames(globalThis)").runInContext(
+    vm.createContext({}),
+  );
+  assert.ok(Array.isArray(rawVmRealmGlobals));
+  const vmRealmGlobals = new Set(rawVmRealmGlobals.filter((name): name is string => typeof name === "string"));
+  const observedProjectGlobals = Array.from(result.result.allGlobals).filter(
+    (name) => !vmRealmGlobals.has(name) || name === "console",
+  );
+
+  assert.deepEqual(observedProjectGlobals, [...EXPECTED_RUNTIME_GLOBALS]);
+  assert.equal(result.result.substratePresent, true);
+  assert.equal(result.result.agentResult, "ok");
+  assert.equal(result.result.processMatchesCwd, true);
+  assert.equal(result.result.budgetWorks, true);
+});

--- a/tests/workflow-comprehension.test.ts
+++ b/tests/workflow-comprehension.test.ts
@@ -1,0 +1,1216 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+import packageJson from "../package.json" with { type: "json" };
+import {
+  COMPREHENSION_SCENARIOS,
+  type ModelGeneration,
+  ModelGenerationError,
+  runComprehensionScenario,
+  selectComprehensionScenarios,
+} from "../src/workflow-comprehension.js";
+
+const VALID_WORKFLOW = `export const meta = { name: "quick", description: "fixture" }
+const [alpha, beta] = await parallel([
+  () => agent("alpha", { label: "alpha" }),
+  () => agent("beta", { label: "beta" }),
+])
+return { alpha, beta }
+`;
+
+function generation(workflow = VALID_WORKFLOW): ModelGeneration {
+  return {
+    workflow,
+    skillLoadingEvidence: {
+      discovered: true,
+      loaded: true,
+      toolCalls: [{ tool: "read", path: "/installed/skills/workflow-authoring/SKILL.md" }],
+    },
+    tokenUsage: { input: 100, output: 50, total: 150, cost: 0.001, cacheRead: 0, cacheWrite: 0 },
+  };
+}
+
+test("comprehension remains a manual, skipped-by-default command", () => {
+  assert.equal(packageJson.scripts.comprehension, "tsx scripts/run-workflow-comprehension.ts");
+  assert.doesNotMatch(packageJson.scripts.test, /comprehension/i);
+  assert.doesNotMatch(packageJson.scripts["release:check"], /comprehension/i);
+  assert.doesNotMatch(packageJson.scripts.prepublishOnly, /comprehension/i);
+});
+
+test("comprehension CLI exposes the coverage suite and exact targeted scenarios without provider calls", () => {
+  const help = execFileSync(process.execPath, ["--import", "tsx", "scripts/run-workflow-comprehension.ts", "--help"], {
+    encoding: "utf8",
+  });
+
+  assert.match(help, /--suite quick\|full\|coverage/);
+  assert.match(help, /--scenario <id>/);
+  assert.throws(
+    () =>
+      execFileSync(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          "scripts/run-workflow-comprehension.ts",
+          "--model",
+          "fixture/model",
+          "--scenario",
+          "not-a-real-scenario",
+        ],
+        { encoding: "utf8", stdio: "pipe" },
+      ),
+    /Unknown scenario not-a-real-scenario/,
+  );
+});
+
+test("quick, full, and coverage scenario sets expose the agreed authoring branches without naming the skill", () => {
+  assert.deepEqual(
+    selectComprehensionScenarios("quick").map(({ id }) => id),
+    ["quick-write"],
+  );
+  assert.deepEqual(
+    selectComprehensionScenarios("full").map(({ id }) => id),
+    ["full-write", "full-edit", "full-review", "full-debug", "full-loop", "full-retry"],
+  );
+  assert.deepEqual(
+    selectComprehensionScenarios("coverage").map(({ id }) => id),
+    ["coverage-fan-out-synthesize", "coverage-generate-filter", "coverage-judge-panel"],
+  );
+
+  const fullText = COMPREHENSION_SCENARIOS.map(({ prompt }) => prompt).join("\n");
+  assert.doesNotMatch(fullText, /workflow-authoring/i);
+  for (const expected of [
+    "workflow(",
+    "control helper",
+    "phase budget",
+    "structured output",
+    "successful dry rounds",
+    "retry(",
+  ]) {
+    assert.match(fullText, new RegExp(expected.replace("(", "\\("), "i"));
+  }
+});
+
+test("a generated workflow is parsed and executed through the real runtime with deterministic fake agents", async () => {
+  const scenario = selectComprehensionScenarios("quick")[0];
+  assert.ok(scenario);
+  const evidence = await runComprehensionScenario({
+    scenario,
+    provider: "fixture",
+    model: "fixture/model",
+    extensionVersion: "2.13.1",
+    contractVersions: { format: "1.0.0", content: "2.13.1" },
+    skillVersion: "2.13.1",
+    generate: async () => generation(),
+  });
+
+  assert.equal(evidence.passed, true);
+  assert.deepEqual(
+    evidence.runtime.calls.map(({ label }) => label),
+    ["alpha", "beta"],
+  );
+  assert.equal(evidence.runtime.topology.maxConcurrent, 2);
+  assert.deepEqual(evidence.runtime.result, { alpha: "result:alpha", beta: "result:beta" });
+  assert.equal(evidence.failure, null);
+  assert.equal(evidence.generatedWorkflow, VALID_WORKFLOW);
+  assert.equal(evidence.skillLoadingEvidence.loaded, true);
+  assert.equal(evidence.tokenUsage.total, 150);
+});
+
+test("quick evidence requires alpha and beta work to reach the returned result", async () => {
+  const scenario = selectComprehensionScenarios("quick")[0];
+  assert.ok(scenario);
+  const compliant = `export const meta = { name: "quick_variant", description: "arbitrary labels preserve task results" }
+const [left, right] = await parallel([
+  () => agent("summarize alpha", { label: "summary:left" }),
+  () => agent("summarize beta", { label: "summary:right" }),
+])
+return { alpha: left, beta: right }`;
+  const unrelated = `export const meta = { name: "quick_mutant", description: "unrelated parallel work" }
+await parallel([
+  () => agent("unrelated one", { label: "unrelated:1" }),
+  () => agent("unrelated two", { label: "unrelated:2" }),
+])
+return { unrelated: true }`;
+
+  const run = (workflow: string) =>
+    runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+
+  assert.equal((await run(compliant)).passed, true);
+  assert.equal((await run(unrelated)).passed, false);
+});
+
+test("quick evidence rejects duplicate task labels", async () => {
+  const scenario = selectComprehensionScenarios("quick")[0];
+  assert.ok(scenario);
+  const duplicateLabels = `export const meta = { name: "quick_duplicate_labels", description: "duplicate labels" }
+const [alpha, beta] = await parallel([
+  () => agent("summarize alpha", { label: "summary" }),
+  () => agent("summarize beta", { label: "summary" }),
+])
+return { alpha, beta }`;
+
+  const evidence = await runComprehensionScenario({
+    scenario,
+    provider: "fixture",
+    model: "fixture/model",
+    extensionVersion: "2.13.1",
+    contractVersions: { format: "1.0.0", content: "2.13.1" },
+    skillVersion: "2.13.1",
+    generate: async () => generation(duplicateLabels),
+  });
+
+  assert.equal(evidence.passed, false);
+});
+
+test("full-write evidence requires structured task calls and completed/missing provenance", async () => {
+  const scenario = selectComprehensionScenarios("full").find(({ id }) => id === "full-write");
+  assert.ok(scenario);
+  const schema = `{ type: "object", properties: { summary: { type: "string" } }, required: ["summary"] }`;
+  const compliant = `export const meta = { name: "write_variant", description: "preserves coverage" }
+const [alpha, beta] = await parallel([
+  () => agent("work unit alpha", { label: "work:left", schema: ${schema} }),
+  () => agent("work unit beta", { label: "work:right", schema: ${schema} }),
+])
+return { completed: alpha ? [alpha] : [], missingWork: beta ? [] : [{ id: "beta", reason: "agent failed" }] }`;
+  const flattened = `export const meta = { name: "write_flattened", description: "flattens structured fields without losing provenance" }
+const schema = { type: "object", properties: { summary: { type: "string" }, confidence: { type: "number" } }, required: ["summary", "confidence"] }
+const [alpha, beta] = await parallel([
+  () => agent("work unit alpha", { label: "work:left", schema }),
+  () => agent("work unit beta", { label: "work:right", schema }),
+])
+return {
+  completed: alpha ? [{ id: "alpha", ...alpha }] : [],
+  missingWork: beta ? [] : [{ id: "beta", reason: "agent failed" }],
+}`;
+  const identityAware = `export const meta = { name: "write_identity", description: "validates structured task identity" }
+const units = ["alpha", "beta"]
+const schema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    status: { type: "string", enum: ["complete"] },
+    summary: { type: "string" },
+  },
+  required: ["id", "status", "summary"],
+}
+const results = await parallel(units.map((id, index) => () => agent("work unit " + id + "; echo id " + id, { label: "work:" + index, schema })))
+const completed = []
+const missingWork = []
+for (let index = 0; index < units.length; index++) {
+  const id = units[index]
+  const result = results[index]
+  if (result && result.id === id && result.status === "complete") completed.push({ id, output: result })
+  else missingWork.push({ id, reason: result ? "invalid identity or status" : "agent failed" })
+}
+return { completed, missingWork }`;
+  const sharedContext = `export const meta = { name: "write_shared_context", description: "mentions every unit in shared context" }
+const schema = { type: "object", properties: { id: { type: "string", enum: ["alpha", "beta"] }, value: { type: "string" } }, required: ["id", "value"] }
+const context = { work: [{ id: "alpha" }, { id: "beta" }] }
+const [alpha, beta] = await parallel([
+  () => agent("work unit alpha; shared context: " + JSON.stringify(context), { label: "author-alpha", schema }),
+  () => agent("work unit beta; shared context: " + JSON.stringify(context), { label: "author-beta", schema }),
+])
+return {
+  completed: alpha ? [{ id: "alpha", value: alpha.value }] : [],
+  missingWork: beta ? [] : [{ id: "beta", reason: "agent failed" }],
+}`;
+  const omitsRedundantControlField = `export const meta = { name: "write_control_projection", description: "preserves useful payload and infers completion from collection placement" }
+const schema = { type: "object", properties: { unitId: { type: "string" }, completed: { type: "boolean" }, summary: { type: "string" } }, required: ["unitId", "completed", "summary"] }
+const [alpha, beta] = await parallel([
+  () => agent("work unit alpha", { label: "work-alpha", schema }),
+  () => agent("work unit beta", { label: "work-beta", schema }),
+])
+return {
+  completed: alpha ? [{ id: "alpha", unitId: alpha.unitId, summary: alpha.summary }] : [],
+  missingWork: beta ? [] : [{ id: "beta", reason: "agent failed" }],
+}`;
+  const renamedPayload = `export const meta = { name: "write_renamed_payload", description: "preserves runtime payload under a domain field" }
+const schema = { type: "object", properties: { output: { type: "string" } }, required: ["output"] }
+const [alpha, beta] = await parallel([
+  () => agent("work unit alpha", { label: "work-alpha", schema }),
+  () => agent("work unit beta", { label: "work-beta", schema }),
+])
+return {
+  completed: alpha ? [{ id: "alpha", data: alpha.output }] : [],
+  missingWork: beta ? [] : [{ id: "beta", reason: "agent failed" }],
+}`;
+  const shallowMutant = `export const meta = { name: "write_mutant", description: "mentions beta without preserving coverage" }
+const schema = ${schema}
+await parallel([
+  () => agent("unrelated structured call", { label: "alpha", schema }),
+  () => agent("beta", { label: "beta" }),
+])
+return { note: "beta" }`;
+
+  const run = (workflow: string) =>
+    runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+
+  assert.equal((await run(compliant)).passed, true);
+  assert.equal((await run(flattened)).passed, true);
+  assert.equal((await run(identityAware)).passed, true);
+  const sharedContextEvidence = await run(sharedContext);
+  assert.equal(sharedContextEvidence.passed, true, JSON.stringify(sharedContextEvidence, null, 2));
+  const controlProjectionEvidence = await run(omitsRedundantControlField);
+  assert.equal(controlProjectionEvidence.passed, true, JSON.stringify(controlProjectionEvidence, null, 2));
+  const renamedPayloadEvidence = await run(renamedPayload);
+  assert.equal(renamedPayloadEvidence.passed, true, JSON.stringify(renamedPayloadEvidence, null, 2));
+  assert.equal((await run(shallowMutant)).passed, false);
+});
+
+test("full scenarios execute writing, editing, reviewing, and debugging behavior", async () => {
+  const workflows = new Map([
+    [
+      "full-write",
+      `export const meta = { name: "write", description: "fixture" }
+const units = ["alpha", "beta"]
+const values = await parallel(units.map(id => () => agent(id, { label: id, schema: { type: "object", properties: { summary: { type: "string" } }, required: ["summary"] } })))
+return { completed: values.filter(Boolean), missing: units.filter((_id, index) => values[index] === null) }`,
+    ],
+    [
+      "full-edit",
+      `export const meta = { name: "edit", description: "fixture", phases: [{ title: "Prepare" }] }
+phase("Prepare", { budget: 100 })
+await agent("prepare", { label: "prepare" })
+const alpha = await workflow("child-workflow", { id: "alpha" })
+const beta = await workflow("child-workflow", { id: "beta" })
+return { alpha, beta }`,
+    ],
+    [
+      "full-review",
+      `export const meta = { name: "review", description: "fixture" }
+const claim = await agent("claim", { label: "claim" })
+const verdict = await verify(claim, { reviewers: 3, threshold: 0.6, lens: ["source", "logic"] })
+return { claim, verdict }`,
+    ],
+    [
+      "full-debug",
+      `export const meta = { name: "debug", description: "fixture" }
+const result = await retry(
+  attempt => agent("attempt " + attempt, { label: "attempt:" + attempt, schema: { type: "object", properties: { acceptable: { type: "boolean" }, answer: { type: "string" } }, required: ["acceptable", "answer"] } }),
+  { attempts: 3, until: value => value.acceptable },
+)
+return { result }`,
+    ],
+    [
+      "full-loop",
+      `export const meta = { name: "loop", description: "truthful bounded discovery" }
+const schema = { type: "object", properties: { findings: { type: "array", items: { type: "object", properties: { id: { type: "string" }, evidence: { type: "string" } }, required: ["id", "evidence"] } } }, required: ["findings"] }
+const findings = []
+const failures = []
+let dry = 0
+let round = 0
+while (round < 5 && dry < 2) {
+  const label = "discovery-round:" + (round + 1)
+  const result = await agent("discover round " + (round + 1), { label, schema })
+  if (result === null) {
+    failures.push({ id: label })
+    dry = 0
+  } else if (result.findings.length === 0) dry++
+  else {
+    dry = 0
+    for (const finding of result.findings) if (!findings.some(existing => existing.id === finding.id)) findings.push(finding)
+  }
+  round++
+}
+return { findings, failedRounds: failures, termination: dry >= 2 ? "successful-dry" : "maximum", complete: failures.length === 0 && dry >= 2 }`,
+    ],
+    [
+      "full-retry",
+      `export const meta = { name: "retry_exact", description: "retry with explicit outcome" }
+const schema = { type: "object", properties: { acceptable: { type: "boolean" }, answer: { type: "string" } }, required: ["acceptable", "answer"] }
+const ledger = []
+const accepted = await retry(
+  async attempt => {
+    const result = await agent("attempt " + attempt, { label: "retry-attempt:" + (attempt + 1), schema })
+    ledger.push({ attempt, result })
+    return result
+  },
+  { attempts: 3, until: value => value !== null && value.acceptable === true },
+)
+return { accepted, attempts: ledger, exhausted: accepted === null || accepted.acceptable !== true }`,
+    ],
+  ]);
+
+  for (const scenario of selectComprehensionScenarios("full")) {
+    const workflow = workflows.get(scenario.id);
+    assert.ok(workflow);
+    const evidence = await runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+    assert.equal(evidence.passed, true, `${scenario.id}: ${evidence.failure?.message}`);
+    if (scenario.id === "full-write") {
+      assert.equal(evidence.runtime.failures[0]?.errorCode, "AGENT_EXECUTION_ERROR");
+      assert.match(evidence.runtime.failures[0]?.message ?? "", /deterministic beta failure/i);
+    }
+  }
+});
+
+test("fan-out-and-synthesize evidence preserves complete contributor coverage through synthesis", async () => {
+  const scenario = selectComprehensionScenarios("coverage").find(({ id }) => id === "coverage-fan-out-synthesize");
+  assert.ok(scenario);
+  const compliant = `export const meta = { name: "fan_out_synthesize", description: "complete contributor coverage" }
+const briefs = ["climate", "transport"]
+const researchSchema = { type: "object", properties: { id: { type: "string" }, finding: { type: "string" } }, required: ["id", "finding"] }
+const results = await parallel(briefs.map(id => () => agent("Research brief " + id, { label: "research:" + id, schema: researchSchema })))
+const contributorCoverage = briefs.map((id, index) => ({ id, result: results[index], missing: results[index] === null }))
+const synthesis = await agent("Synthesize all intended briefs: " + JSON.stringify(contributorCoverage), {
+  label: "synthesis:all-briefs",
+  schema: { type: "object", properties: { summary: { type: "string" }, coveredIds: { type: "array" }, missingIds: { type: "array" } }, required: ["summary", "coveredIds", "missingIds"] },
+})
+return { contributorCoverage, synthesis }`;
+  const contributorPromptsMentionSynthesis = `export const meta = { name: "fan_out_synthesis_word", description: "ordinary contributor wording mentions synthesis" }
+const briefs = ["climate", "transport"]
+const researchSchema = { type: "object", properties: { id: { type: "string" }, finding: { type: "string" } }, required: ["id", "finding"] }
+const results = await parallel(briefs.map(id => () => agent("Research " + id + " for the final synthesis", { label: "research:" + id, schema: researchSchema })))
+const contributorCoverage = briefs.map((id, index) => ({ id, result: results[index], missing: results[index] === null }))
+const synthesis = await agent("Combine complete contributor coverage: " + JSON.stringify(contributorCoverage), {
+  label: "final:all-briefs",
+  schema: { type: "object", properties: { summary: { type: "string" }, coveredIds: { type: "array" }, missingIds: { type: "array" } }, required: ["summary", "coveredIds", "missingIds"] },
+})
+return { contributorCoverage, synthesis }`;
+  const statusLedgerWithPrettyInput = `export const meta = { name: "fan_out_status_ledger", description: "separate status ledger and synthesis payload" }
+const briefs = ["climate", "transport"]
+const schema = { type: "object", properties: { id: { type: "string" }, finding: { type: "string" } }, required: ["id", "finding"] }
+const results = await parallel(briefs.map(id => () => agent("Research brief " + id, { label: "research:" + id, schema })))
+const coverageLedger = briefs.map((id, index) => ({ id, status: results[index] === null ? "missing" : "complete" }))
+const synthesisInput = { intendedBriefIds: briefs, climate: results[0], transport: results[1], coverageLedger }
+const synthesis = await agent("Synthesize complete coverage:\\n" + JSON.stringify(synthesisInput, null, 2), { label: "synthesis:all", schema })
+return { coverageLedger, synthesis }`;
+  const misattributesMissingCoverage = `export const meta = { name: "fan_out_wrong_missing", description: "misattributes missing coverage" }
+const briefs = ["climate", "transport"]
+const schema = { type: "object", properties: { id: { type: "string" }, finding: { type: "string" } }, required: ["id", "finding"] }
+const results = await parallel(briefs.map(id => () => agent("Research brief " + id, { label: "research:" + id, schema })))
+const coverageLedger = [{ id: "climate", status: "complete" }, { id: "transport", status: "complete", missingClimate: true }]
+const synthesisInput = { intendedBriefIds: briefs, climate: results[0], transport: null, coverageLedger }
+const synthesis = await agent("Synthesize complete coverage: " + JSON.stringify(synthesisInput), { label: "synthesis:all", schema })
+return { coverageLedger, synthesis }`;
+  const disassociatesClimatePayload = `export const meta = { name: "fan_out_wrong_payload", description: "scatters climate fields into fabricated data" }
+const briefs = ["climate", "transport"]
+const schema = { type: "object", properties: { id: { type: "string" }, finding: { type: "string" } }, required: ["id", "finding"] }
+const results = await parallel(briefs.map(id => () => agent("Research brief " + id, { label: "research:" + id, schema })))
+const coverageLedger = [{ id: "climate", status: "complete" }, { id: "transport", status: "missing" }]
+const fabricated = { id: "transport", finding: "fabricated", notes: [results[0].id, results[0].finding] }
+const synthesis = await agent("Synthesize with transport missing: " + JSON.stringify(fabricated), { label: "synthesis:all", schema })
+return { coverageLedger, synthesis }`;
+  const omitsMissingContributor = `export const meta = { name: "fan_out_omission", description: "drops failed contributors" }
+const briefs = ["climate", "transport"]
+const schema = { type: "object", properties: { id: { type: "string" }, finding: { type: "string" } }, required: ["id", "finding"] }
+const results = await parallel(briefs.map(id => () => agent("Research brief " + id, { label: "research:" + id, schema })))
+const available = results.filter(Boolean)
+const synthesis = await agent("Synthesize available results: " + JSON.stringify(available), { label: "synthesis:available", schema })
+return { available, synthesis }`;
+  const skipsSynthesis = `export const meta = { name: "fan_out_only", description: "never synthesizes" }
+const briefs = ["climate", "transport"]
+const schema = { type: "object", properties: { id: { type: "string" }, finding: { type: "string" } }, required: ["id", "finding"] }
+const results = await parallel(briefs.map(id => () => agent("Research brief " + id, { label: "research:" + id, schema })))
+return { contributorCoverage: briefs.map((id, index) => ({ id, result: results[index] })) }`;
+
+  const run = (workflow: string) =>
+    runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+
+  const compliantEvidence = await run(compliant);
+  assert.equal(compliantEvidence.passed, true, JSON.stringify(compliantEvidence, null, 2));
+  const synthesisWordingEvidence = await run(contributorPromptsMentionSynthesis);
+  assert.equal(synthesisWordingEvidence.passed, true, JSON.stringify(synthesisWordingEvidence, null, 2));
+  const statusLedgerEvidence = await run(statusLedgerWithPrettyInput);
+  assert.equal(statusLedgerEvidence.passed, true, JSON.stringify(statusLedgerEvidence, null, 2));
+  assert.equal((await run(misattributesMissingCoverage)).passed, false);
+  assert.equal((await run(disassociatesClimatePayload)).passed, false);
+  assert.equal((await run(omitsMissingContributor)).passed, false);
+  assert.equal((await run(skipsSynthesis)).passed, false);
+});
+
+test("generate-and-filter evidence enforces generation, deduplication, bounding, and filter provenance", async () => {
+  const scenario = selectComprehensionScenarios("coverage").find(({ id }) => id === "coverage-generate-filter");
+  assert.ok(scenario);
+  const compliant = `export const meta = { name: "generate_filter", description: "deduplicate and bound before filtering" }
+const generatorSchema = { type: "object", properties: { candidates: { type: "array" } }, required: ["candidates"] }
+const generated = await parallel([0, 1].map(index => () => agent("Generate candidate batch " + index, { label: "generator:" + index, schema: generatorSchema })))
+const retained = []
+const seen = new Set()
+for (const batch of generated) {
+  for (const candidate of batch.candidates) {
+    if (seen.has(candidate.id)) continue
+    seen.add(candidate.id)
+    if (retained.length < 3) retained.push(candidate)
+  }
+}
+const filterSchema = { type: "object", properties: { id: { type: "string" }, accepted: { type: "boolean" }, reason: { type: "string" } }, required: ["id", "accepted", "reason"] }
+const decisions = await parallel(retained.map(candidate => () => agent("Filter candidate: " + JSON.stringify(candidate), { label: "filter:" + candidate.id, schema: filterSchema })))
+return {
+  generatorOutputs: generated,
+  retainedIds: retained.map(candidate => candidate.id),
+  accepted: decisions.filter(decision => decision?.accepted),
+  filterFailures: retained.filter((_candidate, index) => decisions[index] === null).map(candidate => ({ id: candidate.id })),
+}`;
+  const arraySchemaWithNaturalFilterPrompt = `export const meta = { name: "generate_filter_array", description: "accept array generators and natural filter prompts" }
+const generatorSchema = {
+  type: "array",
+  items: { type: "object", properties: { id: { type: "string" }, proposal: { type: "string" } }, required: ["id", "proposal"] },
+}
+const generated = await parallel([
+  () => agent("Return candidate objects", { label: "gen-left", schema: generatorSchema }),
+  () => agent("Return candidate objects", { label: "gen-right", schema: generatorSchema }),
+])
+const retained = []
+const seen = new Set()
+for (const batch of generated) {
+  for (const candidate of batch ?? []) {
+    if (seen.has(candidate.id)) continue
+    seen.add(candidate.id)
+    if (retained.length < 3) retained.push(candidate)
+  }
+}
+const filterSchema = { type: "object", properties: { accept: { type: "boolean" }, reason: { type: "string" } }, required: ["accept", "reason"] }
+const decisions = await parallel(retained.map(candidate => () => agent(
+  "Evaluate candidate " + candidate.id + ". Proposal: " + candidate.proposal,
+  { label: "filter:" + candidate.id, schema: filterSchema },
+)))
+return {
+  generatorOutputs: generated,
+  retainedIds: retained.map(candidate => candidate.id),
+  accepted: decisions.map((decision, index) => ({ decision, candidate: retained[index] })).filter(({ decision }) => decision?.accept).map(({ decision, candidate }) => ({
+    candidateId: candidate.id,
+    accept: decision.accept,
+    reason: decision.reason,
+  })),
+  filterFailures: retained.filter((_candidate, index) => decisions[index] === null).map(candidate => ({ id: candidate.id })),
+}`;
+  const schemaShapedResults = `export const meta = { name: "generate_filter_schema_shapes", description: "honor nested generator and filter schemas" }
+const candidateSchema = { type: "object", properties: { id: { type: "string" }, proposal: { type: "string" } }, required: ["id", "proposal"] }
+const generatorSchema = {
+  type: "object",
+  properties: { candidates: { type: "object", properties: { primary: candidateSchema, shared: candidateSchema }, required: ["primary", "shared"] } },
+  required: ["candidates"],
+}
+const generated = await parallel([
+  () => agent("Generate candidate objects left", { label: "generator:left", schema: generatorSchema }),
+  () => agent("Generate candidate objects right", { label: "generator:right", schema: generatorSchema }),
+])
+const retained = []
+const seen = new Set()
+for (const output of generated) {
+  for (const candidate of [output.candidates.primary, output.candidates.shared]) {
+    if (seen.has(candidate.id)) continue
+    seen.add(candidate.id)
+    if (retained.length < 3) retained.push(candidate)
+  }
+}
+const filterSchema = {
+  type: "object",
+  properties: {
+    candidate: candidateSchema,
+    decision: { type: "object", properties: { accept: { type: "boolean" }, rationale: { type: "string" } }, required: ["accept", "rationale"] },
+  },
+  required: ["candidate", "decision"],
+}
+const decisions = await parallel(retained.map(candidate => () => agent(
+  "Filter candidate " + candidate.id + ": " + candidate.proposal,
+  { label: "filter:generator:" + candidate.id, schema: filterSchema },
+)))
+return {
+  generatorOutputs: generated.map((output, index) => ({ source: index, candidates: output.candidates })),
+  retainedIds: retained.map(candidate => candidate.id),
+  filterResults: decisions.map((decision, index) => ({ id: retained[index].id, decision })),
+  accepted: decisions.map((result, index) => ({ result, candidate: retained[index] })).filter(({ result }) => result?.decision.accept).map(({ candidate }) => ({ id: candidate.id, proposal: candidate.proposal })),
+  filterFailures: retained.filter((_candidate, index) => decisions[index] === null).map(candidate => ({ id: candidate.id })),
+}`;
+  const prefixItemGenerators = `export const meta = { name: "generate_filter_prefix_items", description: "honor tuple generator schemas" }
+const candidate = (id) => ({ type: "object", properties: { id: { const: id }, proposal: { type: "string" } }, required: ["id", "proposal"] })
+const schemas = [
+  { type: "array", prefixItems: [candidate("signal-a"), candidate("shared")], items: false },
+  { type: "array", prefixItems: [candidate("shared"), candidate("signal-b")], items: false },
+]
+const generatorOutputs = await parallel([
+  () => agent("Produce the first candidate batch", { label: "source:prefix-left", schema: schemas[0] }),
+  () => agent("Produce the second candidate batch", { label: "source:prefix-right", schema: schemas[1] }),
+])
+const retained = []
+const seen = new Set()
+for (const batch of generatorOutputs) {
+  for (const item of batch) {
+    if (!seen.has(item.id) && retained.length < 3) {
+      seen.add(item.id)
+      retained.push(item)
+    }
+  }
+}
+const filterSchema = { type: "object", properties: { candidateId: { type: "string" }, accepted: { type: "boolean" }, rationale: { type: "string" } }, required: ["candidateId", "accepted", "rationale"] }
+const filterResults = await parallel(retained.map((item, index) => () => agent(
+  "Context mentions signal-a shared signal-b. Candidate: " + JSON.stringify(item),
+  { label: "filter:prefix:" + index, schema: filterSchema },
+)))
+return {
+  generatorOutputs,
+  retainedCandidateIdentities: retained.map(({ id, proposal }) => ({ id, proposal })),
+  filterResults,
+  acceptedFilterResults: filterResults.filter((result) => result?.accepted),
+  filterFailures: retained.flatMap((item, index) => filterResults[index] === null ? [{ candidateId: item.id }] : []),
+}`;
+  const constCandidateBatches = `export const meta = { name: "generate_filter_const_batches", description: "honor constant candidate batches" }
+const left = [{ id: "signal-a", proposal: "proposal:signal-a" }, { id: "shared", proposal: "proposal:shared:first" }]
+const right = [{ id: "shared", proposal: "proposal:shared:duplicate" }, { id: "signal-b", proposal: "proposal:signal-b" }]
+const generatorSchema = (candidates) => ({ type: "object", properties: { candidates: { const: candidates } }, required: ["candidates"] })
+const generatorOutputs = await parallel([
+  () => agent("Produce left candidates", { label: "source:left", schema: generatorSchema(left) }),
+  () => agent("Produce right candidates", { label: "source:right", schema: generatorSchema(right) }),
+])
+const retained = []
+const seen = new Set()
+for (const batch of generatorOutputs) for (const candidate of batch.candidates) {
+  if (!seen.has(candidate.id) && retained.length < 3) { seen.add(candidate.id); retained.push(candidate) }
+}
+const filterSchema = { type: "object", properties: { candidateId: { type: "string" }, accepted: { type: "boolean" }, reason: { type: "string" } }, required: ["candidateId", "accepted", "reason"] }
+const decisions = await parallel(retained.map(candidate => () => agent("Filter candidate: " + JSON.stringify(candidate), { label: "filter:" + candidate.id, schema: filterSchema })))
+return {
+  generatorOutputs,
+  retainedIds: retained.map(candidate => candidate.id),
+  accepted: decisions.filter(decision => decision?.accepted),
+  filterFailures: retained.filter((_candidate, index) => decisions[index] === null).map(candidate => ({ id: candidate.id })),
+}`;
+  const enumCandidateItems = `export const meta = { name: "generate_filter_enum_items", description: "honor enumerated candidate items" }
+const left = [{ id: "left-only", proposal: "proposal:left" }, { id: "shared", proposal: "proposal:shared" }]
+const right = [{ id: "shared", proposal: "proposal:shared" }, { id: "right-only", proposal: "proposal:right" }]
+const generatorSchema = (allowed) => ({ type: "object", properties: { candidates: { type: "array", items: { enum: allowed }, minItems: 2, maxItems: 2 } }, required: ["candidates"] })
+const generatorOutputs = await parallel([
+  () => agent("Produce left candidates", { label: "source:left", schema: generatorSchema(left) }),
+  () => agent("Produce right candidates", { label: "source:right", schema: generatorSchema(right) }),
+])
+const retained = []
+const seen = new Set()
+for (const batch of generatorOutputs) for (const candidate of batch.candidates) {
+  if (!seen.has(candidate.id) && retained.length < 3) { seen.add(candidate.id); retained.push(candidate) }
+}
+const filterSchema = { type: "object", properties: { candidateId: { type: "string" }, accepted: { type: "boolean" }, reason: { type: "string" } }, required: ["candidateId", "accepted", "reason"] }
+const decisions = await parallel(retained.map(candidate => () => agent("Filter candidate: " + JSON.stringify(candidate), { label: "filter:" + candidate.id, schema: filterSchema })))
+return {
+  generatorOutputs,
+  retainedIds: retained.map(candidate => candidate.id),
+  accepted: decisions.filter(decision => decision?.accepted),
+  filterFailures: retained.filter((_candidate, index) => decisions[index] === null).map(candidate => ({ id: candidate.id })),
+}`;
+  const singleCandidateResults = `export const meta = { name: "generate_filter_single_candidates", description: "deduplicate root candidate results" }
+const generatorSchema = { type: "object", properties: { id: { type: "string", const: "shared" }, proposal: { type: "string", enum: ["proposal:fixed"] } }, required: ["id", "proposal"] }
+const generated = await parallel([
+  () => agent("Generate one candidate left", { label: "source:left", schema: generatorSchema }),
+  () => agent("Generate one candidate right", { label: "source:right", schema: generatorSchema }),
+])
+const retained = []
+const seen = new Set()
+for (const candidate of generated) {
+  if (seen.has(candidate.id)) continue
+  seen.add(candidate.id)
+  if (retained.length < 3) retained.push(candidate)
+}
+const filterSchema = { type: "object", properties: { accept: { type: "boolean" }, reason: { type: "string" } }, required: ["accept", "reason"] }
+const decisions = await parallel(retained.map(candidate => () => agent("Filter " + candidate.id + ": " + candidate.proposal, { label: "filter:" + candidate.id, schema: filterSchema })))
+return {
+  generatorOutputs: generated,
+  retainedIds: retained.map(candidate => candidate.id),
+  accepted: retained.filter((_candidate, index) => decisions[index]?.accept).map((candidate, index) => ({ id: candidate.id, reason: decisions[index].reason })),
+  filterFailures: retained.filter((_candidate, index) => decisions[index]?.accept === false).map(candidate => ({ id: candidate.id, status: "rejected" })),
+}`;
+  const filtersBeforeGeneratorsComplete = `export const meta = { name: "generate_filter_early", description: "starts filters before generation completes" }
+const generatorSchema = { type: "object", properties: { candidates: { type: "array" } }, required: ["candidates"] }
+const generatorPromises = [0, 1].map(index => agent("Generate candidate batch " + index, { label: "generator:" + index, schema: generatorSchema }))
+const retained = [
+  { id: "signal-a", proposal: "proposal:signal-a" },
+  { id: "shared", proposal: "proposal:shared:first" },
+  { id: "signal-b", proposal: "proposal:signal-b" },
+]
+const filterSchema = { type: "object", properties: { id: { type: "string" }, accepted: { type: "boolean" }, reason: { type: "string" } }, required: ["id", "accepted", "reason"] }
+const decisions = await parallel(retained.map(candidate => () => agent("Filter candidate: " + JSON.stringify(candidate), { label: "filter:" + candidate.id, schema: filterSchema })))
+const generated = await Promise.all(generatorPromises)
+return {
+  generatorOutputs: generated,
+  retainedIds: retained.map(candidate => candidate.id),
+  accepted: decisions.filter(decision => decision?.accepted),
+  filterFailures: retained.filter((_candidate, index) => decisions[index] === null).map(candidate => ({ id: candidate.id })),
+}`;
+  const filtersRawDuplicates = `export const meta = { name: "generate_filter_raw", description: "filters before deduplication and bounding" }
+const generatorSchema = { type: "object", properties: { candidates: { type: "array" } }, required: ["candidates"] }
+const generated = await parallel([0, 1].map(index => () => agent("Generate candidate batch " + index, { label: "generator:" + index, schema: generatorSchema })))
+const raw = generated.flatMap(batch => batch.candidates)
+const filterSchema = { type: "object", properties: { id: { type: "string" }, accepted: { type: "boolean" } }, required: ["id", "accepted"] }
+const decisions = await parallel(raw.map((candidate, index) => () => agent("Filter candidate: " + JSON.stringify(candidate), { label: "filter:" + candidate.id + ":" + index, schema: filterSchema })))
+return { generatorOutputs: generated, retainedIds: raw.map(candidate => candidate.id), accepted: decisions.filter(Boolean), filterFailures: [] }`;
+
+  const run = (workflow: string) =>
+    runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+
+  const compliantEvidence = await run(compliant);
+  assert.equal(compliantEvidence.passed, true, JSON.stringify(compliantEvidence, null, 2));
+  const arraySchemaEvidence = await run(arraySchemaWithNaturalFilterPrompt);
+  assert.equal(arraySchemaEvidence.passed, true, JSON.stringify(arraySchemaEvidence, null, 2));
+  const schemaShapedEvidence = await run(schemaShapedResults);
+  assert.equal(schemaShapedEvidence.passed, true, JSON.stringify(schemaShapedEvidence, null, 2));
+  const prefixItemEvidence = await run(prefixItemGenerators);
+  assert.equal(prefixItemEvidence.passed, true, JSON.stringify(prefixItemEvidence, null, 2));
+  const constBatchEvidence = await run(constCandidateBatches);
+  assert.equal(constBatchEvidence.passed, true, JSON.stringify(constBatchEvidence, null, 2));
+  const enumItemEvidence = await run(enumCandidateItems);
+  assert.equal(enumItemEvidence.passed, true, JSON.stringify(enumItemEvidence, null, 2));
+  assert.deepEqual(
+    enumItemEvidence.runtime.calls.slice(0, 2).map(({ result }) => result),
+    [
+      {
+        candidates: [
+          { id: "left-only", proposal: "proposal:left" },
+          { id: "shared", proposal: "proposal:shared" },
+        ],
+      },
+      {
+        candidates: [
+          { id: "shared", proposal: "proposal:shared" },
+          { id: "right-only", proposal: "proposal:right" },
+        ],
+      },
+    ],
+  );
+  const singleCandidateEvidence = await run(singleCandidateResults);
+  assert.equal(singleCandidateEvidence.passed, true, JSON.stringify(singleCandidateEvidence, null, 2));
+  assert.deepEqual(
+    singleCandidateEvidence.runtime.calls.slice(0, 2).map(({ result }) => result),
+    [
+      { id: "shared", proposal: "proposal:fixed" },
+      { id: "shared", proposal: "proposal:fixed" },
+    ],
+  );
+  assert.equal((await run(filtersBeforeGeneratorsComplete)).passed, false);
+  assert.equal((await run(filtersRawDuplicates)).passed, false);
+});
+
+test("judge-panel evidence requires produced candidates, numeric judges, and the unchanged helper winner", async () => {
+  const scenario = selectComprehensionScenarios("coverage").find(({ id }) => id === "coverage-judge-panel");
+  assert.ok(scenario);
+  const compliant = `export const meta = { name: "judge_panel", description: "rank actual produced candidates" }
+const candidateSchema = { type: "object", properties: { id: { type: "string" }, answer: { type: "string" } }, required: ["id", "answer"] }
+const attempts = await parallel([
+  () => agent("Produce candidate draft-a", { label: "candidate:draft-a", schema: candidateSchema }),
+  () => agent("Produce candidate draft-b", { label: "candidate:draft-b", schema: candidateSchema }),
+])
+const winner = await judgePanel(attempts, { judges: 3, rubric: "factual correctness and logical validity" })
+return { attempts, winner }`;
+  const wrappedAttempts = `export const meta = { name: "wrapped_judge_panel", description: "preserve attempt provenance" }
+const candidateSchema = { type: "object", properties: { id: { type: "string" }, answer: { type: "string" } }, required: ["id", "answer"] }
+const producedAttempts = await parallel([
+  () => agent("Produce candidate draft-a", { label: "candidate:draft-a", schema: candidateSchema }),
+  () => agent("Produce candidate draft-b", { label: "candidate:draft-b", schema: candidateSchema }),
+])
+const attempts = producedAttempts.map((attempt, index) => ({ workId: "attempt-" + index, attempt }))
+const winner = await judgePanel(attempts, { judges: 3, rubric: "factual correctness and logical validity" })
+return { producedAttempts: attempts, winningResult: winner }`;
+  const enrichedAttempts = `export const meta = { name: "enriched_judge_panel", description: "losslessly enrich produced attempts" }
+const candidateSchema = { type: "object", properties: { id: { type: "string" }, answer: { type: "string" } }, required: ["id", "answer"] }
+const produced = await parallel([
+  () => agent("Produce candidate draft-a", { label: "candidate:draft-a", schema: candidateSchema }),
+  () => agent("Produce candidate draft-b", { label: "candidate:draft-b", schema: candidateSchema }),
+])
+const attempts = produced.map((attempt, index) => ({ ...attempt, index }))
+const winner = await judgePanel(attempts, { judges: 3, rubric: "factual correctness and logical validity" })
+return { attempts, winner }`;
+  const nestedEnrichment = `export const meta = { name: "nested_enriched_judge_panel", description: "retain produced attempts beside enriched judge inputs" }
+const candidateSchema = { type: "object", properties: { id: { type: "string" }, answer: { type: "string" } }, required: ["id", "answer"] }
+const produced = await parallel([
+  () => agent("Produce candidate draft-a", { label: "candidate:draft-a", schema: candidateSchema }),
+  () => agent("Produce candidate draft-b", { label: "candidate:draft-b", schema: candidateSchema }),
+])
+const producedAttempts = produced.map((attempt, index) => ({ workId: "attempt-" + index, index, attempt }))
+const judgeInputs = producedAttempts.map(entry => ({ ...entry, notes: [] }))
+const winner = await judgePanel(judgeInputs, { judges: 3, rubric: "factual correctness and logical validity" })
+return { producedAttempts, winner }`;
+  const manualJudges = `export const meta = { name: "manual_judges", description: "bypasses judgePanel" }
+const candidateSchema = { type: "object", properties: { id: { type: "string" }, answer: { type: "string" } }, required: ["id", "answer"] }
+const attempts = await parallel([
+  () => agent("Produce candidate draft-a", { label: "candidate:draft-a", schema: candidateSchema }),
+  () => agent("Produce candidate draft-b", { label: "candidate:draft-b", schema: candidateSchema }),
+])
+const judgments = await parallel(attempts.flatMap((attempt, attemptIndex) => [0, 1, 2].map(judgeIndex => () => agent("Judge " + JSON.stringify(attempt), { label: "manual:" + attemptIndex + ":" + judgeIndex, schema: { type: "object", properties: { score: { type: "number" } }, required: ["score"] } }))))
+return { attempts, winner: { index: 1, attempt: attempts[1], score: 1, judgments } }`;
+  const addsCandidateAfterPanel = `export const meta = { name: "extra_candidate", description: "adds a third produced candidate after judging" }
+const schema = { type: "object", properties: { id: { type: "string" }, answer: { type: "string" } }, required: ["id", "answer"] }
+const attempts = await parallel([
+  () => agent("Produce candidate draft-a", { label: "candidate:draft-a", schema }),
+  () => agent("Produce candidate draft-b", { label: "candidate:draft-b", schema }),
+])
+const winner = await judgePanel(attempts, { judges: 3, rubric: "factual correctness and logical validity" })
+const extra = await agent("Produce candidate draft-c", { label: "candidate:draft-c", schema })
+return { attempts: [...attempts, extra], winner }`;
+  const discardsWinner = `export const meta = { name: "discarded_winner", description: "drops the helper result" }
+const schema = { type: "object", properties: { id: { type: "string" }, answer: { type: "string" } }, required: ["id", "answer"] }
+const attempts = await parallel([
+  () => agent("Produce candidate draft-a", { label: "candidate:draft-a", schema }),
+  () => agent("Produce candidate draft-b", { label: "candidate:draft-b", schema }),
+])
+await judgePanel(attempts, { judges: 3, rubric: "factual correctness and logical validity" })
+return { attempts }`;
+
+  const run = (workflow: string) =>
+    runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+
+  const compliantEvidence = await run(compliant);
+  assert.equal(compliantEvidence.passed, true, JSON.stringify(compliantEvidence, null, 2));
+  const wrappedEvidence = await run(wrappedAttempts);
+  assert.equal(wrappedEvidence.passed, true, JSON.stringify(wrappedEvidence, null, 2));
+  const enrichedEvidence = await run(enrichedAttempts);
+  assert.equal(enrichedEvidence.passed, true, JSON.stringify(enrichedEvidence, null, 2));
+  const nestedEvidence = await run(nestedEnrichment);
+  assert.equal(nestedEvidence.passed, true, JSON.stringify(nestedEvidence, null, 2));
+  assert.equal((await run(manualJudges)).passed, false);
+  assert.equal((await run(addsCandidateAfterPanel)).passed, false);
+  assert.equal((await run(discardsWinner)).passed, false);
+});
+
+test("edit evidence identifies preparation by timeline and requires returned child results", async () => {
+  const scenario = selectComprehensionScenarios("full").find(({ id }) => id === "full-edit");
+  assert.ok(scenario);
+  const compliant = `export const meta = { name: "edit_variant", description: "arbitrary preparation label", phases: [{ title: "Prepare" }] }
+phase("Prepare", { budget: 100 })
+const preparation = await agent("prepare child runs", { label: "child:preparation" })
+const alpha = await workflow("child-workflow", { id: "alpha" })
+const beta = await workflow("child-workflow", { id: "beta" })
+return { preparation, childResults: { alpha, beta } }`;
+  const discardsChildren = `export const meta = { name: "edit_mutant", description: "discards child results", phases: [{ title: "Prepare" }] }
+phase("Prepare", { budget: 100 })
+await agent("prepare child runs", { label: "prepare" })
+await workflow("child-workflow", { id: "alpha" })
+await workflow("child-workflow", { id: "beta" })
+return { discarded: true }`;
+
+  const run = (workflow: string) =>
+    runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+
+  assert.equal((await run(compliant)).passed, true);
+  assert.equal((await run(discardsChildren)).passed, false);
+});
+
+test("review evidence requires an executed quality helper and returned claim plus verdict", async () => {
+  const scenario = selectComprehensionScenarios("full").find(({ id }) => id === "full-review");
+  assert.ok(scenario);
+  const commentOnly = `export const meta = { name: "review", description: "fixture" }
+// verify(
+const first = await agent("first", { label: "first" })
+const second = await agent("second", { label: "second" })
+return { unrelated: [first, second] }`;
+
+  const evidence = await runComprehensionScenario({
+    scenario,
+    provider: "fixture",
+    model: "fixture/model",
+    extensionVersion: "2.13.1",
+    contractVersions: { format: "1.0.0", content: "2.13.1" },
+    skillVersion: "2.13.1",
+    generate: async () => generation(commentOnly),
+  });
+
+  assert.equal(evidence.passed, false);
+  assert.equal(evidence.runtime.assertions.find(({ name }) => name === "quality:executed")?.passed, false);
+  assert.equal(evidence.runtime.assertions.find(({ name }) => name === "review:returned-outcome")?.passed, false);
+});
+
+test("review evidence traces the claim through the exact verify contract", async () => {
+  const scenario = selectComprehensionScenarios("full").find(({ id }) => id === "full-review");
+  assert.ok(scenario);
+  const compliant = `export const meta = { name: "review_variant", description: "returns exact verification ledger" }
+const claim = await agent("produce claim", { label: "claim" })
+const helperVerdict = await verify(claim, { reviewers: 3, threshold: 0.6, lens: ["source", "logic"] })
+return { claim, helperVerdict }`;
+  const descriptiveLenses = `export const meta = { name: "review_descriptive_lenses", description: "uses descriptive source and logic lenses" }
+const claim = await agent("produce claim", { label: "claim" })
+const verdict = await verify(claim, {
+  reviewers: 3,
+  threshold: 0.6,
+  lens: ["Adversarial source review", "Adversarial logic review"],
+})
+return { claim, verdict }`;
+  const structuredClaimProjection = `export const meta = { name: "review_structured_claim", description: "verifies a lossless claim projection" }
+const produced = await agent("produce claim", {
+  label: "claim",
+  schema: {
+    type: "object",
+    properties: { claim: { type: "string" } },
+    required: ["claim"],
+    additionalProperties: false,
+  },
+})
+const claim = produced.claim
+const verdict = await verify(claim, { reviewers: 3, threshold: 0.6, lens: ["source", "logic"] })
+return { claim, verdict }`;
+  const morphologicalLenses = `export const meta = { name: "review_logical_lenses", description: "uses source verification and logical validity lenses" }
+const claim = await agent("produce claim", { label: "claim" })
+const verdict = await verify(claim, {
+  reviewers: 3,
+  threshold: 0.6,
+  lens: ["source verification", "logical validity"],
+})
+return { claim, verdict }`;
+  const fabricated = `export const meta = { name: "review_mutant", description: "unrelated verification" }
+const claim = await agent("produce claim", { label: "claim" })
+await verify("unrelated constant", { reviewers: 3, threshold: 0.6, lens: ["source", "logic"] })
+return { claim, verdict: "fabricated" }`;
+  const ignoredOptions = `export const meta = { name: "review_ignored_options", description: "uses invented verify options" }
+const claim = await agent("produce claim", { label: "claim" })
+const helperVerdict = await verify({ claim }, { prompt: "source and logic", label: "verify-claim" })
+return { claim, helperVerdict }`;
+
+  const run = (workflow: string) =>
+    runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+
+  assert.equal((await run(compliant)).passed, true);
+  assert.equal((await run(descriptiveLenses)).passed, true);
+  assert.equal((await run(structuredClaimProjection)).passed, true);
+  assert.equal((await run(morphologicalLenses)).passed, true);
+  assert.equal((await run(fabricated)).passed, false);
+  assert.equal((await run(ignoredOptions)).passed, false);
+});
+
+test("debug evidence requires bounded helper attempts and a returned accepted outcome", async () => {
+  const scenario = selectComprehensionScenarios("full").find(({ id }) => id === "full-debug");
+  assert.ok(scenario);
+  const commentOnly = `export const meta = { name: "debug", description: "fixture" }
+// retry(
+const first = await agent("first", { label: "first" })
+const second = await agent("second", { label: "second" })
+return { unrelated: [first, second] }`;
+
+  const evidence = await runComprehensionScenario({
+    scenario,
+    provider: "fixture",
+    model: "fixture/model",
+    extensionVersion: "2.13.1",
+    contractVersions: { format: "1.0.0", content: "2.13.1" },
+    skillVersion: "2.13.1",
+    generate: async () => generation(commentOnly),
+  });
+
+  assert.equal(evidence.passed, false);
+  assert.equal(evidence.runtime.assertions.find(({ name }) => name === "control:retried")?.passed, false);
+  assert.equal(evidence.runtime.assertions.find(({ name }) => name === "debug:returned-outcome")?.passed, false);
+});
+
+test("debug evidence uses controlled validity and returns the accepted agent result", async () => {
+  const scenario = selectComprehensionScenarios("full").find(({ id }) => id === "full-debug");
+  assert.ok(scenario);
+  const compliant = `export const meta = { name: "debug_variant", description: "bounded semantic gate" }
+const schema = { type: "object", properties: { acceptable: { type: "boolean" }, answer: { type: "string" } }, required: ["acceptable", "answer"] }
+const outcome = await gate(
+  (feedback, attempt) => agent("answer the task; feedback=" + (feedback ?? "none"), { label: "attempt:" + attempt, schema }),
+  value => value.acceptable ? { ok: true } : { ok: false, feedback: "make the answer acceptable" },
+  { attempts: 3 },
+)
+return { acceptedResult: outcome.value, attempts: outcome.attempts }`;
+  const acceptedProjection = `export const meta = { name: "debug_projection", description: "returns required accepted fields" }
+const schema = { type: "object", additionalProperties: false, properties: { acceptable: { type: "boolean" }, answer: { type: "string" } }, required: ["acceptable", "answer"] }
+const outcome = await gate(
+  (feedback, attempt) => agent("answer" + (feedback ? ": " + feedback : ""), { label: "attempt:" + attempt, schema }),
+  value => value.acceptable ? { ok: true } : { ok: false, feedback: "make acceptable" },
+  { attempts: 3 },
+)
+return { accepted: outcome.ok ? { acceptable: outcome.value.acceptable, answer: outcome.value.answer } : null }`;
+  const fabricated = `export const meta = { name: "debug_mutant", description: "fabricates success" }
+let checks = 0
+await gate(
+  (_feedback, attempt) => agent("attempt", { label: "attempt:" + attempt }),
+  () => ({ ok: ++checks > 1 }),
+  { attempts: 2 },
+)
+return { ok: true, result: "fabricated" }`;
+  const documentedGate = `export const meta = { name: "debug_documented_gate", description: "uses documented feedback contract" }
+const schema = { type: "object", properties: { acceptable: { type: "boolean" }, answer: { type: "string" }, feedback: { type: "string" } }, required: ["acceptable", "answer", "feedback"] }
+const result = await gate(
+  (feedback, attempt) => agent("answer" + (feedback ? ": " + feedback : ""), { label: "gate-attempt:" + (attempt + 1), schema }),
+  value => {
+    const ok = value.acceptable === true && value.answer.trim().length > 0
+    const feedback = value.feedback.trim() || "try again"
+    return ok ? { ok: true } : { ok: false, feedback }
+  },
+  { attempts: 3 },
+)
+return { result }`;
+  const duplicateLabels = `export const meta = { name: "debug_duplicate_labels", description: "reuses one label" }
+const schema = { type: "object", properties: { acceptable: { type: "boolean" }, answer: { type: "string" } }, required: ["acceptable", "answer"] }
+const result = await retry(
+  () => agent("answer the task", { label: "attempt", schema }),
+  { attempts: 3, until: value => value.acceptable },
+)
+return { result }`;
+
+  const run = (workflow: string) =>
+    runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+
+  assert.equal((await run(compliant)).passed, true);
+  assert.equal((await run(acceptedProjection)).passed, true);
+  assert.equal((await run(fabricated)).passed, false);
+  const documentedGateEvidence = await run(documentedGate);
+  assert.equal(documentedGateEvidence.passed, true, JSON.stringify(documentedGateEvidence, null, 2));
+  assert.equal((await run(duplicateLabels)).passed, false);
+});
+
+test("loop evidence distinguishes failed rounds from successful dryness", async () => {
+  const scenario = selectComprehensionScenarios("full").find(({ id }) => id === "full-loop");
+  assert.ok(scenario);
+  const numericIdentity = `export const meta = { name: "loop_numeric_identity", description: "preserves a stable numeric round identity" }
+const schema = { type: "object", properties: { findings: { type: "array" } }, required: ["findings"] }
+const findings = []
+const failedRounds = []
+let dry = 0
+for (let index = 0; index < 5 && dry < 2; index++) {
+  const result = await agent("round " + index, { label: "round:" + index, schema })
+  if (result === null) { failedRounds.push(index); dry = 0; continue }
+  findings.push(...result.findings)
+  dry = result.findings.length === 0 ? dry + 1 : 0
+}
+return { findings, failedRounds, termination: "successful dry rounds", complete: failedRounds.length === 0 }`;
+  const hardCodesFinding = `export const meta = { name: "loop_fabricated", description: "discards agent findings" }
+const schema = { type: "object", properties: { findings: { type: "array" } }, required: ["findings"] }
+const failedRounds = []
+let dry = 0
+for (let index = 0; index < 5 && dry < 2; index++) {
+  const result = await agent("round " + index, { label: "round:" + index, schema })
+  if (result === null) { failedRounds.push(index); dry = 0; continue }
+  dry = result.findings.length === 0 ? dry + 1 : 0
+}
+return { findings: [{ id: "alpha", evidence: "fabricated" }], failedRounds, termination: "successful dry rounds", complete: false }`;
+  const countsFailureAsDry = `export const meta = { name: "loop_mutant", description: "counts missing coverage as dry" }
+const schema = { type: "object", properties: { findings: { type: "array" } }, required: ["findings"] }
+const findings = await loopUntilDry({
+  round: async index => {
+    const result = await agent("round " + index, { label: "round:" + index, schema })
+    return result?.findings ?? []
+  },
+  consecutiveEmpty: 2,
+  maxRounds: 5,
+})
+return { findings, failedRounds: [], termination: "dry", complete: true }`;
+
+  const run = (workflow: string) =>
+    runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+
+  assert.equal((await run(numericIdentity)).passed, true);
+  assert.equal((await run(hardCodesFinding)).passed, false);
+  const evidence = await run(countsFailureAsDry);
+  assert.equal(evidence.passed, false);
+  assert.equal(evidence.runtime.assertions.find(({ name }) => name === "loop:successful-dry-stopping")?.passed, false);
+  assert.equal(evidence.runtime.assertions.find(({ name }) => name === "loop:truthful-termination")?.passed, false);
+});
+
+test("retry evidence rejects async predicates and missing attempt ledgers", async () => {
+  const scenario = selectComprehensionScenarios("full").find(({ id }) => id === "full-retry");
+  assert.ok(scenario);
+  const asyncPredicate = `export const meta = { name: "retry_async_mutant", description: "uses unsupported async until" }
+const schema = { type: "object", properties: { acceptable: { type: "boolean" }, answer: { type: "string" } }, required: ["acceptable", "answer"] }
+const result = await retry(
+  attempt => agent("attempt " + attempt, { label: "attempt:" + attempt, schema }),
+  { attempts: 3, until: async value => value !== null && value.acceptable === true },
+)
+return { accepted: result, attempts: [result], exhausted: false }`;
+  const flattenedLedger = `export const meta = { name: "retry_flattened_ledger", description: "preserves result fields in each ledger entry" }
+const schema = { type: "object", properties: { acceptable: { type: "boolean" }, answer: { type: "string" } }, required: ["acceptable", "answer"] }
+const ledger = []
+const result = await retry(
+  async attempt => {
+    const value = await agent("attempt " + attempt, { label: "attempt:" + attempt, schema })
+    ledger.push({ attempt, acceptable: value.acceptable, answer: value.answer })
+    return value
+  },
+  { attempts: 3, until: value => value !== null && value.acceptable === true },
+)
+return { accepted: result, ledger, exhausted: false }`;
+  const finalOnly = `export const meta = { name: "retry_final_mutant", description: "drops attempt history" }
+const schema = { type: "object", properties: { acceptable: { type: "boolean" }, answer: { type: "string" } }, required: ["acceptable", "answer"] }
+const result = await retry(
+  attempt => agent("attempt " + attempt, { label: "attempt:" + attempt, schema }),
+  { attempts: 3, until: value => value !== null && value.acceptable === true },
+)
+return { accepted: result, exhausted: false }`;
+  const run = (workflow: string) =>
+    runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+
+  assert.equal((await run(asyncPredicate)).passed, false);
+  assert.equal((await run(flattenedLedger)).passed, true);
+  assert.equal((await run(finalOnly)).passed, false);
+});
+
+test("edit evidence requires sequential child invocations after preparation", async () => {
+  const scenario = selectComprehensionScenarios("full").find(({ id }) => id === "full-edit");
+  assert.ok(scenario);
+  const childrenOutOfOrder = `export const meta = { name: "edit", description: "fixture", phases: [{ title: "Prepare" }] }
+phase("Prepare", { budget: 100 })
+await agent("prepare", { label: "prepare" })
+const beta = await workflow("child-workflow", { id: "beta" })
+const alpha = await workflow("child-workflow", { id: "alpha" })
+return { alpha, beta }`;
+
+  const evidence = await runComprehensionScenario({
+    scenario,
+    provider: "fixture",
+    model: "fixture/model",
+    extensionVersion: "2.13.1",
+    contractVersions: { format: "1.0.0", content: "2.13.1" },
+    skillVersion: "2.13.1",
+    generate: async () => generation(childrenOutOfOrder),
+  });
+
+  assert.equal(evidence.passed, false);
+  assert.equal(evidence.runtime.assertions.find(({ name }) => name === "nesting:sequential")?.passed, false);
+});
+
+test("parse and runtime failures remain separately visible instead of throwing", async () => {
+  const scenario = selectComprehensionScenarios("quick")[0];
+  assert.ok(scenario);
+  const run = (workflow: string) =>
+    runComprehensionScenario({
+      scenario,
+      provider: "fixture",
+      model: "fixture/model",
+      extensionVersion: "2.13.1",
+      contractVersions: { format: "1.0.0", content: "2.13.1" },
+      skillVersion: "2.13.1",
+      generate: async () => generation(workflow),
+    });
+
+  const malformed = await run("not a workflow");
+  assert.equal(malformed.passed, false);
+  assert.equal(malformed.failure?.stage, "parse");
+  assert.match(malformed.failure?.message ?? "", /meta|export|parse|script|unexpected token/i);
+  assert.deepEqual(malformed.runtime.calls, []);
+
+  const throwsAtRuntime = await run(`export const meta = { name: "throws", description: "valid source" }
+throw new Error("deterministic runtime failure")`);
+  assert.equal(throwsAtRuntime.passed, false);
+  assert.equal(throwsAtRuntime.failure?.stage, "runtime");
+  assert.match(throwsAtRuntime.failure?.message ?? "", /deterministic runtime failure/i);
+});
+
+test("provider generation failures retain complete versioned evidence", async () => {
+  const scenario = selectComprehensionScenarios("quick")[0];
+  assert.ok(scenario);
+  const evidence = await runComprehensionScenario({
+    scenario,
+    provider: "provider-x",
+    modelSelection: {
+      requested: "provider-x/model-y:high",
+      resolved: "provider-x/model-y",
+      thinkingLevel: "high",
+    },
+    extensionVersion: "2.13.1",
+    contractVersions: { format: "1.0.0", content: "2.13.1" },
+    skillVersion: "2.13.1",
+    generate: async () => {
+      throw new ModelGenerationError(
+        "quota unavailable",
+        {
+          discovered: true,
+          loaded: true,
+          toolCalls: [{ tool: "read", path: "/installed/skills/workflow-authoring/SKILL.md" }],
+        },
+        { input: 80, output: 20, total: 100, cost: 0.002, cacheRead: 5, cacheWrite: 0 },
+      );
+    },
+  });
+
+  assert.equal(evidence.formatVersion, 2);
+  assert.equal(evidence.provider, "provider-x");
+  assert.deepEqual(evidence.modelSelection, {
+    requested: "provider-x/model-y:high",
+    resolved: "provider-x/model-y",
+    thinkingLevel: "high",
+  });
+  assert.equal(evidence.extensionVersion, "2.13.1");
+  assert.deepEqual(evidence.contractVersions, { format: "1.0.0", content: "2.13.1" });
+  assert.equal(evidence.skillVersion, "2.13.1");
+  assert.equal(evidence.task.id, "quick-write");
+  assert.equal(evidence.generatedWorkflow, null);
+  assert.equal(evidence.failure?.stage, "generation");
+  assert.equal(evidence.failure?.message, "quota unavailable");
+  assert.equal(evidence.skillLoadingEvidence.loaded, true);
+  assert.equal(evidence.tokenUsage?.total, 100);
+  assert.equal(evidence.passed, false);
+});

--- a/tests/workflow-context-surfaces.test.ts
+++ b/tests/workflow-context-surfaces.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import packageJson from "../package.json" with { type: "json" };
+import {
+  checkWorkflowContextMeasurement,
+  measureWorkflowContextSurfaces,
+  renderWorkflowContextMeasurement,
+  WORKFLOW_CONTEXT_MEASUREMENT_PATH,
+} from "../src/workflow-context-measurement.js";
+import { createWorkflowTool } from "../src/workflow-tool.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+const ROOT = join(import.meta.dirname, "..");
+
+test("workflow context measurement reports Pi-rendered prompt and provider tool definition separately", async () => {
+  const artifact = measureWorkflowContextSurfaces(ROOT);
+  assert.deepEqual(JSON.parse(renderWorkflowContextMeasurement()), artifact);
+
+  assert.equal(artifact.formatVersion, 2);
+  assert.equal(artifact.encoding, "utf8");
+  assert.deepEqual(artifact.sources, ["src/workflow-tool.ts", "skills/workflow-authoring"]);
+  assert.equal(artifact.surfaces.permanentWorkflowPrompt.serialization, "UTF-8 bytes of LF-joined Pi prompt lines");
+  assert.equal(
+    artifact.surfaces.providerVisibleWorkflowToolDefinition.serialization,
+    "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
+  );
+  assert.match(artifact.surfaces.workflowAuthoringSkillDiscovery.serialization, /package-relative location/i);
+  assert.ok(artifact.surfaces.workflowAuthoringSkillDiscovery.bytes > 0);
+  assert.equal(artifact.surfaces.workflowAuthoringSkillCorpus.files, 27);
+  assert.ok(artifact.surfaces.workflowAuthoringSkillCorpus.bytes > 0);
+  assert.equal(artifact.surfaces.representativeAuthoringProfiles.profiles.length, 6);
+  assert.deepEqual(
+    artifact.surfaces.representativeAuthoringProfiles.profiles.map(({ name }) => name),
+    ["write", "edit", "review", "debug", "loop", "retry"],
+  );
+  for (const profile of artifact.surfaces.representativeAuthoringProfiles.profiles) {
+    const expected = profile.files.reduce((sum, path) => sum + Buffer.byteLength(readFileSync(join(ROOT, path))), 0);
+    assert.equal(profile.bytes, expected, `${profile.name} profile must sum its declared files`);
+  }
+  const profileBytes = artifact.surfaces.representativeAuthoringProfiles.profiles
+    .map(({ bytes }) => bytes)
+    .sort((a, b) => a - b);
+  assert.equal(artifact.surfaces.representativeAuthoringProfiles.medianBytes, (profileBytes[2] + profileBytes[3]) / 2);
+
+  await withRenderedWorkflow(async ({ systemPrompt, promptLines, wrappedWorkflow }) => {
+    const expectedLines = new Set(promptLines);
+    const renderedLines = systemPrompt.split("\n").filter((line) => expectedLines.has(line));
+    assert.deepEqual(renderedLines, promptLines, "Pi should render each workflow prompt line exactly once");
+
+    const providerDefinition = JSON.stringify({
+      name: wrappedWorkflow.name,
+      description: wrappedWorkflow.description,
+      parameters: wrappedWorkflow.parameters,
+    });
+    assert.equal(artifact.surfaces.permanentWorkflowPrompt.bytes, Buffer.byteLength(renderedLines.join("\n"), "utf8"));
+    assert.equal(
+      artifact.surfaces.providerVisibleWorkflowToolDefinition.bytes,
+      Buffer.byteLength(providerDefinition, "utf8"),
+    );
+  });
+});
+
+test("workflow context measurement generation is deterministic and committed artifact is fresh", () => {
+  const first = renderWorkflowContextMeasurement();
+  const second = renderWorkflowContextMeasurement();
+
+  assert.equal(first, second);
+  assert.equal(readFileSync(join(ROOT, WORKFLOW_CONTEXT_MEASUREMENT_PATH), "utf8"), first);
+  assert.equal(checkWorkflowContextMeasurement(ROOT), true);
+  assert.equal(checkWorkflowContextMeasurement(ROOT, `${first}stale`), false);
+  assert.equal(packageJson.scripts["context:check"], "tsx scripts/generate-workflow-context-measurement.ts --check");
+  assert.match(packageJson.scripts.test, /release:check/);
+  assert.match(packageJson.scripts["release:check"], /context:check/);
+});
+
+test("context freshness command prints both current byte counts", () => {
+  const output = execFileSync("npm", ["run", "context:check"], { cwd: ROOT, encoding: "utf8" });
+
+  assert.match(output, /Permanent workflow prompt: \d+ bytes/);
+  assert.match(output, /Provider-visible workflow tool definition: \d+ bytes/);
+  assert.match(output, /Workflow-authoring skill discovery: \d+ bytes/);
+  assert.match(output, /Workflow-authoring skill corpus: \d+ bytes across \d+ files/);
+  assert.match(output, /Representative authoring profile median: \d+(?:\.5)? bytes/);
+  assert.match(output, /measurement is fresh/i);
+});
+
+async function withRenderedWorkflow(
+  inspect: (surface: {
+    systemPrompt: string;
+    promptLines: string[];
+    wrappedWorkflow: { name: string; description: string; parameters: unknown };
+  }) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "workflow-context-measurement-"));
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+  try {
+    process.env.PI_CODING_AGENT_DIR = root;
+    await withFakeHomeAsync(root, async () => {
+      const workflow = createWorkflowTool({ cwd: root });
+      const loader = new DefaultResourceLoader({
+        cwd: root,
+        agentDir: root,
+        appendSystemPromptOverride: () => [],
+      });
+      await loader.reload();
+
+      const { session } = await createAgentSession({
+        cwd: root,
+        agentDir: root,
+        tools: ["workflow"],
+        customTools: [workflow],
+        resourceLoader: loader,
+        sessionManager: SessionManager.inMemory(root),
+        settingsManager: SettingsManager.inMemory(),
+      });
+
+      try {
+        const wrappedWorkflow = session.agent.state.tools.find((tool) => tool.name === "workflow");
+        assert.ok(wrappedWorkflow, "Pi should expose the wrapped workflow tool");
+        await inspect({
+          systemPrompt: session.agent.state.systemPrompt,
+          promptLines: [
+            `- workflow: ${workflow.promptSnippet}`,
+            ...(workflow.promptGuidelines ?? []).map((guideline) => `- ${guideline}`),
+          ],
+          wrappedWorkflow,
+        });
+      } finally {
+        session.dispose();
+      }
+    });
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/tests/workflow-delivery-choice.test.ts
+++ b/tests/workflow-delivery-choice.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import test from "node:test";
+import packageJson from "../package.json" with { type: "json" };
+import { evaluateWorkflowDeliveryChoice, WORKFLOW_DELIVERY_CHOICE_SCENARIOS } from "../src/workflow-delivery-choice.js";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const delayed = WORKFLOW_DELIVERY_CHOICE_SCENARIOS.find(({ id }) => id === "background-delivery");
+const inline = WORKFLOW_DELIVERY_CHOICE_SCENARIOS.find(({ id }) => id === "inline-result");
+
+test("delivery-choice scenarios cover background delivery and same-turn inline use", () => {
+  assert.ok(delayed);
+  assert.ok(inline);
+  assert.equal(WORKFLOW_DELIVERY_CHOICE_SCENARIOS.length, 2);
+  assert.equal(delayed.expectedBackground, true);
+  assert.match(delayed.prompt, /deliver.*later|later.*deliver/i);
+  assert.equal(inline.expectedBackground, false);
+  assert.match(inline.prompt, /same turn/i);
+  assert.match(inline.prompt, /waiting/i);
+});
+
+test("delivery-choice scoring accepts the default for later delivery", () => {
+  assert.ok(delayed);
+  assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "return {}" }).passed, true);
+  assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "return {}", background: true }).passed, true);
+  assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "return {}", background: false }).passed, false);
+});
+
+test("delivery-choice scoring requires background false for same-turn use", () => {
+  assert.ok(inline);
+  assert.equal(evaluateWorkflowDeliveryChoice(inline, { script: "return {}", background: false }).passed, true);
+  assert.equal(evaluateWorkflowDeliveryChoice(inline, { script: "return {}" }).passed, false);
+  assert.equal(evaluateWorkflowDeliveryChoice(inline, { script: "return {}", background: true }).passed, false);
+});
+
+test("delivery-choice scoring rejects malformed workflow calls", () => {
+  assert.ok(delayed);
+  assert.equal(evaluateWorkflowDeliveryChoice(delayed, null).passed, false);
+  assert.equal(evaluateWorkflowDeliveryChoice(delayed, { background: true }).passed, false);
+  assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "", background: true }).passed, false);
+  assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "return {}", background: "true" }).passed, false);
+});
+
+test("delivery-choice CLI is package-wired and exposes help without provider calls", () => {
+  assert.equal(packageJson.scripts["delivery-choice"], "tsx scripts/run-workflow-delivery-choice.ts");
+  assert.equal(packageJson.scripts["check:scripts"], "tsc -p tsconfig.scripts.json");
+  assert.match(packageJson.scripts.check, /check:scripts/);
+  assert.doesNotMatch(packageJson.scripts.test, /delivery-choice/i);
+  assert.doesNotMatch(packageJson.scripts["release:check"], /delivery-choice/i);
+  assert.doesNotMatch(packageJson.scripts.prepublishOnly, /delivery-choice/i);
+
+  const help = execFileSync(
+    process.execPath,
+    ["--import", "tsx", "scripts/run-workflow-delivery-choice.ts", "--help"],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+    },
+  );
+  assert.match(help, /--model <provider\/model>/i);
+  assert.match(help, /--output <path>/i);
+});

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -14,30 +14,12 @@ import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 // Exact post-change measurements: ratchet only after reviewing a new accepted form.
 // The prompt baseline intentionally uses an empty agentType registry so user configuration cannot alter it.
-//
-// ALWAYS-ON prompt (promptSnippet line + the single gate line): the authorize-
-// keyword-trigger change took this DOWN from ~6_500 bytes (the ~20 "For workflow, …"
-// how-to lines used to render every turn) to a single opt-in gate line. This PR then
-// added concise task-shape positives to the gate line (#P4: balance the strong
-// "do not call it" negative so the model still recognizes a good fit off-keyword),
-// nudging the rendered always-on surface up to ~766 bytes — still an order of
-// magnitude below the old always-on cost, and still self-priming-safe (no how-to here).
+// The upstream authorization gate is the only always-on guideline. Authoring
+// mechanics stay in the compact static tool definition and discoverable skill.
 const RENDERED_PROMPT_BUDGET_BYTES = 800;
-// TOOL DEFINITION (name + description + parameters): this GREW on purpose. The how-to
-// mechanics moved OUT of the always-on prompt and the per-armed-turn message and INTO
-// the tool's static `description` (see createWorkflowTool / workflowHowToGuidelines),
-// where the model sees them whenever it looks at the tool — on every arming path and on
-// off-keyword natural-language opt-ins — as a cacheable part of the tool definition
-// rather than per-turn priming. So the definition went from ~2_529 to ~8_770 bytes.
-// This is a MOVE, not new weight: it removed ~6.1KB re-injected on EACH armed turn
-// (the armed message dropped from ~6_765 to ~905 bytes). Trimming the how-to text
-// itself to shrink this definition is a SEPARATE concern (#65 / contract-concision
-// work), not this PR's job — this PR does not claim a token saving on the definition.
-// Ratcheted 8_800 → 8_900 for #68: the budget/timeout guideline now names the
-// settings.json defaults (defaultTokenBudget, defaultAgentTimeoutMs) instead of
-// claiming "the defaults are unbounded", which became false once those settings
-// exist. Reviewed wording; ~90 bytes.
-const TOOL_DEFINITION_BUDGET_BYTES = 8_900;
+// #105 corrected omitted timeout/budget semantics to name configured defaults,
+// increasing the compact definition from 3,802 to 3,918 bytes.
+const TOOL_DEFINITION_BUDGET_BYTES = 3_918;
 
 test("rendered workflow prompt contribution stays within its accepted size", async () => {
   await withRenderedWorkflow(async ({ systemPrompt, promptLines }) => {
@@ -68,19 +50,6 @@ test("provider-visible workflow tool definition stays within its accepted size",
       actualBytes <= TOOL_DEFINITION_BUDGET_BYTES,
       `Workflow tool definition is ${actualBytes} bytes; budget is ${TOOL_DEFINITION_BUDGET_BYTES} (parameters: ${parameterBytes} bytes).\n${definitionJson}`,
     );
-  });
-});
-
-test("the how-to mechanics live in the tool DESCRIPTION, not the always-on prompt", async () => {
-  await withRenderedWorkflow(async ({ systemPrompt, wrappedWorkflow }) => {
-    // The description is where the manual now lives (the model sees it whenever it
-    // looks at the tool, on any arming path).
-    assert.match(wrappedWorkflow.description, /How to write the script:/);
-    assert.match(wrappedWorkflow.description, /export const meta = \{/);
-    assert.match(wrappedWorkflow.description, /parallel\(\) takes functions, not promises/);
-
-    // ...and NOT re-rendered into the always-on system prompt every turn.
-    assert.doesNotMatch(systemPrompt, /parallel\(\) takes functions, not promises/);
   });
 });
 

--- a/tests/workflow-release-gate.test.ts
+++ b/tests/workflow-release-gate.test.ts
@@ -28,6 +28,7 @@ test("normal tests and publishing share the model-free release gate", () => {
   assert.match(packageJson.scripts["release:check"], /context:check/);
   assert.match(packageJson.scripts["release:check"], /test:unit/);
   assert.match(packageJson.scripts["release:check"], /release:verify/);
+  assert.equal(packageJson.scripts["guidance:accept"], "tsx scripts/accept-workflow-guidance.ts");
   assert.doesNotMatch(packageJson.scripts["release:check"], /model|provider|comprehension/i);
 });
 
@@ -132,7 +133,7 @@ test("release gate blocks drift in guidance frozen outside provider-backed compr
   assert.match(drift.message, /CONTRIBUTING\.md#protected-workflow-authoring-guidance/);
 });
 
-test("release gate freezes mixed guidance files against contradictory additions during autoresearch", () => {
+test("release gate requires explicit acceptance for mixed guidance files with partial behavioral coverage", () => {
   const patternPath = "skills/workflow-authoring/references/pattern-selection.md";
   const patternSelection = readFileSync(new URL(`../${patternPath}`, import.meta.url), "utf8");
   const contradictory = `${patternSelection}\nTournament workflows should skip brackets and compare every candidate at once.\n`;
@@ -146,9 +147,10 @@ test("release gate freezes mixed guidance files against contradictory additions 
   const drift = diagnostics.find(({ code, subject }) => code === "PROTECTED_GUIDANCE_DRIFT" && subject === patternPath);
   assert.ok(drift);
   assert.match(drift.message, /skills\/workflow-authoring\/references\/pattern-selection\.md/);
-  assert.match(drift.message, /SHA-256.*deliberate.*manual-review gate/i);
+  assert.match(drift.message, /SHA-256.*explicit review checkpoint.*partial behavioral coverage/i);
   assert.match(drift.message, /Revert accidental changes/i);
-  assert.match(drift.message, /intentional reviewed change.*recompute the exact SHA-256.*manually update/is);
+  assert.match(drift.message, /intentional change.*npm run guidance:accept --.*pattern-selection\.md/is);
+  assert.doesNotMatch(drift.message, /anti-overfitting|autoresearch|manually update/i);
   assert.match(drift.message, /WORKFLOW_AUTHORING_FROZEN_FILES/);
   assert.match(drift.message, /src\/workflow-authoring-coverage\.ts/);
   assert.match(drift.message, /CONTRIBUTING\.md#protected-workflow-authoring-guidance/);
@@ -180,13 +182,16 @@ test("contributor docs explain the protected workflow-authoring guidance gate", 
   const contributing = readFileSync(new URL("../CONTRIBUTING.md", import.meta.url), "utf8");
 
   assert.match(contributing, /^## Protected workflow-authoring guidance$/m);
-  assert.match(contributing, /full-file SHA-256 hashes.*deliberate review barriers/is);
-  assert.match(contributing, /mixed or behaviorally uncovered guidance/i);
+  assert.match(contributing, /full-file SHA-256 hashes.*explicit review checkpoints/is);
+  assert.match(contributing, /mixed or partially behavior-covered guidance/i);
   assert.match(contributing, /WORKFLOW_AUTHORING_FROZEN_FILES.*src\/workflow-authoring-coverage\.ts/is);
-  assert.match(contributing, /inspect.*coverage manifest.*behavioral.*provider evidence/is);
+  assert.match(contributing, /housekeeping.*deterministic checks and review/is);
+  assert.match(contributing, /semantic guidance change.*behavioral tests.*provider evidence when needed/is);
   assert.match(contributing, /required anchors.*required text.*deliberate updates/is);
-  assert.match(contributing, /recompute the exact SHA-256.*manually update/is);
+  assert.match(contributing, /npm run guidance:accept --.*skills\/workflow-authoring/is);
+  assert.match(contributing, /updates only explicitly named frozen files/is);
   assert.match(contributing, /guidance:generate.*does not update protected hashes/is);
+  assert.doesNotMatch(contributing, /anti-overfitting|autoresearch/i);
   assert.match(contributing, /npm run docs:check/);
   assert.match(contributing, /npm run context:check/);
   assert.match(contributing, /npm run guidance:check/);

--- a/tests/workflow-release-gate.test.ts
+++ b/tests/workflow-release-gate.test.ts
@@ -119,12 +119,17 @@ test("release gate blocks drift in guidance frozen outside provider-backed compr
     guidanceOverrides: { [patternPath]: withoutTournament },
   });
 
-  assert.ok(
-    diagnostics.some(
-      ({ code, severity, subject }) =>
-        code === "PROTECTED_GUIDANCE_DRIFT" && severity === "error" && subject === "workflow.pattern.tournament",
-    ),
+  const drift = diagnostics.find(
+    ({ code, severity, subject }) =>
+      code === "PROTECTED_GUIDANCE_DRIFT" && severity === "error" && subject === "workflow.pattern.tournament",
   );
+  assert.ok(drift);
+  assert.match(drift.message, /skills\/workflow-authoring\/references\/pattern-selection\.md/);
+  assert.match(drift.message, /required text/i);
+  assert.match(drift.message, /Restore.*accidental/i);
+  assert.match(drift.message, /intentional.*coverage manifest.*behavioral\/provider evidence/is);
+  assert.match(drift.message, /src\/workflow-authoring-coverage\.ts/);
+  assert.match(drift.message, /CONTRIBUTING\.md#protected-workflow-authoring-guidance/);
 });
 
 test("release gate freezes mixed guidance files against contradictory additions during autoresearch", () => {
@@ -138,7 +143,15 @@ test("release gate freezes mixed guidance files against contradictory additions 
     guidanceOverrides: { [patternPath]: contradictory },
   });
 
-  assert.ok(diagnostics.some(({ code, subject }) => code === "PROTECTED_GUIDANCE_DRIFT" && subject === patternPath));
+  const drift = diagnostics.find(({ code, subject }) => code === "PROTECTED_GUIDANCE_DRIFT" && subject === patternPath);
+  assert.ok(drift);
+  assert.match(drift.message, /skills\/workflow-authoring\/references\/pattern-selection\.md/);
+  assert.match(drift.message, /SHA-256.*deliberate.*manual-review gate/i);
+  assert.match(drift.message, /Revert accidental changes/i);
+  assert.match(drift.message, /intentional reviewed change.*recompute the exact SHA-256.*manually update/is);
+  assert.match(drift.message, /WORKFLOW_AUTHORING_FROZEN_FILES/);
+  assert.match(drift.message, /src\/workflow-authoring-coverage\.ts/);
+  assert.match(drift.message, /CONTRIBUTING\.md#protected-workflow-authoring-guidance/);
 });
 
 test("release gate blocks deletion of routing to guidance-frozen capabilities", () => {
@@ -161,6 +174,23 @@ test("release gate blocks deletion of routing to guidance-frozen capabilities", 
       ({ code, subject }) => code === "PROTECTED_GUIDANCE_DRIFT" && subject === "workflow.pattern.tournament",
     ),
   );
+});
+
+test("contributor docs explain the protected workflow-authoring guidance gate", () => {
+  const contributing = readFileSync(new URL("../CONTRIBUTING.md", import.meta.url), "utf8");
+
+  assert.match(contributing, /^## Protected workflow-authoring guidance$/m);
+  assert.match(contributing, /full-file SHA-256 hashes.*deliberate review barriers/is);
+  assert.match(contributing, /mixed or behaviorally uncovered guidance/i);
+  assert.match(contributing, /WORKFLOW_AUTHORING_FROZEN_FILES.*src\/workflow-authoring-coverage\.ts/is);
+  assert.match(contributing, /inspect.*coverage manifest.*behavioral.*provider evidence/is);
+  assert.match(contributing, /required anchors.*required text.*deliberate updates/is);
+  assert.match(contributing, /recompute the exact SHA-256.*manually update/is);
+  assert.match(contributing, /guidance:generate.*does not update protected hashes/is);
+  assert.match(contributing, /npm run docs:check/);
+  assert.match(contributing, /npm run context:check/);
+  assert.match(contributing, /npm run guidance:check/);
+  assert.match(contributing, /npm run release:verify/);
 });
 
 test("release gate rejects unprotected guidance and invented comprehension coverage", () => {

--- a/tests/workflow-release-gate.test.ts
+++ b/tests/workflow-release-gate.test.ts
@@ -182,6 +182,9 @@ test("contributor docs explain the protected workflow-authoring guidance gate", 
   const contributing = readFileSync(new URL("../CONTRIBUTING.md", import.meta.url), "utf8");
 
   assert.match(contributing, /^## Protected workflow-authoring guidance$/m);
+  assert.match(contributing, /keep.*guidance accurate.*runtime.*changes/is);
+  assert.match(contributing, /detailed.*on-demand.*skill.*permanent.*prompt/is);
+  assert.match(contributing, /context checks.*growing unnoticed/is);
   assert.match(contributing, /full-file SHA-256 hashes.*explicit review checkpoints/is);
   assert.match(contributing, /mixed or partially behavior-covered guidance/i);
   assert.match(contributing, /WORKFLOW_AUTHORING_FROZEN_FILES.*src\/workflow-authoring-coverage\.ts/is);
@@ -196,6 +199,17 @@ test("contributor docs explain the protected workflow-authoring guidance gate", 
   assert.match(contributing, /npm run context:check/);
   assert.match(contributing, /npm run guidance:check/);
   assert.match(contributing, /npm run release:verify/);
+});
+
+test("repository instructions route agents to workflow guidance maintenance rules", () => {
+  const agentInstructions = readFileSync(new URL("../AGENTS.md", import.meta.url), "utf8");
+
+  assert.match(agentInstructions, /CONTRIBUTING\.md#protected-workflow-authoring-guidance/);
+  assert.match(agentInstructions, /workflow runtime.*tool API.*workflow-authoring.*skill/is);
+  assert.match(agentInstructions, /stable capability facts.*executable capability contract/is);
+  assert.match(agentInstructions, /detailed authoring guidance.*on-demand skill.*always-on prompt/is);
+  assert.match(agentInstructions, /npm run context:check/);
+  assert.match(agentInstructions, /npm run guidance:accept -- <path>/);
 });
 
 test("release gate rejects unprotected guidance and invented comprehension coverage", () => {

--- a/tests/workflow-release-gate.test.ts
+++ b/tests/workflow-release-gate.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import packageJson from "../package.json" with { type: "json" };
+import { WORKFLOW_AUTHORING_COVERAGE } from "../src/workflow-authoring-coverage.js";
+import { WORKFLOW_CAPABILITY_DEFINITION } from "../src/workflow-capability-contract.js";
+import { checkWorkflowRelease, parseNpmPackFilePaths } from "../src/workflow-release-gate.js";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+
+function publishableFiles(): string[] {
+  const output = execFileSync("npm", ["pack", "--dry-run", "--json"], { cwd: ROOT, encoding: "utf8" });
+  return parseNpmPackFilePaths(output);
+}
+
+test("npm pack parsing keeps only valid publishable file paths", () => {
+  assert.deepEqual(parseNpmPackFilePaths(JSON.stringify([{ files: [{ path: "README.md" }, {}, { path: 42 }] }])), [
+    "README.md",
+  ]);
+  assert.deepEqual(parseNpmPackFilePaths(JSON.stringify({ files: [] })), []);
+});
+
+test("normal tests and publishing share the model-free release gate", () => {
+  assert.match(packageJson.scripts.test, /release:check/);
+  assert.match(packageJson.scripts.prepublishOnly, /release:check/);
+  assert.match(packageJson.scripts["release:check"], /docs:check/);
+  assert.match(packageJson.scripts["release:check"], /context:check/);
+  assert.match(packageJson.scripts["release:check"], /test:unit/);
+  assert.match(packageJson.scripts["release:check"], /release:verify/);
+  assert.doesNotMatch(packageJson.scripts["release:check"], /model|provider|comprehension/i);
+});
+
+test("release gate accepts the aligned contract, package, documentation, and measurements", () => {
+  const diagnostics = checkWorkflowRelease({ root: ROOT, publishableFiles: publishableFiles() });
+
+  assert.deepEqual(diagnostics, []);
+});
+
+test("release gate blocks runtime constraint disagreements", () => {
+  const definition = structuredClone(WORKFLOW_CAPABILITY_DEFINITION);
+  const tokenBudgetIndex = definition.capabilities.findIndex(({ label }) => label === "tokenBudget");
+  const tokenBudget = definition.capabilities[tokenBudgetIndex];
+  assert.ok(tokenBudget);
+  definition.capabilities[tokenBudgetIndex] = {
+    ...tokenBudget,
+    constraints: ["hard total-token budget with no overshoot"],
+  };
+
+  const diagnostics = checkWorkflowRelease({ root: ROOT, definition, publishableFiles: publishableFiles() });
+
+  assert.ok(
+    diagnostics.some(
+      ({ code, severity, subject }) =>
+        code === "RUNTIME_CONSTRAINT_DISAGREEMENT" && severity === "error" && subject === "tokenBudget",
+    ),
+  );
+});
+
+test("release gate names incompatible versions and missing behavior evidence", () => {
+  const definition = structuredClone(WORKFLOW_CAPABILITY_DEFINITION);
+  definition.versions.content.version = "0.0.0";
+  definition.capabilities[0] = { ...definition.capabilities[0], behaviorEvidence: [] };
+
+  const diagnostics = checkWorkflowRelease({
+    root: ROOT,
+    definition,
+    extensionVersion: packageJson.version,
+    skillVersion: "9.0.0",
+    publishableFiles: publishableFiles(),
+  });
+
+  assert.ok(
+    diagnostics.some(
+      ({ code, subject, message }) =>
+        code === "INCOMPATIBLE_VERSION" && subject === "contract content" && message.includes(packageJson.version),
+    ),
+  );
+  assert.ok(diagnostics.some(({ code, subject }) => code === "INCOMPATIBLE_VERSION" && subject === "installed skill"));
+  assert.ok(
+    diagnostics.some(
+      ({ code, subject }) => code === "MISSING_BEHAVIOR_EVIDENCE" && subject === "workflow.runtime.agent",
+    ),
+  );
+});
+
+test("release gate requires auditable coverage for every stable authoring surface", () => {
+  const diagnostics = checkWorkflowRelease({
+    root: ROOT,
+    publishableFiles: publishableFiles(),
+    authoringCoverage: [],
+  });
+
+  assert.ok(
+    diagnostics.some(
+      ({ code, severity, subject }) =>
+        code === "MISSING_AUTHORING_COVERAGE" && severity === "error" && subject === "workflow.runtime.agent",
+    ),
+  );
+  assert.ok(
+    diagnostics.some(
+      ({ code, subject }) => code === "MISSING_AUTHORING_COVERAGE" && subject === "workflow.pattern.tournament",
+    ),
+  );
+});
+
+test("release gate blocks drift in guidance frozen outside provider-backed comprehension", () => {
+  const patternPath = "skills/workflow-authoring/references/pattern-selection.md";
+  const patternSelection = readFileSync(new URL(`../${patternPath}`, import.meta.url), "utf8");
+  const withoutTournament = patternSelection.replace(
+    "| Pairwise comparison beats absolute scoring | Tournament | Let JavaScript run the bounded bracket and byes; agents compare one pair; ledger match failures | [Adapt](../examples/tournament.js) |",
+    "",
+  );
+  assert.notEqual(withoutTournament, patternSelection);
+
+  const diagnostics = checkWorkflowRelease({
+    root: ROOT,
+    publishableFiles: publishableFiles(),
+    guidanceOverrides: { [patternPath]: withoutTournament },
+  });
+
+  assert.ok(
+    diagnostics.some(
+      ({ code, severity, subject }) =>
+        code === "PROTECTED_GUIDANCE_DRIFT" && severity === "error" && subject === "workflow.pattern.tournament",
+    ),
+  );
+});
+
+test("release gate freezes mixed guidance files against contradictory additions during autoresearch", () => {
+  const patternPath = "skills/workflow-authoring/references/pattern-selection.md";
+  const patternSelection = readFileSync(new URL(`../${patternPath}`, import.meta.url), "utf8");
+  const contradictory = `${patternSelection}\nTournament workflows should skip brackets and compare every candidate at once.\n`;
+
+  const diagnostics = checkWorkflowRelease({
+    root: ROOT,
+    publishableFiles: publishableFiles(),
+    guidanceOverrides: { [patternPath]: contradictory },
+  });
+
+  assert.ok(diagnostics.some(({ code, subject }) => code === "PROTECTED_GUIDANCE_DRIFT" && subject === patternPath));
+});
+
+test("release gate blocks deletion of routing to guidance-frozen capabilities", () => {
+  const skillPath = "skills/workflow-authoring/SKILL.md";
+  const skill = readFileSync(new URL(`../${skillPath}`, import.meta.url), "utf8");
+  const withoutPatternRoute = skill.replace(
+    "- **Write or edit:** start with [runtime](references/runtime.md). Add [pattern selection](references/pattern-selection.md) for topology, [lifecycle](references/lifecycle.md) for limits or resume, and [focused recipes](references/focused-recipes.md) for the matching concern.",
+    "",
+  );
+  assert.notEqual(withoutPatternRoute, skill);
+
+  const diagnostics = checkWorkflowRelease({
+    root: ROOT,
+    publishableFiles: publishableFiles(),
+    guidanceOverrides: { [skillPath]: withoutPatternRoute },
+  });
+
+  assert.ok(
+    diagnostics.some(
+      ({ code, subject }) => code === "PROTECTED_GUIDANCE_DRIFT" && subject === "workflow.pattern.tournament",
+    ),
+  );
+});
+
+test("release gate rejects unprotected guidance and invented comprehension coverage", () => {
+  const authoringCoverage = structuredClone(WORKFLOW_AUTHORING_COVERAGE);
+  const tournament = authoringCoverage.find(({ id }) => id === "workflow.pattern.tournament");
+  const judgePanel = authoringCoverage.find(({ id }) => id === "workflow.runtime.judgePanel");
+  assert.ok(tournament);
+  assert.ok(judgePanel);
+  tournament.protectedGuidance = [];
+  judgePanel.comprehensionScenarios = ["not-a-real-scenario"];
+
+  const diagnostics = checkWorkflowRelease({
+    root: ROOT,
+    publishableFiles: publishableFiles(),
+    authoringCoverage,
+  });
+
+  assert.ok(
+    diagnostics.some(({ code, subject }) => code === "UNPROTECTED_AUTHORING_GUIDANCE" && subject === tournament.id),
+  );
+  assert.ok(
+    diagnostics.some(({ code, subject }) => code === "UNKNOWN_COMPREHENSION_SCENARIO" && subject === judgePanel.id),
+  );
+});
+
+test("release gate names omitted package resources and stale generated surfaces", () => {
+  const files = publishableFiles().filter((path) => path !== "skills/workflow-authoring/examples/tournament.js");
+  const diagnostics = checkWorkflowRelease({
+    root: ROOT,
+    publishableFiles: files,
+    publicationOverrides: { "README.md": "stale" },
+    contextMeasurement: "stale",
+    guidanceBaseline: "stale",
+  });
+
+  assert.ok(
+    diagnostics.some(
+      ({ code, subject }) =>
+        code === "MISSING_PACKAGE_RESOURCE" && subject === "skills/workflow-authoring/examples/tournament.js",
+    ),
+  );
+  assert.ok(diagnostics.some(({ code, subject }) => code === "STALE_GENERATED_SURFACE" && subject === "README.md"));
+  assert.ok(
+    diagnostics.some(
+      ({ code, subject }) => code === "STALE_GENERATED_SURFACE" && subject === "docs/workflow-context-surfaces.json",
+    ),
+  );
+  assert.ok(
+    diagnostics.some(
+      ({ code, severity, subject }) =>
+        code === "NON_CONTRACTUAL_PROSE_DRIFT" &&
+        severity === "warning" &&
+        subject === "docs/workflow-guidance-baseline.json",
+    ),
+  );
+});
+
+test("release gate reports unresolved behavior and reference paths precisely", () => {
+  const definition = structuredClone(WORKFLOW_CAPABILITY_DEFINITION);
+  definition.capabilities[0] = {
+    ...definition.capabilities[0],
+    behaviorEvidence: ["tests/does-not-exist.test.ts"],
+    staticReference: { path: "skills/workflow-authoring/references/capabilities.md", anchor: "does-not-exist" },
+  };
+
+  const diagnostics = checkWorkflowRelease({ root: ROOT, definition, publishableFiles: publishableFiles() });
+
+  assert.ok(
+    diagnostics.some(
+      ({ code, subject }) => code === "UNRESOLVED_BEHAVIOR_EVIDENCE" && subject === "tests/does-not-exist.test.ts",
+    ),
+  );
+  assert.ok(
+    diagnostics.some(
+      ({ code, subject }) =>
+        code === "BROKEN_CONTRACT_REFERENCE" &&
+        subject === "skills/workflow-authoring/references/capabilities.md#does-not-exist",
+    ),
+  );
+});

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
-import { type JournalEntry, runWorkflow } from "../src/workflow.js";
+import { type JournalEntry, parseWorkflowScript, runWorkflow } from "../src/workflow.js";
 
 /** Agent runner that counts real invocations and echoes a per-call result. */
 function countingAgent() {
@@ -746,6 +746,31 @@ return results`;
   assert.equal(result.result.length, 2);
 });
 
+test("pipeline forwards a recoverable null to the next stage with original item and index", async () => {
+  const script = `export const meta = { name: 'pipeline_null', description: 'null forwarding' }
+const results = await pipeline(
+  ['alpha'],
+  (item) => agent('first ' + item, { label: 'first' }),
+  (previousValue, originalItem, index) => ({ previousValue, originalItem, index }),
+)
+return results`;
+  const agent = {
+    async run() {
+      throw new Error("recoverable first-stage failure");
+    },
+  };
+
+  const result = await runWorkflow<Array<{ previousValue: null; originalItem: string; index: number }>>(script, {
+    agent,
+    persistLogs: false,
+  });
+
+  assert.deepEqual(
+    Array.from(result.result, ({ previousValue, originalItem, index }) => ({ previousValue, originalItem, index })),
+    [{ previousValue: null, originalItem: "alpha", index: 0 }],
+  );
+});
+
 test("runWorkflow agent with different labels", async () => {
   const script = `export const meta = { name: 'label_test', description: 'labels' }
 const a = await agent('task1', { label: 'worker-1' })
@@ -904,6 +929,17 @@ test("parse-time guard rejects literal Date.now / Math.random / new Date()", asy
       /deterministic|unavailable/i,
       `${expr} literal should be rejected at parse time`,
     );
+  }
+});
+
+test("parse-time guard preserves the source blocklist used by existing workflows", () => {
+  for (const forbidden of ["Date.now()", "Math.random()", "new Date()"]) {
+    const script = `export const meta = { name: 'blocked-prose', description: 'fixture' }
+// ${forbidden} is unavailable here.
+const warning = ${JSON.stringify(`Do not call ${forbidden}`)}
+return { warning }`;
+
+    assert.throws(() => parseWorkflowScript(script), /deterministic|unavailable/i);
   }
 });
 

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -6,22 +6,27 @@ import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
-import {
-  backgroundStartedText,
-  createWorkflowTool,
-  modelRoutingGuideline,
-  WORKFLOW_GATE_GUIDELINE,
-  workflowHowToGuidelines,
-} from "../src/workflow-tool.js";
+import { backgroundStartedText, createWorkflowTool, WORKFLOW_GATE_GUIDELINE } from "../src/workflow-tool.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
-/** Minimal fake ModelRegistry, matching the shape the PR's existing tests use. */
+/** Minimal fake ModelRegistry, matching the shape used by workflow manager tests. */
 function fakeRegistry(models: Array<{ provider: string; id: string }>) {
   return {
     getAvailable: () => models,
     find: () => undefined,
     getAll: () => models,
   } as any;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parameterDescription(tool: ReturnType<typeof createWorkflowTool>, name: string): string {
+  const parameters = tool.parameters;
+  const properties = isRecord(parameters) && isRecord(parameters.properties) ? parameters.properties : {};
+  const parameter = properties[name];
+  return isRecord(parameter) && typeof parameter.description === "string" ? parameter.description : "";
 }
 
 // ─── backgroundStartedText ─────────────────────────────────────────────────────
@@ -44,10 +49,12 @@ test("createWorkflowTool has correct name and label", () => {
   assert.equal(tool.label, "Workflow");
 });
 
-test("createWorkflowTool has description", () => {
-  const tool = createWorkflowTool();
-  assert.ok(tool.description, "description should be truthy");
-  assert.ok(tool.description.length > 20, "tool.description should be more than 20");
+test("createWorkflowTool description states its delegation capability", () => {
+  const description = createWorkflowTool().description;
+
+  assert.match(description, /JavaScript workflow.*delegates work to subagents/i);
+  assert.match(description, /agent\(\).*optionally composing calls.*parallel\(\).*pipeline\(\)/i);
+  assert.doesNotMatch(description, /deterministic|required raw JavaScript|export const meta/i);
 });
 
 test("createWorkflowTool has parameters defined", () => {
@@ -66,139 +73,117 @@ test("createWorkflowTool has renderCall and renderResult", () => {
   assert.equal(typeof tool.renderResult, "function");
 });
 
-test("createWorkflowTool has promptSnippet", () => {
+test("createWorkflowTool promptSnippet describes delegation and optional composition", () => {
+  const snippet = createWorkflowTool().promptSnippet;
+
+  assert.match(snippet, /delegate substantive .* work to subagents/i);
+  assert.match(snippet, /optionally composing agent calls/i);
+  assert.match(snippet, /parallel\(\)/);
+  assert.match(snippet, /pipeline\(\)/);
+  assert.match(snippet, /or both/i);
+  assert.doesNotMatch(snippet, /required script header|export const meta/i);
+});
+
+test("createWorkflowTool keeps permanent guidance to the single upstream gate", () => {
+  const guidance = createWorkflowTool().promptGuidelines;
+
+  assert.deepEqual(guidance, [WORKFLOW_GATE_GUIDELINE]);
+  assert.match(guidance[0], /ONLY call it when the user explicitly opts in/i);
+  assert.match(guidance[0], /you may briefly offer it \(with a rough cost\)/i);
+  assert.doesNotMatch(guidance[0], /export const meta|parallel\(\) requires functions/i);
+});
+
+test("createWorkflowTool permanent guidance omits conditional catalogs and recipes", () => {
+  const all = createWorkflowTool().promptGuidelines.join(" ");
+
+  assert.doesNotMatch(all, /Available agentTypes:/i);
+  assert.doesNotMatch(all, /currently available models/i);
+  assert.doesNotMatch(all, /verify\(|judgePanel\(|loopUntilDry\(|completenessCheck\(/i);
+  assert.doesNotMatch(all, /tokenBudget|agentTimeoutMs|agentRetries/i);
+});
+
+test("createWorkflowTool keeps script syntax in the parameter schema", () => {
   const tool = createWorkflowTool();
-  assert.ok(tool.promptSnippet, "promptSnippet should be truthy");
-  assert.ok(tool.promptSnippet.includes("workflow"), "should contain workflow");
-});
+  const description = parameterDescription(tool, "script");
 
-test("createWorkflowTool always-on promptGuidelines is only the single gate line", () => {
-  const tool = createWorkflowTool();
-  assert.ok(Array.isArray(tool.promptGuidelines), "tool.promptGuidelines should be an array");
-  // #65 / #88: the always-on prompt is a single opt-in gate; the ~20 how-to lines
-  // are NOT always-on — they live in workflowHowToGuidelines (armed-turn only).
-  assert.equal(tool.promptGuidelines.length, 1, "always-on guidelines should be a single gate line");
-  assert.equal(tool.promptGuidelines[0], WORKFLOW_GATE_GUIDELINE);
-  assert.match(tool.promptGuidelines[0], /ONLY call it when the user explicitly opts in/);
-  // The how-to mechanics must NOT be always-on.
-  const all = tool.promptGuidelines.join(" ");
-  assert.doesNotMatch(all, /export const meta = \{/, "meta how-to must not be always-on");
-  assert.doesNotMatch(all, /parallel\(\) takes functions/, "parallel how-to must not be always-on");
-});
-
-test("workflowHowToGuidelines carries the full how-to for an armed turn", () => {
-  const guidelines = workflowHowToGuidelines();
-  assert.ok(Array.isArray(guidelines), "workflowHowToGuidelines should be an array");
-  assert.ok(guidelines.length > 5, "should have several how-to guidelines");
-});
-
-// #P4 (R3): the always-on gate must OFFER rather than FORCE, and must include
-// task-shape positives so it doesn't lean toward under-triggering off-keyword.
-test("WORKFLOW_GATE_GUIDELINE offers (not forces) and carries task-shape positives", () => {
-  const gate = WORKFLOW_GATE_GUIDELINE;
-  // Offer-with-cost, not force.
-  assert.match(gate, /you may briefly offer it \(with a rough cost\)/i, "keeps the non-forcing offer");
-  assert.ok(!/\bMUST\b/.test(gate), "the gate must not force with MUST");
-  // Keeps the explicit-opt-in gate + the negative.
-  assert.match(gate, /ONLY call it when the user explicitly opts in/i);
-  assert.match(gate, /even one that would clearly benefit — do not call it/i);
-  // Task-shape positives (#P4).
-  assert.match(gate, /repo-wide inspection/i);
-  assert.match(gate, /independent parallel research\/checks/i);
-  assert.match(gate, /multi-perspective review/i);
-  assert.match(gate, /fan-out\/fan-in synthesis/i);
-});
-
-// #P2: the how-to mechanics now live in the tool's static description (visible
-// whenever the model looks at the tool), NOT in the always-on prompt.
-test("createWorkflowTool folds the how-to into the tool description", () => {
-  const tool = createWorkflowTool();
-  assert.match(tool.description, /How to write the script:/);
-  assert.match(tool.description, /export const meta = \{/, "meta how-to should be in the description");
-  assert.match(
-    tool.description,
-    /parallel\(\) takes functions, not promises/,
-    "mechanics how-to should be in the description",
+  assert.match(description, /raw JavaScript workflow script.*no Markdown fences/i);
+  assert.match(description, /First statement: export const meta = \{ name:.*description:.*\}\. Add phases:/i);
+  assert.doesNotMatch(
+    description,
+    /First statement: export const meta = \{ name: '[^']+', description: '[^']+', phases:/i,
   );
-  // And it must NOT have leaked back into the always-on gate.
-  assert.doesNotMatch(tool.promptGuidelines.join(" "), /export const meta = \{/);
+  assert.match(description, /phases.*only when.*named phases.*declare only phases it will use/i);
+  assert.match(description, /multiple phases.*phase\('Exact Title'\).*agent options/i);
+  assert.match(description, /await workflow\(savedName, childArgs\).*saved workflow inline/i);
+  assert.match(description, /nesting.*one level.*parent run's concurrency, agent, and token limits/i);
+  assert.match(
+    description,
+    /Optional quality helpers include verify\(\), judgePanel\(\), loopUntilDry\(\), and completenessCheck\(\)/i,
+  );
+  assert.match(description, /Optional control helpers include retry\(\) and gate\(\)/i);
+  assert.match(description, /budget exposes total, spent\(\), and remaining\(\)/i);
+  assert.match(description, /phase\('Name', \{ budget: N \}\).*phase token limit/i);
+  assert.match(description, /optional `agentType` option.*named user or project definition/i);
+  assert.match(description, /bind tools, a model, and role instructions/i);
+  assert.match(description, /name and purpose.*provided in context/i);
+  assert.match(description, /bound model overrides `tier`.*explicit `model` overrides both/i);
+  assert.match(description, /plain JavaScript only.*imports.*require\(\).*filesystem modules/i);
+  assert.match(description, /Date\.now\(\).*Math\.random\(\).*new Date\(\).*unavailable/i);
+  assert.match(description, /args, cwd, process\.cwd\(\), and budget/i);
+  assert.match(description, /must call agent\(\) at least once/i);
+  assert.match(description, /parallel\(\) requires functions, not promises.*results in input order/i);
+  assert.match(description, /pipeline\(items, \.\.\.stages\).*stages sequentially.*items proceed concurrently/i);
+  assert.match(description, /each stage receives.*previousValue.*originalItem.*index/i);
+
+  const guidance = tool.promptGuidelines.join(" ");
+  assert.doesNotMatch(guidance, /Markdown fences|First statement: export const meta/i);
+  assert.doesNotMatch(guidance, /Date\.now\(\)|Math\.random\(\)|new Date\(\)/i);
+  assert.doesNotMatch(guidance, /parallel\(\) requires functions, not promises|results in input order/i);
+  assert.doesNotMatch(guidance, /each stage receives.*previousValue.*originalItem.*index/i);
 });
 
-test("workflowHowToGuidelines routes normal work through tiers and reserves exact models for user requests", () => {
-  const all = workflowHowToGuidelines().join(" ");
-
-  assert.match(all, /opts\.tier/);
-  assert.match(all, /small.+medium.+big/s);
-  assert.match(all, /opts\.model only when the user names/i);
-});
-
-test("workflowHowToGuidelines keep budget and timeout unbounded by default", () => {
-  const all = workflowHowToGuidelines().join(" ");
-  assert.match(all, /do not set tokenBudget or agentTimeoutMs/i);
-  // Unbounded unless the user configured settings defaults (#68).
-  assert.match(all, /runs are unbounded/i);
-  assert.match(all, /defaultTokenBudget/);
-});
-
-test("createWorkflowTool schema describes unbounded default timeout", () => {
+test("createWorkflowTool keeps background behavior in the parameter schema", () => {
   const tool = createWorkflowTool();
-  const parameters = tool.parameters as { properties?: Record<string, { description?: string }> };
-  const description = parameters.properties?.agentTimeoutMs?.description ?? "";
-  assert.match(description, /Omit for no hard timeout/i);
+  const description = parameterDescription(tool, "background");
+
+  assert.match(description, /Default: true/i);
+  assert.match(description, /result is delivered back.*when it finishes/i);
+  assert.match(description, /false only when.*result inline.*same turn/i);
+  assert.doesNotMatch(tool.promptGuidelines.join(" "), /runs are background by default/i);
+});
+
+test("createWorkflowTool schema describes the configured or unbounded timeout", () => {
+  const tool = createWorkflowTool();
+  const description = parameterDescription(tool, "agentTimeoutMs");
+
+  assert.match(description, /Omit to use configured `defaultAgentTimeoutMs`/i);
+  assert.match(description, /without one.*no hard timeout/i);
   assert.match(description, /only when the user asks/i);
 });
 
-test("createWorkflowTool schema exposes concurrency and agentRetries", () => {
+test("createWorkflowTool schema describes the configured or unlimited token budget", () => {
   const tool = createWorkflowTool();
-  const parameters = tool.parameters as { properties?: Record<string, { description?: string }> };
+  const description = parameterDescription(tool, "tokenBudget");
 
-  assert.match(parameters.properties?.concurrency?.description ?? "", /Maximum concurrent agents/i);
-  assert.match(parameters.properties?.agentRetries?.description ?? "", /Retry attempts/i);
+  assert.match(description, /soft pre-call token gate/i);
+  assert.match(description, /concurrent in-flight work can overshoot/i);
+  assert.match(description, /Omit to use configured `defaultTokenBudget`/i);
+  assert.match(description, /without one.*unlimited/i);
+  assert.match(description, /only when the user asks/i);
 });
 
-test("workflowHowToGuidelines mention retry and concurrency controls", () => {
-  const all = workflowHowToGuidelines().join(" ");
+test("createWorkflowTool schema exposes resource controls and large-fan-out authority", () => {
+  const tool = createWorkflowTool();
 
-  assert.match(all, /low concurrency/i);
-  assert.match(all, /agentRetries/i);
-  assert.match(all, /null handling/i);
-});
-
-// ─── modelRoutingGuideline ──────────────────────────────────────────────────────
-
-test("modelRoutingGuideline mentions all three tier names", () => {
-  const text = modelRoutingGuideline();
-  assert.ok(text.includes("small"), "should mention small tier");
-  assert.ok(text.includes("medium"), "should mention medium tier");
-  assert.ok(text.includes("big"), "should mention big tier");
-});
-
-test("modelRoutingGuideline describes each tier purpose", () => {
-  const text = modelRoutingGuideline();
-  assert.ok(text.includes("lightweight"), "should contain lightweight");
-  assert.ok(text.includes("balanced"), "should contain balanced");
-  assert.ok(text.includes("synthesis"), "should contain synthesis");
-});
-
-test("modelRoutingGuideline explains tier vs model priority", () => {
-  const text = modelRoutingGuideline();
-  assert.ok(text.includes("opts.tier"), "should mention opts.tier");
-  assert.ok(text.includes("opts.model"), "should mention opts.model");
-  assert.ok(
-    /opts\.(tier|model).+opts\.(model|tier)/.test(text),
-    "should explain ordering / relationship between tier and model",
-  );
-});
-
-test("modelRoutingGuideline explains when to use each option", () => {
-  const text = modelRoutingGuideline();
-  assert.ok(/small.*(exploration|search|inventory|agents)/i.test(text), "small tier should mention light workloads");
-  assert.ok(/big.*(synthesis|judgment|decision)/i.test(text), "big tier should mention heavy reasoning");
+  assert.match(parameterDescription(tool, "concurrency"), /Maximum concurrent agents/i);
+  assert.match(parameterDescription(tool, "agentRetries"), /Retry attempts/i);
+  assert.match(parameterDescription(tool, "maxAgents"), /1000.*safety ceiling, not a target/i);
+  assert.match(parameterDescription(tool, "maxAgents"), /lower limit.*dynamic or exploratory fan-out/i);
+  assert.match(parameterDescription(tool, "maxAgents"), /large fan-outs.*explicit user intent/i);
 });
 
 test("createWorkflowTool invalid args throws descriptive error", () => {
   const tool = createWorkflowTool();
-  // We can test prepareArguments through the tool definition
   if (tool.prepareArguments) {
     const prepare = tool.prepareArguments as (args: unknown) => unknown;
     assert.throws(() => prepare({ script: 123 }), /script.*string/);
@@ -211,7 +196,7 @@ test("createWorkflowTool with custom cwd creates tool", () => {
   assert.equal(tool.name, "workflow");
 });
 
-test("createWorkflowTool does not add configured model IDs to promptGuidelines", () => {
+test("createWorkflowTool does not add configured model IDs to permanent guidance", () => {
   const manager = new WorkflowManager({ cwd: "/tmp" });
   manager.setModelRegistry(fakeRegistry([{ provider: "router", id: "private-model" }]));
   const tool = createWorkflowTool({ cwd: "/tmp", manager });
@@ -220,14 +205,6 @@ test("createWorkflowTool does not add configured model IDs to promptGuidelines",
 
   manager.setModelRegistry(fakeRegistry([{ provider: "router", id: "later-private-model" }]));
   assert.doesNotMatch(tool.promptGuidelines.join(" "), /router\/later-private-model/);
-});
-
-test("modelRoutingGuideline output is non-empty and well-formed", () => {
-  const text = modelRoutingGuideline();
-  assert.ok(text.length > 50, "should be a substantial instruction");
-  assert.ok(text.endsWith(".") || text.endsWith("") || text.endsWith("`"), "should end properly");
-  assert.ok(!text.includes("undefined"), "no undefined interpolation");
-  assert.ok(!text.includes("[object Object]"), "no object serialization leaks");
 });
 
 // ─── prepareArguments / normalizeWorkflowScript ─────────────────────────────────

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["scripts/**/*.ts", "src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- add one executable capability contract for workflow globals, tool inputs, option shapes, lifecycle constraints, static references, and dynamic catalogue ownership;
- assemble project-owned workflow globals through that contract while preserving the existing runtime closures and VM behavior;
- ship a package-discovered `workflow-authoring` skill with focused references and 11 runtime-tested examples;
- generate capability publications and context measurements, then enforce version, package, link, coverage, runtime-alignment, and freshness checks during normal tests and publishing;
- keep provider-backed comprehension optional while adding model-free replay, capability-coverage protection, and delivery-choice evidence.

Closes #65.

Implements the capability-contract design from [Whamp/pi-dynamic-workflows#22](https://github.com/Whamp/pi-dynamic-workflows/issues/22). Adds evidence for the background-versus-inline decision discussed in #89 without changing #93's trigger authorization behavior.

## Context impact

Compared with `origin/main` at `818fdd8`:

| Surface | Main | This PR | Change |
| --- | ---: | ---: | ---: |
| Permanent workflow prompt | 766 bytes | 742 bytes | -24 |
| Provider-visible workflow tool definition | 9,558 bytes | 3,802 bytes | -5,756 |
| Skill discovery | 0 bytes | 338 bytes | +338 |
| Ordinary workflow-owned always-on total | 10,324 bytes | 4,882 bytes | **-5,442 (-52.7%)** |

Detailed authoring guidance now loads on demand. In the comparative nine-model coverage sample, the optimized skill loaded a median 2,564 tokens versus 8,096 for the pre-trim skill, a 68.3% reduction.

See [`docs/workflow-prompt-guidance-rationale.md`](docs/workflow-prompt-guidance-rationale.md) for the reviewed record of prompt insertions, removals, and compactions. See [`docs/workflow-authoring-evidence.md`](docs/workflow-authoring-evidence.md) for methodology, model matrix, per-scenario results, and reproduction commands.

## Capability and quality evidence

- The capability contract inventories the 18 curated project-owned globals and all current workflow-tool inputs, including `resumeFromRunId`.
- Runtime assembly rejects missing declared implementations, reports and ignores undeclared ones, and preserves implementation identity.
- Live model and `agentType` values remain outside static prompts and generated references.
- The installed skill contains focused write/edit/review/debug routes, exact generated facts, six orchestration patterns, four focused recipes, and a dedicated validated-`gate()` recipe.
- Every stable authoring surface is either covered behaviorally or protected as guidance-frozen.
- Optional comprehension prompts do not name the skill; generated workflows run through the real parser/runtime with deterministic fake agents.

Post-tuning provider-backed validation:

- pre-trim skill: **73/81**;
- optimized skill: **74/81**;
- generate-and-filter: **27/27** optimized versus **26/27** pre-trim;
- all seven configurations other than Qwen and Spark: **63/63** optimized;
- protected GPT-5.4 Mini/Luna coverage gate: **18/18**;
- protected GPT-5.4 Mini/Luna six-scenario core gate: **36/36**.

This is not an independent holdout: the same scenario families informed the guidance changes. An earlier corrected-harness sample scored pre-trim at 75/81 and optimized at 71/81, so provider scores remain sampled, non-blocking evidence. The final candidate did not repeat the earlier nine-model, 162-case core panel.

The delivery-choice harness has deterministic tests and an optional provider CLI; this PR reports no provider-run delivery-choice result. Provider calls are not part of normal tests, release checks, or publishing.

## Compatibility

- preserves #93's single opt-in `promptGuidelines` gate and default background delivery;
- preserves the existing truthy-object `gate().ok` compatibility path;
- preserves the existing regex determinism blocklist and VM substrate;
- keeps `console` available for saved workflows while teaching `log()`;
- changes no live model-route or `agentType` configuration format;
- adds no migration state, feature flag, or dual-running path.

## Verification

- `npm run check`
- `npm run build`
- `npm test` — **1,027/1,027 passed**
- `npm run docs:check`
- `npm run context:check`
- `npm run guidance:check`
- `npm run release:verify` — **0 warnings**
- `npm pack --dry-run` — 166 files; all 27 workflow-authoring skill files included
- `git diff --check`
- CodeGraph changed-file cycle and boundary checks

The PR is one atomic commit based on current `origin/main`. Raw `.auto` experiment data is intentionally excluded from both the commit and package.

