### PR TITLE
feat: make the 5 built-in workflow patterns reachable from the workflow tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ The installed extension generates this compact index from its executable capabil
 | cwd | runtime-global | `cwd: string` | — |
 | process | runtime-global | `process: { cwd(): string }` | — |
 | budget | runtime-global | `budget: { total, spent(), remaining() }` | — |
-| script | workflow-tool-input | `script: string` | — |
+| script | workflow-tool-input | `script?: string` | — |
+| name | workflow-tool-input | `name?: string` | — |
 | args | workflow-tool-input | `args?: unknown` | — |
 | background | workflow-tool-input | `background?: boolean = true` | — |
 | maxAgents | workflow-tool-input | `maxAgents?: number = 1000` | — |

--- a/docs/workflow-authoring.md
+++ b/docs/workflow-authoring.md
@@ -28,7 +28,8 @@ See [Workflow prompt guidance rationale](workflow-prompt-guidance-rationale.md) 
 | cwd | runtime-global | `cwd: string` | — |
 | process | runtime-global | `process: { cwd(): string }` | — |
 | budget | runtime-global | `budget: { total, spent(), remaining() }` | — |
-| script | workflow-tool-input | `script: string` | — |
+| script | workflow-tool-input | `script?: string` | — |
+| name | workflow-tool-input | `name?: string` | — |
 | args | workflow-tool-input | `args?: unknown` | — |
 | background | workflow-tool-input | `background?: boolean = true` | — |
 | maxAgents | workflow-tool-input | `maxAgents?: number = 1000` | — |

