### PR TITLE
feat: merge /workflows-progress-max into /workflows-progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ Pi can manage background runs directly with the `workflow_control` tool instead 
 | `/workflows save <name>` | Save the latest script as a reusable command |
 | `/workflows-trigger off\|on\|status` | Control automatic keyword triggering |
 | `/workflows-trigger set <word>\|reset` | Set or reset the trigger word |
-| `/workflows-progress compact\|detailed\|status` | Choose the live-panel detail level, including fresh/cache token splits |
-| `/workflows-progress-max <N>` | Limit agents shown per phase in detailed mode |
+| `/workflows-progress compact\|detailed\|status\|max <N>` | Live-panel detail level (and max agents shown per phase in detailed mode) |
 | `/workflows-models` | Map model tiers and thinking levels |
 | `/ultracode [off]` | Toggle exhaustive automatic workflows |
 | `/effort off\|high\|ultra` | Set the standing orchestration effort |

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -237,9 +237,9 @@ export function registerWorkflowTriggerCommand(
 }
 
 /**
- * Register the bottom progress-panel preference commands:
+ * Register the bottom progress-panel preference command:
  *  - `/workflows-progress compact|detailed|status` — switch (or report) the panel mode.
- *  - `/workflows-progress-max <1-1000>` — cap agents shown per phase in detailed mode.
+ *  - `/workflows-progress max <1-1000>` — cap agents shown per phase in detailed mode.
  * Both persist via `settingsStore` and take effect on the next live run (the panel
  * live-reads its settings), so no session restart is needed.
  */
