### PR TITLE
fix: preserve per-run limits and token spend across resume; stop stale executions from clobbering run state

### DIFF
--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -93,9 +93,12 @@ export interface PersistedRunState {
   maxAgents?: number;
   /**
    * The run's resolved per-agent timeout, fixed at start (per-run value, else
-   * the manager default at the time). Same rationale as tokenBudget. Absent on
-   * legacy runs (resumed with no imposed timeout, i.e. null — never re-apply a
-   * default that wasn't there).
+   * the manager default at the time). Absent on legacy runs — unlike
+   * tokenBudget, a legacy run's real timeout was never "no timeout" by
+   * omission; it was always the manager's default (pre-A1 resume always fell
+   * back to it), so resume applies the manager's CURRENT default for such
+   * runs rather than null, preserving both the run's original semantics and
+   * pre-fix resume behavior.
    */
   agentTimeoutMs?: number | null;
   /**

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -84,6 +84,31 @@ export interface PersistedRunState {
    */
   toolset?: string;
   /**
+   * The run's resolved cap on total agents, fixed at start (per-run value,
+   * else undefined so runWorkflow applies its own MAX_AGENTS_PER_RUN default).
+   * Resume re-applies THIS value — never the manager's current default — same
+   * rationale as tokenBudget. Absent on legacy runs (resumed with no cap
+   * carried forward, i.e. runWorkflow's own default applies).
+   */
+  maxAgents?: number;
+  /**
+   * The run's resolved per-agent timeout, fixed at start (per-run value, else
+   * the manager default at the time). Same rationale as tokenBudget. Absent on
+   * legacy runs (resumed with no imposed timeout, i.e. null — never re-apply a
+   * default that wasn't there).
+   */
+  agentTimeoutMs?: number | null;
+  /**
+   * The run's resolved concurrency, fixed at start (per-run value, else the
+   * manager's concurrency at the time). Same rationale as tokenBudget.
+   */
+  concurrency?: number;
+  /**
+   * The run's resolved agent-retry count, fixed at start (per-run value, else
+   * the manager default at the time). Same rationale as tokenBudget.
+   */
+  agentRetries?: number;
+  /**
    * Auto-resume attempt counter for the current usage_limit pause-cycle, owned
    * and persisted by UsageLimitScheduler (best-effort). Absent/0 means no
    * auto-resume attempt has been recorded yet.

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -67,6 +67,34 @@ export interface ManagedRun {
    * every agent with the run's startedAt / "now".
    */
   agentTimestamps: Map<number, { startedAt: string; endedAt?: string }>;
+  /**
+   * The run's cap on total agents (per-run value, else left undefined so
+   * runWorkflow applies its own MAX_AGENTS_PER_RUN default), fixed at run
+   * start/resume and carried through resume() — mirrors ManagedRun.tokenBudget
+   * exactly: a resumed run must keep the cap it started with, not silently
+   * regain the (much larger) default because ExecOptions.maxAgents isn't
+   * threaded through resume()'s executeRun() call.
+   */
+  maxAgents?: number;
+  /**
+   * The run's resolved per-agent timeout (per-run value, else the manager
+   * default at the time), fixed at run start/resume — same rationale as
+   * tokenBudget/maxAgents: resume() must not re-resolve against the manager's
+   * CURRENT defaultAgentTimeoutMs.
+   */
+  agentTimeoutMs?: number | null;
+  /**
+   * The run's resolved concurrency (per-run value, else the manager's
+   * concurrency at the time), fixed at run start/resume for the same reason
+   * as tokenBudget.
+   */
+  concurrency?: number;
+  /**
+   * The run's resolved agent-retry count (per-run value, else the manager
+   * default at the time), fixed at run start/resume for the same reason as
+   * tokenBudget.
+   */
+  agentRetries?: number;
 }
 
 /** Per-execution options shared by sync, background, and resume runs. */