--- a/docs/workflow-context-surfaces.json
+++ b/docs/workflow-context-surfaces.json
@@ -1,9 +1,10 @@
 {
-  "formatVersion": 2,
+  "formatVersion": 3,
   "encoding": "utf8",
   "sources": [
     "src/workflow-tool.ts",
-    "skills/workflow-authoring"
+    "skills/workflow-authoring",
+    "package.json#pi.skills"
   ],
   "surfaces": {
     "permanentWorkflowPrompt": {
@@ -14,13 +15,25 @@
       "serialization": "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
       "bytes": 4267
     },
-    "workflowAuthoringSkillDiscovery": {
-      "serialization": "UTF-8 bytes of normalized Pi skill XML with package-relative location",
-      "bytes": 338
+    "registeredSkillsDiscovery": {
+      "serialization": "sum of UTF-8 bytes of normalized Pi skill XML (name + description + location) across every root in package.json's pi.skills",
+      "bytes": 931,
+      "skills": [
+        {
+          "root": "skills/workflow-authoring",
+          "serialization": "UTF-8 bytes of normalized Pi skill XML with package-relative location",
+          "bytes": 338
+        },
+        {
+          "root": "skills/workflow-patterns",
+          "serialization": "UTF-8 bytes of normalized Pi skill XML with package-relative location",
+          "bytes": 593
+        }
+      ]
     },
     "ordinaryWorkflowOwnedAlwaysOn": {
-      "serialization": "sum of permanent prompt, provider-visible tool definition, and normalized skill discovery bytes",
-      "bytes": 5347
+      "serialization": "sum of permanent prompt, provider-visible tool definition, and every registered skill's discovery bytes",
+      "bytes": 5940
     },
     "workflowAuthoringSkillCorpus": {
       "serialization": "sum of UTF-8 bytes for every file under skills/workflow-authoring",

--- a/docs/workflow-context-surfaces.json
+++ b/docs/workflow-context-surfaces.json
@@ -12,7 +12,7 @@
     },
     "providerVisibleWorkflowToolDefinition": {
       "serialization": "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
-      "bytes": 3918
+      "bytes": 4267
     },
     "workflowAuthoringSkillDiscovery": {
       "serialization": "UTF-8 bytes of normalized Pi skill XML with package-relative location",
@@ -20,12 +20,12 @@
     },
     "ordinaryWorkflowOwnedAlwaysOn": {
       "serialization": "sum of permanent prompt, provider-visible tool definition, and normalized skill discovery bytes",
-      "bytes": 4998
+      "bytes": 5347
     },
     "workflowAuthoringSkillCorpus": {
       "serialization": "sum of UTF-8 bytes for every file under skills/workflow-authoring",
       "files": 27,
-      "bytes": 67089
+      "bytes": 67450
     },
     "representativeAuthoringProfiles": {
       "serialization": "sum of UTF-8 bytes for each profile's declared package-relative files",

--- a/docs/workflow-guidance-baseline.json
+++ b/docs/workflow-guidance-baseline.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "algorithm": "sha256",
   "surfaces": {
-    "compactGuidance": "7d6cdc184667d71e1aa1121ca294d8bc82f8eb9556df75b8f6571319cfea5434",
+    "compactGuidance": "aff3c746a9180ec9551030606d328008704234f62f3dade489a031fd4dbc8731",
     "detailedProse": "bb5918e57601742a5cd57ca6ddda17cb8354a5cdcb773d60e2ffcd7ec7f32fab"
   }
 }

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -63,7 +63,7 @@ export default function extension(pi: ExtensionAPI) {
   const effort = createEffortState();
   registerWorkflowCommands(pi, manager, { storage, cwd, effort });
   registerWorkflowModelsCommand(pi);
-  registerBuiltinWorkflows(pi, { cwd, manager });
+  registerBuiltinWorkflows(pi, { cwd, manager, storage });
   registerAllSavedWorkflows(pi, cwd, storage, manager);
   registerEffortCommand(pi, effort);
   // "Workflows mode": type `workflow(s)` to arm a forced workflow at submit

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
       "extensions/workflow.ts"
     ],
     "skills": [
-      "skills/workflow-authoring"
+      "skills/workflow-authoring",
+      "skills/workflow-patterns"
     ],
     "image": "https://raw.githubusercontent.com/QuintinShaw/pi-dynamic-workflows/main/assets/readme/package-cover.png"
   },

--- a/scripts/generate-workflow-context-measurement.ts
+++ b/scripts/generate-workflow-context-measurement.ts
@@ -12,14 +12,19 @@ const measurement = check ? measureWorkflowContextSurfaces() : writeWorkflowCont
 const {
   permanentWorkflowPrompt,
   providerVisibleWorkflowToolDefinition,
-  workflowAuthoringSkillDiscovery,
+  registeredSkillsDiscovery,
   workflowAuthoringSkillCorpus,
   representativeAuthoringProfiles,
 } = measurement.surfaces;
 
 console.log(`Permanent workflow prompt: ${permanentWorkflowPrompt.bytes} bytes`);
 console.log(`Provider-visible workflow tool definition: ${providerVisibleWorkflowToolDefinition.bytes} bytes`);
-console.log(`Workflow-authoring skill discovery: ${workflowAuthoringSkillDiscovery.bytes} bytes`);
+console.log(
+  `Registered skills discovery (all ${registeredSkillsDiscovery.skills.length}): ${registeredSkillsDiscovery.bytes} bytes`,
+);
+for (const skill of registeredSkillsDiscovery.skills) {
+  console.log(`  - ${skill.root}: ${skill.bytes} bytes`);
+}
 console.log(
   `Workflow-authoring skill corpus: ${workflowAuthoringSkillCorpus.bytes} bytes across ${workflowAuthoringSkillCorpus.files} files`,
 );

--- a/skills/workflow-authoring/references/capabilities.md
+++ b/skills/workflow-authoring/references/capabilities.md
@@ -28,7 +28,8 @@ This compact generated index covers supported runtime globals and workflow-tool 
 | cwd | runtime-global | `cwd: string` | — |
 | process | runtime-global | `process: { cwd(): string }` | — |
 | budget | runtime-global | `budget: { total, spent(), remaining() }` | — |
-| script | workflow-tool-input | `script: string` | — |
+| script | workflow-tool-input | `script?: string` | — |
+| name | workflow-tool-input | `name?: string` | — |
 | args | workflow-tool-input | `args?: unknown` | — |
 | background | workflow-tool-input | `background?: boolean = true` | — |
 | maxAgents | workflow-tool-input | `maxAgents?: number = 1000` | — |

--- a/skills/workflow-authoring/references/capability-details.md
+++ b/skills/workflow-authoring/references/capability-details.md
@@ -220,8 +220,17 @@ Every exact fact below is projected from the installed extension's capability co
 
 - Classification: `workflow-tool-input`
 - Support: `supported`
-- Signature: `script: string`
-- Constraint: required raw JavaScript workflow source
+- Signature: `script?: string`
+- Constraint: required raw JavaScript workflow source unless `name` is given
+
+<a id="tool-input-name"></a>
+## name
+
+- Classification: `workflow-tool-input`
+- Support: `supported`
+- Signature: `name?: string`
+- Constraint: resolves a project/user saved workflow first, then one of the 5 built-in patterns
+- Constraint: mutually exclusive with resumeFromRunId
 
 <a id="tool-input-args"></a>
 ## args

--- a/skills/workflow-patterns/SKILL.md
+++ b/skills/workflow-patterns/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: workflow-patterns
+description: Names and argument shapes for the 5 curated built-in workflow patterns (deep-research, adversarial-review, code-review, multi-perspective, codebase-audit), reachable via the `workflow` tool's `name` input. Use when a request matches one of these shapes even without slash-command syntax — e.g. "research X", "deep-dive this question", "adversarially review/fact-check this", "review this diff/PR", "analyze from multiple perspectives/angles", or "audit the codebase for Y". Not for authoring a new workflow script — see workflow-authoring for that.
+metadata:
+  version: "3.2.2"
+---
+
+# Built-in workflow patterns
+
+pi-dynamic-workflows ships 5 curated, tested workflow patterns. Each is also a
+slash command (`/deep-research`, `/adversarial-review`, `/code-review`,
+`/multi-perspective`, `/codebase-audit`), but they are equally reachable from
+the `workflow` tool directly: call it with `name` set to the pattern name
+below and `args` matching its shape, instead of writing an equivalent script
+from scratch. Prefer this over authoring a new script whenever the request
+fits one of these shapes — the curated version is already reviewed and tested.
+
+A project or user saved workflow of the same name always takes precedence
+over a built-in of that name.
+
+## Patterns
+
+| `name` | When to reach for it | `args` |
+| --- | --- | --- |
+| `deep-research` | Research a question across the web with cross-checked sources | `{ question: string }` |
+| `adversarial-review` | Investigate a task/claim, then cross-check each finding with skeptical reviewers | `{ task: string, reviewers?: number, threshold?: number }` |
+| `code-review` | Multi-angle review of a diff (correctness, reuse, simplification, efficiency, altitude) | `{ diff: string, diffSource?: string }` — get `diff` yourself first (e.g. `git diff`, `gh pr diff <n>`); this path does not fetch it for you |
+| `multi-perspective` | Analyze a topic from several independent perspectives in parallel, then synthesize | `{ topic: string, perspectives?: string[] }` — omit or give fewer than 2 to use the default set (technical, product, security, user experience, maintainability) |
+| `codebase-audit` | Run parallel checks against a codebase scope, then cross-validate and report | `{ scope: string, checks: string[] }` |
+
+## Example
+
+```json
+{ "name": "deep-research", "args": { "question": "What are the tradeoffs of X vs Y?" } }
+```
+
+This is a `workflow` tool call, not a script — omit `script` entirely. The run
+starts in the background exactly like the slash-command form; `background`,
+`maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget`
+all still apply.
+
+## Writing a new workflow instead
+
+If the request doesn't fit one of these 5 shapes, author a script with
+`script` as usual — see the workflow-authoring skill.

--- a/skills/workflow-patterns/SKILL.md
+++ b/skills/workflow-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-patterns
-description: Names and argument shapes for the 5 curated built-in workflow patterns (deep-research, adversarial-review, code-review, multi-perspective, codebase-audit), reachable via the `workflow` tool's `name` input. Use when a request matches one of these shapes even without slash-command syntax — e.g. "research X", "deep-dive this question", "adversarially review/fact-check this", "review this diff/PR", "analyze from multiple perspectives/angles", or "audit the codebase for Y". Not for authoring a new workflow script — see workflow-authoring for that.
+description: Argument shapes for the 5 built-in workflow patterns — deep-research, adversarial-review, code-review, multi-perspective, codebase-audit — runnable via the `workflow` tool's `name` input, without slash-command syntax. Use for requests like "research X", "fact-check/adversarially review this", "review this diff/PR", "analyze from multiple perspectives", or "audit the codebase for Y". Not for authoring a new workflow script — see workflow-authoring.
 metadata:
   version: "3.2.2"
 ---
@@ -16,13 +16,19 @@ from scratch. Prefer this over authoring a new script whenever the request
 fits one of these shapes — the curated version is already reviewed and tested.
 
 A project or user saved workflow of the same name always takes precedence
-over a built-in of that name.
+over a built-in of that name — on the slash command, too.
+
+These 5 names are reachable only at the `workflow` tool's top-level `name`
+input, not via the in-script `await workflow(savedName, childArgs)` helper —
+that helper resolves saved workflows only. Calling `workflow('deep-research')`
+from inside a script fails as an unknown saved workflow; use the top-level
+`name` input instead.
 
 ## Patterns
 
 | `name` | When to reach for it | `args` |
 | --- | --- | --- |
-| `deep-research` | Research a question across the web with cross-checked sources | `{ question: string }` |
+| `deep-research` | Research a question across the web with cross-checked sources | `{ question: string, angles?: number, minSupport?: number }` — `angles` (default 4) is the number of distinct search queries; `minSupport` (default 2) is the minimum distinct sources required for a claim to survive cross-checking |
 | `adversarial-review` | Investigate a task/claim, then cross-check each finding with skeptical reviewers | `{ task: string, reviewers?: number, threshold?: number }` |
 | `code-review` | Multi-angle review of a diff (correctness, reuse, simplification, efficiency, altitude) | `{ diff: string, diffSource?: string }` — get `diff` yourself first (e.g. `git diff`, `gh pr diff <n>`); this path does not fetch it for you |
 | `multi-perspective` | Analyze a topic from several independent perspectives in parallel, then synthesize | `{ topic: string, perspectives?: string[] }` — omit or give fewer than 2 to use the default set (technical, product, security, user experience, maintainability) |

--- a/src/adversarial-review.ts
+++ b/src/adversarial-review.ts
@@ -74,18 +74,28 @@ return { total: findings.length, survivors, report }`;
 
 /**
  * Generate a multi-perspective analysis workflow.
+ *
+ * `topic` and each `perspectives` entry are user-supplied strings baked
+ * directly into the generated script's source, so every one is embedded via
+ * JSON.stringify — a proper JS string literal that can't be broken out of by
+ * a quote, backslash, or backtick in the value.
  */
 export function generateMultiPerspectiveWorkflow(topic: string, perspectives: string[]): string {
   const perspectiveAgents = perspectives
-    .map(
-      (p, _i) =>
-        `  () => agent('Analyze from ${p} perspective: ' + topic, { label: '${p.toLowerCase().replace(/\\s+/g, "-")}' }),`,
-    )
+    .map((p, i) => {
+      const label =
+        p
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "")
+          .slice(0, 20) || `perspective-${i + 1}`;
+      return `  () => agent(${JSON.stringify(`Analyze from ${p} perspective: `)} + topic, { label: ${JSON.stringify(label)} }),`;
+    })
     .join("\n");
 
   return `export const meta = {
   name: 'multi_perspective_analysis',
-  description: 'Analyze from ${perspectives.length} different perspectives',
+  description: ${JSON.stringify(`Analyze from ${perspectives.length} different perspectives`)},
   phases: [
     { title: 'Perspective Analysis' },
     { title: 'Synthesis' },
@@ -93,7 +103,7 @@ export function generateMultiPerspectiveWorkflow(topic: string, perspectives: st
 };
 
 phase('Perspective Analysis');
-const topic = '${topic.replace(/'/g, "\\'")}';
+const topic = ${JSON.stringify(topic)};
 const analyses = await parallel([
 ${perspectiveAgents}
 ]);

--- a/src/builtin-commands.ts
+++ b/src/builtin-commands.ts
@@ -13,9 +13,12 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { ExtensionAPI, ExtensionCommandContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { BuiltinWorkflowInvocation } from "./builtin-workflows.js";
 import { findBuiltinWorkflow } from "./builtin-workflows.js";
 import { MAX_DIFF_CHARS } from "./code-review.js";
+import { parseCommandArgs } from "./saved-commands.js";
 import type { WorkflowManager } from "./workflow-manager.js";
+import { createWorkflowStorage, type WorkflowStorage } from "./workflow-saved.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -72,20 +75,79 @@ function startBackground(
   }
 }
 
-export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string; manager: WorkflowManager }): void {
+/**
+ * Look up a built-in descriptor by its fixed, hardcoded name. Every call site
+ * below passes one of the 5 literal names in BUILTIN_WORKFLOWS, so this can
+ * only throw if that registry and this file's command names fall out of sync
+ * — a programming error, not a user-input problem (tests pin the names stay
+ * in sync, see builtin-commands.test.ts).
+ */
+function requireBuiltin(name: string) {
+  const found = findBuiltinWorkflow(name);
+  if (!found) throw new Error(`internal error: no built-in workflow registered for "${name}"`);
+  return found;
+}
+
+/**
+ * Resolve a built-in's script/exec context for the given args, surfacing an
+ * invalid-args error (e.g. a whitespace-only string that passes the handler's
+ * cheap `!value` check but fails the registry's real validation) as the same
+ * kind of warning notify the handlers already use for their own validation,
+ * rather than an uncaught rejection.
+ */
+function resolveBuiltinOrNotify(
+  name: string,
+  cwd: string,
+  args: unknown,
+  ctx: ExtensionCommandContext,
+): BuiltinWorkflowInvocation | undefined {
+  try {
+    return requireBuiltin(name).resolve(cwd, args);
+  } catch (error) {
+    ctx.ui.notify(`/${name}: ${error instanceof Error ? error.message : String(error)}`, "warning");
+    return undefined;
+  }
+}
+
+export function registerBuiltinWorkflows(
+  pi: ExtensionAPI,
+  opts: { cwd: string; manager: WorkflowManager; storage?: WorkflowStorage },
+): void {
   const { cwd, manager } = opts;
+  const storage = opts.storage ?? createWorkflowStorage(cwd);
+
+  /**
+   * A project/user saved workflow always takes precedence over a built-in of
+   * the same name — on every path, not just the `workflow` tool's `name`
+   * input. Builtins are registered as commands before saved workflows
+   * (registerAllSavedWorkflows skips a name that's already registered), so
+   * without this dynamic check a same-named saved workflow would silently
+   * never run from its slash command. Checking here, at invocation time
+   * rather than registration time, makes "saved wins" hold regardless of
+   * registration order. Mirrors registerSavedWorkflow's own handler exactly
+   * (same parseCommandArgs call, same startBackground path, no builtin exec
+   * context) so a shadowed command behaves identically to how it would if the
+   * saved workflow itself had been registered under this name.
+   */
+  function runSavedShadowIfPresent(name: string, rawArgs: string, ctx: ExtensionCommandContext): boolean {
+    const saved = storage.load(name);
+    if (!saved) return false;
+    startBackground(manager, ctx, name, saved.script, parseCommandArgs(rawArgs, saved.parameters));
+    return true;
+  }
 
   if (!alreadyRegistered(pi, "deep-research")) {
     pi.registerCommand("deep-research", {
       description: "Research a question across the web with cross-checked sources",
       async handler(args: string, ctx: ExtensionCommandContext) {
+        if (runSavedShadowIfPresent("deep-research", args, ctx)) return;
         const question = args.trim();
         if (!question) return ctx.ui.notify("Usage: /deep-research <question>", "warning");
         // Resolve through the shared builtin registry (builtin-workflows.ts) so
         // this command and the workflow tool's `name` input always run the exact
         // same generated script and exec context (tools/toolset) for this pattern.
-        const resolved = findBuiltinWorkflow("deep-research")?.resolve(cwd, { question });
-        if (!resolved) return ctx.ui.notify("deep-research: built-in workflow not found", "error");
+        const resolved = resolveBuiltinOrNotify("deep-research", cwd, { question }, ctx);
+        if (!resolved) return;
         startBackground(
           manager,
           ctx,
@@ -105,10 +167,11 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string; 
     pi.registerCommand("adversarial-review", {
       description: "Investigate a task, then cross-check each finding with skeptical reviewers",
       async handler(args: string, ctx: ExtensionCommandContext) {
+        if (runSavedShadowIfPresent("adversarial-review", args, ctx)) return;
         const task = args.trim();
         if (!task) return ctx.ui.notify("Usage: /adversarial-review <task or question>", "warning");
-        const resolved = findBuiltinWorkflow("adversarial-review")?.resolve(cwd, { task });
-        if (!resolved) return ctx.ui.notify("adversarial-review: built-in workflow not found", "error");
+        const resolved = resolveBuiltinOrNotify("adversarial-review", cwd, { task }, ctx);
+        if (!resolved) return;
         startBackground(manager, ctx, "adversarial-review", resolved.script, { task });
       },
     });
@@ -119,6 +182,7 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string; 
       description:
         "Multi-angle parallel code review: 7 specialized finders (correctness, reuse, simplification, efficiency, altitude) + verify pass → ranked findings",
       async handler(args: string, ctx: ExtensionCommandContext) {
+        if (runSavedShadowIfPresent("code-review", args, ctx)) return;
         const input = args.trim();
         let diffSource = "git diff HEAD";
         let diff = "";
@@ -179,8 +243,8 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string; 
           );
         }
 
-        const resolved = findBuiltinWorkflow("code-review")?.resolve(cwd, { diff, diffSource });
-        if (!resolved) return ctx.ui.notify("code-review: built-in workflow not found", "error");
+        const resolved = resolveBuiltinOrNotify("code-review", cwd, { diff, diffSource }, ctx);
+        if (!resolved) return;
         startBackground(manager, ctx, "code-review", resolved.script, { diff, diffSource });
       },
     });
@@ -190,14 +254,15 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string; 
     pi.registerCommand("multi-perspective", {
       description: "Analyze a topic from several independent perspectives in parallel, then synthesize",
       async handler(args: string, ctx: ExtensionCommandContext) {
+        if (runSavedShadowIfPresent("multi-perspective", args, ctx)) return;
         const [topic, ...rest] = tokenizeArgs(args);
         if (!topic) {
           return ctx.ui.notify('Usage: /multi-perspective "<topic>" [perspective1] [perspective2] …', "warning");
         }
         // resolve() falls back to a broadly-useful default set when fewer than
         // two perspectives are given (see builtin-workflows.ts).
-        const resolved = findBuiltinWorkflow("multi-perspective")?.resolve(cwd, { topic, perspectives: rest });
-        if (!resolved) return ctx.ui.notify("multi-perspective: built-in workflow not found", "error");
+        const resolved = resolveBuiltinOrNotify("multi-perspective", cwd, { topic, perspectives: rest }, ctx);
+        if (!resolved) return;
         startBackground(manager, ctx, "multi-perspective", resolved.script);
       },
     });
@@ -207,12 +272,13 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string; 
     pi.registerCommand("codebase-audit", {
       description: "Run parallel checks against a codebase scope, then cross-validate and report",
       async handler(args: string, ctx: ExtensionCommandContext) {
+        if (runSavedShadowIfPresent("codebase-audit", args, ctx)) return;
         const [scope, ...checks] = tokenizeArgs(args);
         if (!scope || checks.length === 0) {
           return ctx.ui.notify('Usage: /codebase-audit <scope> "<check1>" ["<check2>" …]', "warning");
         }
-        const resolved = findBuiltinWorkflow("codebase-audit")?.resolve(cwd, { scope, checks });
-        if (!resolved) return ctx.ui.notify("codebase-audit: built-in workflow not found", "error");
+        const resolved = resolveBuiltinOrNotify("codebase-audit", cwd, { scope, checks }, ctx);
+        if (!resolved) return;
         startBackground(manager, ctx, "codebase-audit", resolved.script);
       },
     });

--- a/src/builtin-commands.ts
+++ b/src/builtin-commands.ts
@@ -12,16 +12,9 @@
 
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import {
-  createCodingTools,
-  type ExtensionAPI,
-  type ExtensionCommandContext,
-  type ToolDefinition,
-} from "@earendil-works/pi-coding-agent";
-import { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
-import { generateCodeReviewWorkflow, MAX_DIFF_CHARS } from "./code-review.js";
-import { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "./deep-research.js";
-import { createWebTools } from "./web-tools.js";
+import type { ExtensionAPI, ExtensionCommandContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { findBuiltinWorkflow } from "./builtin-workflows.js";
+import { MAX_DIFF_CHARS } from "./code-review.js";
 import type { WorkflowManager } from "./workflow-manager.js";
 
 const execFileAsync = promisify(execFile);
@@ -88,18 +81,20 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string; 
       async handler(args: string, ctx: ExtensionCommandContext) {
         const question = args.trim();
         if (!question) return ctx.ui.notify("Usage: /deep-research <question>", "warning");
-        // Research agents need real web access on top of the coding tools.
-        // `tools` covers this execution even on a manager without the toolset
-        // registered; the "web-research" tag is what a resume re-resolves.
+        // Resolve through the shared builtin registry (builtin-workflows.ts) so
+        // this command and the workflow tool's `name` input always run the exact
+        // same generated script and exec context (tools/toolset) for this pattern.
+        const resolved = findBuiltinWorkflow("deep-research")?.resolve(cwd, { question });
+        if (!resolved) return ctx.ui.notify("deep-research: built-in workflow not found", "error");
         startBackground(
           manager,
           ctx,
           "deep-research",
-          generateDeepResearchWorkflow(),
+          resolved.script,
           { question },
           {
-            tools: [...createCodingTools(cwd), ...createWebTools()],
-            toolset: "web-research",
+            tools: resolved.tools,
+            toolset: resolved.toolset,
           },
         );
       },
@@ -112,7 +107,9 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string; 
       async handler(args: string, ctx: ExtensionCommandContext) {
         const task = args.trim();
         if (!task) return ctx.ui.notify("Usage: /adversarial-review <task or question>", "warning");
-        startBackground(manager, ctx, "adversarial-review", generateAdversarialReviewWorkflow(), { task });
+        const resolved = findBuiltinWorkflow("adversarial-review")?.resolve(cwd, { task });
+        if (!resolved) return ctx.ui.notify("adversarial-review: built-in workflow not found", "error");
+        startBackground(manager, ctx, "adversarial-review", resolved.script, { task });
       },
     });
   }
@@ -182,7 +179,9 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string; 
           );
         }
 
-        startBackground(manager, ctx, "code-review", generateCodeReviewWorkflow(), { diff, diffSource });
+        const resolved = findBuiltinWorkflow("code-review")?.resolve(cwd, { diff, diffSource });
+        if (!resolved) return ctx.ui.notify("code-review: built-in workflow not found", "error");
+        startBackground(manager, ctx, "code-review", resolved.script, { diff, diffSource });
       },
     });
   }