@@ -248,47 +248,48 @@ export function registerWorkflowProgressCommands(
   settingsStore: WorkflowSettingsStore = DEFAULT_SETTINGS_STORE,
 ): void {
   pi.registerCommand?.("workflows-progress", {
-    description: "Bottom progress panel: compact | detailed | status",
+    description: "Bottom progress panel: compact | detailed | status | max <N>",
     async handler(args: string, _ctx: ExtensionCommandContext) {
-      const arg = args.trim().toLowerCase();
+      const trimmed = args.trim();
       const say = (content: string) => pi.sendMessage({ customType: "workflows-progress", content, display: true });
-      if (arg === "compact" || arg === "detailed") {
-        const saved = persistProgressSettings(settingsStore, { progressPanelMode: arg });
+      const spaceIdx = trimmed.indexOf(" ");
+      const verb = (spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx)).toLowerCase();
+      const rest = spaceIdx === -1 ? "" : trimmed.slice(spaceIdx + 1).trim();
+
+      if (verb === "compact" || verb === "detailed") {
+        const saved = persistProgressSettings(settingsStore, { progressPanelMode: verb });
         await say(
           saved
-            ? `Workflow progress panel set to ${arg} — takes effect on the next render of a live run (no restart needed).`
-            : `Workflow progress panel set to ${arg} for this session, but the preference could not be saved.`,
+            ? `Workflow progress panel set to ${verb} — takes effect on the next render of a live run (no restart needed).`
+            : `Workflow progress panel set to ${verb} for this session, but the preference could not be saved.`,
         );
         return;
       }
-      await say(
-        `Workflow progress panel is ${loadProgressMode(settingsStore)}. Usage: /workflows-progress compact | detailed | status`,
-      );
-    },
-  });
 
-  pi.registerCommand?.("workflows-progress-max", {
-    description: "Max agents shown per phase in detailed progress mode (1-1000)",
-    async handler(args: string, _ctx: ExtensionCommandContext) {
-      const arg = args.trim();
-      const say = (content: string) => pi.sendMessage({ customType: "workflows-progress", content, display: true });
-      if (!arg) {
+      if (verb === "max") {
+        if (!rest) {
+          await say(
+            `Detailed progress shows up to ${loadProgressMaxAgents(settingsStore)} agents per phase. Usage: /workflows-progress max <1-1000>`,
+          );
+          return;
+        }
+        const n = Number.parseInt(rest, 10);
+        if (!Number.isFinite(n) || n < 1) {
+          await say(`Invalid value "${rest}". Usage: /workflows-progress max <1-1000> (a whole number ≥ 1).`);
+          return;
+        }
+        const clamped = Math.min(1000, n);
+        const saved = persistProgressSettings(settingsStore, { progressPanelMaxAgents: clamped });
         await say(
-          `Detailed progress shows up to ${loadProgressMaxAgents(settingsStore)} agents per phase. Usage: /workflows-progress-max <1-1000>`,
+          saved
+            ? `Detailed progress now shows up to ${clamped} agents per phase.`
+            : `Set to ${clamped} for this session, but the preference could not be saved.`,
         );
         return;
       }
-      const n = Number.parseInt(arg, 10);
-      if (!Number.isFinite(n) || n < 1) {
-        await say(`Invalid value "${arg}". Usage: /workflows-progress-max <1-1000> (a whole number ≥ 1).`);
-        return;
-      }
-      const clamped = Math.min(1000, n);
-      const saved = persistProgressSettings(settingsStore, { progressPanelMaxAgents: clamped });
+
       await say(
-        saved
-          ? `Detailed progress now shows up to ${clamped} agents per phase.`
-          : `Set to ${clamped} for this session, but the preference could not be saved.`,
+        `Workflow progress panel is ${loadProgressMode(settingsStore)}, showing up to ${loadProgressMaxAgents(settingsStore)} agents per phase. Usage: /workflows-progress compact | detailed | status | max <N>`,
       );
     },
   });

--- a/tests/workflow-editor.test.ts
+++ b/tests/workflow-editor.test.ts
@@ -915,7 +915,17 @@ describe("registerWorkflowProgressCommands", () => {
     return { commands, sent, settingsStore, getSettings: () => settings, pi };
   }
 
-  it("persists a valid mode and reports the current one on status", async () => {
+  it("registers a single merged /workflows-progress command (no separate -max command)", async () => {
+    const mod = await load();
+    const { commands, settingsStore, pi } = setup();
+    mod.registerWorkflowProgressCommands(pi, settingsStore);
+
+    assert.ok(commands.get("workflows-progress"), "registers /workflows-progress");
+    assert.equal(commands.get("workflows-progress-max"), undefined, "no separate /workflows-progress-max command");
+    assert.equal(commands.size, 1, "only one command is registered");
+  });
+
+  it("persists a valid mode and reports both mode and max on status", async () => {
     const mod = await load();
     const { commands, sent, settingsStore, getSettings, pi } = setup();
     mod.registerWorkflowProgressCommands(pi, settingsStore);
@@ -927,11 +937,20 @@ describe("registerWorkflowProgressCommands", () => {
     assert.deepEqual(getSettings(), { progressPanelMode: "detailed" });
     assert.match(sent.at(-1)?.content ?? "", /detailed/i);
 
+    await cmd.handler("compact", {});
+    assert.deepEqual(getSettings(), { progressPanelMode: "compact" });
+    assert.match(sent.at(-1)?.content ?? "", /compact/i);
+
     await cmd.handler("status", {});
-    assert.match(sent.at(-1)?.content ?? "", /panel is detailed/i);
+    assert.match(sent.at(-1)?.content ?? "", /panel is compact/i);
+    assert.match(sent.at(-1)?.content ?? "", /up to \d+ agents per phase/i);
+
+    await cmd.handler("", {});
+    assert.match(sent.at(-1)?.content ?? "", /panel is compact/i);
+    assert.match(sent.at(-1)?.content ?? "", /Usage: \/workflows-progress compact \| detailed \| status \| max <N>/);
   });
 
-  it("ignores an invalid mode without persisting", async () => {
+  it("ignores an invalid/unrecognized subverb without persisting, reporting current status", async () => {
     const mod = await load();
     const { commands, sent, settingsStore, getSettings, pi } = setup();
     mod.registerWorkflowProgressCommands(pi, settingsStore);
@@ -941,22 +960,56 @@ describe("registerWorkflowProgressCommands", () => {
     assert.match(sent.at(-1)?.content ?? "", /Usage:/);
   });
 
-  it("clamps and persists the per-phase agent cap, rejecting non-numbers", async () => {
+  it("max <N> clamps and persists the per-phase agent cap, rejecting non-numbers", async () => {
     const mod = await load();
     const { commands, sent, settingsStore, getSettings, pi } = setup();
     mod.registerWorkflowProgressCommands(pi, settingsStore);
 
-    const cmd = commands.get("workflows-progress-max");
-    assert.ok(cmd, "registers /workflows-progress-max");
+    const cmd = commands.get("workflows-progress");
+    assert.ok(cmd, "registers /workflows-progress");
 
-    await cmd.handler("5000", {});
+    await cmd.handler("max 12", {});
+    assert.deepEqual(getSettings(), { progressPanelMaxAgents: 12 });
+    assert.match(sent.at(-1)?.content ?? "", /up to 12 agents per phase/);
+
+    await cmd.handler("max 5000", {});
     assert.deepEqual(getSettings(), { progressPanelMaxAgents: 1000 }, "clamps to 1000");
 
-    await cmd.handler("abc", {});
+    await cmd.handler("max abc", {});
     assert.match(sent.at(-1)?.content ?? "", /Invalid value/);
     assert.deepEqual(getSettings(), { progressPanelMaxAgents: 1000 }, "invalid value does not overwrite");
 
-    await cmd.handler("0", {});
+    await cmd.handler("max 0", {});
     assert.match(sent.at(-1)?.content ?? "", /Invalid value/);
+    assert.deepEqual(getSettings(), { progressPanelMaxAgents: 1000 }, "invalid value does not overwrite");
+  });
+
+  it("max with no number reports the current max and usage", async () => {
+    const mod = await load();
+    const { commands, sent, settingsStore, pi } = setup();
+    mod.registerWorkflowProgressCommands(pi, settingsStore);
+
+    const cmd = commands.get("workflows-progress");
+    assert.ok(cmd, "registers /workflows-progress");
+
+    await cmd.handler("max", {});
+    assert.match(sent.at(-1)?.content ?? "", /shows up to \d+ agents per phase/);
+    assert.match(sent.at(-1)?.content ?? "", /Usage: \/workflows-progress max <1-1000>/);
+  });
+
+  it("is case-insensitive for subverbs", async () => {
+    const mod = await load();
+    const { commands, sent, settingsStore, getSettings, pi } = setup();
+    mod.registerWorkflowProgressCommands(pi, settingsStore);
+
+    const cmd = commands.get("workflows-progress");
+    assert.ok(cmd, "registers /workflows-progress");
+
+    await cmd.handler("DETAILED", {});
+    assert.deepEqual(getSettings(), { progressPanelMode: "detailed" });
+
+    await cmd.handler("MAX 7", {});
+    assert.deepEqual(getSettings(), { progressPanelMode: "detailed", progressPanelMaxAgents: 7 });
+    assert.match(sent.at(-1)?.content ?? "", /up to 7 agents per phase/);
   });
 });


### PR DESCRIPTION
A small UX-maturity cleanup: two top-level commands for the live progress panel become one.

`/workflows-progress` now takes `compact | detailed | status | max <N>`, and the separate `/workflows-progress-max` command is removed (12 → 11 top-level commands).

Behavior is preserved verbatim:
- `compact` / `detailed` — set the panel mode (same confirmations).
- `max <N>` — parse int, reject `<1`/non-numeric, clamp to 1000 (same wording as the old `-max`).
- `status` / no-arg — now reports **both** the mode and the max in one line.

Settings (`progressPanelMode` / `progressPanelMaxAgents`) and the task panel that reads them are untouched — only the command surface changes.

Note: `/workflows-progress-max` is gone (folded into `/workflows-progress max`). Minor user-facing command change.

tsc clean, biome clean, `npm test` **921/921**.
