### PR TITLE
fix: reject stale progress text as an unstructured agent's final result (#111)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -486,6 +486,17 @@ export type AgentRunResult<TSchemaDef extends TSchema | undefined> = TSchemaDef 
  */
 export const DEFAULT_EXCLUDED_SUBAGENT_TOOLS = ["workflow", "workflow_control"];
 
+/**
+ * The full subagent tool denylist: the always-on defaults plus any names the
+ * caller added (via WorkflowAgentOptions.excludeTools) or set on the injected
+ * session options. Extracted so the merge — and its order — is unit-testable;
+ * a spread-order regression that dropped the defaults would slip past a test
+ * that only asserts the constant. The SDK dedupes, so overlap is harmless.
+ */
+export function subagentExcludedTools(extra?: string[], sessionExclude?: string[]): string[] {
+  return [...DEFAULT_EXCLUDED_SUBAGENT_TOOLS, ...(sessionExclude ?? []), ...(extra ?? [])];
+}
+
 export class WorkflowAgent {
   private readonly cwd: string;
   private readonly baseTools: ToolDefinition[];
@@ -695,11 +706,7 @@ export class WorkflowAgent {
       // Deny recursive-orchestration tools in the subagent (#107). Placed after
       // the sessionOptions spread so it always applies; folds in any denylist
       // the caller set on sessionOptions rather than dropping it.
-      excludeTools: [
-        ...DEFAULT_EXCLUDED_SUBAGENT_TOOLS,
-        ...(this.sessionOptions.excludeTools ?? []),
-        ...this.excludeTools,
-      ],
+      excludeTools: subagentExcludedTools(this.excludeTools, this.sessionOptions.excludeTools),
     });
 
     // Name the persisted session so it's identifiable in session pickers.
@@ -750,7 +757,11 @@ export class WorkflowAgent {
         )) as AgentRunResult<TSchemaDef>;
       }
 
