### PR TITLE
fix: clean up terminal runs from in-memory Map to prevent unbounded memory growth

### DIFF
--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -342,6 +342,11 @@ export class WorkflowManager extends EventEmitter {
     return this.executeRun(managed, script, args, exec);
   }
 
+  /** Drop terminal runs from memory after persist; keep paused for resume. */
+  private _cleanupRun(managed: ManagedRun): void {
+    if (managed.status !== "paused") this.runs.delete(managed.runId);
+  }
+
   /** Build a fresh managed run with an empty snapshot. */
   private createManaged(script: string, args?: unknown): ManagedRun {
     const parsed = parseWorkflowScript(script);
@@ -521,6 +526,7 @@ export class WorkflowManager extends EventEmitter {
       // Persist final state
       this.persistRun(managed);
       this.releaseRunLease(managed);
+      this._cleanupRun(managed);
 
       return result;
     } catch (error) {
@@ -565,6 +571,7 @@ export class WorkflowManager extends EventEmitter {
       // Persist final state
       this.persistRun(managed);
       this.releaseRunLease(managed);
+      this._cleanupRun(managed);
 
       throw workflowError;
     }


### PR DESCRIPTION
## Problem

`WorkflowManager.runs` Map accumulates `ManagedRun` objects indefinitely. After each workflow completes, the in-memory `ManagedRun` — holding agent results, journal JSON, logs, and snapshots — is persisted to disk but **never removed from the Map**. 

Each completed run retains ~60–80MB of heap. With 50+ workflows in a long-running Pi session, the heap grows without bound and the process becomes unstable.

## Fix

Added `_cleanupRun(managed)` — a single private method called after `persistRun()` + `releaseRunLease()` in both the success and error paths. Terminal runs (completed / failed / aborted) are removed from the in-memory Map; paused runs are preserved for resume.

The design is safe because:

- **Persisted JSON covers status lookups** — `listRuns()` already reads from disk. All consumers (`/workflows status`, `workflow_control` tool, Navigator, Task Panel) gracefully fall back to persisted state when `getRun()` returns undefined.
- **No functional regression** — only terminal runs are removed; active and paused runs remain in the Map for stop/pause/resume to operate on.
- **The codebase was already designed for this** — the two-layer model (memory Map for active runs, disk JSON for history) already existed; this fix just closes the loop.

## Changes

`src/workflow-manager.ts` (+9 lines):

- New `private _cleanupRun(managed: ManagedRun): void` (line 346)
- Called after `persistRun()` + `releaseRunLease()` in completed path (line 529)
- Called after `persistRun()` + `releaseRunLease()` in error path — only if status !== paused (line 574)

## Verification

Memory monitoring across 3 trivial workflows before and after the fix:

| Before fix | # | runs in Map | heap |
|---|---|---|---|
| | 1 | 1 | 338MB |
| | 2 | 2 | 402MB |
| | 3 | **3** | 482MB |

| After fix | # | runs in Map | heap |
|---|---|---|---|
| | 1 | 1 | 422MB |
| | 2 | 2 | 538MB |
| | 3 | **1** | 406MB (−132MB GC) |

`runs` no longer monotonically increases; GC successfully reclaims freed `ManagedRun` memory.