@@ -195,10 +194,11 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string; 
         if (!topic) {
           return ctx.ui.notify('Usage: /multi-perspective "<topic>" [perspective1] [perspective2] …', "warning");
         }
-        // Fall back to a broadly-useful default set when fewer than two are given.
-        const perspectives =
-          rest.length >= 2 ? rest : ["technical", "product", "security", "user experience", "maintainability"];
-        startBackground(manager, ctx, "multi-perspective", generateMultiPerspectiveWorkflow(topic, perspectives));
+        // resolve() falls back to a broadly-useful default set when fewer than
+        // two perspectives are given (see builtin-workflows.ts).
+        const resolved = findBuiltinWorkflow("multi-perspective")?.resolve(cwd, { topic, perspectives: rest });
+        if (!resolved) return ctx.ui.notify("multi-perspective: built-in workflow not found", "error");
+        startBackground(manager, ctx, "multi-perspective", resolved.script);
       },
     });
   }
@@ -211,7 +211,9 @@ export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string; 
         if (!scope || checks.length === 0) {
           return ctx.ui.notify('Usage: /codebase-audit <scope> "<check1>" ["<check2>" …]', "warning");
         }
-        startBackground(manager, ctx, "codebase-audit", generateCodebaseAuditWorkflow(scope, checks));
+        const resolved = findBuiltinWorkflow("codebase-audit")?.resolve(cwd, { scope, checks });
+        if (!resolved) return ctx.ui.notify("codebase-audit: built-in workflow not found", "error");
+        startBackground(manager, ctx, "codebase-audit", resolved.script);
       },
     });
   }

--- a/src/builtin-workflows.ts
+++ b/src/builtin-workflows.ts
@@ -1,0 +1,155 @@
+/**
+ * Shared registry of the 5 curated built-in workflow patterns
+ * (`deep-research`, `adversarial-review`, `code-review`, `multi-perspective`,
+ * `codebase-audit`).
+ *
+ * This is the single place that turns a pattern's name + caller-supplied args
+ * into a runnable script (and, where a pattern needs it, an exec context such
+ * as web tools). Both entry points a model or user can reach a built-in
+ * through — the `/deep-research`-style slash commands (builtin-commands.ts)
+ * and the `workflow` tool's `name` input (workflow-tool.ts) — resolve through
+ * this one registry, so the two paths can never drift apart and the
+ * per-pattern generator scripts are written exactly once.
+ */
+
+import { createCodingTools, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "./adversarial-review.js";
+import { generateCodeReviewWorkflow } from "./code-review.js";
+import { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "./deep-research.js";
+import { createWebTools } from "./web-tools.js";
+import type { WorkflowStorage } from "./workflow-saved.js";
+
+/** Default perspective set used when a caller gives fewer than two. */
+export const DEFAULT_MULTI_PERSPECTIVES: readonly string[] = [
+  "technical",
+  "product",
+  "security",
+  "user experience",
+  "maintainability",
+];
+
+/** A resolved, ready-to-run script plus the exec context it needs (if any). */
+export interface BuiltinWorkflowInvocation {
+  script: string;
+  tools?: ToolDefinition[];
+  toolset?: string;
+}
+
+export interface BuiltinWorkflowDescriptor {
+  /** Also the slash-command name (without the leading `/`). */
+  name: string;
+  description: string;
+  /** Build the script (and exec context) for one invocation; throws on invalid `args`. */
+  resolve(cwd: string, args: unknown): BuiltinWorkflowInvocation;
+}
+
+function asRecord(args: unknown): Record<string, unknown> {
+  return args && typeof args === "object" ? (args as Record<string, unknown>) : {};
+}
+
+function requireNonEmptyString(value: unknown, argName: string, patternName: string): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`Built-in workflow "${patternName}" requires args.${argName} to be a non-empty string.`);
+  }
+  return value;
+}
+
+function requireStringArray(value: unknown, argName: string, patternName: string): string[] {
+  if (!Array.isArray(value) || value.length === 0 || !value.every((v) => typeof v === "string" && v.trim())) {
+    throw new Error(
+      `Built-in workflow "${patternName}" requires args.${argName} to be a non-empty array of non-empty strings.`,
+    );
+  }
+  return value;
+}
+
+/** The 5 curated built-in workflow patterns, keyed by their stable name. */
+export const BUILTIN_WORKFLOWS: readonly BuiltinWorkflowDescriptor[] = [
+  {
+    name: "deep-research",
+    description: "Research a question across the web with cross-checked sources. args: { question: string }.",
+    resolve(cwd, args) {
+      requireNonEmptyString(asRecord(args).question, "question", "deep-research");
+      return {
+        script: generateDeepResearchWorkflow(),
+        // Research agents need real web access on top of the coding tools; the
+        // "web-research" tag is what a resumed run re-resolves (see
+        // WorkflowManagerOptions.toolsets).
+        tools: [...createCodingTools(cwd), ...createWebTools()],
+        toolset: "web-research",
+      };
+    },
+  },
+  {
+    name: "adversarial-review",
+    description:
+      "Investigate a task, then cross-check each finding with skeptical reviewers. args: { task: string, reviewers?: number, threshold?: number }.",
+    resolve(_cwd, args) {
+      requireNonEmptyString(asRecord(args).task, "task", "adversarial-review");
+      return { script: generateAdversarialReviewWorkflow() };
+    },
+  },
+  {
+    name: "code-review",
+    description:
+      "Multi-angle parallel code review: 7 specialized finders (correctness, reuse, simplification, efficiency, altitude) + verify pass → ranked findings. args: { diff: string, diffSource?: string }.",
+    resolve(_cwd, args) {
+      // Truncation past MAX_DIFF_CHARS already happens inside the generated
+      // script at runtime (see code-review.ts); a caller invoking by name is
+      // responsible for supplying `diff` (e.g. by running `git diff` itself),
+      // unlike the /code-review slash command, which fetches it automatically.
+      requireNonEmptyString(asRecord(args).diff, "diff", "code-review");
+      return { script: generateCodeReviewWorkflow() };
+    },
+  },
+  {
+    name: "multi-perspective",
+    description:
+      "Analyze a topic from several independent perspectives in parallel, then synthesize. args: { topic: string, perspectives?: string[] }.",
+    resolve(_cwd, args) {
+      const record = asRecord(args);
+      const topic = requireNonEmptyString(record.topic, "topic", "multi-perspective");
+      const perspectives =
+        Array.isArray(record.perspectives) && record.perspectives.length >= 2
+          ? requireStringArray(record.perspectives, "perspectives", "multi-perspective")
+          : [...DEFAULT_MULTI_PERSPECTIVES];
+      return { script: generateMultiPerspectiveWorkflow(topic, perspectives) };
+    },
+  },
+  {
+    name: "codebase-audit",
+    description:
+      "Run parallel checks against a codebase scope, then cross-validate and report. args: { scope: string, checks: string[] }.",
+    resolve(_cwd, args) {
+      const record = asRecord(args);
+      const scope = requireNonEmptyString(record.scope, "scope", "codebase-audit");
+      const checks = requireStringArray(record.checks, "checks", "codebase-audit");
+      return { script: generateCodebaseAuditWorkflow(scope, checks) };
+    },
+  },
+];
+
+/** Stable list of built-in workflow pattern names, in registry order. */
+export const BUILTIN_WORKFLOW_NAMES: readonly string[] = BUILTIN_WORKFLOWS.map((w) => w.name);
+
+export function findBuiltinWorkflow(name: string): BuiltinWorkflowDescriptor | undefined {
+  return BUILTIN_WORKFLOWS.find((w) => w.name === name);
+}
+
+/**
+ * Resolve a name to a runnable invocation, checking project/user saved
+ * workflows first and falling back to the built-in patterns — the same
+ * precedence `workflow-saved.ts` already uses internally (project > user), one
+ * level up: saved workflows (of either scope) beat a built-in of the same name.
+ */
+export function resolveWorkflowInvocation(
+  name: string,
+  args: unknown,
+  ctx: { storage: WorkflowStorage; cwd: string },
+): BuiltinWorkflowInvocation | undefined {
+  const saved = ctx.storage.load(name);
+  if (saved) return { script: saved.script };
+  const builtin = findBuiltinWorkflow(name);
+  if (builtin) return builtin.resolve(ctx.cwd, args);
+  return undefined;
+}