-      const text = this.lastAssistantText(session.messages);
+      // Unstructured result: require assistant text AFTER the last tool result.
+      // Text emitted before it is stale progress (the agent's last real action was
+      // a tool call) — accepting it would report an incomplete run as successful
+      // and suppress the AGENT_EMPTY_OUTPUT retry (#111).
+      const text = this.finalAssistantText(session.messages);
       if (!text.trim()) {
         throw new WorkflowError("Subagent produced no assistant output", WorkflowErrorCode.AGENT_EMPTY_OUTPUT, {
           recoverable: true,
@@ -804,6 +815,37 @@ export class WorkflowAgent {
 
   private lastAssistantText(messages: unknown[]): string {
     for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i] as Partial<AssistantMessage> | undefined;
+      if (message?.role !== "assistant" || !Array.isArray(message.content)) continue;
+      const text = message.content
+        .filter((part): part is TextContent => part.type === "text")
+        .map((part) => part.text)
+        .join("");
+      if (text.trim()) return text;
+    }
+    return "";
+  }
+
+  /**
+   * The unstructured agent's FINAL answer: assistant text that appears after the
+   * last tool result. Text before the final tool result is stale progress (the
+   * agent's last real action was a tool call, not answering), so returning it
+   * would mask an incomplete run and suppress AGENT_EMPTY_OUTPUT retries (#111).
+   *
+   * Distinct from lastAssistantText(), which stays deliberately lenient — the
+   * schema path's prose-JSON recovery (resolveStructuredOutput) may need to read
+   * the structured payload out of any assistant message, not only the terminal one.
+   */
+  private finalAssistantText(messages: unknown[]): string {
+    // Locate the last tool result; only assistant text strictly after it counts.
+    let lastToolResult = -1;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if ((messages[i] as { role?: string } | undefined)?.role === "toolResult") {
+        lastToolResult = i;
+        break;
+      }
+    }
+    for (let i = messages.length - 1; i > lastToolResult; i--) {
       const message = messages[i] as Partial<AssistantMessage> | undefined;
       if (message?.role !== "assistant" || !Array.isArray(message.content)) continue;
       const text = message.content

--- a/src/usage-limit-scheduler.ts
+++ b/src/usage-limit-scheduler.ts
@@ -147,12 +147,21 @@ export class UsageLimitScheduler {
 
   private readonly state = new Map<string, RunState>();
   private disposed = false;
+  /**
+   * Runs this scheduler is currently auto-resuming (its own timer fired). Used to
+   * tell an auto-resume's "resumed" event apart from a manual one: an auto-resume
+   * must keep the backoff counter (it IS the backoff), a manual resume resets it.
+   */
+  private readonly autoResumingRunIds = new Set<string>();
 
   private readonly onPaused = (event: { runId?: string; reason?: string; resetHint?: string }): void => {
     this.safe(() => this.handlePaused(event));
   };
   private readonly onTerminal = (event: { runId?: string }): void => {
     this.safe(() => this.cleanup(event?.runId));
+  };
+  private readonly onResumed = (event: { runId?: string }): void => {
+    this.safe(() => this.handleResumed(event));
   };
 
   constructor(manager: SchedulableWorkflowManager, options: UsageLimitSchedulerOptions = {}) {
@@ -171,6 +180,7 @@ export class UsageLimitScheduler {
       });
 
     this.manager.on("paused", this.onPaused);
+    this.manager.on("resumed", this.onResumed);
     this.manager.on("complete", this.onTerminal);
     this.manager.on("error", this.onTerminal);
     this.manager.on("stopped", this.onTerminal);
@@ -185,6 +195,7 @@ export class UsageLimitScheduler {
     if (this.disposed) return;
     this.disposed = true;
     this.manager.off("paused", this.onPaused);
+    this.manager.off("resumed", this.onResumed);
     this.manager.off("complete", this.onTerminal);
     this.manager.off("error", this.onTerminal);
     this.manager.off("stopped", this.onTerminal);
@@ -236,6 +247,21 @@ export class UsageLimitScheduler {
     const entry = this.state.get(runId);
     if (entry?.timer !== undefined) this.clearTimer(entry.timer);
     this.state.delete(runId);
+  }
+
+  /**
+   * A run was resumed. If WE resumed it (auto-resume timer fired), leave the
+   * backoff counter alone — that's the sequence doing its job, and it must still
+   * be able to reach the cap. If a human resumed it (via /workflows), treat that
+   * as a deliberate fresh start: drop the in-memory given-up state and reset the
+   * persisted counter so a later pause re-enters the normal backoff from attempt 1
+   * instead of staying silently given-up forever.
+   */
+  private handleResumed(event: { runId?: string }): void {
+    if (this.disposed || !event?.runId) return;
+    if (this.autoResumingRunIds.has(event.runId)) return;
+    this.cleanup(event.runId);
+    this.persistAttempts(event.runId, 0);
   }
 
   private coldStartRearm(): void {
@@ -308,11 +334,17 @@ export class UsageLimitScheduler {
     this.state.set(runId, { ...entry, timer: undefined });
 
     let resumed = false;
+    // Mark this as OUR resume so handleResumed() (fired synchronously inside
+    // resume(), before it returns) doesn't mistake it for a manual resume and
+    // reset the backoff counter mid-sequence.
+    this.autoResumingRunIds.add(runId);
     try {
       resumed = await this.manager.resume(runId);
     } catch (err) {
       this.diagnostic(`[usage-limit-scheduler] ${runId}: resume() threw`, err);
       resumed = false;
+    } finally {
+      this.autoResumingRunIds.delete(runId);
     }
     if (this.disposed) return;
 

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -91,6 +91,26 @@ function asText(v: unknown): string {
   return typeof v === "string" ? v : String(v ?? "");
 }
 
+/** The (coerced) phase an agent belongs to; "(no phase)" when unset. Shared by
+ *  agents()/agentsByPhase() so grouping and the drilled-in filter always agree. */
+function agentPhaseKey(a: WorkflowAgentSnapshot): string {
+  return a.phase != null ? asText(a.phase) : "(no phase)";
+}
+
+/** Build a render-safe AgentRow: coerce label/phase so a non-string value from a
+ *  corrupt run can't crash the agent row's truncateToWidth() (#110). */
+function toAgentRow(a: WorkflowAgentSnapshot): AgentRow {
+  return {
+    id: a.id,
+    label: asText(a.label),
+    status: a.status,
+    phase: a.phase != null ? asText(a.phase) : a.phase,
+    tokens: a.tokens,
+    tokenUsage: a.tokenUsage,
+    model: a.model,
+  };
+}
+
 export function shortModel(model: string | undefined): string | undefined {
   if (!model) return undefined;
   const m = asText(model);
@@ -170,13 +190,15 @@ export class NavigatorModel {
     if (!snap) return [];
     // Coerce phase keys up front (#110): a non-string phase — from a corrupt
     // persisted run or a script that passed a non-string to phase() — would
-    // otherwise reach truncateToWidth() and crash the overlay. Coercing the
-    // grouping key too (not just the output title) keeps agents grouped under the
-    // same string the drilled-in agents() filter compares against.
-    const order = snap.phases.length ? snap.phases.map(asText) : [];
+    // otherwise reach truncateToWidth() and crash the overlay. Grouping through
+    // the shared agentPhaseKey() (not an inline copy) locks the invariant that
+    // agents land under the same string the drilled-in agents() filter compares
+    // against; the Array.isArray guards mirror agents()/agentsByPhase().
+    const order = Array.isArray(snap.phases) ? snap.phases.map(asText) : [];
     const byPhase = new Map<string, AgentRow[]>();
-    for (const a of snap.agents) {
-      const key = a.phase != null ? asText(a.phase) : "(no phase)";
+    const agents = Array.isArray(snap.agents) ? snap.agents : [];
+    for (const a of agents) {
+      const key = agentPhaseKey(a);
       if (!byPhase.has(key)) byPhase.set(key, []);
       byPhase.get(key)?.push(a);
       if (!order.includes(key)) order.push(key);
@@ -196,20 +218,30 @@ export class NavigatorModel {
 
   agents(runId: string, phase: string): AgentRow[] {
     const snap = this.snapshot(runId)?.snapshot;
-    if (!snap) return [];
-    return snap.agents
-      .filter((a) => (a.phase != null ? asText(a.phase) : "(no phase)") === phase)
-      .map((a) => ({
-        id: a.id,
-        // Coerce label/phase at the boundary so a non-string value from a corrupt
-        // run can't crash the agent row's truncateToWidth() (#110).
-        label: asText(a.label),
-        status: a.status,
-        phase: a.phase != null ? asText(a.phase) : a.phase,
-        tokens: a.tokens,
-        tokenUsage: a.tokenUsage,
-        model: a.model,
-      }));
+    if (!snap || !Array.isArray(snap.agents)) return [];
+    return snap.agents.filter((a) => agentPhaseKey(a) === phase).map((a) => toAgentRow(a));
+  }
+
+  /**
+   * All agents grouped by their (coerced) phase in a SINGLE pass — O(agents).
+   * The navigator's phase pane needs each phase's agents (status colour + the
+   * selected phase's rows); calling agents() once per phase row was O(phases ×
+   * agents) per frame. Callers that render every phase use this instead.
+   */
+  agentsByPhase(runId: string): Map<string, AgentRow[]> {
+    const out = new Map<string, AgentRow[]>();
+    const snap = this.snapshot(runId)?.snapshot;
+    if (!snap || !Array.isArray(snap.agents)) return out;
+    for (const a of snap.agents) {
+      const key = agentPhaseKey(a);
+      let arr = out.get(key);
+      if (!arr) {
+        arr = [];
+        out.set(key, arr);
+      }
+      arr.push(toAgentRow(a));
+    }
+    return out;
   }
 
   agentDetail(runId: string, agentId: number): WorkflowAgentSnapshot | undefined {
@@ -621,13 +653,18 @@ function renderPhasesAgents(
   bodyCap: number,
 ): string[] {
   const phases = model.phases(runId);
+  // Group agents by phase ONCE per frame (O(agents)). leftPhaseRow needs each
+  // visible phase's agents (status colour) and the selected phase's agents drive
+  // the right pane; calling model.agents() per phase row was O(phases × agents).
+  const agentsByPhase = model.agentsByPhase(runId);
+  const agentsOf = (title: string): AgentRow[] => agentsByPhase.get(title) ?? [];
   // Which phase is selected drives the right pane. In "phases" view it's the
   // cursor; in "agents" view it's the drilled-in phase (state.phase).
   const inAgents = state.kind === "agents";
   let selPhaseIdx = inAgents ? phases.findIndex((p) => p.title === state.phase) : state.cursor;
   if (selPhaseIdx < 0) selPhaseIdx = 0;
   const selPhase = phases[selPhaseIdx];
-  const agents = selPhase ? model.agents(runId, selPhase.title) : [];
+  const agents = selPhase ? agentsOf(selPhase.title) : [];
 
   // Narrow-terminal degrade: single pane (spec §7.1).
   if (width < LW_MIN + RW_MIN - 1) {
@@ -654,7 +691,7 @@ function renderPhasesAgents(
     }
     const p = phases[idx];
     const selected = !inAgents && idx === state.cursor;
-    const ag = model.agents(runId, p.title);
+    const ag = agentsOf(p.title);
     let row = leftPhaseRow(p, idx, selected, ag, leftInner, theme);
     if (k === bodyRows - 1 && leftRows.more) {
       row = truncateToWidth(theme.fg("dim", `  ${ELLIPSIS}`), leftInner, "", true);

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_EXCLUDED_SUBAGENT_TOOLS,
   listAvailableModelSpecs,
   resolveAgentModelSpec,
+  subagentExcludedTools,
   usageFromStats,
   WorkflowAgent,
 } from "../src/agent.js";
@@ -23,6 +24,7 @@ import { withFakeHome, withFakeHomeAsync } from "./helpers/fake-home.js";
 type WorkflowAgentPrivates = {
   buildPrompt(prompt: string, options: AgentRunOptions<any>, structured: boolean): string;
   lastAssistantText(messages: unknown[]): string;
+  finalAssistantText(messages: unknown[]): string;
   createSessionManager(): { isPersisted(): boolean; getCwd(): string };
 };
 
@@ -330,6 +332,62 @@ test("DEFAULT_EXCLUDED_SUBAGENT_TOOLS denies the recursive orchestration tools (
   // This is the always-on denylist folded into every subagent session; the guard
   // is a regression fence so it can't be silently narrowed.
   assert.deepEqual(DEFAULT_EXCLUDED_SUBAGENT_TOOLS, ["workflow", "workflow_control"]);
+});
+
+test("subagentExcludedTools always includes the defaults, plus caller/session names (#107)", () => {
+  // This is what run() passes to createAgentSession as excludeTools. Fencing the
+  // merge here catches a spread-order regression that drops the defaults — which
+  // a deepEqual on the constant alone would miss.
+  assert.deepEqual(subagentExcludedTools(), ["workflow", "workflow_control"]);
+  assert.deepEqual(subagentExcludedTools(["pi-subagents"]), ["workflow", "workflow_control", "pi-subagents"]);
+  const merged = subagentExcludedTools(["extra"], ["session-denied"]);
+  assert.ok(merged.includes("workflow") && merged.includes("workflow_control"), "defaults are never dropped");
+  assert.ok(merged.includes("session-denied") && merged.includes("extra"), "both caller lists are folded in");
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// finalAssistantText — the unstructured result must come AFTER the last tool
+// result, so stale progress text can't be reported as a completed answer (#111)
+// ═══════════════════════════════════════════════════════════════════════
+
+const progressThenToolResult = [
+  { role: "assistant", content: [{ type: "text", text: "I'll inspect the repository now." }] },
+  { role: "assistant", content: [{ type: "toolCall", name: "bash", arguments: {} }] },
+  { role: "toolResult", toolName: "bash", content: [{ type: "text", text: "command output" }] },
+];
+
+test("finalAssistantText rejects progress text before a terminal tool result (#111)", () => {
+  const agent = new WorkflowAgent({ cwd: "/tmp" });
+  const text = (agent as unknown as WorkflowAgentPrivates).finalAssistantText(progressThenToolResult);
+  assert.equal(text, "", "text emitted before the final tool result is not a final answer");
+});
+
+test("finalAssistantText accepts a real assistant answer AFTER tools (#111)", () => {
+  const agent = new WorkflowAgent({ cwd: "/tmp" });
+  const messages = [
+    { role: "assistant", content: [{ type: "text", text: "Let me check." }] },
+    { role: "assistant", content: [{ type: "toolCall", name: "bash", arguments: {} }] },
+    { role: "toolResult", toolName: "bash", content: [{ type: "text", text: "output" }] },
+    { role: "assistant", content: [{ type: "text", text: "The answer is 42." }] },
+  ];
+  const text = (agent as unknown as WorkflowAgentPrivates).finalAssistantText(messages);
+  assert.equal(text, "The answer is 42.", "a genuine post-tool answer still counts");
+});
+
+test("finalAssistantText returns a plain answer when no tools were used (#111)", () => {
+  const agent = new WorkflowAgent({ cwd: "/tmp" });
+  const messages = [{ role: "assistant", content: [{ type: "text", text: "Direct answer." }] }];
+  const text = (agent as unknown as WorkflowAgentPrivates).finalAssistantText(messages);
+  assert.equal(text, "Direct answer.");
+});
+
+test("lastAssistantText stays lenient for schema prose extraction (unchanged by #111)", () => {
+  // The schema path's JSON recovery may read the payload from any assistant
+  // message, so lastAssistantText must NOT adopt finalAssistantText's stricter
+  // "after the last tool result" rule.
+  const agent = new WorkflowAgent({ cwd: "/tmp" });
+  const text = (agent as unknown as WorkflowAgentPrivates).lastAssistantText(progressThenToolResult);
+  assert.equal(text, "I'll inspect the repository now.", "lastAssistantText still finds earlier assistant text");
 });
 
 test("WorkflowAgent reuses an injected ModelRegistry instead of building its own", async () => {

--- a/tests/usage-limit-scheduler.test.ts
+++ b/tests/usage-limit-scheduler.test.ts
@@ -341,6 +341,68 @@ test("cold start crossing the cap logs give-up exactly once, then freezes (#106)
   );
 });
 
+test("a manual resume clears the given-up state and resets the counter", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(
+    makeRun({
+      status: "paused",
+      pauseReason: "usage_limit",
+      resetHint: "resets in 10m",
+      autoResumeAttempts: 4, // already given up (cap 3)
+    }),
+  );
+  const clock = createFakeClock();
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+  await flush();
+  assert.equal(scheduler.hasArmedTimer("run-1"), false, "given-up run arms nothing on cold start");
+
+  // User resumes via /workflows → the manager emits "resumed" (not our timer).
+  manager.emit("resumed", { runId: "run-1" });
+  await flush();
+  assert.equal(scheduler.getAttemptCount("run-1"), undefined, "in-memory given-up state cleared");
+  assert.equal(manager.persistence.get("run-1")?.autoResumeAttempts, 0, "persisted counter reset to 0");
+
+  // A later pause now re-enters the normal backoff from attempt 1.
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  assert.equal(scheduler.hasArmedTimer("run-1"), true, "a fresh attempt is armed after the manual resume");
+  assert.equal(scheduler.getAttemptCount("run-1"), 1, "counter starts over at 1");
+  scheduler.dispose();
+});
+
+test("an auto-resume (our own timer firing) does NOT reset the backoff counter", async () => {
+  const manager = new FakeManager();
+  manager.persistence.seed(makeRun({ resetHint: "resets in 10m" }));
+  // Our resume emits "resumed" the same way the real manager does.
+  manager.resumeImpl = async (runId) => {
+    manager.emit("resumed", { runId });
+    return true;
+  };
+  const clock = createFakeClock();
+  const scheduler = new UsageLimitScheduler(manager, {
+    now: clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+    ...TUNABLES,
+  });
+
+  // Two live pauses climb the counter to 2.
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  manager.emit("paused", { runId: "run-1", reason: "usage_limit", resetHint: "resets in 10m" });
+  assert.equal(scheduler.getAttemptCount("run-1"), 2);
+
+  // The timer fires → our resume() runs and emits "resumed". The counter must be
+  // kept (this is the backoff working), not reset by handleResumed.
+  clock.fireAll();
+  await flush();
+  assert.equal(scheduler.getAttemptCount("run-1"), 2, "auto-resume kept the backoff counter");
+  scheduler.dispose();
+});
+
 test("cold-start re-arm uses REMAINING time, not the full base delay", async () => {
   const manager = new FakeManager();
   const pausedAt = new Date(0);


### PR DESCRIPTION
Closes #111.

## #111 — unstructured agent accepts stale progress text as its final result

An unstructured workflow agent that emitted progress text, called a tool, and ended on the tool result was reported **successful** — `lastAssistantText()` scanned backward and returned the earlier progress text as the answer, masking an incomplete run and suppressing the `AGENT_EMPTY_OUTPUT` retry.

Fix: add `finalAssistantText()` — assistant text only *after* the last `toolResult` message — and use it on the unstructured path. `lastAssistantText()` is unchanged and still used by the schema path's prose-JSON recovery (which may legitimately read the payload from any assistant message). Tests cover the reporter's repro, a genuine post-tool answer, a plain answer, and that the schema path stays lenient.

## Also in this patch (tech debt, no separate issue)

- **usage-limit-scheduler:** a **manual** resume now resets `autoResumeAttempts`, so a run that hit the auto-resume cap no longer stays given-up forever in-process after the user resumes it. Auto-resume (the scheduler's own timer, tracked via an `autoResumingRunIds` set) still keeps the backoff counter so it can reach the cap. The "resumed" event fires synchronously inside `resume()`, so the set is populated before it — verified against the manager source.
- **agent:** extract `subagentExcludedTools()` (behavior-identical merge) so the #107 denylist is unit-tested against a spread-order regression, not just a `deepEqual` on the constant.
- **workflow-ui:** group agents by phase in a single **O(agents)** pass (`agentsByPhase`) instead of re-filtering per phase row per frame (was O(phases × agents)); share `agentPhaseKey()`/`toAgentRow()` so grouping and the drilled-in filter can't drift.

## Verification

- 944 tests pass; tsc/biome clean.
- **Two independent expert review passes** — the first caught that the perf change was initially a no-op (unique phase titles); it was reworked into the real single-pass grouping and re-reviewed. All four changes land **FIXED-AT-ROOT**.

Non-blocking follow-ups noted for later (not in this patch): `finalAssistantText` doesn't yet gate on a terminal `stopReason` of error/aborted/length (pre-existing); an unstructured agent that finishes via a `terminate: true` custom tool now deterministically returns AGENT_EMPTY_OUTPUT.

#109 (OOM) is being handled separately.