### PR TITLE
chore: tidy two leftovers from the editor-ownership removal (#101)

### DIFF
--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -234,7 +234,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
     //
     // CAVEAT: the off-keyword natural-language path only sees this description if
     // the host keeps the `workflow` tool in its default active tool set. The
-    // arming paths add the tool on arm (installWorkflowEditor's setActiveTools),
+    // arming paths add the tool on arm (installWorkflowKeywordArming's setActiveTools),
     // but a bare natural-language opt-in with no arm relies on the tool already
     // being active in the host's config — keep `workflow` default-active so the
     // gate line's "fan this out" promise (mechanics available) holds.

--- a/tests/workflow-tools-available.test.ts
+++ b/tests/workflow-tools-available.test.ts
@@ -388,8 +388,6 @@ describe("workflow extension - control tool availability", () => {
             sessionManager: { getSessionId: () => "session-1" },
             ui: {
               setWidget: () => {},
-              getEditorComponent: () => undefined,
-              setEditorComponent: () => {},
             },
           },
         );


### PR DESCRIPTION
Two cosmetic leftovers from #101, no behavior change: (1) a stale comment in `workflow-tool.ts` still referenced the old `installWorkflowEditor` name (now `installWorkflowKeywordArming`); (2) a test's `ui` mock still provided `getEditorComponent`/`setEditorComponent` stubs that nothing consumes anymore (editor wiring is gone) — dropped them, kept `setWidget` for `installTaskPanel`. Verified: zero remaining editor-injection refs in src/tests, tsc + biome clean, tests green.