### PR TITLE
fix: guard /workflows navigator against crashes; validate agent() schema; harden model-tier config

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -692,6 +692,18 @@ export class WorkflowAgent {
     }
 
     if (options.schema) {
+      // Strict OpenAI-compatible providers (e.g. DeepSeek) reject a tool whose top-level
+      // parameters schema isn't a JSON object with a transport-level 400, before any of
+      // this file's SCHEMA_NONCOMPLIANCE/empty-output classification ever runs. Fail fast
+      // here instead, so a script's non-object opts.schema surfaces a clear workflow error.
+      const schemaType = (options.schema as { type?: unknown }).type;
+      if (schemaType !== "object") {
+        throw new WorkflowError(
+          `agent() opts.schema must be a top-level JSON object schema (type: "object") — got type: ${schemaType ?? "undefined"}; wrap array/primitive results in an object, e.g. { type: "object", properties: { items: <your schema> } }`,
+          WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+          { recoverable: false },
+        );
+      }
       customTools.push(createStructuredOutputTool({ schema: options.schema, capture }) as unknown as ToolDefinition);
     }
 

--- a/src/model-tier-config.ts
+++ b/src/model-tier-config.ts
@@ -222,6 +222,21 @@ export function formatTierFallbackNotice(
 // ---------------------------------------------------------------------------
 
 /**
+ * True iff `value` is a usable tiers map: a plain (non-array) object with at
+ * least one entry, every key and value a non-empty string. Anything else
+ * (an array, `{}`, or a tier mapped to `""`) is treated as absent rather than
+ * a truthy-but-broken config — resolveTierModel would silently resolve such
+ * entries to `undefined`/`""` while the caller's "no model-tiers.json
+ * configured" warning only fires on an exactly-null config.
+ */
+function isValidTiersMap(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) return false;
+  return entries.every(([key, val]) => key.trim().length > 0 && typeof val === "string" && val.trim().length > 0);
+}
+
+/**
  * Load the model tier config from disk. Returns null if the file does not
  * exist or is unparseable (callers fall back to a default).
  */