@@ -109,6 +137,21 @@ export interface ExecOptions {
    * it too. See usage-limit-scheduler.ts.
    */
   autoResume?: boolean;
+  /**
+   * Seed for the execution's cumulative token counters — passed through to
+   * runWorkflow's WorkflowRunOptions.initialTokenUsage. Only resume() sets
+   * this (from the persisted run's tokenUsage-at-pause), so the resumed
+   * execution's fresh SharedRuntime starts counting from the already-spent
+   * total instead of zero (see A2 in workflow-manager's resume()).
+   */
+  initialTokenUsage?: {
+    input: number;
+    output: number;
+    total: number;
+    cost: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
 }
 
 export interface WorkflowManagerOptions {
@@ -290,6 +333,13 @@ export class WorkflowManager extends EventEmitter {
       // ManagedRun.tokenBudget) so resume keeps start-time semantics.
       tokenBudget: exec.tokenBudget !== undefined ? exec.tokenBudget : this.defaultTokenBudget,
       toolset: exec.toolset,
+      // Same freeze-at-start pattern as tokenBudget, for the same reason: a
+      // resumed run must keep these values, not re-resolve against the
+      // manager's current defaults (see ManagedRun doc comments).
+      maxAgents: exec.maxAgents,
+      agentTimeoutMs: exec.agentTimeoutMs !== undefined ? exec.agentTimeoutMs : this.defaultAgentTimeoutMs,
+      concurrency: exec.concurrency !== undefined ? exec.concurrency : this.concurrency,
+      agentRetries: exec.agentRetries !== undefined ? exec.agentRetries : this.defaultAgentRetries,
       agentTimestamps: new Map(),
     };
 
@@ -312,6 +362,10 @@ export class WorkflowManager extends EventEmitter {
         autoResume: managed.autoResume,
         tokenBudget: managed.tokenBudget,
         toolset: managed.toolset,
+        maxAgents: managed.maxAgents,
+        agentTimeoutMs: managed.agentTimeoutMs,
+        concurrency: managed.concurrency,
+        agentRetries: managed.agentRetries,
       });
     } catch (err) {
       this.releaseRunLease(managed);
@@ -344,6 +398,11 @@ export class WorkflowManager extends EventEmitter {
     managed.autoResume = exec.autoResume;
     managed.tokenBudget = exec.tokenBudget !== undefined ? exec.tokenBudget : this.defaultTokenBudget;
     managed.toolset = exec.toolset;
+    // Same freeze-at-start pattern as tokenBudget (see startInBackground/ManagedRun).
+    managed.maxAgents = exec.maxAgents;
+    managed.agentTimeoutMs = exec.agentTimeoutMs !== undefined ? exec.agentTimeoutMs : this.defaultAgentTimeoutMs;
+    managed.concurrency = exec.concurrency !== undefined ? exec.concurrency : this.concurrency;
+    managed.agentRetries = exec.agentRetries !== undefined ? exec.agentRetries : this.defaultAgentRetries;
     this.runs.set(managed.runId, managed);
     // Persist the initial state immediately so listRuns()/the task panel can see
     // the run the moment it starts, not only after the first agent journals.
@@ -403,10 +462,27 @@ export class WorkflowManager extends EventEmitter {
       agentRetries,
       confirm,
       tools,
+      initialTokenUsage,
     } = exec;
-    const resolvedAgentTimeoutMs = agentTimeoutMs !== undefined ? agentTimeoutMs : this.defaultAgentTimeoutMs;
-    const resolvedConcurrency = concurrency ?? this.concurrency;
-    const resolvedAgentRetries = agentRetries ?? this.defaultAgentRetries;
+    // maxAgents/agentTimeoutMs/concurrency/agentRetries were resolved (per-run
+    // value, else the manager default at the time) and frozen on the managed
+    // run at start/resume (see ManagedRun doc comments) — read them from there
+    // first, exactly like resolvedTokenBudget below, so a resumed run keeps the
+    // values it started with instead of re-resolving against the manager's
+    // CURRENT defaults. The exec.* fallbacks are a safety net for direct
+    // executeRun callers that skipped the start paths (same rationale as
+    // resolvedTokenBudget's tokenBudget fallback).
+    const resolvedMaxAgents = managed.maxAgents !== undefined ? managed.maxAgents : maxAgents;
+    const resolvedAgentTimeoutMs =
+      managed.agentTimeoutMs !== undefined
+        ? managed.agentTimeoutMs
+        : agentTimeoutMs !== undefined
+          ? agentTimeoutMs
+          : this.defaultAgentTimeoutMs;
+    const resolvedConcurrency =
+      managed.concurrency !== undefined ? managed.concurrency : (concurrency ?? this.concurrency);
+    const resolvedAgentRetries =
+      managed.agentRetries !== undefined ? managed.agentRetries : (agentRetries ?? this.defaultAgentRetries);
     // The budget was resolved (per-run value, else defaultTokenBudget) and frozen
     // on the managed run at start/resume — read it from there so a resumed run
     // keeps the budget it started with. exec.tokenBudget is a safety net for
@@ -438,7 +514,7 @@ export class WorkflowManager extends EventEmitter {
         signal: managed.controller.signal,
         concurrency: resolvedConcurrency,
         agentRetries: resolvedAgentRetries,
-        maxAgents,
+        maxAgents: resolvedMaxAgents,
         agentTimeoutMs: resolvedAgentTimeoutMs,
         tokenBudget: resolvedTokenBudget,
         tools: resolvedTools,
@@ -447,6 +523,12 @@ export class WorkflowManager extends EventEmitter {
         loadSavedWorkflow: this.loadSavedWorkflow,
         resumeJournal,
         resumeFromRunId: resumeJournal ? managed.runId : undefined,
+        // Seed the fresh SharedRuntime's spend counter from the persisted total
+        // (resume()) so the hard tokenBudget cap holds cumulatively across a
+        // pause/resume cycle instead of resetting to zero each time (see A2 —
+        // runWorkflow only applies this on the fresh-SharedRuntime branch, never
+        // overriding an inherited options.sharedRuntime from a nested workflow()).
+        initialTokenUsage,
         onAgentJournal: (entry) => {
           // Append (crash-safe-ish): keep the latest entry per index, then persist.
           // This is the high-frequency progress persist (fires once per completed
@@ -504,6 +586,37 @@ export class WorkflowManager extends EventEmitter {
             const ts = managed.agentTimestamps.get(agent.id);
             if (ts) ts.endedAt = new Date().toISOString();
           }
+          // Progressive run-wide token aggregate (A2): workflow.ts's onTokenUsage
+          // callback below fires exactly once, only when the whole script finishes
+          // successfully (a deliberate, tested contract — see
+          // "agent() accumulates usage across multiple agents" in agent.test.ts,
+          // which asserts one final event, not one per agent). A run that
+          // pauses/aborts/fails mid-flight never reaches it, so without tracking
+          // it here too, a paused run's persisted tokenUsage would stay whatever
+          // it was (usually unset) — starving resume()'s spend-seeding of the
+          // very data it needs. Accumulate additively from every onAgentEnd
+          // instead: a cache-hit replay reports tokens: 0 (see agent()'s replay
+          // branch in workflow.ts), so replaying the unchanged prefix on resume
+          // is a no-op add here, matching the "already historically spent, don't
+          // double-count" semantics of journal replay.
+          const priorUsage = managed.snapshot.tokenUsage;
+          const usage = {
+            input: priorUsage?.input ?? 0,
+            output: priorUsage?.output ?? 0,
+            total: priorUsage?.total ?? 0,
+            cost: priorUsage?.cost ?? 0,
+            cacheRead: priorUsage?.cacheRead ?? 0,
+            cacheWrite: priorUsage?.cacheWrite ?? 0,
+          };
+          usage.total += event.tokens ?? 0;
+          if (event.tokenUsage) {
+            usage.input += event.tokenUsage.input;
+            usage.output += event.tokenUsage.output;
+            usage.cost += event.tokenUsage.cost;
+            usage.cacheRead += event.tokenUsage.cacheRead;
+            usage.cacheWrite += event.tokenUsage.cacheWrite;
+          }
+          managed.snapshot.tokenUsage = usage;
           this.emit("agentEnd", { runId: managed.runId, ...event });
           progress();
         },
@@ -528,9 +641,13 @@ export class WorkflowManager extends EventEmitter {
       managed.result = result;
       this.emit("complete", { runId: managed.runId, result });
 
-      // Persist final state
+      // Persist final state. persistRun()/writeRunToDisk() already no-op if
+      // `managed` has been superseded (resume()/deleteRun() took over this
+      // runId) — see isCurrent(). Guard the lease release the same way: a
+      // stale execution settling after resume() has already acquired a NEW
+      // lease for this runId must not touch that newer lease's bookkeeping.
       this.persistRun(managed);
-      this.releaseRunLease(managed);
+      if (this.isCurrent(managed)) this.releaseRunLease(managed);
 
       return result;
     } catch (error) {
@@ -572,12 +689,26 @@ export class WorkflowManager extends EventEmitter {
         this.emit("error", { runId: managed.runId, error: workflowError });
       }
 
-      // Persist final state
+      // Persist final state (see the success-path comment above for the
+      // isCurrent() rationale — same guard, same reason).
       this.persistRun(managed);
-      this.releaseRunLease(managed);
+      if (this.isCurrent(managed)) this.releaseRunLease(managed);
 
       throw workflowError;
     }
+  }
+
+  /**
+   * True when `managed` is still the live, current entry for its runId in
+   * `this.runs` — false once resume() has replaced it with a new ManagedRun
+   * object for the same runId, or deleteRun() has removed it entirely. A
+   * superseded ManagedRun's async completion (executeRun's promise settling
+   * well after something else already took over or tore down that runId)
+   * must not write to disk or touch lease state on the newer execution's
+   * behalf — see writeRunToDisk() and executeRun()'s post-await persist calls.
+   */
+  private isCurrent(managed: ManagedRun): boolean {
+    return this.runs.get(managed.runId) === managed;
   }
 
   private releaseRunLease(managed: ManagedRun): void {
@@ -623,6 +754,13 @@ export class WorkflowManager extends EventEmitter {
    * pause()/resume()/stop().
    */
   private persistRun(managed: ManagedRun): void {
+    // A superseded execution's persist call must not touch the CURRENT
+    // execution's pending-timer bookkeeping for this runId (see isCurrent()).
+    // writeRunToDisk() below re-checks this too (it's the sole choke point
+    // schedulePersist()'s deferred timer also funnels through), so this is a
+    // belt-and-suspenders early-out specifically for the timer-clearing side
+    // effect, which writeRunToDisk() alone wouldn't prevent.
+    if (!this.isCurrent(managed)) return;
     const timer = this.persistTimers.get(managed.runId);
     if (timer) {
       clearTimeout(timer);
@@ -632,6 +770,14 @@ export class WorkflowManager extends EventEmitter {
   }
 
   private writeRunToDisk(managed: ManagedRun) {
+    // The sole choke point for every disk write (both persistRun()'s direct
+    // calls and schedulePersist()'s deferred timer funnel through here) — skip
+    // silently when `managed` is no longer the current entry for its runId
+    // (see isCurrent()). This is an expected race outcome (resume() replaced
+    // it, or deleteRun() removed it), not an error: writing anyway would
+    // resurrect a torn-down run's file, or clobber a newer execution's
+    // in-progress/completed state with this stale one's.
+    if (!this.isCurrent(managed)) return;
     try {
       this.persistence.save({
         runId: managed.runId,
@@ -650,6 +796,10 @@ export class WorkflowManager extends EventEmitter {
         // Start-time execution context, re-read by resume() (see ManagedRun).
         tokenBudget: managed.tokenBudget,
         toolset: managed.toolset,
+        maxAgents: managed.maxAgents,
+        agentTimeoutMs: managed.agentTimeoutMs,
+        concurrency: managed.concurrency,
+        agentRetries: managed.agentRetries,
         // Why a usage-limit pause happened, so the navigator / a future cold start
         // can show it and (eventually) re-arm resume after the budget refills.
         pauseReason: managed.status === "paused" && isProviderUsageLimit(managed.error) ? "usage_limit" : undefined,
@@ -738,6 +888,20 @@ export class WorkflowManager extends EventEmitter {
     const script = opts?.script ?? persisted.script;
     const args = opts?.args !== undefined ? opts.args : persisted.args;
 
+    // Normalize the persisted total-at-pause once: PersistedRunState.tokenUsage
+    // has optional cost/cacheRead/cacheWrite (legacy runs may lack them), but
+    // both the seeded snapshot and initialTokenUsage need concrete numbers.
+    const priorTokenUsage = persisted.tokenUsage
+      ? {
+          input: persisted.tokenUsage.input,
+          output: persisted.tokenUsage.output,
+          total: persisted.tokenUsage.total,
+          cost: persisted.tokenUsage.cost ?? 0,
+          cacheRead: persisted.tokenUsage.cacheRead ?? 0,
+          cacheWrite: persisted.tokenUsage.cacheWrite ?? 0,
+        }
+      : undefined;
+
     const controller = new AbortController();
     const managed: ManagedRun = {
       runId,
@@ -751,6 +915,11 @@ export class WorkflowManager extends EventEmitter {
         runningCount: 0,
         doneCount: 0,
         errorCount: 0,
+        // Seed the live snapshot's aggregate from the persisted total-at-pause
+        // (see A2) so a pause that lands before this resume's first agent
+        // completes doesn't lose the prior spend — onAgentEnd accumulates on
+        // top of this rather than starting from scratch.
+        tokenUsage: priorTokenUsage,
       },
       controller,
       startedAt: new Date(),
@@ -770,6 +939,23 @@ export class WorkflowManager extends EventEmitter {
       // re-resolves so e.g. a resumed /deep-research keeps its web tools.
       tokenBudget: persisted.tokenBudget !== undefined ? persisted.tokenBudget : null,
       toolset: persisted.toolset,
+      // Restore the same start-time execution context for the other four
+      // per-run knobs (see ManagedRun doc comments) — same rationale as
+      // tokenBudget: never re-resolve against the manager's CURRENT defaults.
+      // maxAgents: legacy/never-set runs resume with no cap carried forward
+      // (runWorkflow's own MAX_AGENTS_PER_RUN default applies), exactly as if
+      // maxAgents had never been passed at all.
+      maxAgents: persisted.maxAgents,
+      // agentTimeoutMs/tokenBudget share the same "explicit null is meaningful
+      // and must survive" concern, so legacy runs fall back to null (no forced
+      // timeout) rather than silently regaining the manager's current default.
+      agentTimeoutMs: persisted.agentTimeoutMs !== undefined ? persisted.agentTimeoutMs : null,
+      // concurrency/agentRetries have no "explicit opt-out sentinel" the way
+      // tokenBudget's null does — a legacy run without a persisted value falls
+      // back to the manager's current values, matching how this execution
+      // resolved unset concurrency/agentRetries before this fix ever existed.
+      concurrency: persisted.concurrency !== undefined ? persisted.concurrency : this.concurrency,
+      agentRetries: persisted.agentRetries !== undefined ? persisted.agentRetries : this.defaultAgentRetries,
       // Fresh per-resume: agents (and any prior timing) are rebuilt live as
       // onAgentStart/onAgentEnd fire again for this attempt (see `agents: []`
       // above); the journal, not this map, is what makes replayed agents cheap.
@@ -783,7 +969,19 @@ export class WorkflowManager extends EventEmitter {
     const resumeJournal = new Map((persisted.journal ?? []).map((e) => [e.index, e] as const));
     this.emit("resumed", { runId });
     // Run in the background; executeRun records status/errors on the managed run.
-    void this.executeRun(managed, script, args, { resumeJournal }).catch(() => {});
+    // initialTokenUsage seeds the resumed execution's fresh SharedRuntime.spent
+    // (A2) from the persisted total-at-pause, so the tokenBudget cap holds
+    // cumulatively instead of resetting to zero. Note: shared.agentCount is
+    // deliberately NOT seeded the same way — it doesn't need to be. Unlike
+    // token spend (whose cache-hit replay branch skips recordTokens() to avoid
+    // double-counting already-spent tokens), agent()'s shared.agentCount++
+    // fires unconditionally for EVERY call, cache-hit or live, before the
+    // replay check runs (see workflow.ts). Because resume() always replays the
+    // whole script from callIndex 0, that replay alone reconstructs the
+    // correct cumulative count inside this fresh SharedRuntime by the time any
+    // new live agent runs — so maxAgents (via A1) is already a genuine
+    // cumulative cap across resume with no extra seeding required.
+    void this.executeRun(managed, script, args, { resumeJournal, initialTokenUsage: priorTokenUsage }).catch(() => {});
     return true;
   }
 
@@ -859,10 +1057,29 @@ export class WorkflowManager extends EventEmitter {
 
   /**
    * Delete a persisted run.
+   *
+   * If `runId` is still live in this process (running or paused-in-memory),
+   * abort its controller FIRST, before any teardown below — a live run left
+   * un-aborted would otherwise keep executing in the background indefinitely
+   * (burning API calls/tokens/holding a worktree) after its record is gone.
+   * Aborting first, while `managed` is still `this.runs.get(runId)`, costs
+   * nothing extra: the abort signal is fire-and-forget (cooperative — the
+   * execution winds down on its own schedule), so the exact instant we flip
+   * `this.runs`/release the lease/delete files relative to it doesn't matter
+   * for correctness. What DOES matter is that once this method returns, the
+   * aborted execution's eventual settle (executeRun's success/catch path,
+   * asynchronously, possibly much later) must be a harmless no-op rather than
+   * a resurrection — that's what isCurrent() guarantees: `this.runs.delete()`
+   * below means executeRun's later persistRun()/releaseRunLease() calls on
+   * this same `managed` object find `this.runs.get(runId) !== managed` (in
+   * fact `undefined`, since the entry is gone) and skip writing/releasing.
    */
   deleteRun(runId: string): boolean {
     const managed = this.runs.get(runId);
-    if (managed) this.releaseRunLease(managed);
+    if (managed) {
+      if (!managed.controller.signal.aborted) managed.controller.abort();
+      this.releaseRunLease(managed);
+    }
     this.runs.delete(runId);
     // Cancel any pending throttled write so a deferred persist can't fire after
     // deletion and resurrect the run's file on disk.

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -492,7 +492,12 @@ export class WorkflowManager extends EventEmitter {
     // toolset tag (how a resumed /deep-research keeps its web tools); else the
     // agent layer's default coding tools.
     const resolvedTools = tools ?? (managed.toolset ? this.toolsets?.[managed.toolset]?.() : undefined);
-    const progress = () => onProgress?.(managed.snapshot);
+    // Gated the same way as this.emitLive() below (see isCurrent()) — a stale
+    // execution's progress callback would otherwise keep driving live UI
+    // (task panel, etc.) for a run that's been superseded or deleted.
+    const progress = () => {
+      if (this.isCurrent(managed)) onProgress?.(managed.snapshot);
+    };
     // Let a host abort (e.g. Esc during a blocking tool call) cancel this run.
     if (externalSignal) {
       if (externalSignal.aborted) managed.controller.abort();
@@ -529,6 +534,14 @@ export class WorkflowManager extends EventEmitter {
         // runWorkflow only applies this on the fresh-SharedRuntime branch, never
         // overriding an inherited options.sharedRuntime from a nested workflow()).
         initialTokenUsage,
+        // Retried-attempt spend (see WorkflowRunOptions.onRetrySpend and A2):
+        // recordTokens() in workflow.ts already folded this into
+        // shared.spent/tokenUsage, but onAgentEnd never sees a retried
+        // (non-final) attempt — fold it into the same persisted aggregate here
+        // so a run paused after a retry doesn't under-count against the budget.
+        onRetrySpend: (tokens) => {
+          this.accumulateTokenUsage(managed, tokens);
+        },
         onAgentJournal: (entry) => {
           // Append (crash-safe-ish): keep the latest entry per index, then persist.
           // This is the high-frequency progress persist (fires once per completed
@@ -541,7 +554,7 @@ export class WorkflowManager extends EventEmitter {
         },
         onLog: (message) => {
           managed.snapshot.logs.push(message);
-          this.emit("log", { runId: managed.runId, message });
+          this.emitLive(managed, "log", { runId: managed.runId, message });
           progress();
         },
         onPhase: (title) => {
@@ -549,7 +562,7 @@ export class WorkflowManager extends EventEmitter {
           if (!managed.snapshot.phases.includes(title)) {
             managed.snapshot.phases.push(title);
           }
-          this.emit("phase", { runId: managed.runId, title });
+          this.emitLive(managed, "phase", { runId: managed.runId, title });
           progress();
         },
         onAgentStart: (event) => {
@@ -565,7 +578,7 @@ export class WorkflowManager extends EventEmitter {
           // Real per-agent start time, captured the moment the agent actually
           // starts (not the run's startedAt) — see agentTimestamps.
           managed.agentTimestamps.set(id, { startedAt: new Date().toISOString() });
-          this.emit("agentStart", { runId: managed.runId, ...event });
+          this.emitLive(managed, "agentStart", { runId: managed.runId, ...event });
           progress();
         },
         onAgentEnd: (event) => {
@@ -599,25 +612,8 @@ export class WorkflowManager extends EventEmitter {
           // branch in workflow.ts), so replaying the unchanged prefix on resume
           // is a no-op add here, matching the "already historically spent, don't
           // double-count" semantics of journal replay.
-          const priorUsage = managed.snapshot.tokenUsage;
-          const usage = {
-            input: priorUsage?.input ?? 0,
-            output: priorUsage?.output ?? 0,
-            total: priorUsage?.total ?? 0,
-            cost: priorUsage?.cost ?? 0,
-            cacheRead: priorUsage?.cacheRead ?? 0,
-            cacheWrite: priorUsage?.cacheWrite ?? 0,
-          };
-          usage.total += event.tokens ?? 0;
-          if (event.tokenUsage) {
-            usage.input += event.tokenUsage.input;
-            usage.output += event.tokenUsage.output;
-            usage.cost += event.tokenUsage.cost;
-            usage.cacheRead += event.tokenUsage.cacheRead;
-            usage.cacheWrite += event.tokenUsage.cacheWrite;
-          }
-          managed.snapshot.tokenUsage = usage;
-          this.emit("agentEnd", { runId: managed.runId, ...event });
+          this.accumulateTokenUsage(managed, event.tokens ?? 0, event.tokenUsage);
+          this.emitLive(managed, "agentEnd", { runId: managed.runId, ...event });
           progress();
         },
         onAgentHistory: (event) => {
@@ -627,19 +623,23 @@ export class WorkflowManager extends EventEmitter {
           if (agent) {
             agent.history = event.history;
           }
-          this.emit("agentHistory", { runId: managed.runId, ...event });
+          this.emitLive(managed, "agentHistory", { runId: managed.runId, ...event });
           progress();
         },
         onTokenUsage: (usage) => {
           managed.snapshot.tokenUsage = usage;
-          this.emit("tokenUsage", { runId: managed.runId, usage });
+          this.emitLive(managed, "tokenUsage", { runId: managed.runId, usage });
           progress();
         },
       });
 
       managed.status = "completed";
       managed.result = result;
-      this.emit("complete", { runId: managed.runId, result });
+      // Gated the same way as disk/lease below (see emitLive()): a stale
+      // execution's "complete" would otherwise still deliver a result for a
+      // run that's been superseded or deleted (e.g. background result
+      // delivery into the conversation) even though it's no longer current.
+      this.emitLive(managed, "complete", { runId: managed.runId, result });
 
       // Persist final state. persistRun()/writeRunToDisk() already no-op if
       // `managed` has been superseded (resume()/deleteRun() took over this
@@ -675,8 +675,10 @@ export class WorkflowManager extends EventEmitter {
         managed.status = "failed";
       }
       managed.error = workflowError;
+      // Both branches gated via emitLive() (see its doc comment) — a stale
+      // execution's "paused"/"error" is equally misleading once superseded.
       if (usageLimitPaused) {
-        this.emit("paused", {
+        this.emitLive(managed, "paused", {
           runId: managed.runId,
           reason: "usage_limit",
           error: workflowError,
@@ -686,7 +688,7 @@ export class WorkflowManager extends EventEmitter {
         // Guarded: EventEmitter throws on an unlistened "error" emit, which
         // would abort this catch block mid-way — skipping the final persist,
         // the lease release, and the real error rethrow below.
-        this.emit("error", { runId: managed.runId, error: workflowError });
+        this.emitLive(managed, "error", { runId: managed.runId, error: workflowError });
       }
 
       // Persist final state (see the success-path comment above for the
@@ -709,6 +711,62 @@ export class WorkflowManager extends EventEmitter {
    */
   private isCurrent(managed: ManagedRun): boolean {
     return this.runs.get(managed.runId) === managed;
+  }
+
+  /**
+   * Emit an event on behalf of `managed`, but only while it's still the
+   * current entry for its runId (see isCurrent()) — mirrors the disk/lease
+   * guard for the observer-facing side of the same problem. A superseded
+   * execution's progress/terminal events (log, phase, agentStart/End,
+   * tokenUsage, complete, error, paused) are not just stale-but-harmless:
+   * "complete" in particular can drive background result delivery into the
+   * conversation, so letting a deleted/superseded run's stale settle still
+   * fire it would deliver a result for a run that, from the caller's POV, no
+   * longer exists (or has since been superseded by a newer execution whose
+   * own events already tell the true story). No event in this set has a
+   * legitimate reason to still reach listeners once superseded — unlike
+   * disk writes there's no "expected race, harmless no-op" nuance here, it's
+   * simply wrong to notify twice (or for a run that's gone). Events emitted
+   * directly by pause()/stop()/resume()/deleteRun() themselves are NOT routed
+   * through this helper — those methods own the transition and ARE current
+   * at the moment they fire, same precedent as their persist/lease calls.
+   */
+  private emitLive(managed: ManagedRun, event: string, payload: unknown): void {
+    if (this.isCurrent(managed)) this.emit(event, payload);
+  }
+
+  /**
+   * Additively fold one agent-call's token cost into the run-wide persisted
+   * aggregate (managed.snapshot.tokenUsage), seeded (on resume) from the
+   * persisted total-at-pause — see A2. Shared by onAgentEnd (a completed or
+   * finally-failed agent call) and onRetrySpend (a failed attempt that WILL
+   * be retried, whose cost recordTokens() already folded into
+   * shared.spent/tokenUsage in workflow.ts, but which onAgentEnd never sees —
+   * see WorkflowRunOptions.onRetrySpend for why that needs its own channel).
+   */
+  private accumulateTokenUsage(
+    managed: ManagedRun,
+    tokens: number,
+    tokenUsage?: { input: number; output: number; cost: number; cacheRead: number; cacheWrite: number },
+  ): void {
+    const prior = managed.snapshot.tokenUsage;
+    const usage = {
+      input: prior?.input ?? 0,
+      output: prior?.output ?? 0,
+      total: prior?.total ?? 0,
+      cost: prior?.cost ?? 0,
+      cacheRead: prior?.cacheRead ?? 0,
+      cacheWrite: prior?.cacheWrite ?? 0,
+    };
+    usage.total += tokens;
+    if (tokenUsage) {
+      usage.input += tokenUsage.input;
+      usage.output += tokenUsage.output;
+      usage.cost += tokenUsage.cost;
+      usage.cacheRead += tokenUsage.cacheRead;
+      usage.cacheWrite += tokenUsage.cacheWrite;
+    }
+    managed.snapshot.tokenUsage = usage;
   }
 
   private releaseRunLease(managed: ManagedRun): void {
@@ -946,10 +1004,17 @@ export class WorkflowManager extends EventEmitter {
       // (runWorkflow's own MAX_AGENTS_PER_RUN default applies), exactly as if
       // maxAgents had never been passed at all.
       maxAgents: persisted.maxAgents,
-      // agentTimeoutMs/tokenBudget share the same "explicit null is meaningful
-      // and must survive" concern, so legacy runs fall back to null (no forced
-      // timeout) rather than silently regaining the manager's current default.
-      agentTimeoutMs: persisted.agentTimeoutMs !== undefined ? persisted.agentTimeoutMs : null,
+      // agentTimeoutMs: unlike tokenBudget, a legacy run's real timeout at
+      // start was never "no timeout" by omission — it was always
+      // this.defaultAgentTimeoutMs, because pre-A1 resume() never threaded
+      // agentTimeoutMs through at all and unconditionally fell back to the
+      // manager default (see executeRun's resolvedAgentTimeoutMs fallback
+      // chain). Falling back to null here would change what a legacy run's
+      // resume actually does versus both its original start AND pre-fix
+      // resume behavior. So — deliberately unlike tokenBudget's null
+      // fallback — legacy runs resume with the manager's CURRENT default,
+      // matching the only semantics such a run ever had.
+      agentTimeoutMs: persisted.agentTimeoutMs !== undefined ? persisted.agentTimeoutMs : this.defaultAgentTimeoutMs,
       // concurrency/agentRetries have no "explicit opt-out sentinel" the way
       // tokenBudget's null does — a legacy run without a persisted value falls
       // back to the manager's current values, matching how this execution

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -128,6 +128,20 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   resumeFromRunId?: string;
   /** Called after each live agent completes so the caller can persist the journal. */
   onAgentJournal?: (entry: JournalEntry) => void;
+  /**
+   * Called once per FAILED-AND-RETRIED attempt (not the final attempt of an
+   * agent() call, which reports its own tokens via onAgentEnd as before),
+   * with that attempt's token cost. recordTokens() already folds a retried
+   * attempt's spend into shared.spent/shared.tokenUsage (so the run-wide
+   * budget was never leaky) — but onAgentEnd only ever reports the FINAL
+   * attempt's tokens, so a caller accumulating a persisted total purely from
+   * onAgentEnd (see WorkflowManager) would under-count by exactly the
+   * wasted retried attempts' spend. This is a separate, silent channel
+   * specifically so retried-attempt spend can be accounted for without
+   * changing onAgentEnd's one-call-per-agent-call cadence (a contract other
+   * code depends on).
+   */
+  onRetrySpend?: (tokens: number) => void;
   /** Internal: shared runtime inherited by a nested workflow() call. */
   sharedRuntime?: SharedRuntime;
   /**
@@ -678,6 +692,11 @@ export async function runWorkflow<T = unknown>(
               log(
                 `agent "${label}" attempt ${attempt}/${maxAttempts} failed: ${workflowError.code} ${workflowError.message}; retrying`,
               );
+              // This attempt's spend already accrued into shared.spent/tokenUsage
+              // above (recordTokens) — but it will never reach onAgentEnd (only
+              // the final attempt does), so report it on the dedicated channel
+              // instead (see WorkflowRunOptions.onRetrySpend).
+              options.onRetrySpend?.(tokens);
               continue;
             }
 

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -118,6 +118,24 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   /** Internal: shared runtime inherited by a nested workflow() call. */
   sharedRuntime?: SharedRuntime;
   /**
+   * Seed the FRESH SharedRuntime's cumulative spend/tokenUsage counters from a
+   * previously-persisted total (resume()), instead of starting at zero. Used
+   * only on the fresh-SharedRuntime branch below — never applied when
+   * `sharedRuntime` is supplied (a nested workflow() call inherits the
+   * parent's live, already-correct counters and must not be re-seeded).
+   * Without this, a resumed run's tokenBudget cap silently resets: it would
+   * enforce the ceiling against only what THIS execution spends, ignoring
+   * whatever was already spent before the pause.
+   */
+  initialTokenUsage?: {
+    input: number;
+    output: number;
+    total: number;
+    cost: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  /**
    * Shared store for this run. One instance is created per top-level run and
    * propagated into nested workflow() calls. Pass an existing instance to share
    * state across a parent and child run; omit to create a fresh isolated store.
@@ -323,11 +341,29 @@ export async function runWorkflow<T = unknown>(
     options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2),
   );
   // Global caps + budget are shared with any nested workflow() so they hold across nesting.
+  // options.initialTokenUsage (resume() only) seeds spent/tokenUsage so the
+  // tokenBudget ceiling holds cumulatively across a pause/resume cycle instead
+  // of resetting to zero (see WorkflowRunOptions.initialTokenUsage). Deliberately
+  // NOT applied when options.sharedRuntime is supplied — that branch inherits a
+  // parent workflow()'s already-live counters, which must not be re-seeded.
+  //
+  // agentCount is NOT seeded here, unlike spent/tokenUsage — and doesn't need
+  // to be: resume() always replays the whole script from callIndex 0, and
+  // agent()'s `shared.agentCount++` fires unconditionally for every call
+  // (cache-hit replay or live) before the replay-vs-live branch runs. That
+  // replay alone reconstructs the correct cumulative count in this fresh
+  // SharedRuntime by the time any new live agent executes, so maxAgents stays
+  // a genuine cumulative cap across resume with no extra seeding. Token spend
+  // needs seeding precisely because its cache-hit branch deliberately does NOT
+  // re-run recordTokens() (to avoid double-counting already-spent tokens) —
+  // there is no replay-based reconstruction for it the way there is for count.
   const shared: SharedRuntime = options.sharedRuntime ?? {
     limiter: createLimiter(concurrency),
     agentCount: 0,
-    spent: 0,
-    tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
+    spent: options.initialTokenUsage?.total ?? 0,
+    tokenUsage: options.initialTokenUsage
+      ? { ...options.initialTokenUsage }
+      : { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
     depth: 0,
   };
   const limiter = shared.limiter;

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -376,6 +376,52 @@ return { xs, after }`;
 );
 
 test(
+  "resuming a legacy persisted run (no agentTimeoutMs field) falls back to the manager's CURRENT default, not null",
+  withTempCwd(async (cwd) => {
+    // A run persisted before this fix existed never had an agentTimeoutMs
+    // field at all — and its only real timeout, both at its original start
+    // AND under pre-fix resume(), was always the manager's default (pre-fix
+    // resume never threaded agentTimeoutMs through, so it fell straight to
+    // this.defaultAgentTimeoutMs via executeRun's fallback chain). Falling
+    // back to null here would silently grant such a run an unbounded timeout
+    // it never had. Use a slow agent so only a real 20ms enforcement times it
+    // out — an unbounded (null) fallback would let it complete instead.
+    const manager = new WorkflowManager({ cwd, agent: delayedAgent(60), defaultAgentTimeoutMs: 20 });
+    const pers = manager.getPersistence();
+    const runId = "legacy-no-agent-timeout-1";
+    pers.save({
+      runId,
+      workflowName: "legacy",
+      script: oneAgentScript,
+      args: undefined,
+      status: "paused",
+      phases: [],
+      agents: [],
+      logs: [],
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      // Deliberately no maxAgents/agentTimeoutMs/concurrency/agentRetries —
+      // simulates a run persisted by pre-A1 code.
+    });
+
+    const resumed = await manager.resume(runId);
+    assert.equal(resumed, true);
+    for (let i = 0; i < 200 && manager.getRun(runId)?.status === "running"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    const persisted = manager.getPersistence().load(runId);
+    assert.equal(
+      persisted?.agentTimeoutMs,
+      20,
+      "resume must apply the manager's current defaultAgentTimeoutMs for a legacy run, not leave it unbounded",
+    );
+    const agent = persisted?.agents.find((a) => a.label === "a");
+    assert.match(agent?.error ?? "", /timed out after 20ms/, "the legacy run's agent must actually time out at 20ms");
+  }),
+);
+
+test(
   "resume seeds the token-spend counter from the persisted total, so the budget holds cumulatively (#A2)",
   withTempCwd(async (cwd) => {
     // 'first' completes normally (spends 100). 'second' hangs on its first
@@ -434,6 +480,60 @@ return { a, b, c }`;
     assert.equal(resumed?.status, "failed", "the tokenBudget must hold cumulatively across resume");
     const finalRun = manager.getRun(runId);
     assert.equal(finalRun?.error?.code, WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED);
+  }),
+);
+
+test(
+  "a retried (failed-then-succeeded) attempt's spend is not lost from the persisted total when the run pauses before completing",
+  withTempCwd(async (cwd) => {
+    // 'a's first attempt spends 40 tokens then fails with an empty output
+    // (recoverable -> retried); its second attempt spends 25 more and
+    // succeeds. onAgentEnd only ever reports the FINAL attempt's tokens (25)
+    // — the first attempt's 40 would be invisible to a persisted total built
+    // purely from onAgentEnd. 'b' then hangs so we can pause() and inspect
+    // the persisted state BEFORE the run fully completes (a full completion
+    // would paper over the gap via workflow.ts's own final onTokenUsage,
+    // which always includes every attempt's spend regardless of this fix).
+    let aAttempts = 0;
+    const agent = {
+      async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+        if (prompt === "a") {
+          aAttempts++;
+          if (aAttempts === 1) {
+            options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 40, cost: 0 });
+            return ""; // empty output -> recoverable AGENT_EMPTY_OUTPUT -> retried
+          }
+          options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 25, cost: 0 });
+          return "a-result";
+        }
+        return new Promise(() => {}); // 'b' hangs until paused
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent });
+    manager.on("error", () => {});
+
+    const script = `export const meta = { name: 'retry_spend_demo', description: 'retry spend' }
+const a = await agent('a', { label: 'a' })
+const b = await agent('b', { label: 'b' })
+return { a, b }`;
+
+    const { runId, promise } = manager.startInBackground(script, undefined, { agentRetries: 1 });
+    promise.catch(() => {});
+    for (let i = 0; i < 200 && aAttempts < 2; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(aAttempts, 2, "'a' should have failed once and be retrying by now");
+    // Let 'b' actually start (and begin hanging) before pausing.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(manager.pause(runId), true);
+
+    const paused = manager.getPersistence().load(runId);
+    assert.equal(paused?.status, "paused");
+    assert.equal(
+      paused?.tokenUsage?.total,
+      65,
+      "the persisted total must include the failed-then-retried attempt's 40 tokens, not just the final attempt's 25",
+    );
   }),
 );
 
@@ -1903,6 +2003,158 @@ test(
       finalState?.status,
       "completed",
       "the stale execution's later settle must not clobber the resumed run's persisted state",
+    );
+  }),
+);
+
+test(
+  "resume() superseding a NEVER-ABORTED failed run suppresses a stray sibling agent's later agentEnd event (#1)",
+  withTempCwd(async (cwd) => {
+    // Key insight: pause()/stop()/deleteRun() all abort the run's shared
+    // signal before/while superseding it — so a straggling agent, once it
+    // resolves, hits agent()'s own throwIfAborted() and never reaches
+    // onAgentEnd at all (aborted-and-superseded is already covered by the
+    // A3/A4 disk/lease guard, and never emits events in the first place).
+    // The REAL gap is a run that reaches "failed" WITHOUT any abort — e.g. a
+    // parallel() fan-out where one sibling ('failer') throws a plain
+    // non-recoverable error while another ('straggler') is still in flight:
+    // Promise.all rejects immediately (failing the whole run) but does NOT
+    // cancel 'straggler', and nothing ever aborts the run's signal. resume()
+    // is then callable on this "failed" run (no abort needed) and builds a
+    // BRAND NEW managed/controller — leaving the OLD 'straggler' running
+    // against the OLD (now superseded) managed with a signal that will NEVER
+    // trip throwIfAborted(). When it finally resolves, it WILL reach
+    // onAgentEnd — this must be suppressed because the old managed is no
+    // longer current, not because of any abort.
+    let stragglerSettles = 0;
+    const agent = {
+      async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+        if (prompt === "failer") {
+          throw new WorkflowError("boom", WorkflowErrorCode.AGENT_EXECUTION_ERROR, { recoverable: false });
+        }
+        // "straggler": a real delay, entirely unrelated to the sibling's
+        // failure or to abort — it just takes time to answer.
+        await new Promise((resolve) => setTimeout(resolve, 60));
+        stragglerSettles++;
+        options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
+        return "straggler-done";
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent });
+    manager.on("error", () => {});
+    const agentEndsByLabel = new Map<string, number>();
+    manager.on("agentEnd", (e: { label: string }) => {
+      agentEndsByLabel.set(e.label, (agentEndsByLabel.get(e.label) ?? 0) + 1);
+    });
+
+    const script = `export const meta = { name: 'stray_sibling_demo', description: 'stray sibling agent' }
+const xs = await parallel([
+  () => agent('failer', { label: 'failer' }),
+  () => agent('straggler', { label: 'straggler' }),
+])
+return xs`;
+
+    const { runId, promise } = manager.startInBackground(script);
+    promise.catch(() => {});
+    for (let i = 0; i < 200 && manager.getRun(runId)?.status !== "failed"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(manager.getRun(runId)?.status, "failed", "the run must fail (via 'failer') without ever aborting");
+    assert.equal(
+      manager.getRun(runId)?.controller.signal.aborted,
+      false,
+      "confirms this failure path never aborts — the real gap this test targets",
+    );
+    const oldManaged = manager.getRun(runId);
+
+    // Resume: builds a brand-new managed/controller for this runId. The OLD
+    // managed's 'straggler' call is still in flight, entirely unaffected.
+    assert.equal(await manager.resume(runId), true);
+    assert.notEqual(manager.getRun(runId), oldManaged, "resume() must have replaced the managed run object");
+
+    // Wait past BOTH the old and the new execution's 'straggler' (each ~60ms
+    // from its own start) so both have settled.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    assert.equal(stragglerSettles, 2, "both the old (stale) and new (current) straggler calls actually ran");
+    assert.equal(
+      agentEndsByLabel.get("straggler"),
+      1,
+      "only the current execution's straggler should emit agentEnd — the stale one must be suppressed",
+    );
+  }),
+);
+
+test(
+  "writeRunToDisk's own isCurrent guard is independently load-bearing: a stale schedulePersist deferred timer must not write (#2)",
+  withTempCwd(async (cwd) => {
+    // persistRun() early-returns on a stale `managed` before it would clear
+    // any pending throttled timer — so mutation testing showed removing
+    // writeRunToDisk's OWN isCurrent check survives the suite: every OTHER
+    // test's stale write happens to arrive via a direct persistRun() call
+    // (already guarded there). The one path that funnels straight into
+    // writeRunToDisk WITHOUT ever going through persistRun() is
+    // schedulePersist()'s deferred setTimeout callback — reachable only when
+    // a stale (never-aborted, superseded) execution's onAgentJournal fires
+    // AFTER supersede and schedules a BRAND NEW timer for a runId that
+    // nothing else currently has one pending for (see the "stray sibling"
+    // test above for why resume() on a never-aborted failed run is the way
+    // to get a genuinely stale-but-still-running agent call).
+    //
+    // Timing: the OLD execution's 'straggler' (its first invocation) settles
+    // quickly (30ms) and alone registers the stray timer; the NEW
+    // execution's OWN 'straggler' (second invocation) is deliberately much
+    // slower (500ms) so it can't interfere with or mask the stray timer's
+    // ~400ms throttle window.
+    let stragglerCalls = 0;
+    const agent = {
+      async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+        if (prompt === "failer") {
+          throw new WorkflowError("boom", WorkflowErrorCode.AGENT_EXECUTION_ERROR, { recoverable: false });
+        }
+        stragglerCalls++;
+        const delayMs = stragglerCalls === 1 ? 30 : 500;
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
+        return `straggler-${stragglerCalls}`;
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent });
+    manager.on("error", () => {});
+
+    const script = `export const meta = { name: 'stray_timer_demo', description: 'stray schedulePersist timer' }
+const xs = await parallel([
+  () => agent('failer', { label: 'failer' }),
+  () => agent('straggler', { label: 'straggler' }),
+])
+return xs`;
+
+    const { runId, promise } = manager.startInBackground(script);
+    promise.catch(() => {});
+    for (let i = 0; i < 200 && manager.getRun(runId)?.status !== "failed"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(manager.getRun(runId)?.status, "failed");
+    assert.equal(manager.getRun(runId)?.controller.signal.aborted, false, "never aborted — the real gap");
+
+    assert.equal(await manager.resume(runId), true);
+
+    // Wait past the OLD straggler's 30ms settle (registers the stray timer)
+    // but stay well before its ~400ms throttle fires, and well before the
+    // NEW straggler's own 500ms settle.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const beforeStaleWrite = manager.getPersistence().load(runId);
+    assert.ok(beforeStaleWrite, "run should still be persisted at this point");
+
+    // Wait past the stray timer's ~400ms throttle window, but still short of
+    // the NEW execution's own straggler settling at ~500ms.
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    const afterStaleWindow = manager.getPersistence().load(runId);
+    assert.equal(
+      afterStaleWindow?.updatedAt,
+      beforeStaleWrite?.updatedAt,
+      "the stray schedulePersist timer (from the stale execution's straggler) must not write to disk",
     );
   }),
 );

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -305,6 +305,139 @@ test(
 );
 
 test(
+  "resume re-resolves the run's maxAgents/agentTimeoutMs and keeps its start-time values (#A1)",
+  withTempCwd(async (cwd) => {
+    // 'a' hangs on its first invocation (pause point), then on its second
+    // invocation (post-resume) resolves slower than the run's OWN frozen
+    // agentTimeoutMs (30ms) but well under the manager's defaultAgentTimeoutMs
+    // (5000ms) — it only times out if agentTimeoutMs survived resume.
+    let aAttempts = 0;
+    const zeroUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 };
+    const agent = {
+      async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+        if (prompt === "a") {
+          aAttempts++;
+          if (aAttempts === 1) return new Promise(() => {}); // hang until paused
+          await new Promise((resolve) => setTimeout(resolve, 60));
+          options?.onUsage?.(zeroUsage);
+          return "a-result";
+        }
+        options?.onUsage?.(zeroUsage);
+        return `${prompt}-result`;
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent, defaultAgentTimeoutMs: 5000 });
+    manager.on("error", () => {});
+
+    // Three agents fanned out via parallel() with maxAgents: 3 so the cap is
+    // fully consumed by the fan-out itself (each reserves a slot atomically,
+    // in call order, before any of them actually run) — a 4th call ('after')
+    // then only succeeds if the cap has silently reverted to the ~1000 default.
+    const script = `export const meta = { name: 'cap_demo', description: 'agent cap across resume' }
+const xs = await parallel(['a','b','c'].map((label) => () => agent(label, { label })))
+const after = await agent('after', { label: 'after' })
+return { xs, after }`;
+
+    const { runId, promise } = manager.startInBackground(script, undefined, { maxAgents: 3, agentTimeoutMs: 30 });
+    promise.catch(() => {});
+    // Pause well before 'a's own 30ms agentTimeoutMs would fire on the ORIGINAL
+    // execution too (it's frozen for the whole run, not just post-resume) — 5ms
+    // is enough for 'b'/'c' (no artificial delay) to complete and journal.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.equal(aAttempts, 1, "'a' should be in flight before pausing");
+    assert.equal(manager.pause(runId), true);
+
+    const paused = manager.getPersistence().load(runId);
+    assert.equal(paused?.status, "paused");
+    assert.equal(paused?.maxAgents, 3, "maxAgents persists with the run");
+    assert.equal(paused?.agentTimeoutMs, 30, "agentTimeoutMs persists with the run");
+    assert.ok((paused?.journal?.length ?? 0) >= 2, "'b' and 'c' should be journaled before pause");
+
+    assert.equal(await manager.resume(runId), true);
+    for (let i = 0; i < 200 && manager.getRun(runId)?.status === "running"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    const resumed = manager.getPersistence().load(runId);
+    const aAgent = resumed?.agents.find((ag) => ag.label === "a");
+    assert.match(
+      aAgent?.error ?? "",
+      /timed out after 30ms/,
+      "agentTimeoutMs must survive resume, not reset to the manager default",
+    );
+    // The resumed run must still enforce maxAgents: 3 — the 4th call ('after',
+    // after a/b/c already reserved a slot each in the fan-out) must throw
+    // AGENT_LIMIT_EXCEEDED, failing the run, not silently pass under a
+    // reverted-to-default cap of ~1000.
+    assert.equal(resumed?.status, "failed", "maxAgents must survive resume, not reset to the 1000 default");
+    const finalRun = manager.getRun(runId);
+    assert.equal(finalRun?.error?.code, WorkflowErrorCode.AGENT_LIMIT_EXCEEDED);
+  }),
+);
+
+test(
+  "resume seeds the token-spend counter from the persisted total, so the budget holds cumulatively (#A2)",
+  withTempCwd(async (cwd) => {
+    // 'first' completes normally (spends 100). 'second' hangs on its first
+    // attempt (pause point), then on its second attempt (post-resume) spends
+    // 60 more — 100 + 60 = 160, over the 150 budget, but neither half alone
+    // would trip it. 'third' only runs if the budget wrongly reset to 0 at
+    // resume; it must instead be blocked before it even starts.
+    let secondAttempts = 0;
+    const zeroUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 };
+    const agent = {
+      async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+        if (prompt === "first") {
+          options?.onUsage?.({ ...zeroUsage, total: 100 });
+          return "first-result";
+        }
+        if (prompt === "second") {
+          if (++secondAttempts === 1) return new Promise(() => {}); // hang until paused
+          options?.onUsage?.({ ...zeroUsage, total: 60 });
+          return "second-result";
+        }
+        options?.onUsage?.({ ...zeroUsage, total: 1 });
+        return "third-result";
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent });
+    manager.on("error", () => {});
+
+    const script = `export const meta = { name: 'seed_demo', description: 'three sequential agents' }
+const a = await agent('first', { label: 'first' })
+const b = await agent('second', { label: 'second' })
+const c = await agent('third', { label: 'third' })
+return { a, b, c }`;
+
+    const { runId, promise } = manager.startInBackground(script, undefined, { tokenBudget: 150 });
+    promise.catch(() => {});
+    for (let i = 0; i < 200 && secondAttempts === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(secondAttempts, 1, "'second' should be in flight before pausing");
+    assert.equal(manager.pause(runId), true);
+
+    const paused = manager.getPersistence().load(runId);
+    assert.equal(paused?.status, "paused");
+    assert.equal(paused?.tokenUsage?.total, 100, "pre-pause spend (agent 1) is persisted, not lost mid-run");
+
+    assert.equal(await manager.resume(runId), true);
+    for (let i = 0; i < 200 && manager.getRun(runId)?.status === "running"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    const resumed = manager.getPersistence().load(runId);
+    // The cumulative spend (100 + 60 = 160) must be reflected...
+    assert.equal(resumed?.tokenUsage?.total, 160, "final tokenUsage reflects both the pre-pause and post-resume spend");
+    // ...and must have tripped the budget once the SUM exceeded it — the run
+    // fails with TOKEN_BUDGET_EXHAUSTED on 'third', not a reset-to-zero pass.
+    assert.equal(resumed?.status, "failed", "the tokenBudget must hold cumulatively across resume");
+    const finalRun = manager.getRun(runId);
+    assert.equal(finalRun?.error?.code, WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED);
+  }),
+);
+
+test(
   "manager forwards exec concurrency and agentRetries to runtime",
   withTempCwd(async (cwd) => {
     let active = 0;
@@ -1674,6 +1807,103 @@ test(
 
     da.resolve("done");
     await promise.catch(() => {});
+  }),
+);
+
+test(
+  "deleteRun aborts a live run so its later (delayed) settle can't resurrect the deleted file (#A3)",
+  withTempCwd(async (cwd) => {
+    // delayedAgent always resolves after a fixed real delay, IGNORING the abort
+    // signal entirely — so the stale execution's eventual settle is driven
+    // purely by its own timer, independent of whether deleteRun()'s abort call
+    // actually interrupts it. This isolates the identity-guard mechanism (the
+    // resurrection must not happen) from the separate "did abort() fire" check.
+    const manager = new WorkflowManager({ cwd, agent: delayedAgent(40) });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    promise.catch(() => {});
+    await new Promise((resolve) => setTimeout(resolve, 15)); // let the agent start
+
+    const liveManaged = manager.getRun(runId);
+    assert.ok(liveManaged, "the run should be tracked while running");
+    assert.equal(liveManaged?.controller.signal.aborted, false, "not aborted yet, before delete");
+
+    const deleted = manager.deleteRun(runId);
+    assert.equal(deleted, true);
+    assert.equal(
+      liveManaged?.controller.signal.aborted,
+      true,
+      "deleteRun must abort a live run's controller so it winds down instead of running forever in the background",
+    );
+    assert.equal(manager.getRun(runId), undefined);
+    assert.equal(manager.getPersistence().load(runId), null, "deleted immediately");
+
+    // Wait past the stale execution's delayed (40ms) resolution settling.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    assert.equal(
+      manager.getPersistence().load(runId),
+      null,
+      "the stale execution's later settle must not resurrect the deleted run's file",
+    );
+    assert.equal(manager.getRun(runId), undefined);
+  }),
+);
+
+test(
+  "resume immediately after pause is not clobbered by the stale paused execution's delayed settle (#A4)",
+  withTempCwd(async (cwd) => {
+    let secondAttempts = 0;
+    const agent = {
+      async run(prompt: string, options?: { signal?: AbortSignal; onUsage?: (u: AgentUsage) => void }) {
+        if (prompt === "first") {
+          options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
+          return "first-result";
+        }
+        // "second"
+        secondAttempts++;
+        if (secondAttempts === 1) {
+          // First attempt: hang until aborted, then reject only after an
+          // artificial delay, so the stale settle races the resumed execution.
+          return new Promise((_resolve, reject) => {
+            const fire = () => setTimeout(() => reject(new Error("aborted (delayed)")), 40);
+            if (options?.signal?.aborted) fire();
+            else options?.signal?.addEventListener("abort", fire, { once: true });
+          });
+        }
+        options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
+        return "second-result";
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent });
+    manager.on("error", () => {});
+
+    const { runId, promise } = manager.startInBackground(twoAgentScript);
+    promise.catch(() => {});
+    for (let i = 0; i < 200 && secondAttempts === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(secondAttempts, 1, "'second' should be in flight before pausing");
+
+    assert.equal(manager.pause(runId), true);
+    // Immediately resume — races the stale execution's still-pending (delayed) rejection.
+    assert.equal(await manager.resume(runId), true);
+
+    for (let i = 0; i < 200 && manager.getRun(runId)?.status === "running"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    const afterResume = manager.getPersistence().load(runId);
+    assert.equal(afterResume?.status, "completed", "the resumed execution's outcome");
+
+    // Wait past the stale first execution's delayed (40ms) rejection settling.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    const finalState = manager.getPersistence().load(runId);
+    assert.equal(
+      finalState?.status,
+      "completed",
+      "the stale execution's later settle must not clobber the resumed run's persisted state",
+    );
   }),
 );
 

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -513,6 +513,67 @@ return { a, second }`;
   assert.equal(result.result.second, "blocked");
 });
 
+test("runWorkflow initialTokenUsage seeds the run-wide budget so it holds cumulatively across resume (#A2)", async () => {
+  // Simulates what WorkflowManager.resume() passes: a prior execution already
+  // spent 60 (persisted). This fresh execution's own SharedRuntime must start
+  // counting from there — 'a' (allowed: seeded 60 + budget 100 leaves 40
+  // headroom) then spends 60 more, landing at 120; 'b' must then be blocked,
+  // even though neither the seed alone (60) nor 'a' alone (60) would trip it.
+  const script = `export const meta = { name: 'seeded_budget', description: 'seed' }
+const a = await agent('a', { label: 'a' })
+let blocked = false
+try { await agent('b', { label: 'b' }) } catch (e) { blocked = (e && e.code) === 'TOKEN_BUDGET_EXHAUSTED' }
+return { a, blocked }`;
+
+  const result = await runWorkflow<{ a: unknown; blocked: boolean }>(script, {
+    agent: fakeAgent({ input: 60, output: 0, total: 60, cost: 0 }),
+    tokenBudget: 100,
+    initialTokenUsage: { input: 60, output: 0, total: 60, cost: 0, cacheRead: 0, cacheWrite: 0 },
+    persistLogs: false,
+  });
+
+  assert.equal(result.result.a, "ok", "'a' itself is allowed to run (remaining was 40 > 0 before it)");
+  assert.equal(
+    result.result.blocked,
+    true,
+    "'b' must be blocked once the seeded + this-run spend sums past the budget",
+  );
+  assert.equal(result.tokenUsage?.total, 120, "final total reflects the seed (60) plus 'a's spend (60); 'b' never ran");
+});
+
+test("runWorkflow initialTokenUsage integrates correctly with phase() sub-budgets (seeded baseline isn't corrupted)", async () => {
+  // phase()'s sub-budget deliberately re-bases from shared.spent AT the
+  // phase() call (see workflow.ts's phase(): "Re-declaring re-bases from the
+  // current spent"), so a seed doesn't make the phase's OWN ceiling trip any
+  // sooner than usual — it only shifts the visible baseline. This mirrors the
+  // existing "phase sub-budget throws..." test's budget/spend shape exactly,
+  // plus a seed, to confirm seeding doesn't corrupt that mechanism.
+  const script = `export const meta = { name: 'seeded_phase_budget', description: 'seed' }
+const spentAtStart = budget.spent()
+phase('noisy', { budget: 100 })
+let blocked = false
+await agent('a', { label: '1' })
+try { await agent('b', { label: '2' }) } catch (e) { blocked = (e && e.code) === 'TOKEN_BUDGET_EXHAUSTED' }
+return { spentAtStart, blocked }`;
+
+  const result = await runWorkflow<{ spentAtStart: number; blocked: boolean }>(script, {
+    agent: fakeAgent({ input: 100, output: 0, total: 100, cost: 0 }),
+    initialTokenUsage: { input: 40, output: 0, total: 40, cost: 0, cacheRead: 0, cacheWrite: 0 },
+    persistLogs: false,
+  });
+
+  assert.equal(
+    result.result.spentAtStart,
+    40,
+    "budget.spent() reflects the seed before any agent in this execution runs",
+  );
+  assert.equal(
+    result.result.blocked,
+    true,
+    "the phase sub-budget still gates normally on top of a seeded run-wide total",
+  );
+});
+
 test("token budget exhaustion inside parallel() halts (non-recoverable, not swallowed)", async () => {
   // A warm-up agent spends the whole budget (soft gate: spent accrues after it
   // finishes); the agent() inside parallel() then hits the gate and must


### PR DESCRIPTION
## What

Four related fixes in the workflow run manager's pause/resume/delete lifecycle:

1. **Per-run limits survive resume.** `maxAgents`, `agentTimeoutMs`, `concurrency`, and `agentRetries` are now resolved once at run start, persisted with the run, and restored verbatim on resume — the same freeze-at-start pattern `tokenBudget`/`toolset` already use. Previously a resumed run silently re-resolved them against the manager's current defaults (e.g. regaining a much larger agent cap than it started with). Legacy runs persisted before these fields existed resume with the manager's current default timeout, matching their original semantics.

2. **`tokenBudget` is now a genuinely cumulative cap across pause/resume.** The resumed execution's spend counters are seeded from the persisted total-at-pause instead of restarting at zero. Since the run-level usage aggregate previously only materialized on full success, the manager now accumulates per-agent usage progressively (including tokens spent on failed-then-retried attempts), so a paused run always has an accurate total to seed from. Cache-hit replays report zero tokens, so nothing is double-counted.

3. **`deleteRun()` aborts a live run before teardown.** Previously a deleted run's execution kept running in the background indefinitely, and its eventual settle could resurrect the deleted run's files on disk.

4. **A superseded execution can no longer clobber newer state.** A fast pause→resume race (or a delete) leaves the old execution settling asynchronously later; its disk writes, lease release, progress callbacks, and events (`complete`/`error`/`paused`/progress events) are now all gated on an identity check — only the current execution for a run ID may persist state, release the lease, or notify listeners. `pause()`/`stop()`/`resume()`/`deleteRun()` themselves are exempt: they own the transition at the moment they run.

## Why

3 and 4 share one root cause — a stale `ManagedRun`'s async completion acting on behalf of a run it no longer represents — and share one mechanism: a single identity check at the disk-write choke point, the lease releases in the execution's own settle paths, and event emission. 1 and 2 restore the invariant that a run resumes with exactly the execution context it started with.

## Verification

- 12 new regression tests (limit restoration via a 3-way fan-out, cumulative budget across pause/resume, delete-abort with no resurrection, pause→resume racing a delayed stale settle, stale deferred-timer disk write, straggler-sibling event suppression, legacy-run timeout fallback, retried-attempt spend accounting). Each was confirmed to fail with its guard reverted.
- Full suite: 1051/1051 pass; lint, typecheck, docs checks, and the release gate all clean.