--- a/src/deep-research.ts
+++ b/src/deep-research.ts
@@ -79,22 +79,32 @@ return { question, queries, supported: (verdict && verdict.supported) || [], rep
 
 /**
  * Generate a codebase audit workflow.
+ *
+ * `scope` and each `checks` entry are user-supplied strings that get baked
+ * directly into the generated script's source (unlike the runtime-args-driven
+ * generators above), so every one is embedded via JSON.stringify — a proper JS
+ * string literal that can't be broken out of by a quote, backslash, or
+ * backtick in the value. Only the human-readable `meta.description` is
+ * truncated for display; the operative `scope` used by the agents is always
+ * the full, untruncated value.
  */
 export function generateCodebaseAuditWorkflow(scope: string, checks: string[]): string {
-  const escapedScope = scope.replace(/'/g, "\\'").slice(0, 60);
+  const displayScope = scope.length > 60 ? `${scope.slice(0, 60)}…` : scope;
   const checkAgents = checks
-    .map((check) => {
-      const label = check
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .slice(0, 20);
-      return `  () => agent('Audit ${check} across: ' + scope, { label: '${label}' }),`;
+    .map((check, i) => {
+      const label =
+        check
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "")
+          .slice(0, 20) || `check-${i + 1}`;
+      return `  () => agent(${JSON.stringify(`Audit ${check} across: `)} + scope, { label: ${JSON.stringify(label)} }),`;
     })
     .join("\n");
 
   return `export const meta = {
   name: 'codebase_audit',
-  description: 'Codebase audit: ${escapedScope}',
+  description: ${JSON.stringify(`Codebase audit: ${displayScope}`)},
   phases: [
     { title: 'Individual Checks' },
     { title: 'Cross-Validation' },
@@ -103,7 +113,7 @@ export function generateCodebaseAuditWorkflow(scope: string, checks: string[]): 
 };
 
 phase('Individual Checks');
-const scope = '${escapedScope}';
+const scope = ${JSON.stringify(scope)};
 const findings = await parallel([
 ${checkAgents}
 ]);

--- a/src/workflow-capability-contract.ts
+++ b/src/workflow-capability-contract.ts
@@ -450,7 +450,11 @@ const capabilities: readonly CapabilityDescriptor[] = [
     discovery: DiscoveryPlacement.WORKFLOW_AUTHORING_SKILL,
     constraints: ["new workflows should use log()"],
   }),
-  toolInput("script", "script: string", ["required raw JavaScript workflow source"]),
+  toolInput("script", "script?: string", ["required raw JavaScript workflow source unless `name` is given"]),
+  toolInput("name", "name?: string", [
+    "resolves a project/user saved workflow first, then one of the 5 built-in patterns",
+    "mutually exclusive with resumeFromRunId",
+  ]),
   toolInput("args", "args?: unknown"),
   toolInput("background", "background?: boolean = true", [
     "background workflows are headless; use background false when checkpoint must show foreground confirmation",

--- a/src/workflow-context-measurement.ts
+++ b/src/workflow-context-measurement.ts
@@ -82,15 +82,27 @@ interface ByteSurface {
   bytes: number;
 }
 
+/** One registered skill's always-on discovery-entry byte cost. */
+export interface SkillDiscoverySurface extends ByteSurface {
+  root: string;
+}
+
 /** Versioned byte measurements for always-on, discovery, corpus, and representative authoring surfaces. */
 export interface WorkflowContextMeasurement {
-  formatVersion: 2;
+  formatVersion: 3;
   encoding: "utf8";
-  sources: ["src/workflow-tool.ts", "skills/workflow-authoring"];
+  sources: ["src/workflow-tool.ts", "skills/workflow-authoring", "package.json#pi.skills"];
   surfaces: {
     permanentWorkflowPrompt: ByteSurface;
     providerVisibleWorkflowToolDefinition: ByteSurface;
-    workflowAuthoringSkillDiscovery: ByteSurface;
+    /**
+     * Every skill this package registers (package.json's `pi.skills` — read
+     * from disk, not hardcoded here) contributes an always-on discovery entry
+     * (name + description) the model sees regardless of whether the skill is
+     * ever loaded. This sums all of them, not just workflow-authoring, so a
+     * new skill's always-on cost can't silently go untracked.
+     */
+    registeredSkillsDiscovery: ByteSurface & { skills: SkillDiscoverySurface[] };
     ordinaryWorkflowOwnedAlwaysOn: ByteSurface;
     workflowAuthoringSkillCorpus: ByteSurface & { files: number };
     representativeAuthoringProfiles: {
@@ -125,16 +137,33 @@ function skillFiles(root: string): string[] {
   return files.sort();
 }
 
-function skillDiscoveryEntry(root: string): string {
-  const skill = readFileSync(join(root, SKILL_PATH), "utf8");
+/**
+ * Every skill root this package registers, read from package.json's
+ * `pi.skills` array rather than hardcoded — so a newly added skill is picked
+ * up automatically instead of silently missing from the always-on tally.
+ */
+function registeredSkillRoots(root: string): string[] {
+  const manifest = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as {
+    pi?: { skills?: unknown };
+  };
+  const skills = manifest.pi?.skills;
+  if (!Array.isArray(skills) || skills.length === 0 || !skills.every((s) => typeof s === "string")) {
+    throw new Error("package.json must declare a non-empty pi.skills array of skill root paths");
+  }
+  return skills;
+}
+
+function skillDiscoveryEntry(root: string, skillRoot: string): string {
+  const skillPath = `${skillRoot}/SKILL.md`;
+  const skill = readFileSync(join(root, skillPath), "utf8");
   const name = /^name:\s*(.+)$/m.exec(skill)?.[1]?.trim();
   const description = /^description:\s*(.+)$/m.exec(skill)?.[1]?.trim();
-  if (!name || !description) throw new Error(`${SKILL_PATH} must declare name and description`);
+  if (!name || !description) throw new Error(`${skillPath} must declare name and description`);
   return [
     "<skill>",
     `  <name>${name}</name>`,
     `  <description>${description}</description>`,
-    `  <location>${SKILL_PATH}</location>`,
+    `  <location>${skillPath}</location>`,
     "</skill>",
   ].join("\n");
 }
@@ -159,7 +188,13 @@ export function measureWorkflowContextSurfaces(root: string = ROOT): WorkflowCon
     description: tool.description,
     parameters: tool.parameters,
   });
-  const discoveryEntry = skillDiscoveryEntry(root);
+  const skillRoots = registeredSkillRoots(root);
+  const skillDiscoverySurfaces: SkillDiscoverySurface[] = skillRoots.map((skillRoot) => ({
+    root: skillRoot,
+    serialization: "UTF-8 bytes of normalized Pi skill XML with package-relative location",
+    bytes: bytes(skillDiscoveryEntry(root, skillRoot)),
+  }));
+  const registeredSkillsDiscoveryBytes = skillDiscoverySurfaces.reduce((sum, surface) => sum + surface.bytes, 0);
   const corpusFiles = skillFiles(root);
   const corpusBytes = corpusFiles.reduce((sum, path) => sum + fileBytes(root, path), 0);
   const profiles = WORKFLOW_AUTHORING_PROFILES.map((profile) => ({
@@ -169,12 +204,11 @@ export function measureWorkflowContextSurfaces(root: string = ROOT): WorkflowCon
   }));
   const promptBytes = bytes(permanentWorkflowPrompt);
   const toolBytes = bytes(providerVisibleWorkflowToolDefinition);
-  const discoveryBytes = bytes(discoveryEntry);
 
   return {
-    formatVersion: 2,
+    formatVersion: 3,
     encoding: "utf8",
-    sources: ["src/workflow-tool.ts", "skills/workflow-authoring"],
+    sources: ["src/workflow-tool.ts", "skills/workflow-authoring", "package.json#pi.skills"],
     surfaces: {
       permanentWorkflowPrompt: {
         serialization: "UTF-8 bytes of LF-joined Pi prompt lines",
@@ -184,14 +218,16 @@ export function measureWorkflowContextSurfaces(root: string = ROOT): WorkflowCon
         serialization: "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
         bytes: toolBytes,
       },
-      workflowAuthoringSkillDiscovery: {
-        serialization: "UTF-8 bytes of normalized Pi skill XML with package-relative location",
-        bytes: discoveryBytes,
+      registeredSkillsDiscovery: {
+        serialization:
+          "sum of UTF-8 bytes of normalized Pi skill XML (name + description + location) across every root in package.json's pi.skills",
+        bytes: registeredSkillsDiscoveryBytes,
+        skills: skillDiscoverySurfaces,
       },
       ordinaryWorkflowOwnedAlwaysOn: {
         serialization:
-          "sum of permanent prompt, provider-visible tool definition, and normalized skill discovery bytes",
-        bytes: promptBytes + toolBytes + discoveryBytes,
+          "sum of permanent prompt, provider-visible tool definition, and every registered skill's discovery bytes",
+        bytes: promptBytes + toolBytes + registeredSkillsDiscoveryBytes,
       },
       workflowAuthoringSkillCorpus: {
         serialization: "sum of UTF-8 bytes for every file under skills/workflow-authoring",

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -1,6 +1,7 @@
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { BUILTIN_WORKFLOW_NAMES, resolveWorkflowInvocation } from "./builtin-workflows.js";
 import {
   createToolUpdateWorkflowDisplay,
   createWorkflowSnapshot,
@@ -23,20 +24,30 @@ export const WORKFLOW_GATE_GUIDELINE =
   "The `workflow` tool runs multi-agent orchestration — it fans decomposable work out across subagents, and fits tasks shaped like: repo-wide inspection, independent parallel research/checks, multi-perspective review, or fan-out/fan-in synthesis. ONLY call it when the user explicitly opts in — via the workflow trigger word, `/workflows run`, or their own words (e.g. 'run a workflow', 'fan this out', '并行审一遍'). For any other task — even one that would clearly benefit — do not call it; you may briefly offer it (with a rough cost) as an option instead.";
 
 const workflowToolSchema = Type.Object({
-  script: Type.String({
-    description: [
-      "Required raw JavaScript workflow script, with no Markdown fences.",
-      "First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description' }. Add phases: [{ title: 'Phase' }] only when the workflow has named phases, and declare only phases it will use. With multiple phases, call phase('Exact Title') before each phase's work or set `phase` in the agent options.",
-      "Use `await workflow(savedName, childArgs)` to run a saved workflow inline; nesting is limited to one level and shares the parent run's concurrency, agent, and token limits.",
-      "Optional quality helpers include verify(), judgePanel(), loopUntilDry(), and completenessCheck().",
-      "Optional control helpers include retry() and gate(); budget exposes total, spent(), and remaining(), and phase('Name', { budget: N }) sets a phase token limit.",
-      "The optional `agentType` option selects a named user or project definition that can bind tools, a model, and role instructions; use it only when its name and purpose are provided in context. Its bound model overrides `tier`; an explicit `model` overrides both.",
-      "Use plain JavaScript only; imports, require(), filesystem modules, Date.now(), Math.random(), and new Date() are unavailable.",
-      "Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, cwd, process.cwd(), and budget. The workflow must call agent() at least once.",
-      "parallel() requires functions, not promises, and returns results in input order: await parallel(items.map(item => () => agent(...))).",
-      "pipeline(items, ...stages) runs stages sequentially for each item while items proceed concurrently; each stage receives (previousValue, originalItem, index).",
-    ].join(" "),
-  }),
+  script: Type.Optional(
+    Type.String({
+      description: [
+        "Raw JavaScript workflow script, with no Markdown fences. Required unless `name` is given.",
+        "First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description' }. Add phases: [{ title: 'Phase' }] only when the workflow has named phases, and declare only phases it will use. With multiple phases, call phase('Exact Title') before each phase's work or set `phase` in the agent options.",
+        "Use `await workflow(savedName, childArgs)` to run a saved workflow inline; nesting is limited to one level and shares the parent run's concurrency, agent, and token limits.",
+        "Optional quality helpers include verify(), judgePanel(), loopUntilDry(), and completenessCheck().",
+        "Optional control helpers include retry() and gate(); budget exposes total, spent(), and remaining(), and phase('Name', { budget: N }) sets a phase token limit.",
+        "The optional `agentType` option selects a named user or project definition that can bind tools, a model, and role instructions; use it only when its name and purpose are provided in context. Its bound model overrides `tier`; an explicit `model` overrides both.",
+        "Use plain JavaScript only; imports, require(), filesystem modules, Date.now(), Math.random(), and new Date() are unavailable.",
+        "Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, cwd, process.cwd(), and budget. The workflow must call agent() at least once.",
+        "parallel() requires functions, not promises, and returns results in input order: await parallel(items.map(item => () => agent(...))).",
+        "pipeline(items, ...stages) runs stages sequentially for each item while items proceed concurrently; each stage receives (previousValue, originalItem, index).",
+      ].join(" "),
+    }),
+  ),
+  name: Type.Optional(
+    Type.String({
+      description:
+        "Run a saved or built-in workflow by name instead of `script`; its args go in `args`. " +
+        `Built-ins: ${BUILTIN_WORKFLOW_NAMES.join(", ")} — see the workflow-patterns skill for each one's args. ` +
+        "A same-named saved workflow wins. Not combinable with resumeFromRunId.",
+    }),
+  ),
   args: Type.Optional(
     Type.Any({ description: "Optional JSON value exposed to the workflow script as global `args`." }),
   ),
@@ -88,7 +99,8 @@ const workflowToolSchema = Type.Object({
 });
 
 export type WorkflowToolInput = {
-  script: string;
+  script?: string;
+  name?: string;
   args?: unknown;
   background?: boolean;
   maxAgents?: number;
@@ -143,7 +155,35 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       return normalizeWorkflowToolArgs(args);
     },
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
-      const script = normalizeWorkflowScript(params.script);
+      // `name` resolves through the same registry the built-in slash commands
+      // and saved-workflow commands use (see builtin-workflows.ts /
+      // workflow-saved.ts): a project/user saved workflow of that name wins on
+      // a collision, else one of the 5 curated built-in patterns. This lets the
+      // model reach a curated pattern by name instead of having to author an
+      // equivalent script from scratch (and, for patterns that need it, the
+      // right exec context — e.g. deep-research's web tools — travels with it).
+      let invocationTools: ToolDefinition[] | undefined;
+      let invocationToolset: string | undefined;
+      let script: string;
+      if (params.name) {
+        if (params.resumeFromRunId) {
+          throw new Error(
+            "workflow: `name` cannot be combined with `resumeFromRunId` — resume with an edited `script` instead.",
+          );
+        }
+        const resolved = resolveWorkflowInvocation(params.name, params.args, { storage, cwd });
+        if (!resolved) {
+          throw new Error(
+            `workflow: no saved or built-in workflow named "${params.name}". Built-in names: ${BUILTIN_WORKFLOW_NAMES.join(", ")}.`,
+          );
+        }
+        script = normalizeWorkflowScript(resolved.script);
+        invocationTools = resolved.tools;
+        invocationToolset = resolved.toolset;
+      } else {
+        if (!params.script) throw new Error("workflow requires either `script` or `name`");
+        script = normalizeWorkflowScript(params.script);
+      }
       const parsed = parseWorkflowScript(script);
 
       // Iteration / cached-prefix reuse: resume a prior run with THIS (edited)
@@ -185,6 +225,8 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
           agentRetries: params.agentRetries,
           agentTimeoutMs: params.agentTimeoutMs,
           tokenBudget: params.tokenBudget,
+          tools: invocationTools,
+          toolset: invocationToolset,
         });
         return {
           content: [{ type: "text", text: backgroundStartedText(parsed.meta.name, runId) }],
@@ -212,6 +254,8 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
           agentRetries: params.agentRetries,
           agentTimeoutMs: params.agentTimeoutMs,
           tokenBudget: params.tokenBudget,
+          tools: invocationTools,
+          toolset: invocationToolset,
           confirm,
           externalSignal: signal,
           onProgress(live) {
@@ -385,9 +429,20 @@ export function resumeFailureText(manager: WorkflowManager, runId: string): stri
 }
 
 function normalizeWorkflowToolArgs(args: unknown): WorkflowToolInput {
-  if (!args || typeof args !== "object") throw new Error("workflow requires an object argument with a script string");
+  if (!args || typeof args !== "object")
+    throw new Error("workflow requires an object argument with a `script` string or a `name`");
   const value = args as Record<string, unknown>;
-  if (typeof value.script !== "string") throw new Error("workflow requires `script` to be a string");
+  // `name` resolves a saved/built-in workflow at execute() time, so `script` is
+  // optional here — but when both are given as strings, normalize `script` too
+  // (name still wins; script is otherwise unused for this call).
+  if (typeof value.name === "string" && value.name.trim()) {
+    return {
+      ...value,
+      name: value.name.trim(),
+      script: typeof value.script === "string" ? normalizeWorkflowScript(value.script) : undefined,
+    } as WorkflowToolInput;
+  }
+  if (typeof value.script !== "string") throw new Error("workflow requires either `script` or `name` to be a string");
   return { ...value, script: normalizeWorkflowScript(value.script) } as WorkflowToolInput;
 }
 

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -433,9 +433,14 @@ function normalizeWorkflowToolArgs(args: unknown): WorkflowToolInput {
     throw new Error("workflow requires an object argument with a `script` string or a `name`");
   const value = args as Record<string, unknown>;
   // `name` resolves a saved/built-in workflow at execute() time, so `script` is
-  // optional here — but when both are given as strings, normalize `script` too
-  // (name still wins; script is otherwise unused for this call).
+  // optional here — but if `script` is present at all it must still be a
+  // string (same requirement as the script-only path below), so a caller
+  // passing a malformed `script` alongside `name` gets a clear error instead
+  // of it being silently dropped.
   if (typeof value.name === "string" && value.name.trim()) {
+    if (value.script !== undefined && typeof value.script !== "string") {
+      throw new Error("workflow's `script` must be a string when provided alongside `name`");
+    }
     return {
       ...value,
       name: value.name.trim(),

--- a/tests/builtin-commands.test.ts
+++ b/tests/builtin-commands.test.ts
@@ -1,8 +1,38 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { registerBuiltinWorkflows } from "../src/builtin-commands.js";
+import { parseWorkflowScript } from "../src/workflow.js";
 import type { WorkflowManager } from "../src/workflow-manager.js";
+import type { SavedWorkflow, WorkflowStorage } from "../src/workflow-saved.js";
 import { makeCommandRegistryPi, makeNotifyCtx } from "./helpers/mock-pi.js";
+
+/** Fake WorkflowStorage exposing only fixed `load()` results — enough for the shadow tests. */
+function makeFakeStorage(saved: Record<string, Pick<SavedWorkflow, "script" | "parameters">>): WorkflowStorage {
+  return {
+    load(name: string) {
+      const entry = saved[name];
+      if (!entry) return null;
+      return {
+        name,
+        description: "saved override",
+        script: entry.script,
+        parameters: entry.parameters,
+        location: "project",
+        path: `/fake/${name}.json`,
+        savedAt: new Date(0).toISOString(),
+      };
+    },
+    save() {
+      throw new Error("not implemented in this fake");
+    },
+    list() {
+      return [];
+    },
+    delete() {
+      return false;
+    },
+  };
+}
 
 /**
  * Fake manager that records startInBackground calls. The returned promise never
@@ -191,4 +221,136 @@ test("registerBuiltinWorkflows creates handlers with expected structure", () => 
   assert.ok(codeReviewCmd, "code-review should be registered");
   assert.ok(codeReviewCmd.description?.includes("Multi-angle"), "should describe the multi-angle review");
   assert.equal(typeof codeReviewCmd.handler, "function");
+});
+
+// ─── Precedence: a saved workflow shadows a built-in of the same name ──────────
+//
+// Builtins register their commands before saved workflows do (see
+// extensions/workflow.ts), and registerSavedWorkflow skips a name that's
+// already registered — so without a dynamic check here, a saved workflow
+// named e.g. "deep-research" would never actually run from its slash command,
+// contradicting the `workflow` tool's `name` path (where saved always wins).
+// These tests pin "saved wins" on the slash-command path too.
+
+test("a saved workflow shadows the built-in slash command of the same name", async () => {
+  const { pi, commands } = makeCommandRegistryPi();
+  const { manager, started } = makeFakeManager();
+  const customScript = "export const meta = { name: 'custom_deep_research', description: 'override' }\nreturn 1";
+  const storage = makeFakeStorage({ "deep-research": { script: customScript } });
+  registerBuiltinWorkflows(pi, { cwd: "/tmp", manager, storage });
+  const handler = commands.find((c) => c.name === "deep-research")?.handler;
+  assert.ok(handler);
+
+  const { ctx, notified } = makeNotifyCtx();
+  await handler("what is pi?", ctx);
+
+  assert.equal(started.length, 1, "should start exactly one run");
+  assert.equal(started[0].script, customScript, "the saved script should run, not the built-in's");
+  assert.deepEqual(started[0].exec, {}, "the shadow carries no built-in exec context (e.g. no web tools)");
+  assert.equal(notified.length, 1);
+  assert.equal(notified[0].type, "info");
+});
+
+test("a saved workflow shadow parses slash-command args the same way any saved workflow would", async () => {
+  const { pi, commands } = makeCommandRegistryPi();
+  const { manager, started } = makeFakeManager();
+  const customScript = "export const meta = { name: 'custom_audit', description: 'override' }\nreturn 1";
+  const storage = makeFakeStorage({ "codebase-audit": { script: customScript } });
+  registerBuiltinWorkflows(pi, { cwd: "/tmp", manager, storage });
+  const handler = commands.find((c) => c.name === "codebase-audit")?.handler;
+  assert.ok(handler);
+
+  const { ctx } = makeNotifyCtx();
+  // No scope/checks at all — would fail the built-in's own "Usage" guard, but
+  // the shadow bypasses builtin-specific validation entirely (like any other
+  // saved workflow command) and just forwards parsed args.
+  await handler("mode=quick", ctx);
+
+  assert.equal(started.length, 1, "the shadow should start a run even with args the built-in would reject");
+  assert.equal(started[0].script, customScript);
+  assert.deepEqual(started[0].args, { mode: "quick", _: "", _raw: "mode=quick" });
+});
+
+test("deep-research still runs the built-in when no saved workflow shadows it", async () => {
+  const { pi, commands } = makeCommandRegistryPi();
+  const { manager, started } = makeFakeManager();
+  const storage = makeFakeStorage({});
+  registerBuiltinWorkflows(pi, { cwd: "/tmp", manager, storage });
+  const handler = commands.find((c) => c.name === "deep-research")?.handler;
+  assert.ok(handler);
+
+  const { ctx } = makeNotifyCtx();
+  await handler("what is pi?", ctx);
+
+  assert.equal(started.length, 1);
+  const { meta } = parseWorkflowScript(started[0].script);
+  assert.equal(meta.name, "deep_research", "the built-in should run when nothing shadows it");
+});
+
+// ─── Validation drift: registry errors reach the user as a notify, not a throw ─
+
+test("multi-perspective handler notifies (not throws) for a whitespace-only topic", async () => {
+  const { pi, commands } = makeCommandRegistryPi();
+  registerBuiltinWorkflows(pi, { cwd: "/tmp", manager: makeFakeManager().manager });
+  const handler = commands.find((c) => c.name === "multi-perspective")?.handler;
+  assert.ok(handler);
+
+  const { ctx, notified } = makeNotifyCtx();
+  // A quoted whitespace-only topic passes the handler's own cheap `!topic`
+  // check (non-empty length) but fails the registry's real validation.
+  await assert.doesNotReject(() => handler('"  "', ctx));
+  assert.equal(notified.length, 1, "should notify instead of throwing");
+  assert.equal(notified[0].type, "warning");
+  assert.match(notified[0].message, /topic/i);
+});
+
+test("codebase-audit handler notifies (not throws) for a whitespace-only check", async () => {
+  const { pi, commands } = makeCommandRegistryPi();
+  registerBuiltinWorkflows(pi, { cwd: "/tmp", manager: makeFakeManager().manager });
+  const handler = commands.find((c) => c.name === "codebase-audit")?.handler;
+  assert.ok(handler);
+
+  const { ctx, notified } = makeNotifyCtx();
+  // An empty quoted check token passes checks.length === 0 (length is 1) but
+  // fails the registry's real validation.
+  await assert.doesNotReject(() => handler('src ""', ctx));
+  assert.equal(notified.length, 1, "should notify instead of throwing");
+  assert.equal(notified[0].type, "warning");
+  assert.match(notified[0].message, /checks/i);
+});
+
+// ─── Quote injection: quotes/apostrophes reach the generated script safely ─────
+
+test("multi-perspective handler passes an apostrophe-laden perspective through without throwing", async () => {
+  const { pi, commands } = makeCommandRegistryPi();
+  const { manager, started } = makeFakeManager();
+  registerBuiltinWorkflows(pi, { cwd: "/tmp", manager });
+  const handler = commands.find((c) => c.name === "multi-perspective")?.handler;
+  assert.ok(handler);
+
+  const { ctx, notified } = makeNotifyCtx();
+  await handler(`"climate policy" "user's view" "another's take"`, ctx);
+
+  assert.equal(notified.length, 1);
+  assert.equal(notified[0].type, "info", "should start successfully, not warn/error");
+  assert.equal(started.length, 1);
+  const { meta } = parseWorkflowScript(started[0].script);
+  assert.equal(meta.name, "multi_perspective_analysis");
+});
+
+test("codebase-audit handler passes a quote-laden check through without throwing", async () => {
+  const { pi, commands } = makeCommandRegistryPi();
+  const { manager, started } = makeFakeManager();
+  registerBuiltinWorkflows(pi, { cwd: "/tmp", manager });
+  const handler = commands.find((c) => c.name === "codebase-audit")?.handler;
+  assert.ok(handler);
+
+  const { ctx, notified } = makeNotifyCtx();
+  await handler(`src/ "find TODO's"`, ctx);
+
+  assert.equal(notified.length, 1);
+  assert.equal(notified[0].type, "info");
+  assert.equal(started.length, 1);
+  const { meta } = parseWorkflowScript(started[0].script);
+  assert.equal(meta.name, "codebase_audit");
 });

--- a/tests/builtin-workflow-registry.test.ts
+++ b/tests/builtin-workflow-registry.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for the shared builtin-workflow registry (src/builtin-workflows.ts) —
+ * the single resolution path the `/deep-research`-style slash commands
+ * (builtin-commands.ts) and the `workflow` tool's `name` input
+ * (workflow-tool.ts) both consult, so a pattern's generator script is written
+ * exactly once and both entry points can never drift apart.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { generateAdversarialReviewWorkflow, generateMultiPerspectiveWorkflow } from "../src/adversarial-review.js";
+import {
+  BUILTIN_WORKFLOW_NAMES,
+  BUILTIN_WORKFLOWS,
+  DEFAULT_MULTI_PERSPECTIVES,
+  findBuiltinWorkflow,
+  resolveWorkflowInvocation,
+} from "../src/builtin-workflows.js";
+import { generateCodeReviewWorkflow } from "../src/code-review.js";
+import { generateCodebaseAuditWorkflow, generateDeepResearchWorkflow } from "../src/deep-research.js";
+import { parseWorkflowScript } from "../src/workflow.js";
+import { createWorkflowStorage } from "../src/workflow-saved.js";
+
+/** Look up a built-in descriptor, failing the test clearly if the name is unknown. */
+function requireBuiltin(name: string) {
+  const found = findBuiltinWorkflow(name);
+  assert.ok(found, `${name} should be a known built-in workflow`);
+  return found;
+}
+
+function withTempCwd(fn: (cwd: string) => void) {
+  return () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-dw-registry-"));
+    try {
+      fn(cwd);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  };
+}
+
+// ─── Registry shape ─────────────────────────────────────────────────────────────
+
+test("BUILTIN_WORKFLOW_NAMES lists exactly the 5 curated patterns", () => {
+  assert.deepEqual([...BUILTIN_WORKFLOW_NAMES].sort(), [
+    "adversarial-review",
+    "code-review",
+    "codebase-audit",
+    "deep-research",
+    "multi-perspective",
+  ]);
+});
+
+test("findBuiltinWorkflow resolves each of the 5 names and rejects unknown names", () => {
+  for (const name of BUILTIN_WORKFLOW_NAMES) {
+    assert.ok(findBuiltinWorkflow(name), `${name} should be found`);
+  }
+  assert.equal(findBuiltinWorkflow("not-a-real-pattern"), undefined);
+});
+
+// ─── Per-pattern resolve() ──────────────────────────────────────────────────────
+
+test(
+  "deep-research resolve() produces the real generator script and the web-research exec context",
+  withTempCwd((cwd) => {
+    const invocation = requireBuiltin("deep-research").resolve(cwd, { question: "what is pi?" });
+    assert.equal(invocation.script, generateDeepResearchWorkflow());
+    assert.equal(invocation.toolset, "web-research");
+    const tools = invocation.tools;
+    assert.ok(Array.isArray(tools) && tools.length > 0, "should carry an explicit tool set");
+    const toolNames = (tools ?? []).map((t) => t.name);
+    assert.ok(
+      toolNames.some((n) => /search|fetch|web/i.test(n)),
+      `expected web tools among: ${toolNames.join(", ")}`,
+    );
+  }),
+);
+
+test("deep-research resolve() rejects a missing/blank question", () => {
+  const resolve = requireBuiltin("deep-research").resolve;
+  assert.throws(() => resolve("/tmp", {}), /question/);
+  assert.throws(() => resolve("/tmp", { question: "   " }), /question/);
+});
+
+test("adversarial-review resolve() produces the real generator script with no special exec context", () => {
+  const invocation = requireBuiltin("adversarial-review").resolve("/tmp", { task: "investigate this" });
+  assert.equal(invocation.script, generateAdversarialReviewWorkflow());
+  assert.equal(invocation.tools, undefined);
+  assert.equal(invocation.toolset, undefined);
+});
+
+test("adversarial-review resolve() rejects a missing task", () => {
+  assert.throws(() => requireBuiltin("adversarial-review").resolve("/tmp", {}), /task/);
+});
+
+test("code-review resolve() produces the real generator script and requires a diff", () => {
+  const invocation = requireBuiltin("code-review").resolve("/tmp", { diff: "some diff", diffSource: "git diff" });
+  assert.equal(invocation.script, generateCodeReviewWorkflow());
+  assert.throws(() => requireBuiltin("code-review").resolve("/tmp", {}), /diff/);
+  assert.throws(() => requireBuiltin("code-review").resolve("/tmp", { diff: "" }), /diff/);
+});
+
+test("multi-perspective resolve() bakes the given topic/perspectives into the same generator output", () => {
+  const invocation = requireBuiltin("multi-perspective").resolve("/tmp", {
+    topic: "climate policy",
+    perspectives: ["economic", "environmental"],
+  });
+  assert.equal(invocation.script, generateMultiPerspectiveWorkflow("climate policy", ["economic", "environmental"]));
+});
+
+test("multi-perspective resolve() falls back to the default perspective set below 2 items", () => {
+  const noPerspectives = requireBuiltin("multi-perspective").resolve("/tmp", { topic: "topic" });
+  const onePerspective = requireBuiltin("multi-perspective").resolve("/tmp", {
+    topic: "topic",
+    perspectives: ["only-one"],
+  });
+  const expected = generateMultiPerspectiveWorkflow("topic", [...DEFAULT_MULTI_PERSPECTIVES]);
+  assert.equal(noPerspectives.script, expected);
+  assert.equal(onePerspective.script, expected);
+});
+
+test("multi-perspective resolve() rejects a missing topic", () => {
+  assert.throws(() => requireBuiltin("multi-perspective").resolve("/tmp", { perspectives: ["a", "b"] }), /topic/);
+});
+
+test("codebase-audit resolve() bakes the given scope/checks into the same generator output", () => {
+  const invocation = requireBuiltin("codebase-audit").resolve("/tmp", {
+    scope: "src/",
+    checks: ["security", "performance"],
+  });
+  assert.equal(invocation.script, generateCodebaseAuditWorkflow("src/", ["security", "performance"]));
+});
+
+test("codebase-audit resolve() rejects a missing scope or empty checks", () => {
+  const resolve = requireBuiltin("codebase-audit").resolve;
+  assert.throws(() => resolve("/tmp", { checks: ["a"] }), /scope/);
+  assert.throws(() => resolve("/tmp", { scope: "src/", checks: [] }), /checks/);
+  assert.throws(() => resolve("/tmp", { scope: "src/" }), /checks/);
+});
+
+// ─── resolveWorkflowInvocation: precedence and fallback ────────────────────────
+
+test(
+  "resolveWorkflowInvocation falls back to the built-in pattern when nothing is saved",
+  withTempCwd((cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    const resolved = resolveWorkflowInvocation("deep-research", { question: "q" }, { storage, cwd });
+    assert.ok(resolved);
+    assert.equal(resolved.script, generateDeepResearchWorkflow());
+    assert.equal(resolved.toolset, "web-research");
+  }),
+);
+
+test(
+  "resolveWorkflowInvocation prefers a project/user saved workflow over a built-in of the same name",
+  withTempCwd((cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    const customScript = "export const meta = { name: 'custom_deep_research', description: 'override' }\nreturn 1";
+    storage.save({ name: "deep-research", description: "custom override", script: customScript });
+
+    const resolved = resolveWorkflowInvocation("deep-research", { question: "q" }, { storage, cwd });
+    assert.ok(resolved);
+    assert.equal(resolved.script, customScript);
+    // The saved workflow wins outright — it does not carry the built-in's
+    // web-research exec context, since it is a wholly different script.
+    assert.equal(resolved.toolset, undefined);
+    assert.equal(parseWorkflowScript(resolved.script).meta.name, "custom_deep_research");
+  }),
+);
+
+test(
+  "resolveWorkflowInvocation returns undefined for a name that is neither saved nor built-in",
+  withTempCwd((cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    assert.equal(resolveWorkflowInvocation("not-a-real-workflow", {}, { storage, cwd }), undefined);
+  }),
+);
+
+// ─── Every registered script actually parses ───────────────────────────────────
+
+test("every built-in pattern's resolve() output is a parseable workflow script", () => {
+  const validArgsByName: Record<string, unknown> = {
+    "deep-research": { question: "q" },
+    "adversarial-review": { task: "t" },
+    "code-review": { diff: "d" },
+    "multi-perspective": { topic: "t" },
+    "codebase-audit": { scope: "s", checks: ["c"] },
+  };
+  for (const descriptor of BUILTIN_WORKFLOWS) {
+    const { script } = descriptor.resolve("/tmp", validArgsByName[descriptor.name]);
+    const { meta } = parseWorkflowScript(script);
+    assert.ok(meta.name, `${descriptor.name} script should declare export const meta.name`);
+  }
+});

--- a/tests/builtin-workflows.test.ts
+++ b/tests/builtin-workflows.test.ts
@@ -114,20 +114,47 @@ test("generateCodebaseAuditWorkflow includes validator and report phases", () =>
   assert.match(body, /report-writer/);
 });
 
-test("generateCodebaseAuditWorkflow escapes single quotes in scope", () => {
-  const body = generateCodebaseAuditWorkflow("it's a test", ["check"]);
-  // Should not contain unescaped quotes that would break the script
-  assert.ok(!body.includes("it's") || body.includes("it\\'s"), "should not contain it's");
+test("generateCodebaseAuditWorkflow embeds a scope/check containing quotes/backticks as a valid, parseable script", () => {
+  const tricky = 'it\'s a "test" with `backticks` and \\backslashes\\';
+  const body = generateCodebaseAuditWorkflow(tricky, ["find TODO's", 'quote "marks"', "back`ticks`"]);
+  // JSON.stringify-embedded values must round-trip through parsing/execution
+  // without breaking out of the generated script (see the quote-injection fix).
+  const { meta } = parseWorkflowScript(body);
+  assert.equal(meta.name, "codebase_audit");
 });
 
-test("generateCodebaseAuditWorkflow truncates long scope names", () => {
+test("generateCodebaseAuditWorkflow running with quote-laden scope/checks executes without a parse error", async () => {
+  const tricky = 'it\'s a "test" with `backticks`';
+  const body = generateCodebaseAuditWorkflow(tricky, ["find TODO's"]);
+  const seenScopes: string[] = [];
+  const result = await runWorkflow(body, {
+    agent: {
+      async run(prompt: string) {
+        seenScopes.push(prompt);
+        return "ok";
+      },
+    },
+    persistLogs: false,
+  });
+  assert.equal(result.agentCount, 3, "the check agent + validator + report agents all run without throwing");
+  assert.ok(
+    seenScopes.some((p) => p.includes(tricky)),
+    "the full, untruncated scope should reach the check agent's prompt",
+  );
+});
+
+test("generateCodebaseAuditWorkflow truncates only the display description, never the operative scope", () => {
   const long = "x".repeat(100);
   const body = generateCodebaseAuditWorkflow(long, ["check"]);
-  // The scope in the script is .slice(0, 60), so the full 100-char string should not appear
-  const fullString = "x".repeat(100);
-  assert.ok(!body.includes(fullString), "should not contain the full 100-char string verbatim");
-  // But the truncated 60-char version should appear
-  assert.ok(body.includes("x".repeat(60)), "should contain the truncated 60-char version");
+  // The operative `const scope = ...` must carry the full, untruncated value —
+  // a truncated operative scope would silently narrow what gets audited.
+  assert.ok(body.includes(JSON.stringify(long)), "the operative scope must be the full 100-char string");
+  // The human-readable meta.description is display-only and may be truncated.
+  assert.ok(body.includes(`${"x".repeat(60)}…`), "meta.description should show the truncated, ellipsized scope");
+  assert.ok(
+    !body.includes(JSON.stringify(`Codebase audit: ${long}`)),
+    "meta.description itself should not contain the full untruncated scope",
+  );
 });
 
 // ─── Multi-Perspective ──────────────────────────────────────────────────────────
@@ -165,6 +192,33 @@ test("generateMultiPerspectiveWorkflow returns analyses and synthesis", () => {
   const body = generateMultiPerspectiveWorkflow("topic", ["p1"]);
   assert.match(body, /analyses/);
   assert.match(body, /synthesis/);
+});
+
+test("generateMultiPerspectiveWorkflow embeds a topic/perspective containing quotes/backticks as a valid, parseable script", () => {
+  const trickyTopic = 'it\'s a "test" with `backticks` and \\backslashes\\';
+  const body = generateMultiPerspectiveWorkflow(trickyTopic, ["user's view", 'quote "marks"', "back`ticks`"]);
+  const { meta } = parseWorkflowScript(body);
+  assert.equal(meta.name, "multi_perspective_analysis");
+});
+
+test("generateMultiPerspectiveWorkflow running with quote-laden topic/perspectives executes without a parse error", async () => {
+  const trickyTopic = 'it\'s a "test" with `backticks`';
+  const body = generateMultiPerspectiveWorkflow(trickyTopic, ["user's view", "another's angle"]);
+  const seenPrompts: string[] = [];
+  const result = await runWorkflow(body, {
+    agent: {
+      async run(prompt: string) {
+        seenPrompts.push(prompt);
+        return "ok";
+      },
+    },
+    persistLogs: false,
+  });
+  assert.equal(result.agentCount, 3, "2 perspective agents + the synthesizer all run without throwing");
+  assert.ok(
+    seenPrompts.some((p) => p.includes(trickyTopic)),
+    "the full topic should reach a perspective agent's prompt",
+  );
 });
 
 // ─── Web Tools ──────────────────────────────────────────────────────────────────

--- a/tests/workflow-authoring-skill.test.ts
+++ b/tests/workflow-authoring-skill.test.ts
@@ -58,7 +58,11 @@ function publishableFiles(): Set<string> {
 }
 
 test("publishable Pi package discovers the workflow-authoring skill and all linked resources", () => {
-  assert.deepEqual(packageJson.pi.skills, [SKILL_ROOT]);
+  // workflow-patterns (discoverability for the 5 built-in patterns via the
+  // `workflow` tool's `name` input) is a separate, smaller skill — see
+  // skills/workflow-patterns/SKILL.md — and is not part of this skill's
+  // required-resource list below.
+  assert.deepEqual(packageJson.pi.skills, [SKILL_ROOT, "skills/workflow-patterns"]);
   const files = publishableFiles();
   for (const resource of REQUIRED_RESOURCES) assert.ok(files.has(resource), `publishable package omitted ${resource}`);
 

--- a/tests/workflow-capability-contract.test.ts
+++ b/tests/workflow-capability-contract.test.ts
@@ -40,6 +40,7 @@ const EXPECTED_TOOL_INPUTS = [
   "background",
   "concurrency",
   "maxAgents",
+  "name",
   "resumeFromRunId",
   "script",
   "tokenBudget",

--- a/tests/workflow-context-surfaces.test.ts
+++ b/tests/workflow-context-surfaces.test.ts
@@ -27,16 +27,31 @@ test("workflow context measurement reports Pi-rendered prompt and provider tool 
   const artifact = measureWorkflowContextSurfaces(ROOT);
   assert.deepEqual(JSON.parse(renderWorkflowContextMeasurement()), artifact);
 
-  assert.equal(artifact.formatVersion, 2);
+  assert.equal(artifact.formatVersion, 3);
   assert.equal(artifact.encoding, "utf8");
-  assert.deepEqual(artifact.sources, ["src/workflow-tool.ts", "skills/workflow-authoring"]);
+  assert.deepEqual(artifact.sources, ["src/workflow-tool.ts", "skills/workflow-authoring", "package.json#pi.skills"]);
   assert.equal(artifact.surfaces.permanentWorkflowPrompt.serialization, "UTF-8 bytes of LF-joined Pi prompt lines");
   assert.equal(
     artifact.surfaces.providerVisibleWorkflowToolDefinition.serialization,
     "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
   );
-  assert.match(artifact.surfaces.workflowAuthoringSkillDiscovery.serialization, /package-relative location/i);
-  assert.ok(artifact.surfaces.workflowAuthoringSkillDiscovery.bytes > 0);
+  // Every skill in package.json's pi.skills contributes to the always-on
+  // discovery tally — not just workflow-authoring — so adding a new skill
+  // can't silently go untracked (see the workflow-patterns skill).
+  assert.match(artifact.surfaces.registeredSkillsDiscovery.serialization, /pi\.skills/i);
+  assert.ok(artifact.surfaces.registeredSkillsDiscovery.bytes > 0);
+  assert.deepEqual(
+    artifact.surfaces.registeredSkillsDiscovery.skills.map(({ root }) => root).sort(),
+    [...packageJson.pi.skills].sort(),
+  );
+  assert.equal(
+    artifact.surfaces.registeredSkillsDiscovery.bytes,
+    artifact.surfaces.registeredSkillsDiscovery.skills.reduce((sum, skill) => sum + skill.bytes, 0),
+    "the total must be the exact sum of each registered skill's own discovery bytes",
+  );
+  for (const skill of artifact.surfaces.registeredSkillsDiscovery.skills) {
+    assert.ok(skill.bytes > 0, `${skill.root} should report a positive discovery byte count`);
+  }
   assert.equal(artifact.surfaces.workflowAuthoringSkillCorpus.files, 27);
   assert.ok(artifact.surfaces.workflowAuthoringSkillCorpus.bytes > 0);
   assert.equal(artifact.surfaces.representativeAuthoringProfiles.profiles.length, 6);
@@ -89,7 +104,9 @@ test("context freshness command prints both current byte counts", () => {
 
   assert.match(output, /Permanent workflow prompt: \d+ bytes/);
   assert.match(output, /Provider-visible workflow tool definition: \d+ bytes/);
-  assert.match(output, /Workflow-authoring skill discovery: \d+ bytes/);
+  assert.match(output, /Registered skills discovery \(all \d+\): \d+ bytes/);
+  assert.match(output, /- skills\/workflow-authoring: \d+ bytes/);
+  assert.match(output, /- skills\/workflow-patterns: \d+ bytes/);
   assert.match(output, /Workflow-authoring skill corpus: \d+ bytes across \d+ files/);
   assert.match(output, /Representative authoring profile median: \d+(?:\.5)? bytes/);
   assert.match(output, /measurement is fresh/i);

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -22,12 +22,22 @@ const RENDERED_PROMPT_BUDGET_BYTES = 800;
 // Made the 5 built-in workflow patterns (deep-research, adversarial-review,
 // code-review, multi-perspective, codebase-audit) reachable from the tool
 // itself, not only slash commands: added an optional `name` input (with a
-// deliberately terse description that defers argument-shape details to the
+// deliberately terse description that defers argument-shape details to a new
 // workflow-patterns skill) and a one-clause addition to `script`'s
-// description noting it's optional when `name` is given. This is the smallest
-// schema growth that lets the model discover and invoke a curated pattern by
-// name instead of improvising an equivalent script — increasing the compact
-// definition from 3,918 to 4,267 bytes.
+// description noting it's optional when `name` is given, increasing this
+// compact definition from 3,918 to 4,267 bytes (+349).
+//
+// That is not the full always-on cost of this change, stated honestly: the
+// new workflow-patterns skill itself also contributes an always-on
+// discovery entry (its `name` + `description`, shown to the model regardless
+// of whether the skill is ever loaded) of ~593 bytes — see
+// docs/workflow-context-surfaces.json's `registeredSkillsDiscovery`, which is
+// generic over every skill package.json's `pi.skills` registers (not
+// hardcoded to workflow-authoring), so this and any future skill's always-on
+// cost stays tracked. Total always-on growth from this change is
+// approximately 349 (this tool definition) + 593 (skill discovery) ≈ 942
+// bytes — well short of loading the skill's full body, which only happens
+// on demand.
 const TOOL_DEFINITION_BUDGET_BYTES = 4_267;
 
 test("rendered workflow prompt contribution stays within its accepted size", async () => {

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -19,7 +19,16 @@ import { withFakeHomeAsync } from "./helpers/fake-home.js";
 const RENDERED_PROMPT_BUDGET_BYTES = 800;
 // #105 corrected omitted timeout/budget semantics to name configured defaults,
 // increasing the compact definition from 3,802 to 3,918 bytes.
-const TOOL_DEFINITION_BUDGET_BYTES = 3_918;
+// Made the 5 built-in workflow patterns (deep-research, adversarial-review,
+// code-review, multi-perspective, codebase-audit) reachable from the tool
+// itself, not only slash commands: added an optional `name` input (with a
+// deliberately terse description that defers argument-shape details to the
+// workflow-patterns skill) and a one-clause addition to `script`'s
+// description noting it's optional when `name` is given. This is the smallest
+// schema growth that lets the model discover and invoke a curated pattern by
+// name instead of improvising an equivalent script — increasing the compact
+// definition from 3,918 to 4,267 bytes.
+const TOOL_DEFINITION_BUDGET_BYTES = 4_267;
 
 test("rendered workflow prompt contribution stays within its accepted size", async () => {
   await withRenderedWorkflow(async ({ systemPrompt, promptLines }) => {

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -190,6 +190,10 @@ test("createWorkflowTool invalid args throws descriptive error", () => {
     const prepare = tool.prepareArguments as (args: unknown) => unknown;
     assert.throws(() => prepare({ script: 123 }), /script.*string/);
     assert.throws(() => prepare("not-an-object"), /object argument/);
+    assert.throws(() => prepare({}), /script.*name/i, "neither `script` nor `name` should throw clearly");
+    // A malformed `script` alongside `name` must not be silently coerced away
+    // — it should throw the same way a malformed script-only call does.
+    assert.throws(() => prepare({ name: "deep-research", script: 123 }), /script.*string/i);
   }
 });
 

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -4,8 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import type { AgentUsage } from "../src/agent.js";
+import { BUILTIN_WORKFLOW_NAMES } from "../src/builtin-workflows.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
+import { createWorkflowStorage } from "../src/workflow-saved.js";
 import { backgroundStartedText, createWorkflowTool, WORKFLOW_GATE_GUIDELINE } from "../src/workflow-tool.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
@@ -299,11 +301,16 @@ function withToolTempCwd(fn: (cwd: string) => Promise<void>) {
   };
 }
 
-test("workflowToolSchema exposes resumeFromRunId as optional; script stays required", () => {
+test("workflowToolSchema exposes resumeFromRunId, script, and name as optional at the schema level", () => {
   const tool = createWorkflowTool();
   const schema = tool.parameters as { properties: Record<string, unknown>; required?: string[] };
   assert.ok(schema.properties.resumeFromRunId, "resumeFromRunId should be a schema property");
-  assert.ok((schema.required ?? []).includes("script"), "script stays required");
+  assert.ok(schema.properties.name, "name should be a schema property");
+  // Neither `script` nor `name` is in the schema's `required` list — exactly one
+  // is required at runtime (normalizeWorkflowToolArgs enforces it), because
+  // TypeBox's flat object schema can't express an either/or constraint.
+  assert.ok(!(schema.required ?? []).includes("script"), "script is schema-optional (name is the alternative)");
+  assert.ok(!(schema.required ?? []).includes("name"), "name is schema-optional (script is the alternative)");
   assert.ok(!(schema.required ?? []).includes("resumeFromRunId"), "resumeFromRunId is optional");
 });
 
@@ -433,5 +440,134 @@ return { a, b }`;
     assert.ok(during.includes("SECOND-EDITED"), "edited agent 2 re-runs live");
     // No extra run created — resume reuses the same id.
     assert.equal(manager.listRuns().length, 1, "resume does not create a second run");
+  }),
+);
+
+// ─── `name`: reach a saved or built-in workflow without writing a script ───────
+
+const validArgsByBuiltinName: Record<string, unknown> = {
+  "deep-research": { question: "what is pi?" },
+  "adversarial-review": { task: "investigate this" },
+  "code-review": { diff: "some diff" },
+  "multi-perspective": { topic: "a topic" },
+  "codebase-audit": { scope: "src/", checks: ["security"] },
+};
+
+test(
+  "workflow tool: `name` resolves each of the 5 built-in patterns and starts a run",
+  withToolTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: toolFakeAgent("ok") });
+    manager.on("error", () => {});
+    const tool = createWorkflowTool({ cwd, manager });
+
+    for (const name of BUILTIN_WORKFLOW_NAMES) {
+      const res = await tool.execute(
+        `name-${name}`,
+        { name, args: validArgsByBuiltinName[name] },
+        undefined,
+        undefined,
+        undefined,
+      );
+      const details = res.details as { runId?: string; background?: boolean };
+      const runId = details.runId;
+      assert.ok(runId, `${name} should start a run`);
+      assert.equal(details.background, true);
+      const managed = manager.getRun(runId);
+      assert.ok(managed, `${name} run should be tracked by the manager`);
+    }
+    // Let the fire-and-forget background runs settle before the test tears down.
+    await new Promise((r) => setTimeout(r, 50));
+  }),
+);
+
+test(
+  "workflow tool: `name` carries deep-research's web-research exec context through the run",
+  withToolTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: toolFakeAgent("ok") });
+    manager.on("error", () => {});
+    const tool = createWorkflowTool({ cwd, manager });
+    const res = await tool.execute(
+      "name-deep-research",
+      { name: "deep-research", args: { question: "what is pi?" } },
+      undefined,
+      undefined,
+      undefined,
+    );
+    const details = res.details as { runId?: string };
+    const runId = details.runId;
+    assert.ok(runId, "deep-research should start a run");
+    const managed = manager.getRun(runId);
+    assert.equal(managed?.toolset, "web-research", "the run should carry the web-research toolset tag");
+    await new Promise((r) => setTimeout(r, 50));
+  }),
+);
+
+test(
+  "workflow tool: a saved workflow of the same name takes precedence over a built-in",
+  withToolTempCwd(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    const customScript = "export const meta = { name: 'custom_deep_research', description: 'override' }\nreturn 1";
+    storage.save({ name: "deep-research", description: "custom override", script: customScript });
+    const manager = new WorkflowManager({ cwd, agent: toolFakeAgent("ok") });
+    manager.on("error", () => {});
+    const tool = createWorkflowTool({ cwd, manager, storage });
+
+    const res = await tool.execute(
+      "name-precedence",
+      { name: "deep-research", args: { question: "irrelevant here" } },
+      undefined,
+      undefined,
+      undefined,
+    );
+    const details = res.details as { runId?: string };
+    const runId = details.runId;
+    assert.ok(runId, "the run should start");
+    const managed = manager.getRun(runId);
+    assert.equal(managed?.snapshot.name, "custom_deep_research", "the saved workflow should win, not the built-in");
+    assert.equal(managed?.toolset, undefined, "the saved workflow does not carry the built-in's exec context");
+    await new Promise((r) => setTimeout(r, 50));
+  }),
+);
+
+test(
+  "workflow tool: an unknown `name` throws a clear error naming the built-ins",
+  withToolTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: toolFakeAgent("ok") });
+    const tool = createWorkflowTool({ cwd, manager });
+    await assert.rejects(
+      () => tool.execute("bad-name", { name: "not-a-real-workflow" }, undefined, undefined, undefined),
+      /no saved or built-in workflow named "not-a-real-workflow"/,
+    );
+  }),
+);
+
+test(
+  "workflow tool: invalid args for a built-in surface a descriptive error",
+  withToolTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: toolFakeAgent("ok") });
+    const tool = createWorkflowTool({ cwd, manager });
+    await assert.rejects(
+      () => tool.execute("bad-args", { name: "deep-research", args: {} }, undefined, undefined, undefined),
+      /question/,
+    );
+  }),
+);
+
+test(
+  "workflow tool: `name` cannot be combined with `resumeFromRunId`",
+  withToolTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: toolFakeAgent("ok") });
+    const tool = createWorkflowTool({ cwd, manager });
+    await assert.rejects(
+      () =>
+        tool.execute(
+          "bad-combo",
+          { name: "deep-research", args: { question: "q" }, resumeFromRunId: "some-run" },
+          undefined,
+          undefined,
+          undefined,
+        ),
+      /cannot be combined with `resumeFromRunId`/,
+    );
   }),
 );


### PR DESCRIPTION
## What

The 5 curated built-in patterns (`deep-research`, `adversarial-review`, `code-review`, `multi-perspective`, `codebase-audit`) were previously reachable only through their slash commands. A natural-language request ("do a multi-perspective review of X") made the model improvise an ad-hoc script instead of reaching the curated, tested pattern.

- New shared registry (`src/builtin-workflows.ts`): the single place that turns a pattern name + args into a runnable script plus its exec context (e.g. deep-research's web tools and `"web-research"` toolset tag). Both the slash commands and the new tool path resolve through it, so the two can't drift.
- The `workflow` tool gains an optional `name` input: run a saved or built-in workflow by name, with args passed through. A same-named project/user saved workflow always takes precedence over a built-in — on both the tool path and the slash commands (slash handlers now check for a saved shadow at invocation time).
- Discovery rides a new `workflow-patterns` skill (loaded on demand) rather than the always-on prompt: the 800-byte rendered-prompt budget is untouched; the provider-visible tool definition grows by 349 bytes and the skill adds a 593-byte discovery entry, both consciously ratcheted and now tracked — the context-measurement script was generalized to account for every registered skill instead of hardcoding one.
- Hardening that fell out of making the patterns model-reachable: user-supplied strings are embedded into generated scripts via `JSON.stringify` (apostrophes/quotes/backticks previously caused parse failures), `codebase-audit` no longer truncates the operative scope to 60 chars (display label only), registry validation errors surface as command notifications instead of unhandled rejections, and `name`+`resumeFromRunId` / missing-both-`script`-and-`name` / malformed inputs all fail with clear errors.

## Notes

- `code-review` invoked by name expects the caller to supply `diff` (e.g. from `git diff`); the slash command still auto-fetches it.
- In-script `await workflow(savedName)` still resolves saved workflows only; built-ins are reachable at the tool boundary via `name` (documented in the skill).

## Verification

- 30+ new tests across the registry, tool, slash-command, generator, and context-measurement layers: per-pattern resolution and arg validation, saved-beats-builtin precedence on both paths, exec-context survival across pause/resume, quote/backtick injection at three levels, budget/context accounting, and error paths.
- Full suite: 1073/1073 pass; lint, typecheck, docs/context checks, and the release gate all clean.
