### PR TITLE
fix: harden /workflows against corrupt data (#110), stop autoResume counter runaway (#106), deny recursive orchestration tools in subagents (#107)

### DIFF
--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -34,6 +34,9 @@ export default function extension(pi: ExtensionAPI) {
     toolsets: {
       "web-research": () => [...createCodingTools(cwd), ...createWebTools()],
     },
+    // On top of the always-on workflow/workflow_control denial in subagents
+    // (#107), let users block additional recursive-orchestration tools.
+    excludeSubagentTools: settings.excludeSubagentTools,
     defaultAgentTimeoutMs: settings.defaultAgentTimeoutMs ?? null,
     defaultTokenBudget: settings.defaultTokenBudget ?? null,
     concurrency: settings.defaultConcurrency,

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -205,6 +205,13 @@ export interface WorkflowAgentOptions {
   cwd?: string;
   /** Extra tools available to the subagent in addition to the structured output tool. */
   tools?: ToolDefinition[];
+  /**
+   * Extra tool NAMES to deny in the subagent session, on top of the always-on
+   * defaults ({@link DEFAULT_EXCLUDED_SUBAGENT_TOOLS}). Lets the host exclude
+   * other recursive-orchestration tools it registers (e.g. a pi-subagents tool)
+   * so a workflow subagent can't fan out through them either (#107).
+   */
+  excludeTools?: string[];
   /** Override any createAgentSession option (model, modelRuntime, resourceLoader, etc.). */
   session?: Partial<CreateAgentSessionOptions>;
   /** Extra system guidance prepended to every subagent task. */
@@ -468,9 +475,22 @@ export type AgentRunResult<TSchemaDef extends TSchema | undefined> = TSchemaDef 
   ? Static<TSchemaDef>
   : string;
 
+/**
+ * Orchestration tools ALWAYS denied to workflow subagents. The `workflow` and
+ * `workflow_control` tools are registered globally by the extension, so — unless
+ * excluded — a subagent's session sees them and can start its own independent
+ * background workflows. Those nested runs recursively fan out and are NOT bounded
+ * by the parent run's maxAgents / concurrency / progress / accounting, and can
+ * drain a shared provider quota and pile up paused runs (#107). Callers may deny
+ * additional tool names via WorkflowAgentOptions.excludeTools.
+ */
+export const DEFAULT_EXCLUDED_SUBAGENT_TOOLS = ["workflow", "workflow_control"];
+
 export class WorkflowAgent {
   private readonly cwd: string;
   private readonly baseTools: ToolDefinition[];
+  /** Extra subagent tool-name denylist, merged with the always-on defaults. */
+  private readonly excludeTools: string[];
   private readonly sessionOptions: Partial<CreateAgentSessionOptions>;
   private readonly persistAgentSessions: boolean;
   private readonly instructions?: string;
@@ -489,6 +509,7 @@ export class WorkflowAgent {
   constructor(options: WorkflowAgentOptions = {}) {
     this.cwd = options.cwd ?? process.cwd();
     this.baseTools = options.tools ?? createCodingTools(this.cwd);
+    this.excludeTools = options.excludeTools ?? [];
     this.sessionOptions = options.session ?? {};
     this.persistAgentSessions = options.persistAgentSessions ?? false;
     this.instructions = options.instructions;
@@ -671,6 +692,14 @@ export class WorkflowAgent {
       // Per-call model/thinking wins over any sessionOptions defaults.
       ...(resolvedModel ? { model: resolvedModel } : {}),
       ...(resolvedThinkingLevel ? { thinkingLevel: resolvedThinkingLevel } : {}),
+      // Deny recursive-orchestration tools in the subagent (#107). Placed after
+      // the sessionOptions spread so it always applies; folds in any denylist
+      // the caller set on sessionOptions rather than dropping it.
+      excludeTools: [
+        ...DEFAULT_EXCLUDED_SUBAGENT_TOOLS,
+        ...(this.sessionOptions.excludeTools ?? []),
+        ...this.excludeTools,
+      ],
     });
 
     // Name the persisted session so it's identifiable in session pickers.

--- a/src/usage-limit-scheduler.ts
+++ b/src/usage-limit-scheduler.ts
@@ -264,11 +264,22 @@ export class UsageLimitScheduler {
 
     if (params.attempts > this.maxAttempts) {
       const alreadyLogged = existing?.gaveUp === true;
-      this.state.set(runId, { attempts: params.attempts, gaveUp: true });
-      this.persistAttempts(runId, params.attempts);
-      if (!alreadyLogged) {
+      // Freeze the counter at a single sentinel (maxAttempts + 1) instead of
+      // storing the raw overflow. coldStartRearm() reads the persisted count and
+      // adds 1 on every restart; without this clamp a given-up run's counter
+      // grew without bound (…6, 7, 8… → "giving up after 23") across cold starts
+      // (#106). Clamping makes the persisted value idempotent — a rearm of an
+      // already-given-up run rewrites the same 6.
+      const frozen = this.maxAttempts + 1;
+      this.state.set(runId, { attempts: frozen, gaveUp: true });
+      this.persistAttempts(runId, frozen);
+      // Log the give-up exactly once per crossing. In-process the gaveUp flag
+      // guards it; across restarts a fresh scheduler has no memory, so also
+      // suppress when this arm is merely re-giving-up an already-capped run
+      // (params.attempts already past the sentinel, i.e. prior was ≥ frozen).
+      if (!alreadyLogged && params.attempts <= frozen) {
         this.diagnostic(
-          `[usage-limit-scheduler] ${runId}: giving up after ${params.attempts - 1} auto-resume attempt(s) ` +
+          `[usage-limit-scheduler] ${runId}: giving up after ${this.maxAttempts} auto-resume attempt(s) ` +
             `(max ${this.maxAttempts}); leaving paused for manual resume`,
         );
       }

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -142,6 +142,13 @@ export interface WorkflowManagerOptions {
    */
   toolsets?: Record<string, () => ToolDefinition[]>;
   /**
+   * Extra tool NAMES to deny in every subagent session, on top of the always-on
+   * `workflow`/`workflow_control` defaults (see DEFAULT_EXCLUDED_SUBAGENT_TOOLS).
+   * Host wiring passes settings.excludeSubagentTools here so users can also block
+   * other recursive-orchestration tools (#107).
+   */
+  excludeSubagentTools?: string[];
+  /**
    * Persist each subagent transcript as a real pi session file under the
    * standard sessions directory. Default false (in-memory, discarded).
    */
@@ -165,6 +172,7 @@ export class WorkflowManager extends EventEmitter {
   private defaultAgentRetries: number;
   private defaultTokenBudget: number | null;
   private toolsets?: Record<string, () => ToolDefinition[]>;
+  private excludeSubagentTools?: string[];
   private persistAgentSessions: boolean;
 
   constructor(options: WorkflowManagerOptions = {}) {
@@ -180,6 +188,7 @@ export class WorkflowManager extends EventEmitter {
     this.defaultAgentRetries = options.defaultAgentRetries ?? 0;
     this.defaultTokenBudget = options.defaultTokenBudget ?? null;
     this.toolsets = options.toolsets;
+    this.excludeSubagentTools = options.excludeSubagentTools;
     this.persistAgentSessions = options.persistAgentSessions ?? false;
     this.persistence = createRunPersistence(this.cwd);
     this.recoverStaleRuns();
@@ -433,6 +442,7 @@ export class WorkflowManager extends EventEmitter {
         agentTimeoutMs: resolvedAgentTimeoutMs,
         tokenBudget: resolvedTokenBudget,
         tools: resolvedTools,
+        excludeTools: this.excludeSubagentTools,
         confirm,
         loadSavedWorkflow: this.loadSavedWorkflow,
         resumeJournal,

--- a/src/workflow-settings.ts
+++ b/src/workflow-settings.ts
@@ -42,6 +42,13 @@ export interface WorkflowSettings {
    * `summary`/`synthesis` fields are never truncated.
    */
   deliveredResultMaxChars?: number;
+  /**
+   * Extra tool names to deny in workflow subagent sessions, on top of the
+   * always-on `workflow`/`workflow_control` defaults (#107). Use it to block
+   * other recursive-orchestration tools you have installed (e.g. a pi-subagents
+   * tool) so a subagent can't fan out through them.
+   */
+  excludeSubagentTools?: string[];
 }
 
 export interface WorkflowSettingsStore {
@@ -164,6 +171,10 @@ function normalizeSettings(value: unknown): WorkflowSettings {
   }
   const deliveredResultMaxChars = normalizeInteger(raw.deliveredResultMaxChars, 1, 1_000_000);
   if (deliveredResultMaxChars !== undefined) settings.deliveredResultMaxChars = deliveredResultMaxChars;
+  if (Array.isArray(raw.excludeSubagentTools)) {
+    const names = raw.excludeSubagentTools.filter((t): t is string => typeof t === "string" && t.trim().length > 0);
+    if (names.length) settings.excludeSubagentTools = names;
+  }
   return settings;
 }
 

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -80,10 +80,22 @@ interface AgentRow {
 }
 
 /** Short, human-friendly model label: drop the provider prefix for display. */
+/**
+ * Coerce a possibly-non-string value from a (corrupt) persisted run to a string,
+ * so it can never reach a downstream truncateToWidth()/visibleWidth() as a
+ * non-string and crash the whole /workflows overlay via text.slice() (#110).
+ * Applied at every Model read boundary that feeds the renderer: phase titles,
+ * agent labels/phases, and run names.
+ */
+function asText(v: unknown): string {
+  return typeof v === "string" ? v : String(v ?? "");
+}
+
 export function shortModel(model: string | undefined): string | undefined {
   if (!model) return undefined;
-  const slash = model.indexOf("/");
-  return slash > 0 ? model.slice(slash + 1) : model;
+  const m = asText(model);
+  const slash = m.indexOf("/");
+  return slash > 0 ? m.slice(slash + 1) : m;
 }
 
 /** Reads run/phase/agent data from the manager, preferring live snapshots. */
@@ -104,7 +116,11 @@ export class NavigatorModel {
   runs(): RunRow[] {
     return this.manager.listRuns().map((p) => {
       const live = this.manager.getRun(p.runId);
-      const agents = (live?.snapshot.agents ?? p.agents) as WorkflowAgentSnapshot[];
+      // Array guard (#110): a structurally corrupt persisted run (agents not an
+      // array) would otherwise throw "agents is not iterable" here and crash the
+      // runs list itself — i.e. /workflows would fail to open at all.
+      const rawAgents = live?.snapshot.agents ?? p.agents;
+      const agents = (Array.isArray(rawAgents) ? rawAgents : []) as WorkflowAgentSnapshot[];
       const usage = live?.snapshot.tokenUsage ?? p.tokenUsage;
       // The run-level aggregate is authoritative but only lands when the run
       // ends; per-agent figures update live. Use whichever accounts for more
@@ -116,7 +132,7 @@ export class NavigatorModel {
         fromAgents.fresh + fromAgents.cacheRead > fromUsage.fresh + fromUsage.cacheRead ? fromAgents : fromUsage;
       return {
         runId: p.runId,
-        name: live?.snapshot.name ?? p.workflowName,
+        name: asText(live?.snapshot.name ?? p.workflowName),
         status: live?.status ?? p.status,
         done: agents.filter((a) => a.status === "done").length,
         total: agents.length,
@@ -140,20 +156,27 @@ export class NavigatorModel {
   }
 
   runName(runId: string): string {
-    return this.snapshot(runId)?.snapshot.name ?? runId;
+    return asText(this.snapshot(runId)?.snapshot.name ?? runId);
   }
 
   runStatus(runId: string): string {
-    return this.snapshot(runId)?.status ?? "unknown";
+    // Coerce (#110): a corrupt persisted run can carry a non-string status, which
+    // would otherwise crash twoPaneHeader's truncateToWidth() with text.slice().
+    return asText(this.snapshot(runId)?.status ?? "unknown");
   }
 
   phases(runId: string): PhaseRow[] {
     const snap = this.snapshot(runId)?.snapshot;
     if (!snap) return [];
-    const order = snap.phases.length ? [...snap.phases] : [];
+    // Coerce phase keys up front (#110): a non-string phase — from a corrupt
+    // persisted run or a script that passed a non-string to phase() — would
+    // otherwise reach truncateToWidth() and crash the overlay. Coercing the
+    // grouping key too (not just the output title) keeps agents grouped under the
+    // same string the drilled-in agents() filter compares against.
+    const order = snap.phases.length ? snap.phases.map(asText) : [];
     const byPhase = new Map<string, AgentRow[]>();
     for (const a of snap.agents) {
-      const key = a.phase ?? "(no phase)";
+      const key = a.phase != null ? asText(a.phase) : "(no phase)";
       if (!byPhase.has(key)) byPhase.set(key, []);
       byPhase.get(key)?.push(a);
       if (!order.includes(key)) order.push(key);
@@ -162,7 +185,7 @@ export class NavigatorModel {
       const agents = byPhase.get(title) ?? [];
       const usage = aggregateAgentUsage(agents);
       return {
-        title,
+        title, // already coerced to a string above
         done: agents.filter((a) => a.status === "done").length,
         total: agents.length,
         fresh: usage.fresh,
@@ -175,12 +198,14 @@ export class NavigatorModel {
     const snap = this.snapshot(runId)?.snapshot;
     if (!snap) return [];
     return snap.agents
-      .filter((a) => (a.phase ?? "(no phase)") === phase)
+      .filter((a) => (a.phase != null ? asText(a.phase) : "(no phase)") === phase)
       .map((a) => ({
         id: a.id,
-        label: a.label,
+        // Coerce label/phase at the boundary so a non-string value from a corrupt
+        // run can't crash the agent row's truncateToWidth() (#110).
+        label: asText(a.label),
         status: a.status,
-        phase: a.phase,
+        phase: a.phase != null ? asText(a.phase) : a.phase,
         tokens: a.tokens,
         tokenUsage: a.tokenUsage,
         model: a.model,
@@ -202,12 +227,15 @@ type StackFrame = {
 };
 
 function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
+  // Array guards (#110): a structurally corrupt persisted run (phases/logs/agents
+  // not arrays) would otherwise throw when mapped/spread and crash the overlay.
+  const agents = Array.isArray(p.agents) ? p.agents : [];
   return {
-    name: p.workflowName,
-    phases: p.phases,
+    name: asText(p.workflowName),
+    phases: Array.isArray(p.phases) ? p.phases : [],
     currentPhase: p.currentPhase,
-    logs: p.logs,
-    agents: p.agents.map((a) => ({
+    logs: Array.isArray(p.logs) ? p.logs : [],
+    agents: agents.map((a) => ({
       id: a.id,
       label: a.label,
       phase: a.phase,
@@ -223,10 +251,10 @@ function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
       tokenUsage: a.tokenUsage,
       model: a.model,
     })),
-    agentCount: p.agents.length,
-    runningCount: p.agents.filter((a) => a.status === "running").length,
-    doneCount: p.agents.filter((a) => a.status === "done").length,
-    errorCount: p.agents.filter((a) => a.status === "error").length,
+    agentCount: agents.length,
+    runningCount: agents.filter((a) => a.status === "running").length,
+    doneCount: agents.filter((a) => a.status === "done").length,
+    errorCount: agents.filter((a) => a.status === "error").length,
     tokenUsage: p.tokenUsage ? { ...p.tokenUsage } : undefined,
     runId: p.runId,
   };
@@ -817,19 +845,26 @@ export function renderNavigator(
     const a = model.agentDetail(state.runId, state.agentId);
     lines.push(theme.bold(a ? a.label : "agent"));
     if (a) {
+      // Coerce every dynamic value before wrap() (#110): a non-string prompt is
+      // reachable even from a LIVE run — agent(42) in a model-written script is
+      // never type-checked — and would crash wrap()'s text.split(). Persisted
+      // error/status/history text can be non-string on a corrupt run too.
       const body: string[] = [];
-      body.push(dim("Status: ") + (a.status ?? ""));
+      body.push(dim("Status: ") + asText(a.status ?? ""));
       if (a.model) body.push(dim("Model: ") + (shortModel(a.model) ?? ""));
-      if (a.error) body.push(dim("Error: ") + a.error);
+      if (a.error) body.push(dim("Error: ") + asText(a.error));
       if (a.errorCode) body.push(`${dim("Error code: ")}${a.errorCode}${a.recoverable ? " (recoverable)" : ""}`);
       body.push("", dim("Prompt:"));
-      body.push(...wrap(a.prompt ?? "", width));
+      body.push(...wrap(asText(a.prompt ?? ""), width));
       body.push("", dim("Result:"));
-      body.push(...wrap(a.resultPreview ?? "(none)", width));
+      body.push(...wrap(asText(a.resultPreview ?? "(none)"), width));
       if (a.history?.length) {
         body.push("", dim("History:"));
         for (const entry of a.history) {
-          body.push(...wrap(`${historyLabel(entry)}: ${entry.text}`, width));
+          // Skip a null/primitive element from a corrupt persisted history —
+          // historyLabel() reads entry.kind and would throw on it (#110).
+          if (!entry || typeof entry !== "object") continue;
+          body.push(...wrap(`${historyLabel(entry)}: ${asText(entry.text)}`, width));
         }
       }
       pushScrollable(body);
@@ -840,12 +875,13 @@ export function renderNavigator(
     lines.push(theme.bold(w ? w.name : "saved workflow"));
     if (w) {
       const body: string[] = [];
-      if (w.description) body.push(dim("Description: ") + w.description);
+      if (w.description) body.push(dim("Description: ") + asText(w.description));
       body.push(dim("Location: ") + (w.location === "user" ? "user (~/.pi)" : "project (.pi)"));
-      body.push(dim("Saved at: ") + w.savedAt);
+      body.push(dim("Saved at: ") + asText(w.savedAt));
       if (w.parameters) body.push(dim("Parameters: ") + JSON.stringify(w.parameters));
       body.push("", dim("Script:"));
-      body.push(...wrap(w.script, width));
+      // Coerce (#110): corrupt saved-workflow JSON can carry a non-string script.
+      body.push(...wrap(asText(w.script), width));
       pushScrollable(body);
     }
   }

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -6,7 +6,13 @@ import test from "node:test";
 import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
 import type { AgentRunOptions, AgentUsage } from "../src/agent.js";
-import { listAvailableModelSpecs, resolveAgentModelSpec, usageFromStats, WorkflowAgent } from "../src/agent.js";
+import {
+  DEFAULT_EXCLUDED_SUBAGENT_TOOLS,
+  listAvailableModelSpecs,
+  resolveAgentModelSpec,
+  usageFromStats,
+  WorkflowAgent,
+} from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { resolveModelSpecWithThinking } from "../src/model-spec.js";
 import type { ModelTierConfig } from "../src/model-tier-config.js";
@@ -300,6 +306,7 @@ test("WorkflowAgent constructor accepts all option shapes without throwing", () 
     { cwd: "/tmp" },
     { cwd: "/tmp", instructions: "custom instruction" },
     { cwd: "/tmp", tools: [], session: {}, instructions: "test" },
+    { cwd: "/tmp", excludeTools: ["pi-subagents"] },
     { cwd: "/tmp", mainModel: "openai/gpt-4.1" },
     { cwd: "/tmp", tools: [], session: {}, instructions: "test", mainModel: "openai/gpt-4.1" },
     {
@@ -315,6 +322,14 @@ test("WorkflowAgent constructor accepts all option shapes without throwing", () 
     const agent = opts ? new WorkflowAgent(opts) : new WorkflowAgent();
     assert.ok(agent instanceof WorkflowAgent, `agent should be constructed for options: ${JSON.stringify(opts)}`);
   }
+});
+
+test("DEFAULT_EXCLUDED_SUBAGENT_TOOLS denies the recursive orchestration tools (#107)", () => {
+  // Subagents must never see the globally-registered orchestration tools, or they
+  // could start independent nested workflows that bypass the parent run's caps.
+  // This is the always-on denylist folded into every subagent session; the guard
+  // is a regression fence so it can't be silently narrowed.
+  assert.deepEqual(DEFAULT_EXCLUDED_SUBAGENT_TOOLS, ["workflow", "workflow_control"]);
 });
 
 test("WorkflowAgent reuses an injected ModelRegistry instead of building its own", async () => {

--- a/tests/usage-limit-scheduler.test.ts
+++ b/tests/usage-limit-scheduler.test.ts
@@ -258,6 +258,89 @@ test("attempt cap reached: gives up, arms no further timers", async () => {
   scheduler.dispose();
 });
 
+test("cold start past the cap: no growth, no timer, no repeated give-up log (#106)", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(
+    makeRun({
+      status: "paused",
+      pauseReason: "usage_limit",
+      resetHint: "resets in 1m",
+      autoResumeAttempts: 4, // already past the cap (maxAttempts 3 → sentinel 4)
+    }),
+  );
+  const diagnostics: string[] = [];
+
+  // Several Pi restarts, each a fresh scheduler (= a cold start). Before the fix,
+  // coldStartRearm() did prior+1 and arm() persisted the raw overflow, so the
+  // counter climbed (5, 6, 7…) and a give-up line printed on every boot.
+  for (let restart = 0; restart < 3; restart++) {
+    const clock = createFakeClock();
+    const scheduler = new UsageLimitScheduler(manager, {
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      onDiagnostic: (m) => diagnostics.push(m),
+      ...TUNABLES,
+    });
+    await flush();
+    assert.equal(clock.pendingCount(), 0, `restart ${restart}: no timer armed past the cap`);
+    assert.equal(
+      manager.persistence.get("run-1")?.autoResumeAttempts,
+      4,
+      `restart ${restart}: attempts frozen at the sentinel, never incremented`,
+    );
+    scheduler.dispose();
+  }
+
+  assert.equal(
+    diagnostics.filter((m) => m.includes("giving up")).length,
+    0,
+    "an already-given-up run must not re-log the give-up diagnostic on every cold start",
+  );
+});
+
+test("cold start crossing the cap logs give-up exactly once, then freezes (#106)", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(
+    makeRun({
+      status: "paused",
+      pauseReason: "usage_limit",
+      resetHint: "resets in 1m",
+      autoResumeAttempts: 3, // exactly at maxAttempts — the next arm crosses the cap
+    }),
+  );
+  const diagnostics: string[] = [];
+  const boot = async () => {
+    const clock = createFakeClock();
+    const scheduler = new UsageLimitScheduler(manager, {
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      onDiagnostic: (m) => diagnostics.push(m),
+      ...TUNABLES,
+    });
+    await flush();
+    return { clock, scheduler };
+  };
+
+  const first = await boot();
+  assert.equal(first.clock.pendingCount(), 0, "crossing the cap arms no timer");
+  first.scheduler.dispose();
+  const second = await boot();
+  second.scheduler.dispose();
+
+  assert.equal(
+    manager.persistence.get("run-1")?.autoResumeAttempts,
+    4,
+    "counter freezes at the sentinel (maxAttempts + 1), not 5+",
+  );
+  assert.equal(
+    diagnostics.filter((m) => m.includes("giving up")).length,
+    1,
+    "give-up logs once at the crossing, not again on the next cold start",
+  );
+});
+
 test("cold-start re-arm uses REMAINING time, not the full base delay", async () => {
   const manager = new FakeManager();
   const pausedAt = new Date(0);

--- a/tests/workflow-settings.test.ts
+++ b/tests/workflow-settings.test.ts
@@ -90,6 +90,25 @@ describe("workflow settings", () => {
     });
   });
 
+  it("loads and normalizes excludeSubagentTools, dropping non-string/blank entries (#107)", () => {
+    withSettingsPath((settingsPath) => {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+
+      writeFileSync(settingsPath, JSON.stringify({ excludeSubagentTools: ["pi-subagents", "spawn"] }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { excludeSubagentTools: ["pi-subagents", "spawn"] });
+
+      // Non-string and blank entries are filtered out.
+      writeFileSync(settingsPath, JSON.stringify({ excludeSubagentTools: ["keep", 42, "", "  ", null] }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), { excludeSubagentTools: ["keep"] });
+
+      // An all-invalid (or empty) list yields no key at all.
+      writeFileSync(settingsPath, JSON.stringify({ excludeSubagentTools: [1, 2, ""] }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+      writeFileSync(settingsPath, JSON.stringify({ excludeSubagentTools: "nope" }), "utf-8");
+      assert.deepEqual(loadWorkflowSettings(settingsPath), {});
+    });
+  });
+
   it("normalizes default concurrency and agent retries", () => {
     withSettingsPath((settingsPath) => {
       mkdirSync(dirname(settingsPath), { recursive: true });

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -267,6 +267,221 @@ test("NavigatorState drills runs -> phases -> agents -> detail and back", () => 
   assert.equal(state.back(), false, "back at top returns false (caller closes)");
 });
 
+test("non-string phase titles are coerced, so the navigator never crashes on bad data (#110)", () => {
+  // A corrupt persisted run (or a script that passed a non-string to phase())
+  // could put a non-string into snapshot.phases. It used to reach the SDK's
+  // truncateToWidth(), whose text.slice() threw and crashed the whole overlay.
+  const snapshot: WorkflowSnapshot = {
+    name: "wf",
+    phases: [42 as unknown as string, "Real Phase"],
+    currentPhase: "Real Phase",
+    logs: [],
+    agents: [],
+    agentCount: 0,
+    runningCount: 0,
+    doneCount: 0,
+    errorCount: 0,
+  };
+  const manager: Pick<WorkflowManager, "listRuns" | "getRun"> = {
+    listRuns: () => [
+      {
+        runId: "run-bad",
+        workflowName: "wf",
+        status: "running",
+        phases: snapshot.phases,
+        agents: [],
+        logs: [],
+      } as unknown as PersistedRunState,
+    ],
+    getRun: (id: string) =>
+      id === "run-bad" ? ({ runId: "run-bad", status: "running", snapshot } as unknown as ManagedRun) : undefined,
+  };
+  const model = new NavigatorModel(manager as unknown as WorkflowManager);
+
+  // Data boundary coerces the bad title to a string.
+  const phases = model.phases("run-bad");
+  assert.equal(phases[0].title, "42", "non-string title is coerced to a string");
+  assert.equal(phases[1].title, "Real Phase");
+
+  // Render the exact path that crashed: drilled into the run's phases view.
+  const state = new NavigatorState();
+  assert.ok(state.drill(model), "drill into the run's phases");
+  assert.equal(state.kind, "phases");
+  assert.doesNotThrow(() => renderNavigator(state, model, 80), "rendering must not throw on a non-string title");
+});
+
+test("non-string agent labels and run names are coerced too, not just phase titles (#110)", () => {
+  // Same corrupt-data root cause reaches truncateToWidth() via the agent row
+  // (a.label) and the two-pane header (run name), not only the phase title.
+  const snapshot: WorkflowSnapshot = {
+    name: 999 as unknown as string, // non-string run name → header truncateToWidth
+    phases: ["Work"],
+    currentPhase: "Work",
+    logs: [],
+    agents: [
+      {
+        id: 1,
+        label: 42 as unknown as string, // non-string agent label → agent-row truncateToWidth
+        phase: "Work",
+        prompt: "do it",
+        status: "running",
+        tokens: 0,
+      },
+    ],
+    agentCount: 1,
+    runningCount: 1,
+    doneCount: 0,
+    errorCount: 0,
+  };
+  const manager: Pick<WorkflowManager, "listRuns" | "getRun"> = {
+    listRuns: () => [
+      {
+        runId: "run-corrupt",
+        workflowName: 999 as unknown as string,
+        status: "running",
+        phases: ["Work"],
+        agents: snapshot.agents,
+        logs: [],
+      } as unknown as PersistedRunState,
+    ],
+    getRun: (id: string) =>
+      id === "run-corrupt"
+        ? ({ runId: "run-corrupt", status: "running", snapshot } as unknown as ManagedRun)
+        : undefined,
+  };
+  const model = new NavigatorModel(manager as unknown as WorkflowManager);
+
+  assert.equal(model.runName("run-corrupt"), "999", "non-string run name coerced");
+  assert.equal(model.runs()[0].name, "999", "non-string name coerced in the runs list too");
+  assert.equal(model.agents("run-corrupt", "Work")[0].label, "42", "non-string agent label coerced");
+
+  // The agent grouped under the coerced phase key stays reachable (no lookup drift).
+  assert.equal(model.phases("run-corrupt")[0].total, 1, "agent stays grouped under its phase");
+
+  // Render every view — runs list, phases, and the drilled agent row/header.
+  const state = new NavigatorState();
+  assert.doesNotThrow(() => renderNavigator(state, model, 80), "runs list must not throw");
+  assert.ok(state.drill(model));
+  assert.doesNotThrow(() => renderNavigator(state, model, 80), "phases + agent row + header must not throw");
+});
+
+test("structurally corrupt persisted runs never crash the navigator (#110)", () => {
+  // A non-string status crashed twoPaneHeader (same text.slice signature as #110);
+  // non-array agents/phases crashed the runs list itself so /workflows wouldn't
+  // even open. getRun() returns undefined to force the persisted path.
+  const manager: Pick<WorkflowManager, "listRuns" | "getRun"> = {
+    listRuns: () => [
+      {
+        runId: "corrupt-1",
+        workflowName: { bad: 1 } as unknown as string,
+        status: { obj: true } as unknown as string,
+        phases: null as unknown as string[],
+        agents: null as unknown as [],
+        logs: null as unknown as string[],
+      } as unknown as PersistedRunState,
+    ],
+    getRun: () => undefined,
+  };
+  const model = new NavigatorModel(manager as unknown as WorkflowManager);
+
+  assert.doesNotThrow(() => model.runs(), "runs() must not throw on non-array agents");
+  assert.equal(typeof model.runStatus("corrupt-1"), "string", "non-string status coerced");
+  assert.doesNotThrow(() => model.phases("corrupt-1"), "phases() must not throw on non-array phases");
+  assert.doesNotThrow(() => model.agents("corrupt-1", "x"), "agents() must not throw");
+
+  // The runs list must open, and drilling in must not crash either.
+  assert.doesNotThrow(() => renderNavigator(new NavigatorState(), model, 80), "runs list must render");
+  const state = new NavigatorState();
+  assert.ok(state.drill(model));
+  assert.doesNotThrow(() => renderNavigator(state, model, 80), "drilled view must render (non-string status header)");
+});
+
+test("non-string agent prompt in the detail view is coerced, reachable from a live run (#110)", () => {
+  // agent(42) in a model-written script is never type-checked, so a non-string
+  // prompt reaches the detail view's wrap() and used to crash text.split().
+  const snapshot: WorkflowSnapshot = {
+    name: "wf",
+    phases: ["P"],
+    currentPhase: "P",
+    logs: [],
+    agents: [{ id: 1, label: "a", phase: "P", prompt: 42 as unknown as string, status: "done", tokens: 0 }],
+    agentCount: 1,
+    runningCount: 0,
+    doneCount: 1,
+    errorCount: 0,
+  };
+  const manager: Pick<WorkflowManager, "listRuns" | "getRun"> = {
+    listRuns: () => [
+      {
+        runId: "live-1",
+        workflowName: "wf",
+        status: "running",
+        phases: ["P"],
+        agents: snapshot.agents,
+        logs: [],
+      } as unknown as PersistedRunState,
+    ],
+    getRun: (id: string) =>
+      id === "live-1" ? ({ runId: "live-1", status: "running", snapshot } as unknown as ManagedRun) : undefined,
+  };
+  const model = new NavigatorModel(manager as unknown as WorkflowManager);
+  const state = new NavigatorState();
+  assert.ok(state.drill(model)); // → phases
+  assert.ok(state.drill(model)); // → agents
+  assert.ok(state.drill(model)); // → detail
+  assert.equal(state.kind, "detail");
+  assert.doesNotThrow(() => renderNavigator(state, model, 80), "detail view must not throw on a non-string prompt");
+});
+
+test("a null/primitive element in a corrupt agent history doesn't crash the detail view (#110)", () => {
+  // historyLabel(entry) reads entry.kind; a null element (valid JSON from a
+  // corrupt persisted run) would throw. Live history never emits null entries.
+  const snapshot: WorkflowSnapshot = {
+    name: "wf",
+    phases: ["P"],
+    currentPhase: "P",
+    logs: [],
+    agents: [
+      {
+        id: 1,
+        label: "a",
+        phase: "P",
+        prompt: "do it",
+        status: "error",
+        history: [
+          null as unknown as { role: string; kind: string; text: string },
+          { role: "tool", kind: "toolResult", toolName: "read", text: "ok" },
+        ],
+      },
+    ],
+    agentCount: 1,
+    runningCount: 0,
+    doneCount: 0,
+    errorCount: 1,
+  };
+  const manager: Pick<WorkflowManager, "listRuns" | "getRun"> = {
+    listRuns: () => [
+      {
+        runId: "hist-1",
+        workflowName: "wf",
+        status: "completed",
+        phases: ["P"],
+        agents: snapshot.agents,
+        logs: [],
+      } as unknown as PersistedRunState,
+    ],
+    getRun: (id: string) =>
+      id === "hist-1" ? ({ runId: "hist-1", status: "completed", snapshot } as unknown as ManagedRun) : undefined,
+  };
+  const model = new NavigatorModel(manager as unknown as WorkflowManager);
+  const state = new NavigatorState();
+  assert.ok(state.drill(model));
+  assert.ok(state.drill(model));
+  assert.ok(state.drill(model));
+  assert.equal(state.kind, "detail");
+  assert.doesNotThrow(() => renderNavigator(state, model, 80), "null history entry must be skipped, not crash");
+});
+
 test("NavigatorState cursor wraps and detail scroll clamps at 0", () => {
   const model = new NavigatorModel(fakeManager());
   const state = new NavigatorState();


### PR DESCRIPTION
Closes #110. Closes #106. Closes #107.

Three independent bug fixes reported on 3.2.0. Each was root-caused, fixed, adversarially reviewed (twice, by an independent reviewer), and verified with a real pi run.

## #110 — `/workflows` overlay crashes with `text.slice is not a function`

The navigator passed values from persisted run data straight to the SDK's `truncateToWidth()`; a non-string value threw and took the whole overlay down. The reported crash (a phase title) was one corner of a broader gap — a non-string `status`, or a run whose `agents`/`phases`/`logs` wasn't an array, crashed it the same way, and in the non-array-`agents` case the runs list wouldn't even open.

Fix: coerce every dynamic value at the render boundary (`phases()` title + grouping key, `agents()` label/phase, `runs()`/`runName()` name, `runStatus()`, and the detail/saved views' prompt/result/error/history/script) via a small `asText()` helper, guard the array assumptions in `runs()`/`persistedToSnapshot()`, and skip null/primitive history entries. A non-string prompt is reachable from a **live** run too (`agent(42)` is never type-checked), which is why the guard is at the render boundary, not in persistence load.

## #106 — cold-start rearm increments `autoResumeAttempts` past the cap forever

A run past the auto-resume cap had its counter bumped on every Pi restart (`coldStartRearm` did `prior + 1`, and `arm()` persisted the raw overflow), so it climbed without bound and re-logged `giving up after N (max 5)` on each cold start.

Fix: `arm()`'s give-up branch freezes the persisted counter at a sentinel (`maxAttempts + 1`) and logs the give-up once at the crossing, not on every restart. Legacy inflated counters self-heal to the sentinel; raising `maxAttempts` later revives auto-resume.

## #107 — workflow subagents can recursively invoke `workflow` and bypass run limits

Subagent sessions inherited the globally-registered `workflow`/`workflow_control` tools, so a subagent could start independent nested runs that the parent's `maxAgents`/concurrency/accounting never bounded (reporter observed 174 persisted runs, 164 paused after the shared quota was drained).

Fix: `WorkflowAgent` passes `excludeTools` (default `workflow` + `workflow_control`) to `createAgentSession`; a new `excludeSubagentTools` setting denies additional orchestration tools (e.g. `pi-subagents`). Verified before/after with a real pi subagent — it listed the tools before the fix and did not after. Inline nested `workflow('name')` composition is unaffected: it runs in-process through the bounded DSL (shared limiter / maxAgents / token budget), not a subagent session.

## Verification

- 937 unit tests pass (new regressions for all three, incl. corrupt-data + live-path crash repros, cold-start-past-cap, and the subagent denylist).
- Two independent adversarial-review passes; the first found #110 was initially incomplete (agent label + run name + status + arrays), which is now covered.
- Real pi (pi 0.80.10 + deepseek): #107 before/after subagent tool-visibility contrast.

Note for library consumers: `registerBuiltinWorkflows` was already `{cwd, manager}` as of 3.2.0; this PR adds `WorkflowManagerOptions.excludeSubagentTools` and `WorkflowAgentOptions.excludeTools` (both optional, backward-compatible).

#109 (OOM) is tracked separately — it's largely in the SDK's `AgentSession.dispose()`; this repo already disposes sessions and caps per-agent history, and #107 removes the recursive-fan-out amplifier that made it acute.