@@ -232,10 +247,7 @@ export function loadModelTierConfig(configPath?: string): ModelTierConfig | null
     const raw = readFileSync(path, "utf-8");
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object") return null;
-    if (!parsed.tiers || typeof parsed.tiers !== "object") return null;
-    for (const val of Object.values(parsed.tiers)) {
-      if (typeof val !== "string") return null;
-    }
+    if (!isValidTiersMap(parsed.tiers)) return null;
     return parsed as ModelTierConfig;
   } catch {
     return null;
@@ -244,8 +256,18 @@ export function loadModelTierConfig(configPath?: string): ModelTierConfig | null
 
 /**
  * Save a model tier config to disk. Creates parent directories if needed.
+ *
+ * Refuses a degenerate `tiers` (e.g. all-empty-string, from buildDefaultTierConfig
+ * with an empty model registry) using the same isValidTiersMap check the loader
+ * uses — otherwise the write side could produce exactly the shape loadModelTierConfig
+ * now rejects on the next read, silently discarding the "saved" config.
  */
 export function saveModelTierConfig(config: ModelTierConfig, configPath?: string): void {
+  if (!isValidTiersMap(config?.tiers)) {
+    throw new Error(
+      "Refusing to save a degenerate model tier config: tiers must be a non-empty map of tier name to a non-empty model spec string.",
+    );
+  }
   const path = configPath ?? getModelTierConfigPath();
   const dir = dirname(path);
   if (!existsSync(dir)) {

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -1105,91 +1105,112 @@ export function openWorkflowNavigator(
       const act = (data: string) => {
         const itemKind = state.kind === "runs" ? state.itemKindAt(model, state.cursor) : undefined;
         const action = keyToAction(parseKey(data), state.kind, itemKind);
-        switch (action.type) {
-          case "move":
-            state.move(action.delta, currentCount(state, model));
-            break;
-          case "drill":
-            state.drill(model);
-            break;
-          case "back":
-            if (!state.back()) {
+        // Single error boundary around the whole dispatch: any case here can call
+        // into manager/storage methods that throw synchronously on bad on-disk
+        // state (corrupt persisted scripts, EACCES/ENOSPC, a stale run lease) —
+        // uncaught, that would crash/freeze this TUI overlay's input handler,
+        // which has no boundary of its own (#330 audit). A per-case try/catch
+        // (see "restart" below) can still add a friendlier, action-specific
+        // message; this is the backstop for every other case, present and future.
+        try {
+          switch (action.type) {
+            case "move":
+              state.move(action.delta, currentCount(state, model));
+              break;
+            case "drill":
+              state.drill(model);
+              break;
+            case "back":
+              if (!state.back()) {
+                cleanup();
+                done(undefined);
+              }
+              break;
+            case "close":
               cleanup();
               done(undefined);
-            }
-            break;
-          case "close":
-            cleanup();
-            done(undefined);
-            return;
-          case "deleteSaved": {
-            if (state.kind === "runs") {
-              const saved = model.saved();
-              const runCount = model.runs().length;
-              const item = saved[state.cursor - runCount];
-              if (item) {
-                model.deleteSaved(item.name);
-                ui.notify(`Deleted /${item.name}`, "info");
+              return;
+            case "deleteSaved": {
+              if (state.kind === "runs") {
+                const saved = model.saved();
+                const runCount = model.runs().length;
+                const item = saved[state.cursor - runCount];
+                if (item) {
+                  model.deleteSaved(item.name);
+                  ui.notify(`Deleted /${item.name}`, "info");
+                }
+              } else if (state.kind === "savedDetail" && state.savedName) {
+                model.deleteSaved(state.savedName);
+                ui.notify(`Deleted /${state.savedName}`, "info");
+                state.back();
               }
-            } else if (state.kind === "savedDetail" && state.savedName) {
-              model.deleteSaved(state.savedName);
-              ui.notify(`Deleted /${state.savedName}`, "info");
-              state.back();
-            }
-            break;
-          }
-          case "pause": {
-            const id = state.activeRunId(model);
-            if (id) ui.notify(manager.pause(id) ? `Paused ${id}` : `Cannot pause ${id}`, "info");
-            break;
-          }
-          case "stop": {
-            const id = state.activeRunId(model);
-            if (id) ui.notify(manager.stop(id) ? `Stopped ${id}` : `Cannot stop ${id}`, "info");
-            break;
-          }
-          case "restart": {
-            const id = state.activeRunId(model);
-            const run = id ? manager.listRuns().find((r) => r.runId === id) : undefined;
-            if (!run?.script) {
-              ui.notify(id ? `Cannot restart ${id} (no script saved)` : "No run selected to restart", "warning");
               break;
             }
-            const { runId: newId } = manager.startInBackground(run.script, run.args);
-            ui.notify(`Restarted ${run.workflowName || "workflow"} as ${newId}`, "info");
-            break;
-          }
-          case "save": {
-            const id = state.activeRunId(model);
-            const run = id ? manager.listRuns().find((r) => r.runId === id) : undefined;
-            if (!run?.script) {
-              ui.notify("No saved run script to save", "warning");
-            } else if (!opts.storage) {
-              ui.notify("Saving is not available (no storage)", "error");
-            } else {
-              const storage = opts.storage;
-              const name = run.workflowName || "workflow";
-              let saved: ReturnType<WorkflowStorage["save"]>;
-              try {
-                saved = storage.save({
-                  name,
-                  description: run.workflowName,
-                  script: run.script,
-                  location: "project",
-                });
-              } catch (error) {
-                ui.notify(error instanceof Error ? error.message : String(error), "error");
+            case "pause": {
+              const id = state.activeRunId(model);
+              if (id) ui.notify(manager.pause(id) ? `Paused ${id}` : `Cannot pause ${id}`, "info");
+              break;
+            }
+            case "stop": {
+              const id = state.activeRunId(model);
+              if (id) ui.notify(manager.stop(id) ? `Stopped ${id}` : `Cannot stop ${id}`, "info");
+              break;
+            }
+            case "restart": {
+              const id = state.activeRunId(model);
+              const run = id ? manager.listRuns().find((r) => r.runId === id) : undefined;
+              if (!run?.script) {
+                ui.notify(id ? `Cannot restart ${id} (no script saved)` : "No run selected to restart", "warning");
                 break;
               }
-              registerSavedWorkflow(pi, opts.cwd ?? process.cwd(), saved, undefined, () =>
-                storage.list().some((w) => w.name === saved.name),
-              );
-              ui.notify(`Saved /${name}`, "info");
+              try {
+                const { runId: newId } = manager.startInBackground(run.script, run.args);
+                ui.notify(`Restarted ${run.workflowName || "workflow"} as ${newId}`, "info");
+              } catch (error) {
+                ui.notify(
+                  `Failed to restart ${run.workflowName || "workflow"}: ${error instanceof Error ? error.message : error}`,
+                  "error",
+                );
+              }
+              break;
             }
-            break;
+            case "save": {
+              const id = state.activeRunId(model);
+              const run = id ? manager.listRuns().find((r) => r.runId === id) : undefined;
+              if (!run?.script) {
+                ui.notify("No saved run script to save", "warning");
+              } else if (!opts.storage) {
+                ui.notify("Saving is not available (no storage)", "error");
+              } else {
+                const storage = opts.storage;
+                const name = run.workflowName || "workflow";
+                let saved: ReturnType<WorkflowStorage["save"]>;
+                try {
+                  saved = storage.save({
+                    name,
+                    description: run.workflowName,
+                    script: run.script,
+                    location: "project",
+                  });
+                } catch (error) {
+                  ui.notify(error instanceof Error ? error.message : String(error), "error");
+                  break;
+                }
+                registerSavedWorkflow(pi, opts.cwd ?? process.cwd(), saved, undefined, () =>
+                  storage.list().some((w) => w.name === saved.name),
+                );
+                ui.notify(`Saved /${name}`, "info");
+              }
+              break;
+            }
+            default:
+              return;
           }
-          default:
-            return;
+        } catch (error) {
+          ui.notify(
+            `Workflow action "${action.type}" failed: ${error instanceof Error ? error.message : error}`,
+            "error",
+          );
         }
         rerender();
       };

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -3,8 +3,9 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
-import { createFauxCore, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { createFauxCore, fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
 import { ModelRegistry, ModelRuntime } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
 import type { AgentRunOptions, AgentUsage } from "../src/agent.js";
 import {
   DEFAULT_EXCLUDED_SUBAGENT_TOOLS,
@@ -295,6 +296,69 @@ test("WorkflowAgent.run(): tier routing resolves correctly through the real (non
         secondResult,
         "the SAME config object must be reused across run() calls — the file was read/parsed only once",
       );
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// WorkflowAgent.run(): opts.schema must be a top-level JSON object schema
+// (#330 audit) — a non-object schema (e.g. array/primitive) would otherwise
+// reach a strict OpenAI-compatible provider (DeepSeek) as an invalid tool
+// parameters schema and fail with an opaque transport-level 400.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test("WorkflowAgent.run() rejects a non-object top-level schema before touching the model registry", async () => {
+  const agent = new WorkflowAgent({ cwd: "/tmp" });
+  await assert.rejects(
+    agent.run("task", { schema: Type.Array(Type.Object({ finding: Type.String() })) }),
+    (error: unknown) => {
+      assert.ok(error instanceof WorkflowError);
+      assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+      assert.match(error.message, /opts\.schema must be a top-level JSON object schema/);
+      assert.match(error.message, /got type: array/);
+      return true;
+    },
+  );
+});
+
+test("WorkflowAgent.run() still completes with a normal object schema (no regression)", async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-schema-ok-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-schema-ok-cwd-"));
+  const core = createFauxCore({
+    provider: "fauxtest-schema",
+    models: [{ id: "faux-model", name: "Faux Model", contextWindow: 128000, maxTokens: 4096 }],
+  });
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const runtime = await ModelRuntime.create({ authPath: join(home, "auth.json"), modelsPath: null });
+      runtime.registerProvider("fauxtest-schema", {
+        name: "Faux Test Schema",
+        baseUrl: "http://127.0.0.1:9/faux",
+        apiKey: "faux-dummy-key-not-used",
+        api: core.api,
+        streamSimple: core.streamSimple as never,
+        models: core.models.map((m) => ({
+          id: m.id,
+          name: m.name ?? m.id,
+          reasoning: false,
+          input: ["text"] as ("text" | "image")[],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: m.contextWindow ?? 128000,
+          maxTokens: m.maxTokens ?? 4096,
+        })),
+      });
+      const registry = new ModelRegistry(runtime);
+      core.setResponses([
+        fauxAssistantMessage(fauxToolCall("structured_output", { verdict: "ok" }), { stopReason: "toolUse" }),
+      ]);
+
+      const agent = new WorkflowAgent({ cwd, modelRegistry: registry, mainModel: "fauxtest-schema/faux-model" });
+      const result = await agent.run("task", { schema: Type.Object({ verdict: Type.String() }) });
+
+      assert.deepEqual(result, { verdict: "ok" });
     });
   } finally {
     rmSync(home, { recursive: true, force: true });

--- a/tests/model-tier-config.test.ts
+++ b/tests/model-tier-config.test.ts
@@ -14,7 +14,7 @@
  */
 
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
@@ -388,6 +388,26 @@ describe("model-tier-config", () => {
       rmSync(tmpDir, { recursive: true, force: true });
     });
 
+    it("refuses to save a degenerate config (all-empty tiers) instead of writing what the loader would reject (#330 audit follow-up)", async () => {
+      const { saveModelTierConfig, loadModelTierConfig } = await loadModule();
+      const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
+      const cfgPath = join(tmpDir, "model-tiers.json");
+      const degenerate = { tiers: { small: "", medium: "", big: "" } };
+      assert.throws(() => saveModelTierConfig(degenerate, cfgPath), /degenerate/);
+      assert.equal(existsSync(cfgPath), false, "no file should be written");
+      assert.equal(loadModelTierConfig(cfgPath), null);
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("refuses to save a config whose tiers is an empty object", async () => {
+      const { saveModelTierConfig } = await loadModule();
+      const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
+      const cfgPath = join(tmpDir, "model-tiers.json");
+      assert.throws(() => saveModelTierConfig({ tiers: {} }, cfgPath));
+      assert.equal(existsSync(cfgPath), false);
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
     it("returns null when file does not exist", async () => {
       const { loadModelTierConfig } = await loadModule();
       assert.equal(loadModelTierConfig(join(tmpdir(), "nonexistent-test-file.json")), null);
@@ -436,6 +456,52 @@ describe("model-tier-config", () => {
       writeFileSync(cfgPath, '{"tiers": {"small": "gpt-4.1-mini"}}', "utf-8");
       const result = loadModelTierConfig(cfgPath);
       assert.equal(result?.tiers.small, "gpt-4.1-mini");
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns null when tiers is an empty array (#330 audit)", async () => {
+      const { loadModelTierConfig } = await loadModule();
+      const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
+      const cfgPath = join(tmpDir, "model-tiers.json");
+      writeFileSync(cfgPath, '{"tiers": []}', "utf-8");
+      assert.equal(loadModelTierConfig(cfgPath), null);
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns null when tiers is a non-empty array (#330 audit)", async () => {
+      const { loadModelTierConfig } = await loadModule();
+      const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
+      const cfgPath = join(tmpDir, "model-tiers.json");
+      writeFileSync(cfgPath, '{"tiers": ["openai/gpt-4.1-mini", "openai/gpt-5"]}', "utf-8");
+      assert.equal(loadModelTierConfig(cfgPath), null);
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns null when tiers is an empty object (#330 audit)", async () => {
+      const { loadModelTierConfig } = await loadModule();
+      const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
+      const cfgPath = join(tmpDir, "model-tiers.json");
+      writeFileSync(cfgPath, '{"tiers": {}}', "utf-8");
+      assert.equal(loadModelTierConfig(cfgPath), null);
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("returns null when a tier value is an empty string (#330 audit)", async () => {
+      const { loadModelTierConfig } = await loadModule();
+      const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
+      const cfgPath = join(tmpDir, "model-tiers.json");
+      writeFileSync(cfgPath, '{"tiers": {"small": ""}}', "utf-8");
+      assert.equal(loadModelTierConfig(cfgPath), null);
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("still loads a normal valid config (no regression)", async () => {
+      const { loadModelTierConfig } = await loadModule();
+      const tmpDir = mkdtempSync(join(tmpdir(), "mtc-test-"));
+      const cfgPath = join(tmpDir, "model-tiers.json");
+      writeFileSync(cfgPath, '{"tiers": {"small": "openai/gpt-4.1-mini"}}', "utf-8");
+      const result = loadModelTierConfig(cfgPath);
+      assert.deepEqual(result, { tiers: { small: "openai/gpt-4.1-mini" } });
       rmSync(tmpDir, { recursive: true, force: true });
     });
   });

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -1,11 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import type { Component } from "@earendil-works/pi-tui";
 import type { WorkflowSnapshot } from "../src/display.js";
 import { WorkflowErrorCode } from "../src/errors.js";
 import type { PersistedRunState } from "../src/run-persistence.js";
+import { parseWorkflowScript } from "../src/workflow.js";
 import type { ManagedRun, WorkflowManager } from "../src/workflow-manager.js";
 import type { SavedWorkflow } from "../src/workflow-saved.js";
-import { keyToAction, NavigatorModel, NavigatorState, renderNavigator } from "../src/workflow-ui.js";
+import {
+  keyToAction,
+  NavigatorModel,
+  NavigatorState,
+  openWorkflowNavigator,
+  renderNavigator,
+} from "../src/workflow-ui.js";
 
 /** Fake manager exposing one running run with two phases. */
 function fakeManager(): Pick<WorkflowManager, "listRuns" | "getRun"> {
@@ -986,4 +995,171 @@ test("runs list aggregates per-agent figures for live runs whose run-level usage
   assert.equal(model.runs()[0].fresh, 1200);
   const lines = renderNavigator(new NavigatorState(), model, 80);
   assert.match(lines.join("\n"), /1,200 tok|1[ .\u00a0]200 tok/);
+});
+
+test("restarting a run with a corrupt persisted script notifies an error instead of crashing the overlay (#330 audit)", async () => {
+  const notifications: { message: string; type?: string }[] = [];
+  const fakeUi = {
+    notify: (message: string, type?: string) => {
+      notifications.push({ message, type });
+    },
+    custom: <T>(
+      factory: (
+        tui: unknown,
+        theme: unknown,
+        keybindings: unknown,
+        done: (result: T) => void,
+      ) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>,
+    ) => {
+      const tui = { requestRender: () => {}, terminal: { rows: 24 } };
+      const theme = {
+        fg: (_name: string, s: string) => s,
+        bg: (_name: string, s: string) => s,
+        bold: (s: string) => s,
+      };
+      const component = factory(tui, theme, {}, () => {});
+      return Promise.resolve(component).then((c) => {
+        capturedComponent = c;
+        return undefined as unknown as T;
+      });
+    },
+  };
+  let capturedComponent: (Component & { dispose?(): void }) | undefined;
+
+  // A run whose persisted script is missing the required `export const meta`
+  // block \u2014 exactly the kind of corrupt on-disk run-persistence data #330
+  // found no schema validation guards against.
+  const corruptScript = "console.log('not a workflow script')";
+  const fakeManager = {
+    on: () => {},
+    off: () => {},
+    listRuns: () => [
+      {
+        runId: "run-corrupt",
+        workflowName: "corrupt-run",
+        status: "completed",
+        phases: [],
+        agents: [],
+        logs: [],
+        script: corruptScript,
+        args: undefined,
+      } as unknown as PersistedRunState,
+    ],
+    getRun: () => undefined,
+    startInBackground: (script: string) => {
+      // Mirrors the real WorkflowManager.startInBackground, which parses the
+      // script synchronously before doing anything else.
+      parseWorkflowScript(script);
+      return { runId: "should-not-be-reached" };
+    },
+  } as unknown as WorkflowManager;
+
+  openWorkflowNavigator({} as ExtensionAPI, fakeManager, fakeUi as unknown as ExtensionUIContext).catch(() => {});
+
+  // Let the custom()'s factory promise resolve before driving input.
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.ok(capturedComponent, "openWorkflowNavigator should have produced a component");
+  assert.doesNotThrow(() => capturedComponent?.handleInput("r"), "restart must not throw/crash the overlay");
+
+  assert.equal(notifications.length, 1);
+  assert.equal(notifications[0].type, "error");
+  assert.match(notifications[0].message, /Failed to restart corrupt-run/);
+});
+
+function fakeUiCapturingComponent(): {
+  ui: ExtensionUIContext;
+  notifications: { message: string; type?: string }[];
+  getComponent: () => (Component & { dispose?(): void }) | undefined;
+} {
+  const notifications: { message: string; type?: string }[] = [];
+  let capturedComponent: (Component & { dispose?(): void }) | undefined;
+  const ui = {
+    notify: (message: string, type?: string) => {
+      notifications.push({ message, type });
+    },
+    custom: <T>(
+      factory: (
+        tui: unknown,
+        theme: unknown,
+        keybindings: unknown,
+        done: (result: T) => void,
+      ) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>,
+    ) => {
+      const tui = { requestRender: () => {}, terminal: { rows: 24 } };
+      const theme = {
+        fg: (_name: string, s: string) => s,
+        bg: (_name: string, s: string) => s,
+        bold: (s: string) => s,
+      };
+      const component = factory(tui, theme, {}, () => {});
+      return Promise.resolve(component).then((c) => {
+        capturedComponent = c;
+        return undefined as unknown as T;
+      });
+    },
+  } as unknown as ExtensionUIContext;
+  return { ui, notifications, getComponent: () => capturedComponent };
+}
+
+test("deleting a saved workflow whose storage.delete throws (e.g. EACCES) notifies an error instead of crashing the overlay (#330 audit follow-up)", async () => {
+  const { ui, notifications, getComponent } = fakeUiCapturingComponent();
+
+  // No runs, one saved workflow — cursor 0 lands on the saved item (itemKind "saved").
+  const fakeManager = {
+    on: () => {},
+    off: () => {},
+    listRuns: () => [] as PersistedRunState[],
+    getRun: () => undefined,
+  } as unknown as WorkflowManager;
+  const storage = {
+    list: () => [{ name: "flaky", description: "", location: "project", path: "/x", savedAt: "2025-01-01" }],
+    delete: () => {
+      throw new Error("EACCES: permission denied, unlink '/x'");
+    },
+  };
+
+  openWorkflowNavigator({} as ExtensionAPI, fakeManager, ui, { storage }).catch(() => {});
+  await Promise.resolve();
+  await Promise.resolve();
+
+  const component = getComponent();
+  assert.ok(component, "openWorkflowNavigator should have produced a component");
+  assert.doesNotThrow(() => component?.handleInput("x"), "deleteSaved must not throw/crash the overlay");
+
+  assert.equal(notifications.length, 1);
+  assert.equal(notifications[0].type, "error");
+  assert.match(notifications[0].message, /deleteSaved.*failed/);
+  assert.match(notifications[0].message, /EACCES/);
+});
+
+test("stopping a run whose manager.stop throws (cold-run lease/persistence failure) notifies an error instead of crashing the overlay (#330 audit follow-up)", async () => {
+  const { ui, notifications, getComponent } = fakeUiCapturingComponent();
+
+  const fakeManager = {
+    on: () => {},
+    off: () => {},
+    listRuns: () =>
+      [
+        { runId: "run-cold", workflowName: "cold-run", status: "running", phases: [], agents: [], logs: [] },
+      ] as unknown as PersistedRunState[],
+    getRun: () => undefined,
+    stop: () => {
+      throw new Error("ENOSPC: no space left on device");
+    },
+  } as unknown as WorkflowManager;
+
+  openWorkflowNavigator({} as ExtensionAPI, fakeManager, ui).catch(() => {});
+  await Promise.resolve();
+  await Promise.resolve();
+
+  const component = getComponent();
+  assert.ok(component, "openWorkflowNavigator should have produced a component");
+  assert.doesNotThrow(() => component?.handleInput("x"), "stop must not throw/crash the overlay");
+
+  assert.equal(notifications.length, 1);
+  assert.equal(notifications[0].type, "error");
+  assert.match(notifications[0].message, /stop.*failed/);
+  assert.match(notifications[0].message, /ENOSPC/);
 });


### PR DESCRIPTION
Fixes three defects found during a routine codebase review:

## 1. `/workflows` navigator crashes on bad on-disk state
A single error boundary now wraps the whole action-dispatch switch in `src/workflow-ui.ts`. Several actions (restarting a run, deleting a saved workflow, stopping a run) call into code that can throw synchronously on bad on-disk state — a corrupt persisted script, a permissions error, a full disk, a stale lease — and that was previously uncaught, crashing the whole `/workflows` overlay. All of these now surface a clear notification instead.

## 2. `agent()` schema not enforced as a top-level object
`WorkflowAgent.run()` now validates that a script's `opts.schema` is a top-level JSON object schema before doing any session/tool setup. Passing a non-object schema (e.g. a bare array schema) now throws a clear, actionable error instead of failing opaquely against a strict provider.

## 3. `model-tiers.json` degenerate `tiers` silently accepted
`loadModelTierConfig`'s validation is now a proper structural check (rejects arrays, empty maps, and blank keys/values, not just a couple of specific shapes), and the save path uses the same check before writing — so a degenerate config can no longer be silently written and then silently discarded on the next load.

## Verification
958 tests pass (up from 954), covering the new guards and confirming existing behavior for valid inputs is unchanged.