### PR TITLE
fix: mitigate subagent memory retention (#109) — abort session on timeout + shared no-extensions loader

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -6,6 +6,7 @@ import {
   type CreateAgentSessionOptions,
   createAgentSession,
   createCodingTools,
+  DefaultResourceLoader,
   getAgentDir,
   ModelRegistry,
   ModelRuntime,
@@ -516,6 +517,11 @@ export class WorkflowAgent {
    * loadTierConfig() below for why this is scoped per-instance.
    */
   private tierConfigBox?: { value: ModelTierConfig | null };
+  /**
+   * Shared resource loader for every subagent of this run, built once. See
+   * getSharedResourceLoader — this is the #109 memory mitigation.
+   */
+  private sharedResourceLoaderPromise?: Promise<DefaultResourceLoader>;
 
   constructor(options: WorkflowAgentOptions = {}) {
     this.cwd = options.cwd ?? process.cwd();
@@ -526,6 +532,53 @@ export class WorkflowAgent {
     this.instructions = options.instructions;
     this.mainModel = options.mainModel;
     this.sharedRegistry = options.modelRegistry;
+  }
+
+  /**
+   * A resource loader shared by every subagent of this run, built once (#109).
+   *
+   * Without a resourceLoader, createAgentSession() builds a fresh
+   * DefaultResourceLoader per subagent and reloads it — re-running EVERY installed
+   * extension factory each time (verified: N subagents → N factory runs). Each
+   * such factory that arms a load-time timer/listener then roots its subagent
+   * session forever, because AgentSession.dispose() emits no session_shutdown to
+   * run the cleanup — the dominant #109 leak, and one our own extension
+   * (UsageLimitScheduler) can trigger.
+   *
+   * `noExtensions: true` skips loading host extensions; skills, prompts, and
+   * AGENTS.md context still load. The subagent keeps the tools this workflow
+   * hands it via `customTools` (coding tools + any toolset like web-research) —
+   * those are unaffected. What it loses is HOST EXTENSION-REGISTERED tools (MCP
+   * bridges, browser tools, anything a host extension added via ctx.registerTool):
+   * pre-change a subagent session inherited those from the full host extension
+   * set, now it does not, so an agentType `tools` allowlist naming one matches
+   * nothing. This is a deliberate trade-off — it also structurally kills recursive
+   * orchestration in subagents (no extension runtime at all), beyond the name-level
+   * #107 denylist — and must be release-noted. `createAgentSession` with a shared
+   * resourceLoader is a supported embedding pattern. runWorkflow builds one
+   * WorkflowAgent per run, so this loader's lifetime is exactly one run: built
+   * once, reused by all its subagents, then dropped with the agent.
+   */
+  private getSharedResourceLoader(agentDir: string): Promise<DefaultResourceLoader> {
+    if (!this.sharedResourceLoaderPromise) {
+      this.sharedResourceLoaderPromise = (async () => {
+        const loader = new DefaultResourceLoader({
+          cwd: this.cwd,
+          agentDir,
+          settingsManager: SettingsManager.create(this.cwd, agentDir),
+          noExtensions: true,
+        });
+        await loader.reload();
+        return loader;
+      })().catch((err) => {
+        // Don't let a transient build failure (e.g. EMFILE during reload's disk
+        // I/O) poison every subagent AND every retry of this run — clear the memo
+        // so the next caller rebuilds instead of replaying the same rejection.
+        this.sharedResourceLoaderPromise = undefined;
+        throw err;
+      });
+    }
+    return this.sharedResourceLoaderPromise;
   }
 
   /**
@@ -695,6 +748,11 @@ export class WorkflowAgent {
       // not have valid auth, causing silent empty responses.
       settingsManager: SettingsManager.create(this.cwd, agentDir),
       customTools,
+      // Shared per-run loader with no host extensions (#109) — see
+      // getSharedResourceLoader. An injected resourceLoader (tests / embedders)
+      // wins and skips the shared build entirely; the ...this.sessionOptions
+      // spread below re-applies the same injected value harmlessly.
+      resourceLoader: this.sessionOptions.resourceLoader ?? (await this.getSharedResourceLoader(agentDir)),
       // Share the resolved registry's ModelRuntime (catalog + auth, including
       // extension-registered providers) with the subagent session. pi >= 0.80.8
       // takes modelRuntime here; the old modelRegistry option is gone.

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -525,6 +525,8 @@ export async function runWorkflow<T = unknown>(
       try {
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
           usage = undefined;
+          const externalSignal = options.signal;
+          let onExternalAbort: (() => void) | undefined;
           try {
             throwIfAborted();
             // This agent's own fan-out already breached maxAgents while this
@@ -532,43 +534,57 @@ export async function runWorkflow<T = unknown>(
             // real API call instead of draining the whole reserved queue.
             if (batch?.cancelled) throw agentLimitError();
 
-            // Run agent with timeout
-            const result = await withTimeout(
-              agentRunner.run(prompt, {
-                label,
-                // Identifiable name for persisted sessions (persistAgentSessions).
-                sessionName: `workflow:${runId} ${label}`,
-                schema: agentOptions.schema,
-                signal: options.signal,
-                instructions: buildAgentInstructions(assignedPhase, agentOptions, agentDef, resolvedIsolation),
-                model: modelSpec,
-                tier: agentOptions.tier,
-                modelRegistry: options.modelRegistry,
-                toolNames: agentDef?.tools,
-                disallowedToolNames: agentDef?.disallowedTools,
-                // Per-agent store tools track this agent's writes by the
-                // run-unique deltaKey so the delta can be journaled and replayed
-                // correctly on resume, even when a nested workflow() run shares
-                // this store concurrently with the parent run.
-                systemTools: createAgentStoreTools(store, deltaKey),
-                cwd: runCwd,
-                onModelResolved: (id: string) => {
-                  displayModel = id;
-                },
-                onModelFallback: (spec: string) => {
-                  // Make the silent degrade visible in /workflows, not just console.
-                  log(`${label}: model "${spec}" unavailable — using the session default`);
-                },
-                onUsage: (u: AgentUsage) => {
-                  usage = u;
-                },
-                onHistory: (history: AgentHistoryEntry[]) => {
-                  options.onAgentHistory?.({ label, phase: assignedPhase, history });
-                },
-              }),
-              timeout,
+            // Per-attempt abort: on timeout we abort THIS agent so its session is
+            // disposed and its heavy state (messages, etc.) released, instead of
+            // leaving it streaming in the background — retries would otherwise
+            // stack live sessions on top of each other (#109). Linked to the run's
+            // external signal so an outer abort still cancels the agent too; the
+            // link is torn down per attempt in finally so listeners don't accrue.
+            const agentController = new AbortController();
+            if (externalSignal) {
+              if (externalSignal.aborted) agentController.abort();
+              else {
+                onExternalAbort = () => agentController.abort();
+                externalSignal.addEventListener("abort", onExternalAbort, { once: true });
+              }
+            }
+            const runPromise = agentRunner.run(prompt, {
               label,
-            );
+              // Identifiable name for persisted sessions (persistAgentSessions).
+              sessionName: `workflow:${runId} ${label}`,
+              schema: agentOptions.schema,
+              signal: agentController.signal,
+              instructions: buildAgentInstructions(assignedPhase, agentOptions, agentDef, resolvedIsolation),
+              model: modelSpec,
+              tier: agentOptions.tier,
+              modelRegistry: options.modelRegistry,
+              toolNames: agentDef?.tools,
+              disallowedToolNames: agentDef?.disallowedTools,
+              // Per-agent store tools track this agent's writes by the
+              // run-unique deltaKey so the delta can be journaled and replayed
+              // correctly on resume, even when a nested workflow() run shares
+              // this store concurrently with the parent run.
+              systemTools: createAgentStoreTools(store, deltaKey),
+              cwd: runCwd,
+              onModelResolved: (id: string) => {
+                displayModel = id;
+              },
+              onModelFallback: (spec: string) => {
+                // Make the silent degrade visible in /workflows, not just console.
+                log(`${label}: model "${spec}" unavailable — using the session default`);
+              },
+              onUsage: (u: AgentUsage) => {
+                usage = u;
+              },
+              onHistory: (history: AgentHistoryEntry[]) => {
+                options.onAgentHistory?.({ label, phase: assignedPhase, history });
+              },
+            });
+            // After a timeout the run() promise still settles later, rejecting with
+            // "aborted" once agentController fires; the race has already resolved,
+            // so swallow that to avoid an unhandled rejection.
+            runPromise.catch(() => {});
+            const result = await withTimeout(runPromise, timeout, label, () => agentController.abort());
 
             throwIfAborted();
             if (isEmptyTextAgentResult(result, agentOptions.schema)) {
@@ -629,6 +645,10 @@ export async function runWorkflow<T = unknown>(
               return null;
             }
             throw workflowError;
+          } finally {
+            // Drop this attempt's external-abort listener so it doesn't accrue one
+            // entry per attempt on the run's signal for the whole run (#109 hygiene).
+            if (onExternalAbort) externalSignal?.removeEventListener("abort", onExternalAbort);
           }
         }
         return null;
@@ -1214,14 +1234,30 @@ function normalizeAgentRetries(value: unknown): number {
 
 /**
  * Run a promise with a timeout.
+ *
+ * `onTimeout` fires when the deadline hits, BEFORE the timeout rejection wins the
+ * race — the caller uses it to abort the underlying work (e.g. the subagent
+ * session) so it can release its resources instead of streaming on in the
+ * background with the whole session graph (messages, etc.) retained (#109). The
+ * losing promise still settles later; the caller must swallow its rejection.
  */
-async function withTimeout<T>(promise: Promise<T>, ms: number | null, label: string): Promise<T> {
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number | null,
+  label: string,
+  onTimeout?: () => void,
+): Promise<T> {
   if (ms === null) return promise;
 
   let timeoutId: NodeJS.Timeout | undefined;
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
+      try {
+        onTimeout?.();
+      } catch {
+        // Best-effort cleanup; never let it mask the timeout error.
+      }
       reject(
         new WorkflowError(
           `Agent "${label}" timed out after ${ms}ms; raise or omit timeoutMs/agentTimeoutMs to allow longer runs`,

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -345,6 +345,21 @@ test("subagentExcludedTools always includes the defaults, plus caller/session na
   assert.ok(merged.includes("session-denied") && merged.includes("extra"), "both caller lists are folded in");
 });
 
+test("the subagent resource loader is built once per run and shared across subagents (#109)", () => {
+  // The #109 mitigation: one no-extensions loader per run, reused by every
+  // subagent, instead of createAgentSession re-running every extension factory
+  // (and rooting each disposed session) per subagent. Memoization is the invariant.
+  const agent = new WorkflowAgent({ cwd: "/tmp" });
+  type Priv = { getSharedResourceLoader(agentDir: string): Promise<unknown> };
+  const a = agent as unknown as Priv;
+  const first = a.getSharedResourceLoader("/tmp/agentdir");
+  const second = a.getSharedResourceLoader("/tmp/agentdir");
+  assert.equal(first, second, "same promise — the loader is built once and shared, not rebuilt per subagent");
+  // reload() may reject in a bare temp dir; we only assert memoization here.
+  first.catch(() => {});
+  second.catch(() => {});
+});
+
 // ═══════════════════════════════════════════════════════════════════════
 // finalAssistantText — the unstructured result must come AFTER the last tool
 // result, so stale progress text can't be reported as a completed answer (#111)

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -170,6 +170,48 @@ test(
 );
 
 test(
+  "an agent timeout aborts the subagent so its session can be released (#109)",
+  withTempCwd(async (cwd) => {
+    // A subagent whose run() never resolves on its own — only an abort ends it.
+    // Before the fix, a timeout rejected the race but left this running in the
+    // background with its session (and full messages) retained.
+    let sawAbort = false;
+    const hangingUntilAborted = {
+      async run(_prompt: string, options?: { signal?: AbortSignal }) {
+        return new Promise((_resolve, reject) => {
+          const signal = options?.signal;
+          if (signal?.aborted) {
+            sawAbort = true;
+            reject(new Error("aborted"));
+            return;
+          }
+          signal?.addEventListener(
+            "abort",
+            () => {
+              sawAbort = true;
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        });
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent: hangingUntilAborted, defaultAgentTimeoutMs: 20 });
+
+    const result = await manager.runSync(oneAgentScript);
+
+    // Timed out → recoverable, no retry configured, so the agent result is null.
+    assert.equal((result.result as { a: unknown }).a, null);
+    const agent = manager.listRuns()[0]?.agents[0];
+    assert.equal(agent?.status, "error");
+    assert.match(agent?.error ?? "", /timed out/);
+    // The key #109 property: the timeout aborted the subagent, so run()'s finally
+    // disposes its session instead of leaking it while it streams on.
+    assert.equal(sawAbort, true, "the timing-out subagent must receive an abort");
+  }),
+);
+
+test(
   "manager defaultTokenBudget applies when run options omit tokenBudget (#68)",
   withTempCwd(async (cwd) => {
     // Each agent reports 100 tokens against a default budget of 50: the first


### PR DESCRIPTION
Refs #109.

Two in-repo mitigations for the OOM where completed background workflows leave heap unreclaimed (reporter: ~1GB per workflow, OOM after 3-4 runs). The root cause is largely **upstream in the SDK** — `AgentSession.dispose()` emits no `session_shutdown` and keeps `agent.state.messages`, and the SessionManager mirrors the transcript — and is already tracked there (earendil-works/pi#2752, earendil-works/pi#6101), so no duplicate is filed. These changes bound the in-repo damage.

Confirmed with a runtime experiment (N subagents in one process, a reload counter, a `WeakRef` liveness probe on each disposed session): `createAgentSession()` without a `resourceLoader` re-runs **every installed extension factory per subagent** (N subagents → N factory runs), and any extension that armed a load-time timer (cleanup keyed to `session_shutdown`, which `dispose()` never emits) then roots the disposed session — every disposed session stayed retained, heap grew monotonically. Our own `UsageLimitScheduler` is exactly such a trigger for a usage-limit-paused run.

## 1. Abort the subagent on timeout (`src/workflow.ts`)
`withTimeout()` gained an `onTimeout` callback. Each attempt builds a per-attempt `AbortController` (linked to the run's external signal; listener removed in a per-attempt `finally`) whose signal is passed to the subagent. On timeout we abort it → `run()`'s `finally` disposes its session, instead of leaving it streaming in the background — and a retry no longer stacks a second live session. The race still settles as `AGENT_TIMEOUT` (recoverable), classification preserved.

## 2. Shared per-run no-extensions resource loader (`src/agent.ts`)
`WorkflowAgent` now builds **one** `DefaultResourceLoader({ noExtensions: true })` per run, memoized (and un-poisoned on reload failure), shared by all its subagents. This removes the per-subagent factory re-run and the entire retention path (no extension timers armed inside subagents), and **structurally** closes recursive fan-out in subagents (no extension runtime — beyond #107's name denylist). Provider resolution is unaffected: the workflow passes `modelRuntime` (the host registry, with all extension-registered providers) into every subagent session independent of the loader.

## Behavior change (release note)
Workflow subagents **no longer inherit host extension-registered tools** (MCP bridges, browser tools, anything a host extension added via `ctx.registerTool`). The tools a workflow hands subagents via `customTools` (coding tools + toolsets like web-research) and `agentType` are unaffected; skills/prompts/AGENTS.md context still load. An `agentType` `tools` allowlist naming a host-extension tool now matches nothing. This is a deliberate trade-off (it also enforces #107 structurally); if real demand surfaces, the follow-up is precise explicit per-agent tool injection, not a coarse switch.

## Verification
- 946 unit tests pass; tsc/biome clean. New tests: timeout aborts the subagent; the shared loader is built once per run.
- Two independent expert review passes (mitigation 1 FIXED-AT-ROOT, mitigation 2 MITIGATES); three pre-merge defects the second pass found are all fixed (corrected the capability comment, un-poisoned the memoized loader on failure, removed the per-attempt abort listener in `finally`).
- Runtime heap experiment confirmed the mechanism and that the shared loader drops per-subagent factory runs to zero and keeps disposed sessions collectable.

#109 stays open (upstream root remains); this bounds it in-repo.