### PR TITLE
fix: bound run memory and disk growth; harden saved-workflow persistence

### DIFF
--- a/src/fs-persistence.ts
+++ b/src/fs-persistence.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared filesystem primitives for JSON-backed persistence.
+ *
+ * Both run-persistence.ts (workflow runs) and workflow-saved.ts (saved
+ * workflow commands) persist plain-JSON records to per-record files under a
+ * project/user directory, and both need the same three guarantees:
+ *
+ *  1. Atomic writes with a recovery backup — a crash mid-write must never
+ *     corrupt the live file, and a later-discovered-truncated primary must
+ *     still be recoverable from the last good write.
+ *  2. Corrupt-file recovery on read — a truncated/corrupt primary falls back
+ *     to its `.bak` sidecar instead of losing the record.
+ *  3. A missing or unreadable directory degrades to "no files" rather than
+ *     throwing — a listing must never crash because one storage location is
+ *     temporarily inaccessible (not yet created, deleted mid-race, EACCES).
+ *
+ * This module is the single implementation of all three; run-persistence.ts
+ * and workflow-saved.ts both call into it rather than maintaining parallel
+ * copies.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+
+/** Filesystem operations used by JSON persistence. Exposed for testing. */
+export type PersistenceFsLayer = {
+  existsSync: typeof existsSync;
+  mkdirSync: typeof mkdirSync;
+  readdirSync: typeof readdirSync;
+  readFileSync: typeof readFileSync;
+  renameSync: typeof renameSync;
+  statSync: typeof statSync;
+  unlinkSync: typeof unlinkSync;
+  writeFileSync: typeof writeFileSync;
+};
+
+/** The real node:fs implementations. */
+export function defaultPersistenceFs(): PersistenceFsLayer {
+  return { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync };
+}
+
+/** Merge a partial test override on top of the real node:fs implementations. */
+export function resolvePersistenceFs(overrides?: Partial<PersistenceFsLayer>): PersistenceFsLayer {
+  const base = defaultPersistenceFs();
+  return overrides ? { ...base, ...overrides } : base;
+}
+
+/** Ensure `dir` exists (recursive mkdir), idempotent. */
+export function ensureDir(fs: PersistenceFsLayer, dir: string): void {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+/**
+ * Atomically write JSON to `path`: tmp-write + rename (atomic on the same
+ * filesystem, so a crash mid-write can't corrupt the live file), then
+ * best-effort refresh a `.bak` sidecar from the just-written good state —
+ * the recovery fallback readJsonWithBackupRecovery() uses if the primary is
+ * later found truncated (e.g. a rename that itself got interrupted by a
+ * power loss on a filesystem/OS combination where rename isn't fully atomic).
+ */
+export function writeJsonAtomicWithBackup(fs: PersistenceFsLayer, path: string, data: unknown): void {
+  const json = JSON.stringify(data, null, 2);
+  fs.writeFileSync(`${path}.tmp`, json);
+  fs.renameSync(`${path}.tmp`, path);
+  try {
+    fs.writeFileSync(`${path}.bak`, json);
+  } catch {
+    // Backup is best-effort; the primary write already succeeded.
+  }
+}
+
+/**
+ * Read JSON from `path`, falling back to `path.bak` if the primary is
+ * missing or fails to parse. Returns null if neither candidate parses.
+ */
+export function readJsonWithBackupRecovery<T>(fs: PersistenceFsLayer, path: string): T | null {
+  for (const candidate of [path, `${path}.bak`]) {
+    try {
+      if (!fs.existsSync(candidate)) continue;
+      return JSON.parse(fs.readFileSync(candidate, "utf-8")) as T;
+    } catch {
+      // Corrupt candidate -> fall through to the next candidate.
+    }
+  }
+  return null;
+}
+
+/**
+ * List `.json` record files in `dir`. A missing directory (never created
+ * yet) or an unreadable one (deleted between the existsSync check and
+ * readdirSync, permission-denied, etc.) both degrade to an empty list
+ * rather than throwing — callers (run listings, saved-workflow listings)
+ * must never crash a navigator/listing because one storage location is
+ * temporarily inaccessible.
+ */
+export function listJsonFilesSafe(fs: PersistenceFsLayer, dir: string): string[] {
+  try {
+    if (!fs.existsSync(dir)) return [];
+    return fs.readdirSync(dir).filter((f) => f.endsWith(".json"));
+  } catch {
+    return [];
+  }
+}
+
+/** Best-effort unlink; ignores missing-file/permission errors, reports whether it deleted anything. */
+export function unlinkIfExistsSafe(fs: PersistenceFsLayer, path: string): boolean {
+  try {
+    if (fs.existsSync(path)) {
+      fs.unlinkSync(path);
+      return true;
+    }
+  } catch {
+    // ignore
+  }
+  return false;
+}

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -257,16 +257,28 @@ export function createRunPersistence(
     listCache = undefined;
   };
 
-  // Per-file mtime+size cache, keyed by absolute path: even once the
+  // Per-file mtime+size+ino cache, keyed by absolute path: even once the
   // TTL-level listCache above expires (the active panel polls roughly every
   // 300ms, i.e. faster than or comparable to the TTL), most run files on
   // disk haven't changed since the last recompute. Re-stat is cheap; re-read
   // + re-JSON.parse is not, and scales with total lifetime run history, not
-  // with what actually changed. A file whose (mtimeMs, size) matches what we
-  // last parsed is reused as-is instead of being re-read; entries for files
-  // that vanished between recomputes are pruned so this cache can't grow
-  // unbounded independent of what's actually on disk.
-  const fileStateCache = new Map<string, { mtimeMs: number; size: number; state: PersistedRunState }>();
+  // with what actually changed. A file whose (mtimeMs, size, ino) all match
+  // what we last parsed is reused as-is instead of being re-read; entries
+  // for files that vanished between recomputes are pruned so this cache
+  // can't grow unbounded independent of what's actually on disk.
+  //
+  // ino is load-bearing, not redundant with mtime+size: save() writes via
+  // tmp-write + rename (writeJsonAtomicWithBackup), and a rename onto an
+  // existing path allocates a NEW inode for the replacement file. Two
+  // consecutive saves landing in the same mtime tick (400ms-throttled
+  // progress persists vs. 1-2s mtime granularity on HFS+/many network
+  // mounts/some Docker volume drivers is entirely realistic) with
+  // coincidentally equal byte length (e.g. "paused" and "failed" are the
+  // same length) would otherwise be indistinguishable from "unchanged" by
+  // (mtimeMs, size) alone — serving stale, previously-cached content
+  // forever until something ELSE about the file changes. The inode always
+  // changes on such a rename, so adding it closes that hole for free.
+  const fileStateCache = new Map<string, { mtimeMs: number; size: number; ino: number; state: PersistedRunState }>();
 
   const removeStaleLegacyLock = (runId: string): boolean => {
     const lock = legacyLockPath(runId);
@@ -290,15 +302,17 @@ export function createRunPersistence(
         try {
           const stat = _statSync(path);
           const cached = fileStateCache.get(path);
-          // Reuse the last parse when the file is byte-identical (same mtime
-          // + size) to what produced it — the dominant case on every poll
-          // tick once a run goes terminal and stops changing.
-          if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+          // Reuse the last parse when the file is byte-identical (same
+          // mtime + size + inode) to what produced it — the dominant case
+          // on every poll tick once a run goes terminal and stops changing.
+          // ino is what actually rules out a false "unchanged" match on a
+          // coarse-mtime filesystem (see the field doc comment above).
+          if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size && cached.ino === stat.ino) {
             if (!byRunId.has(cached.state.runId)) byRunId.set(cached.state.runId, cached.state);
             continue;
           }
           const state = JSON.parse(_readFileSync(path, "utf-8")) as PersistedRunState;
-          fileStateCache.set(path, { mtimeMs: stat.mtimeMs, size: stat.size, state });
+          fileStateCache.set(path, { mtimeMs: stat.mtimeMs, size: stat.size, ino: stat.ino, state });
           if (!byRunId.has(state.runId)) byRunId.set(state.runId, state);
         } catch {
           // Skip corrupted/unreadable files; don't let a stale cache entry

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -2,11 +2,19 @@
  * Workflow run state persistence for pause/resume support.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentUsage } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import type { WorkflowErrorCode } from "./errors.js";
+import {
+  ensureDir as ensureDirFs,
+  listJsonFilesSafe,
+  type PersistenceFsLayer,
+  readJsonWithBackupRecovery,
+  resolvePersistenceFs,
+  unlinkIfExistsSafe,
+  writeJsonAtomicWithBackup,
+} from "./fs-persistence.js";
 import { workflowProjectPaths } from "./workflow-paths.js";
 
 export type RunStatus = "pending" | "running" | "paused" | "completed" | "failed" | "aborted";
@@ -155,16 +163,28 @@ interface LockFile {
 /**
  * Filesystem operations used by run persistence.
  * Exposed for testing – pass overrides to inject mock implementations.
+ * (Alias of the shared PersistenceFsLayer — see fs-persistence.ts.)
  */
-export type FsLayer = {
-  existsSync: typeof existsSync;
-  mkdirSync: typeof mkdirSync;
-  readdirSync: typeof readdirSync;
-  readFileSync: typeof readFileSync;
-  renameSync: typeof renameSync;
-  unlinkSync: typeof unlinkSync;
-  writeFileSync: typeof writeFileSync;
-};
+export type FsLayer = PersistenceFsLayer;
+
+/**
+ * Retention policy for terminal (completed/failed/aborted) runs kept on
+ * disk. Bounded so a long-lived project directory can't accumulate an
+ * unbounded number of run files (each polled/listed on every list() call).
+ * A run in "running" or "paused" status is NEVER counted against this cap
+ * or evicted by it — only genuinely finished runs age out, oldest (by
+ * updatedAt) first, once the terminal-run count exceeds the cap. 300 is
+ * generous enough to cover weeks of typical usage while keeping list()'s
+ * per-call directory scan bounded.
+ */
+export const DEFAULT_MAX_TERMINAL_RUNS_ON_DISK = 300;
+
+const TERMINAL_RUN_STATUSES: ReadonlySet<RunStatus> = new Set(["completed", "failed", "aborted"]);
+
+export interface RunPersistenceOptions {
+  /** Override DEFAULT_MAX_TERMINAL_RUNS_ON_DISK (tests; advanced tuning). */
+  maxTerminalRunsOnDisk?: number;
+}
 
 /**
  * `list()` does a full readdirSync + per-file readFileSync + JSON.parse of the
@@ -178,24 +198,24 @@ export type FsLayer = {
  */
 const LIST_CACHE_TTL_MS = 300;
 
-export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>): RunPersistence {
-  const _existsSync = fsOverride?.existsSync ?? existsSync;
-  const _mkdirSync = fsOverride?.mkdirSync ?? mkdirSync;
-  const _readdirSync = fsOverride?.readdirSync ?? readdirSync;
-  const _readFileSync = fsOverride?.readFileSync ?? readFileSync;
-  const _renameSync = fsOverride?.renameSync ?? renameSync;
-  const _unlinkSync = fsOverride?.unlinkSync ?? unlinkSync;
-  const _writeFileSync = fsOverride?.writeFileSync ?? writeFileSync;
+export function createRunPersistence(
+  cwd: string,
+  fsOverride?: Partial<FsLayer>,
+  options?: RunPersistenceOptions,
+): RunPersistence {
+  const fs = resolvePersistenceFs(fsOverride);
+  const _existsSync = fs.existsSync;
+  const _readFileSync = fs.readFileSync;
+  const _statSync = fs.statSync;
+  const _unlinkSync = fs.unlinkSync;
+  const _writeFileSync = fs.writeFileSync;
+  const maxTerminalRunsOnDisk = options?.maxTerminalRunsOnDisk ?? DEFAULT_MAX_TERMINAL_RUNS_ON_DISK;
 
   const paths = workflowProjectPaths(cwd);
   const runsDir = paths.runsDir;
   const legacyRunsDir = paths.legacyRunsDir;
 
-  const ensureDir = () => {
-    if (!_existsSync(runsDir)) {
-      _mkdirSync(runsDir, { recursive: true });
-    }
-  };
+  const ensureDir = () => ensureDirFs(fs, runsDir);
 
   const runPath = (dir: string, runId: string) => join(dir, `${runId}.json`);
   const primaryRunPath = (runId: string) => runPath(runsDir, runId);
@@ -237,6 +257,17 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     listCache = undefined;
   };
 
+  // Per-file mtime+size cache, keyed by absolute path: even once the
+  // TTL-level listCache above expires (the active panel polls roughly every
+  // 300ms, i.e. faster than or comparable to the TTL), most run files on
+  // disk haven't changed since the last recompute. Re-stat is cheap; re-read
+  // + re-JSON.parse is not, and scales with total lifetime run history, not
+  // with what actually changed. A file whose (mtimeMs, size) matches what we
+  // last parsed is reused as-is instead of being re-read; entries for files
+  // that vanished between recomputes are pruned so this cache can't grow
+  // unbounded independent of what's actually on disk.
+  const fileStateCache = new Map<string, { mtimeMs: number; size: number; state: PersistedRunState }>();
+
   const removeStaleLegacyLock = (runId: string): boolean => {
     const lock = legacyLockPath(runId);
     const existing = readLockAt(lock);
@@ -249,36 +280,94 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
     return true;
   };
 
+  const computeList = (): PersistedRunState[] => {
+    const byRunId = new Map<string, PersistedRunState>();
+    const seenPaths = new Set<string>();
+    for (const dir of [runsDir, legacyRunsDir]) {
+      for (const file of listJsonFilesSafe(fs, dir)) {
+        const path = join(dir, file);
+        seenPaths.add(path);
+        try {
+          const stat = _statSync(path);
+          const cached = fileStateCache.get(path);
+          // Reuse the last parse when the file is byte-identical (same mtime
+          // + size) to what produced it — the dominant case on every poll
+          // tick once a run goes terminal and stops changing.
+          if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+            if (!byRunId.has(cached.state.runId)) byRunId.set(cached.state.runId, cached.state);
+            continue;
+          }
+          const state = JSON.parse(_readFileSync(path, "utf-8")) as PersistedRunState;
+          fileStateCache.set(path, { mtimeMs: stat.mtimeMs, size: stat.size, state });
+          if (!byRunId.has(state.runId)) byRunId.set(state.runId, state);
+        } catch {
+          // Skip corrupted/unreadable files; don't let a stale cache entry
+          // for a file that's now failing to read linger either.
+          fileStateCache.delete(path);
+        }
+      }
+    }
+    // Prune cache entries for files that no longer exist (deleted runs) so
+    // this map's size tracks what's actually on disk, not lifetime history.
+    for (const path of fileStateCache.keys()) {
+      if (!seenPaths.has(path)) fileStateCache.delete(path);
+    }
+    return [...byRunId.values()].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+  };
+
+  // Bound the number of terminal (completed/failed/aborted) runs kept on
+  // disk (see DEFAULT_MAX_TERMINAL_RUNS_ON_DISK) — called after every save()
+  // whose state is terminal, since that's the only time the terminal count
+  // can grow. Running/paused runs are never candidates: they're filtered out
+  // before the cap is even considered.
+  const enforceRetention = () => {
+    const terminal = computeList()
+      .filter((r) => TERMINAL_RUN_STATUSES.has(r.status))
+      .sort((a, b) => new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime());
+    const excess = terminal.length - maxTerminalRunsOnDisk;
+    if (excess <= 0) return;
+    for (const run of terminal.slice(0, excess)) {
+      deleteRunFiles(run.runId);
+    }
+    invalidateListCache();
+  };
+
+  const deleteRunFiles = (runId: string): boolean => {
+    let deleted = false;
+    for (const path of candidateRunPaths(runId)) {
+      const dir = path === primaryRunPath(runId) ? runsDir : legacyRunsDir;
+      // Best-effort cleanup of the sidecar files alongside the primary.
+      for (const sidecar of [`${path}.bak`, `${path}.tmp`, lockPath(dir, runId)]) {
+        unlinkIfExistsSafe(fs, sidecar);
+        fileStateCache.delete(sidecar);
+      }
+      if (unlinkIfExistsSafe(fs, path)) deleted = true;
+      fileStateCache.delete(path);
+    }
+    return deleted;
+  };
+
   return {
     save(state: PersistedRunState) {
       ensureDir();
       state.updatedAt = new Date().toISOString();
       const path = primaryRunPath(state.runId);
-      const json = JSON.stringify(state, null, 2);
       // Atomic write: a crash mid-write can't corrupt the live file (tmp+rename is
       // atomic on the same filesystem). A .bak from the previous good save is the
       // recovery fallback if the primary is somehow truncated.
-      _writeFileSync(`${path}.tmp`, json);
-      _renameSync(`${path}.tmp`, path);
-      try {
-        _writeFileSync(`${path}.bak`, json);
-      } catch {
-        // backup is best-effort; the primary write already succeeded
-      }
+      writeJsonAtomicWithBackup(fs, path, state);
       invalidateListCache();
+      // Only a terminal write can grow the terminal-run count, so only check
+      // the cap then — a "running"/"paused" save is on the hot path (every
+      // progress tick) and must not pay for a retention scan.
+      if (TERMINAL_RUN_STATUSES.has(state.status)) enforceRetention();
     },
 
     load(runId: string): PersistedRunState | null {
       // Try the primary, then the .bak — so a corrupt primary doesn't lose the run.
       for (const path of candidateRunPaths(runId)) {
-        for (const candidate of [path, `${path}.bak`]) {
-          try {
-            if (!_existsSync(candidate)) continue;
-            return JSON.parse(_readFileSync(candidate, "utf-8")) as PersistedRunState;
-          } catch {
-            // corrupt candidate -> fall through to the next candidate
-          }
-        }
+        const state = readJsonWithBackupRecovery<PersistedRunState>(fs, path);
+        if (state) return state;
       }
       return null;
     },
@@ -291,56 +380,15 @@ export function createRunPersistence(cwd: string, fsOverride?: Partial<FsLayer>)
       if (listCache && now - listCacheAt < LIST_CACHE_TTL_MS) {
         return [...listCache];
       }
-      const byRunId = new Map<string, PersistedRunState>();
-      for (const dir of [runsDir, legacyRunsDir]) {
-        try {
-          if (!_existsSync(dir)) continue;
-          const files = _readdirSync(dir).filter((f) => f.endsWith(".json"));
-          for (const file of files) {
-            try {
-              const state = JSON.parse(_readFileSync(join(dir, file), "utf-8")) as PersistedRunState;
-              if (!byRunId.has(state.runId)) byRunId.set(state.runId, state);
-            } catch {
-              // Skip corrupted files
-            }
-          }
-        } catch {
-          // Skip unreadable directories; another storage location may still work.
-        }
-      }
-      const result = [...byRunId.values()].sort(
-        (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-      );
+      const result = computeList();
       listCache = result;
       listCacheAt = now;
       return [...result];
     },
 
     delete(runId: string): boolean {
-      let deleted = false;
       try {
-        for (const path of candidateRunPaths(runId)) {
-          const dir = path === primaryRunPath(runId) ? runsDir : legacyRunsDir;
-          // Best-effort cleanup of the sidecar files alongside the primary.
-          for (const sidecar of [`${path}.bak`, `${path}.tmp`, lockPath(dir, runId)]) {
-            try {
-              if (_existsSync(sidecar)) _unlinkSync(sidecar);
-            } catch {
-              // ignore sidecar cleanup failures
-            }
-          }
-          try {
-            if (_existsSync(path)) {
-              _unlinkSync(path);
-              deleted = true;
-            }
-          } catch {
-            // ignore per-file cleanup failures
-          }
-        }
-        return deleted;
-      } catch {
-        return deleted;
+        return deleteRunFiles(runId);
       } finally {
         invalidateListCache();
       }

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -1193,12 +1193,19 @@ export class WorkflowManager extends EventEmitter {
       if (managed.status !== "running" && managed.status !== "paused") return false;
       // Whether this run's OWN executeRun() promise has already fully settled
       // matters for whether stop() itself must be the one to call
-      // recordTerminalRun(): a "paused" run got there via pause() or a
-      // usage-limit checkpoint, both of which already ran executeRun()'s
-      // catch tail to completion at pause time (it deliberately skipped
-      // recordTerminalRun() then, since "paused" isn't terminal) — so there
-      // is no FUTURE tail left that will ever call it for this managed
-      // object. A "running" run, by contrast, still has that tail pending;
+      // recordTerminalRun(): a usage-limit checkpoint runs executeRun()'s
+      // catch tail to completion before "paused" is ever observable (it
+      // deliberately skipped recordTerminalRun() then, since "paused" isn't
+      // terminal) — so there is no FUTURE tail left that will ever call it
+      // for this managed object. A manual pause() sets "paused" while its
+      // cooperative abort may still be settling; in that narrow window the
+      // tail later settles this object to "aborted" (terminal) and records a
+      // SECOND time — a tolerated duplicate: recordTerminalRun() is
+      // idempotent-safe under duplicates (re-validates the current entry),
+      // the lease was already cleared here, and the worst case is the
+      // stopped run leaving memory earlier than FIFO order (persistence
+      // fallback covers every consumer). A "running" run, by contrast,
+      // always still has that tail pending;
       // it (not stop()) is what calls recordTerminalRun() once it actually
       // settles to "aborted" — see the `runs` field doc comment's rule that
       // eviction eligibility must wait for the real settle, not a request to

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -196,10 +196,91 @@ export interface WorkflowManagerOptions {
    * standard sessions directory. Default false (in-memory, discarded).
    */
   persistAgentSessions?: boolean;
+  /**
+   * How many terminal (completed/failed/aborted) runs to retain full
+   * in-memory state for before the oldest is evicted from `runs` (see the
+   * class-level doc comment on that field). Defaults to
+   * DEFAULT_MAX_TERMINAL_RUNS_IN_MEMORY; exposed mainly for tests that want
+   * to observe eviction without creating dozens of runs.
+   */
+  maxTerminalRunsInMemory?: number;
 }
 
+/**
+ * Statuses in which a run's execution has genuinely settled — no promise is
+ * still pending, no lease is still held, nothing will asynchronously mutate
+ * this ManagedRun again. "paused" is deliberately excluded: both a manual
+ * pause() and a usage-limit checkpoint leave the run resumable and, from the
+ * in-memory-retention question's point of view, still "the run the user is
+ * looking at" — only completed/failed/aborted runs are eviction candidates.
+ * See the `runs` field doc comment for the full eviction lifecycle contract.
+ */
+const IN_MEMORY_TERMINAL_STATUSES: ReadonlySet<RunStatus> = new Set(["completed", "failed", "aborted"]);
+
+/**
+ * How many terminal (completed/failed/aborted) runs' full in-memory state
+ * (agents array, journal, snapshot, agentTimestamps) to retain in `runs`
+ * before the oldest is evicted. Kept small: a terminal run's data is fully
+ * on disk (run-persistence.ts) by the time it's eviction-eligible, so the
+ * in-memory copy exists only to serve a `getRun()`/`getSnapshot()` caller
+ * that wants the LIVE object (vs. listRuns()'s persisted view) for a run
+ * that *just* finished — a handful is enough for that; unbounded retention
+ * is exactly the leak this bounds (run-level analog of the subagent
+ * memory-retention mitigation in agent.ts).
+ */
+const DEFAULT_MAX_TERMINAL_RUNS_IN_MEMORY = 20;
+
 export class WorkflowManager extends EventEmitter {
+  /**
+   * Lifecycle contract for `runs`:
+   *
+   *  - An entry is added when a run starts (startInBackground/runSync) or is
+   *    resumed (resume()), always with a live AbortController and (usually)
+   *    an active RunLease.
+   *  - While status is "running" or "paused", the entry is NEVER evicted —
+   *    its execution could still settle (a pending executeRun() promise) or
+   *    it is mid-usage-limit-checkpoint/manually-paused and still considered
+   *    "the current state of this run" by callers. Eviction only ever
+   *    considers an entry AFTER executeRun() has fully settled it to
+   *    "completed" | "failed" | "aborted" (see IN_MEMORY_TERMINAL_STATUSES)
+   *    and persisted + released its lease — i.e. strictly after the same
+   *    isCurrent()-gated persistRun()/releaseRunLease() calls in
+   *    executeRun()'s success/catch tails.
+   *  - Once terminal, an entry becomes eviction-ELIGIBLE (recordTerminalRun())
+   *    but is not necessarily evicted immediately: up to
+   *    maxTerminalRunsInMemory terminal entries are kept, oldest evicted
+   *    first, so a `getRun()` call immediately after completion (e.g. the
+   *    "complete" event's own synchronous listeners — task-panel's result
+   *    delivery, `/workflows watch`) still sees the live object. Once
+   *    evicted, the entry is simply removed from `runs`; nothing else reads
+   *    or writes it again.
+   *  - Every caller of getRun()/getSnapshot() must treat "undefined"/null as
+   *    "no live in-memory copy right now" and fall back to listRuns() (backed
+   *    by run-persistence.ts, which is what's authoritative for a run once
+   *    the in-memory copy is gone) — this mirrors how those callers already
+   *    treat any run this process never had in memory (e.g. one started by a
+   *    different process and only ever seen via listRuns()). resume() never
+   *    depends on `runs` for a run's state either: it always reloads from
+   *    persistence, so an evicted runId resumes exactly like one from a
+   *    prior process.
+   *  - isCurrent(managed) composes with eviction the same way it composes
+   *    with resume()/deleteRun() replacing or removing an entry: eviction
+   *    removes the map entry outright, so a stale execution's later settle
+   *    (isCurrent() check) sees `this.runs.get(runId) !== managed` (in fact
+   *    undefined) and correctly no-ops, exactly as it would after
+   *    resume()/deleteRun().
+   */
   private runs = new Map<string, ManagedRun>();
+  /**
+   * FIFO of runIds that reached IN_MEMORY_TERMINAL_STATUSES, oldest first —
+   * the eviction order for `runs` (see its doc comment). A runId can appear
+   * more than once (e.g. resumed after eviction, then terminates again);
+   * evicting is idempotent (recordTerminalRun() re-checks the CURRENT status
+   * of the current map entry for that id before deleting), so duplicates
+   * are harmless.
+   */
+  private terminalRunQueue: string[] = [];
+  private maxTerminalRunsInMemory: number;
   private persistence: RunPersistence;
   private cwd: string;
   private concurrency: number;
@@ -233,6 +314,7 @@ export class WorkflowManager extends EventEmitter {
     this.toolsets = options.toolsets;
     this.excludeSubagentTools = options.excludeSubagentTools;
     this.persistAgentSessions = options.persistAgentSessions ?? false;
+    this.maxTerminalRunsInMemory = options.maxTerminalRunsInMemory ?? DEFAULT_MAX_TERMINAL_RUNS_IN_MEMORY;
     this.persistence = createRunPersistence(this.cwd);
     this.recoverStaleRuns();
   }
@@ -647,7 +729,13 @@ export class WorkflowManager extends EventEmitter {
       // stale execution settling after resume() has already acquired a NEW
       // lease for this runId must not touch that newer lease's bookkeeping.
       this.persistRun(managed);
-      if (this.isCurrent(managed)) this.releaseRunLease(managed);
+      if (this.isCurrent(managed)) {
+        this.releaseRunLease(managed);
+        // Now (and only now — after the run's data is safely on disk and its
+        // lease released) does this run become eviction-eligible; see the
+        // `runs` field doc comment.
+        this.recordTerminalRun(managed.runId);
+      }
 
       return result;
     } catch (error) {
@@ -694,7 +782,16 @@ export class WorkflowManager extends EventEmitter {
       // Persist final state (see the success-path comment above for the
       // isCurrent() rationale — same guard, same reason).
       this.persistRun(managed);
-      if (this.isCurrent(managed)) this.releaseRunLease(managed);
+      if (this.isCurrent(managed)) {
+        this.releaseRunLease(managed);
+        // "paused" (manual pause() or a usage-limit checkpoint) is
+        // deliberately NOT eviction-eligible — only a genuinely settled
+        // terminal status is (see IN_MEMORY_TERMINAL_STATUSES / the `runs`
+        // field doc comment). recordTerminalRun() itself re-checks this too,
+        // but skip the call entirely here so a paused run never even enters
+        // the eviction queue.
+        if (IN_MEMORY_TERMINAL_STATUSES.has(managed.status)) this.recordTerminalRun(managed.runId);
+      }
 
       throw workflowError;
     }
@@ -733,6 +830,33 @@ export class WorkflowManager extends EventEmitter {
    */
   private emitLive(managed: ManagedRun, event: string, payload: unknown): void {
     if (this.isCurrent(managed)) this.emit(event, payload);
+  }
+
+  /**
+   * Mark `runId` as eviction-eligible now that its execution has genuinely
+   * settled to a terminal status (completed/failed/aborted — see
+   * IN_MEMORY_TERMINAL_STATUSES), and evict the oldest eligible entries
+   * beyond maxTerminalRunsInMemory. Callers must only invoke this after the
+   * same isCurrent()-gated persistRun()/releaseRunLease() sequence executeRun()
+   * already uses (see the `runs` field doc comment for the full contract) —
+   * this method itself re-validates the CURRENT entry's status before
+   * deleting anything, so it never evicts a run that isn't (or is no longer)
+   * genuinely terminal, including one resumed back to "running" after being
+   * queued here but before its turn to be evicted came up.
+   */
+  private recordTerminalRun(runId: string): void {
+    this.terminalRunQueue.push(runId);
+    while (this.terminalRunQueue.length > this.maxTerminalRunsInMemory) {
+      const oldest = this.terminalRunQueue.shift();
+      if (oldest === undefined) break;
+      const current = this.runs.get(oldest);
+      // Re-check the CURRENT entry for this id (not the ManagedRun object
+      // that was terminal when queued) — resume() may have since replaced
+      // it with a fresh, live execution, which must never be evicted here.
+      if (current && IN_MEMORY_TERMINAL_STATUSES.has(current.status)) {
+        this.runs.delete(oldest);
+      }
+    }
   }
 
   /**

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -1191,11 +1191,27 @@ export class WorkflowManager extends EventEmitter {
     const managed = this.runs.get(runId);
     if (managed) {
       if (managed.status !== "running" && managed.status !== "paused") return false;
+      // Whether this run's OWN executeRun() promise has already fully settled
+      // matters for whether stop() itself must be the one to call
+      // recordTerminalRun(): a "paused" run got there via pause() or a
+      // usage-limit checkpoint, both of which already ran executeRun()'s
+      // catch tail to completion at pause time (it deliberately skipped
+      // recordTerminalRun() then, since "paused" isn't terminal) — so there
+      // is no FUTURE tail left that will ever call it for this managed
+      // object. A "running" run, by contrast, still has that tail pending;
+      // it (not stop()) is what calls recordTerminalRun() once it actually
+      // settles to "aborted" — see the `runs` field doc comment's rule that
+      // eviction eligibility must wait for the real settle, not a request to
+      // abort. Without this, stopping an already-paused run left it in
+      // `runs` forever (no future tail to mark it eviction-eligible) — a
+      // small leak in exactly the class this manager otherwise bounds.
+      const hadNoPendingSettle = managed.status === "paused";
       managed.controller.abort();
       managed.status = "aborted";
       this.emit("stopped", { runId });
       this.persistRun(managed);
       this.releaseRunLease(managed);
+      if (hadNoPendingSettle) this.recordTerminalRun(runId);
       return true;
     }
 

--- a/src/workflow-saved.ts
+++ b/src/workflow-saved.ts
@@ -2,8 +2,16 @@
  * Save and load reusable workflow commands.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  ensureDir as ensureDirFs,
+  listJsonFilesSafe,
+  type PersistenceFsLayer,
+  readJsonWithBackupRecovery,
+  resolvePersistenceFs,
+  unlinkIfExistsSafe,
+  writeJsonAtomicWithBackup,
+} from "./fs-persistence.js";
 import { workflowProjectPaths, workflowUserSavedDir } from "./workflow-paths.js";
 
 export interface SavedWorkflow {
@@ -51,17 +59,14 @@ export function assertSafeSavedWorkflowName(name: string): void {
   }
 }
 
-export function createWorkflowStorage(cwd: string): WorkflowStorage {
+export function createWorkflowStorage(cwd: string, fsOverride?: Partial<PersistenceFsLayer>): WorkflowStorage {
+  const fs = resolvePersistenceFs(fsOverride);
   const paths = workflowProjectPaths(cwd);
   const projectDir = paths.savedDir;
   const legacyProjectDir = paths.legacySavedDir;
   const userDir = workflowUserSavedDir();
 
-  const ensureDir = (dir: string) => {
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
-    }
-  };
+  const ensureDir = (dir: string) => ensureDirFs(fs, dir);
 
   const workflowPath = (name: string, location: "project" | "user") => {
     assertSafeSavedWorkflowName(name);
@@ -73,21 +78,20 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
     return join(legacyProjectDir, `${name}.json`);
   };
 
+  // Same atomic-write-with-backup + corrupt-file recovery contract as
+  // run-persistence.ts (see fs-persistence.ts) — a saved workflow is a
+  // user-authored artifact just as worth protecting from a crash mid-write
+  // or a truncated file as a run's resumable state is.
   const loadFromFile = (path: string, location: "project" | "user"): SavedWorkflow | null => {
-    try {
-      if (!existsSync(path)) return null;
-      const data = JSON.parse(readFileSync(path, "utf-8"));
-      if (!data || typeof data !== "object" || !isSafeSavedWorkflowName((data as { name?: string }).name ?? "")) {
-        return null;
-      }
-      return {
-        ...data,
-        location,
-        path,
-      };
-    } catch {
+    const data = readJsonWithBackupRecovery<Record<string, unknown>>(fs, path);
+    if (!data || typeof data !== "object" || !isSafeSavedWorkflowName((data as { name?: string }).name ?? "")) {
       return null;
     }
+    return {
+      ...(data as Omit<SavedWorkflow, "location" | "path">),
+      location,
+      path,
+    };
   };
 
   return {
@@ -104,7 +108,7 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
         savedAt: new Date().toISOString(),
       };
 
-      writeFileSync(path, JSON.stringify(saved, null, 2));
+      writeJsonAtomicWithBackup(fs, path, saved);
       return saved;
     },
 
@@ -127,8 +131,11 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
 
       const seen = new Set<string>();
       const addDir = (dir: string, location: "project" | "user") => {
-        if (!existsSync(dir)) return;
-        for (const file of readdirSync(dir).filter((f) => f.endsWith(".json"))) {
+        // A missing or unreadable directory (not yet created, deleted
+        // mid-race, permission-denied) degrades to "no files" here — same
+        // guard run-persistence.ts's list() uses — rather than throwing and
+        // taking down the whole listing over one bad storage location.
+        for (const file of listJsonFilesSafe(fs, dir)) {
           const wf = loadFromFile(join(dir, file), location);
           if (wf && !seen.has(wf.name)) {
             seen.add(wf.name);
@@ -152,14 +159,16 @@ export function createWorkflowStorage(cwd: string): WorkflowStorage {
 
       for (const loc of locations) {
         const path = workflowPath(name, loc);
-        if (existsSync(path)) {
-          unlinkSync(path);
+        // Clean up the .bak sidecar too, mirroring run-persistence.ts's delete()
+        // (sidecar cleanup does not by itself count as "deleted the workflow").
+        unlinkIfExistsSafe(fs, `${path}.bak`);
+        if (unlinkIfExistsSafe(fs, path)) {
           deleted = true;
         }
         if (loc === "project") {
           const legacyPath = legacyProjectWorkflowPath(name);
-          if (existsSync(legacyPath)) {
-            unlinkSync(legacyPath);
+          unlinkIfExistsSafe(fs, `${legacyPath}.bak`);
+          if (unlinkIfExistsSafe(fs, legacyPath)) {
             deleted = true;
           }
         }

--- a/tests/run-persistence.test.ts
+++ b/tests/run-persistence.test.ts
@@ -451,12 +451,16 @@ test(
 // invalidated synchronously by every save()/delete() this instance performs.
 // ═══════════════════════════════════════════════════════════════════════════
 
-function baseRunState(runId: string, updatedAt = "2024-01-01T00:00:00.000Z"): PersistedRunState {
+function baseRunState(
+  runId: string,
+  updatedAt = "2024-01-01T00:00:00.000Z",
+  status: PersistedRunState["status"] = "completed",
+): PersistedRunState {
   return {
     runId,
     workflowName: "wf",
     script: "export const meta = { name: 'w', description: 'w' }",
-    status: "completed",
+    status,
     phases: [],
     agents: [],
     logs: [],
@@ -481,7 +485,11 @@ test(
       }) as typeof readFileSync,
     });
 
-    rp.save(baseRunState("cache-1"));
+    // "running" (non-terminal): a terminal save would trigger the retention
+    // scan (see enforceRetention() in run-persistence.ts), which itself reads
+    // and mtime-caches this file as a side effect — defeating the point of
+    // this test, which measures list()'s OWN caching in isolation.
+    rp.save(baseRunState("cache-1", undefined, "running"));
     // save() doesn't touch readdirSync/readFileSync, but reset for clarity.
     readdirCalls = 0;
     readFileCalls = 0;
@@ -571,6 +579,69 @@ test(
     await new Promise((r) => setTimeout(r, 400));
     rp.list();
     assert.ok(readdirCalls >= 2, "list() should read disk again once the TTL has elapsed");
+  }),
+);
+
+test(
+  "createRunPersistence list() does not re-parse a file whose mtime/size are unchanged, even across TTL expiry",
+  withTempCwd(async (cwd) => {
+    let readFileCalls = 0;
+    const rp = createRunPersistence(cwd, {
+      readFileSync: ((...args: Parameters<typeof readFileSync>) => {
+        readFileCalls++;
+        return readFileSync(...args);
+      }) as typeof readFileSync,
+    });
+
+    // Two runs: one that will never change again ("stable"), one that will
+    // be re-saved between list() calls ("changing"). Both are "running" so
+    // retention-enforcement (a terminal-only path) never fires here.
+    rp.save(baseRunState("stable", "2024-01-01T00:00:00.000Z", "running"));
+    rp.save(baseRunState("changing", "2024-01-01T00:00:00.000Z", "running"));
+    readFileCalls = 0;
+
+    const first = rp.list();
+    assert.equal(first.length, 2);
+    assert.equal(readFileCalls, 2, "first (cold) scan parses both files");
+
+    // Wait past the TTL so the next list() forces a real disk re-scan
+    // (readdirSync fires again), then re-save only "changing" with a
+    // different byte size (not just mtime) so this test's signal doesn't
+    // depend on the filesystem's mtime resolution.
+    await new Promise((r) => setTimeout(r, 400));
+    rp.save({ ...baseRunState("changing", "2024-01-02T00:00:00.000Z", "running"), logs: ["it changed"] });
+    readFileCalls = 0;
+
+    const second = rp.list();
+    assert.equal(second.length, 2);
+    assert.equal(readFileCalls, 1, "only the file that actually changed on disk should be re-parsed");
+  }),
+);
+
+test(
+  "createRunPersistence retention: terminal runs beyond the cap are evicted oldest-first; running/paused are never touched",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd, undefined, { maxTerminalRunsOnDisk: 3 });
+
+    // 5 terminal runs, oldest to newest.
+    for (let i = 0; i < 5; i++) {
+      rp.save(baseRunState(`terminal-${i}`, `2024-01-0${i + 1}T00:00:00.000Z`, "completed"));
+    }
+    // A running and a paused run — must survive retention regardless of age.
+    rp.save(baseRunState("still-running", "2023-01-01T00:00:00.000Z", "running"));
+    rp.save(baseRunState("still-paused", "2023-01-01T00:00:00.000Z", "paused"));
+
+    const runIds = rp.list().map((r) => r.runId);
+    const terminalKept = runIds.filter((id) => id.startsWith("terminal-"));
+    assert.equal(terminalKept.length, 3, "only maxTerminalRunsOnDisk terminal runs are kept");
+    assert.deepEqual(
+      new Set(terminalKept),
+      new Set(["terminal-2", "terminal-3", "terminal-4"]),
+      "the oldest terminal runs are evicted first, newest are kept",
+    );
+    assert.ok(runIds.includes("still-running"), "a running run is never evicted by retention");
+    assert.ok(runIds.includes("still-paused"), "a paused run is never evicted by retention");
+    assert.equal(rp.load("terminal-0"), null, "an evicted run's file is actually gone from disk");
   }),
 );
 

--- a/tests/run-persistence.test.ts
+++ b/tests/run-persistence.test.ts
@@ -1,5 +1,14 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  type statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -619,17 +628,87 @@ test(
 );
 
 test(
-  "createRunPersistence retention: terminal runs beyond the cap are evicted oldest-first; running/paused are never touched",
+  "createRunPersistence list() re-parses when mtime+size are unchanged but the inode differs (closes the same-tick-rename false-positive)",
+  withTempCwd(async (cwd) => {
+    // A fully faked fs layer: real filesystems can't reliably produce two
+    // saves with identical mtime+size but different inodes on demand
+    // (mtime granularity is OS/filesystem dependent), so this simulates the
+    // exact scenario directly — two 400ms-throttled persists landing in the
+    // same coarse mtime tick (realistic on HFS+, many network mounts, and
+    // some Docker volume drivers) with coincidentally equal byte length
+    // ("paused" and "failed" are both 6 characters).
+    const runsDir = workflowProjectPaths(cwd).runsDir;
+    const filePath = join(runsDir, "r.json");
+
+    const makeContent = (status: string) =>
+      JSON.stringify({
+        runId: "r",
+        workflowName: "w",
+        script: "s",
+        status,
+        phases: [],
+        agents: [],
+        logs: [],
+        startedAt: "t",
+        updatedAt: "t",
+      });
+    const contentA = makeContent("paused");
+    const contentB = makeContent("failed");
+    assert.equal(contentA.length, contentB.length, "fixture must have equal byte length to isolate the ino signal");
+
+    let currentContent = contentA;
+    // Same mtime+size across both "generations" — only the inode differs,
+    // exactly as it would after tmp+rename replaces the file with a new one
+    // in the same tick on a coarse-mtime filesystem/mount.
+    const stat = { mtimeMs: 1_700_000_000_000, size: contentA.length, ino: 111 } as ReturnType<typeof statSync>;
+
+    const rp = createRunPersistence(cwd, {
+      existsSync: ((p: string) => p === runsDir || p === filePath) as typeof existsSync,
+      readdirSync: (() => ["r.json"]) as unknown as typeof readdirSync,
+      statSync: (() => stat) as unknown as typeof statSync,
+      readFileSync: (() => currentContent) as unknown as typeof readFileSync,
+    });
+
+    const first = rp.list();
+    assert.equal(first[0]?.status, "paused");
+
+    // Simulate a same-tick rename onto the same path: content changes,
+    // mtime and size stay identical, only the inode changes.
+    currentContent = contentB;
+    (stat as unknown as { ino: number }).ino = 222;
+
+    // Past the TTL so the next list() call actually re-scans.
+    await new Promise((r) => setTimeout(r, 400));
+    const second = rp.list();
+    assert.equal(
+      second[0]?.status,
+      "failed",
+      "a changed inode must be treated as a changed file, even with identical mtime+size — otherwise this would serve stale cached content forever",
+    );
+  }),
+);
+
+test(
+  "createRunPersistence retention: terminal runs beyond the cap are evicted oldest-first; running/paused survive purely because of the status filter, not save order",
   withTempCwd(async (cwd) => {
     const rp = createRunPersistence(cwd, undefined, { maxTerminalRunsOnDisk: 3 });
 
-    // 5 terminal runs, oldest to newest.
+    // Save running/paused FIRST: save() always overwrites `updatedAt` to
+    // "now" (see run-persistence.ts's save()), so saving these first gives
+    // them the OLDEST real updatedAt of everything in this test — deliberately
+    // the worst case for them. If enforceRetention()'s status filter were
+    // removed (evicting purely oldest-by-updatedAt regardless of status),
+    // these two would be among the very FIRST candidates evicted. Saving
+    // terminal runs LAST (as the earlier, accidentally-passing version of
+    // this test did) would let recency alone protect running/paused,
+    // masking whether the status filter does anything at all.
+    rp.save(baseRunState("still-running", "2023-01-01T00:00:00.000Z", "running"));
+    rp.save(baseRunState("still-paused", "2023-01-01T00:00:00.000Z", "paused"));
+
+    // Now enough terminal runs (saved after, so newer) to exceed the cap.
     for (let i = 0; i < 5; i++) {
       rp.save(baseRunState(`terminal-${i}`, `2024-01-0${i + 1}T00:00:00.000Z`, "completed"));
     }
-    // A running and a paused run — must survive retention regardless of age.
-    rp.save(baseRunState("still-running", "2023-01-01T00:00:00.000Z", "running"));
-    rp.save(baseRunState("still-paused", "2023-01-01T00:00:00.000Z", "paused"));
 
     const runIds = rp.list().map((r) => r.runId);
     const terminalKept = runIds.filter((id) => id.startsWith("terminal-"));
@@ -637,10 +716,16 @@ test(
     assert.deepEqual(
       new Set(terminalKept),
       new Set(["terminal-2", "terminal-3", "terminal-4"]),
-      "the oldest terminal runs are evicted first, newest are kept",
+      "the oldest terminal runs are evicted first among themselves, newest are kept",
     );
-    assert.ok(runIds.includes("still-running"), "a running run is never evicted by retention");
-    assert.ok(runIds.includes("still-paused"), "a paused run is never evicted by retention");
+    assert.ok(
+      runIds.includes("still-running"),
+      "a running run survives even though it has the OLDEST updatedAt of everything saved here",
+    );
+    assert.ok(
+      runIds.includes("still-paused"),
+      "a paused run survives even though it has the OLDEST updatedAt of everything saved here",
+    );
     assert.equal(rp.load("terminal-0"), null, "an evicted run's file is actually gone from disk");
   }),
 );

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -2950,3 +2950,112 @@ test(
     assert.ok(promptsDuringResume.includes("SECOND-ORIGINAL"), "persisted script's original agent 2 re-ran");
   }),
 );
+
+// ═══════════════════════════════════════════════════════════════════════════
+// `runs` map eviction (run-level analog of the subagent memory-retention
+// mitigation): terminal runs' in-memory ManagedRun (agents array, journal,
+// snapshot) must not accumulate forever, but the navigator/resume must keep
+// working against persisted state once a run's in-memory copy is gone.
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(
+  "completed runs beyond maxTerminalRunsInMemory are evicted from the in-memory map, but stay listable via listRuns()",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: fakeAgent(), maxTerminalRunsInMemory: 2 });
+    const runIds: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      const result = await manager.runSync(oneAgentScript);
+      assert.ok(result.runId);
+      runIds.push(result.runId as string);
+    }
+
+    // Only the 2 most recent terminal runs still have a live ManagedRun.
+    assert.equal(manager.getRun(runIds[0]), undefined, "oldest completed run's in-memory state is evicted");
+    assert.equal(manager.getRun(runIds[1]), undefined, "2nd oldest completed run's in-memory state is evicted");
+    assert.ok(manager.getRun(runIds[2]), "3rd run (within the cap) is still in memory");
+    assert.ok(manager.getRun(runIds[3]), "most recent run is still in memory");
+
+    // But every run is still reachable via listRuns() (backed by persistence)
+    // — eviction from the in-memory map must never mean "the run vanished".
+    const listed = manager
+      .listRuns()
+      .map((r) => r.runId)
+      .sort();
+    assert.deepEqual(listed, [...runIds].sort(), "all runs remain listable after eviction");
+    for (const id of runIds) {
+      const persisted = manager.listRuns().find((r) => r.runId === id);
+      assert.equal(persisted?.status, "completed");
+      assert.equal(persisted?.agents[0]?.status, "done", "persisted agent detail survives eviction too");
+    }
+  }),
+);
+
+test(
+  "eviction never removes a running or paused run's in-memory entry, however many terminal runs pile up around it",
+  withTempCwd(async (cwd) => {
+    const held = deferredAgent();
+    // A dedicated manager for the long-running run so its agent (never
+    // resolving until we say so) doesn't block the terminal runs below.
+    const runningManager = new WorkflowManager({ cwd, agent: held.runner, maxTerminalRunsInMemory: 1 });
+    const { runId: runningId, promise: runningPromise } = runningManager.startInBackground(oneAgentScript);
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(runningManager.getRun(runningId)?.status, "running");
+
+    // Pause a second run so it sits in memory as "paused".
+    const pausedManager = new WorkflowManager({ cwd, agent: held.runner, maxTerminalRunsInMemory: 1 });
+    const { runId: pausedId } = pausedManager.startInBackground(oneAgentScript);
+    await new Promise((r) => setTimeout(r, 10));
+    assert.equal(pausedManager.pause(pausedId), true);
+    assert.equal(pausedManager.getRun(pausedId)?.status, "paused");
+
+    // Now complete several terminal runs on a manager with a tiny cap and
+    // confirm neither the running nor the paused run's manager evicted them
+    // (they're on other manager instances, but exercises the same in-process
+    // eviction path with a maximally aggressive cap of 1).
+    const busyManager = new WorkflowManager({ cwd, agent: fakeAgent(), maxTerminalRunsInMemory: 1 });
+    for (let i = 0; i < 3; i++) {
+      await busyManager.runSync(oneAgentScript);
+    }
+
+    assert.equal(runningManager.getRun(runningId)?.status, "running", "the running run's entry survives eviction");
+    assert.equal(pausedManager.getRun(pausedId)?.status, "paused", "the paused run's entry survives eviction");
+
+    held.resolve();
+    await runningPromise.catch(() => {});
+  }),
+);
+
+test(
+  "resume() succeeds for a run whose in-memory ManagedRun was already evicted (reads persisted state, not the map)",
+  withTempCwd(async (cwd) => {
+    // A non-recoverable WorkflowError propagates all the way up (unlike a
+    // plain agent error, which workflow.ts swallows per-agent and the run
+    // still completes) — this settles the run to "failed" (evictable and,
+    // per WorkflowManager.resume()'s status guard, still resumable).
+    const failingAgent = {
+      async run() {
+        throw new WorkflowError("fatal agent error", WorkflowErrorCode.AGENT_EXECUTION_ERROR, { recoverable: false });
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent: failingAgent, maxTerminalRunsInMemory: 1 });
+    manager.on("error", () => {});
+
+    const first = await manager.runSync(oneAgentScript).catch((e) => e);
+    void first;
+    const evictedRunId = manager.listRuns()[0]?.runId as string;
+
+    // Push it out of the in-memory cap with more failing runs.
+    for (let i = 0; i < 2; i++) {
+      await manager.runSync(oneAgentScript).catch(() => {});
+    }
+    assert.equal(manager.getRun(evictedRunId), undefined, "the run's in-memory entry has been evicted");
+
+    // Fix the agent so the resumed attempt succeeds, then resume the evicted run.
+    const succeedingAgent = fakeAgent();
+    const manager2 = new WorkflowManager({ cwd, agent: succeedingAgent, maxTerminalRunsInMemory: 1 });
+    const resumed = await manager2.resume(evictedRunId);
+    assert.equal(resumed, true, "resume works purely from persisted state even though the in-memory copy is gone");
+    await new Promise((r) => setTimeout(r, 50));
+    assert.equal(manager2.listRuns().find((r) => r.runId === evictedRunId)?.status, "completed");
+  }),
+);

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -2991,7 +2991,7 @@ test(
 );
 
 test(
-  "eviction never removes a running or paused run's in-memory entry, however many terminal runs pile up around it",
+  "eviction never removes a running or paused run's in-memory entry, however many terminal runs pile up around it (separate managers, no queue pressure)",
   withTempCwd(async (cwd) => {
     const held = deferredAgent();
     // A dedicated manager for the long-running run so its agent (never
@@ -3022,6 +3022,139 @@ test(
 
     held.resolve();
     await runningPromise.catch(() => {});
+  }),
+);
+
+test(
+  "recordTerminalRun's status re-validation guard: a resumed (live, running) run survives an overflow triggered by its OWN stale queue entry",
+  withTempCwd(async (cwd) => {
+    // Repro for the guard's necessity (single manager, real queue pressure —
+    // unlike the cross-manager test above, which has no queue interaction at
+    // all and is structurally unable to catch this class of bug):
+    //
+    //  1. Run A fails (non-recoverable) -> terminalRunQueue = [A].
+    //  2. A is resumed -> a FRESH, live ManagedRun replaces the map entry for
+    //     "A" (status "running"), but the STALE "A" queue entry from step 1
+    //     is still sitting at the front of terminalRunQueue.
+    //  3. Run B terminates -> recordTerminalRun("B") pushes the queue over
+    //     maxTerminalRunsInMemory (1), so it shifts the front — the STALE "A"
+    //     entry — and must decide whether to evict.
+    //
+    // Without the guard (evict unconditionally on shift), the LIVE, still-
+    // running resumed run A is deleted from `runs` — its eventual settle
+    // then fails isCurrent(), silently skipping the final persist AND lease
+    // release (run stuck "running" on disk forever, lease leaked). With the
+    // guard, recordTerminalRun() re-reads the CURRENT entry for "A" at
+    // eviction time, sees status "running" (not terminal), and skips it.
+    let aAttempts = 0;
+    let resolveHang: ((v: unknown) => void) | undefined;
+    const agent = {
+      async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+        if (prompt === "A1") {
+          aAttempts++;
+          if (aAttempts === 1) {
+            throw new WorkflowError("fatal agent error", WorkflowErrorCode.AGENT_EXECUTION_ERROR, {
+              recoverable: false,
+            });
+          }
+          // Second attempt (post-resume): hang so A stays "running" in
+          // memory while B's overflow fires — exactly the window the bug
+          // needs to matter.
+          return new Promise((resolve) => {
+            resolveHang = resolve;
+          });
+        }
+        options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
+        return "ok";
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent, maxTerminalRunsInMemory: 1 });
+    manager.on("error", () => {});
+
+    const scriptA = `export const meta = { name: 'run_a', description: 'a' }
+const a = await agent('A1', { label: 'a' })
+return { a }`;
+    const scriptB = `export const meta = { name: 'run_b', description: 'b' }
+const b = await agent('B1', { label: 'b' })
+return { b }`;
+
+    // 1. A fails -> enqueued (terminal), still evictable in principle.
+    const { runId: runAId, promise: aPromise } = manager.startInBackground(scriptA);
+    await aPromise.catch(() => {});
+    assert.equal(manager.getRun(runAId)?.status, "failed");
+
+    // 2. Resume A: a fresh, live ManagedRun replaces the map entry; the old
+    // queue entry for "A" is now stale (still at the front of the queue).
+    const resumed = await manager.resume(runAId);
+    assert.equal(resumed, true);
+    assert.equal(manager.getRun(runAId)?.status, "running", "resumed run A is live and running (hung on attempt 2)");
+
+    // 3. B terminates -> overflows the cap (1), shifting the stale "A" entry.
+    const { promise: bPromise } = manager.startInBackground(scriptB);
+    await bPromise.catch(() => {});
+
+    // The guard must have refused to evict the LIVE, running resumed A.
+    assert.ok(manager.getRun(runAId), "the guard must protect the live resumed run A from its own stale queue entry");
+    assert.equal(manager.getRun(runAId)?.status, "running");
+
+    // Clean up the hung agent so nothing keeps the process alive, and prove
+    // the surviving entry settles normally afterward.
+    resolveHang?.("done");
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(manager.getRun(runAId)?.status, "completed", "the protected entry still settles correctly");
+  }),
+);
+
+test(
+  "paused-exclusion in executeRun's catch tail: a usage-limit pause must never create eviction pressure on an unrelated, genuinely-terminal run",
+  withTempCwd(async (cwd) => {
+    // A separate repro from the one above: here the mutation under test is
+    // the catch tail's `if (IN_MEMORY_TERMINAL_STATUSES.has(managed.status))`
+    // gate around recordTerminalRun() — NOT the guard inside recordTerminalRun
+    // itself. Reached via the usage-limit branch (not manual pause()), which
+    // is a distinct code path through executeRun's catch tail.
+    //
+    // Sequence with maxTerminalRunsInMemory 1:
+    //  1. T completes -> terminalRunQueue = [T], within the cap.
+    //  2. P pauses on a usage limit. If the catch tail's paused-exclusion gate
+    //     were removed, this would ALSO call recordTerminalRun("P"), pushing
+    //     the queue to [T, P] — over the cap — and evicting the FRONT entry,
+    //     T, purely because P paused (T is genuinely terminal so the
+    //     recordTerminalRun-internal guard would not save it). With the gate,
+    //     a paused settle never enqueues at all, so T is never touched.
+    const agent = {
+      async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+        if (prompt === "P1") {
+          throw new WorkflowError(
+            "Codex usage limit reached (plus plan). Resets in ~3h.",
+            WorkflowErrorCode.PROVIDER_USAGE_LIMIT,
+            { recoverable: false, resetHint: "Resets in ~3h" },
+          );
+        }
+        options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
+        return "ok";
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent, maxTerminalRunsInMemory: 1 });
+    manager.on("error", () => {});
+    manager.on("paused", () => {});
+
+    const scriptT = `export const meta = { name: 'run_t', description: 't' }
+const t = await agent('T1', { label: 't' })
+return { t }`;
+    const scriptP = `export const meta = { name: 'run_p', description: 'p' }
+const p = await agent('P1', { label: 'p' })
+return { p }`;
+
+    const t = await manager.runSync(scriptT);
+    const tId = t.runId as string;
+    assert.equal(manager.getRun(tId)?.status, "completed");
+
+    const { runId: pId, promise: pPromise } = manager.startInBackground(scriptP);
+    await pPromise.catch(() => {});
+    assert.equal(manager.getRun(pId)?.status, "paused");
+
+    assert.ok(manager.getRun(tId), "T must survive — a paused settle must never count against the terminal-run cap");
   }),
 );
 
@@ -3057,5 +3190,44 @@ test(
     assert.equal(resumed, true, "resume works purely from persisted state even though the in-memory copy is gone");
     await new Promise((r) => setTimeout(r, 50));
     assert.equal(manager2.listRuns().find((r) => r.runId === evictedRunId)?.status, "completed");
+  }),
+);
+
+test(
+  "stop() on an already-paused run marks it eviction-eligible (its own executeRun tail already settled at pause time, so no future tail ever will)",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, agent: da.runner, maxTerminalRunsInMemory: 1 });
+    manager.on("error", () => {});
+
+    const { runId: pausedId, promise } = manager.startInBackground(oneAgentScript);
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(manager.pause(pausedId), true);
+    assert.equal(manager.getRun(pausedId)?.status, "paused");
+
+    // Let pause()'s abort-triggered executeRun() tail fully settle BEFORE
+    // stopping — the realistic case the fix targets. By now the run's only
+    // executeRun() promise has already resolved once (as "paused", which is
+    // deliberately NOT enqueued for eviction — see IN_MEMORY_TERMINAL_STATUSES),
+    // so nothing will ever call recordTerminalRun() for it again except
+    // stop() itself.
+    da.resolve("done");
+    await promise.catch(() => {});
+    assert.equal(manager.getRun(pausedId)?.status, "paused", "still paused; the already-settled tail didn't change it");
+
+    assert.equal(manager.stop(pausedId), true);
+    assert.equal(manager.getRun(pausedId)?.status, "aborted");
+
+    // One more terminal run overflows the cap (1): the stopped run must be
+    // the one evicted — proving stop() itself recorded it terminal-eligible
+    // (without that, it would sit in `runs` forever: no pending tail left to
+    // ever call recordTerminalRun() for it).
+    const other = await manager.runSync(oneAgentScript);
+    assert.ok(manager.getRun(other.runId), "the newest terminal run is in memory");
+    assert.equal(
+      manager.getRun(pausedId),
+      undefined,
+      "stop() must have recorded the already-settled paused run as terminal-eligible, so it's evicted here",
+    );
   }),
 );

--- a/tests/workflow-saved.test.ts
+++ b/tests/workflow-saved.test.ts
@@ -299,3 +299,103 @@ test(
     assert.deepEqual(storage.list(), []);
   }),
 );
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Write safety: atomic write-with-backup + corrupt-file recovery, unified
+// with run-persistence.ts via fs-persistence.ts (previously saved-workflow
+// writes were a plain writeFileSync with no backup/recovery).
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(
+  "createWorkflowStorage save writes atomically (tmp+rename, no leftover .tmp) and leaves a .bak",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    storage.save({ name: "atomic-wf", description: "d", script: "s" });
+    const path = join(workflowProjectPaths(cwd).savedDir, "atomic-wf.json");
+    assert.ok(existsSync(path), "primary written");
+    assert.ok(existsSync(`${path}.bak`), ".bak written");
+    assert.equal(existsSync(`${path}.tmp`), false, "no leftover .tmp");
+  }),
+);
+
+test(
+  "createWorkflowStorage save survives a simulated crash mid-write: a rename that never completes leaves the previous good file intact",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd, {
+      // Simulate a crash between the .tmp write and the rename: the .tmp
+      // lands on disk but the atomic rename into place never happens. The
+      // previously-saved good primary must still be there and loadable —
+      // exactly the property tmp+rename is supposed to give us.
+      renameSync: () => {
+        throw new Error("simulated crash before rename completed");
+      },
+    });
+    const goodStorage = createWorkflowStorage(cwd);
+    goodStorage.save({ name: "crash-wf", description: "good version", script: "good script" });
+
+    assert.throws(() => storage.save({ name: "crash-wf", description: "new version", script: "new script" }));
+
+    // The primary file must be untouched — still the last good save.
+    const recovered = goodStorage.load("crash-wf");
+    assert.equal(recovered?.description, "good version", "primary is unaffected by the failed rename");
+    assert.equal(recovered?.script, "good script");
+  }),
+);
+
+test(
+  "createWorkflowStorage load recovers from .bak when the primary is corrupt",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    storage.save({ name: "corrupt-recovery", description: "good", script: "good script" });
+    const path = join(workflowProjectPaths(cwd).savedDir, "corrupt-recovery.json");
+    writeFileSync(path, "{ truncated by a crash", "utf-8");
+
+    const loaded = storage.load("corrupt-recovery");
+    assert.ok(loaded, "load falls back to the intact .bak");
+    assert.equal(loaded?.script, "good script");
+  }),
+);
+
+test(
+  "createWorkflowStorage delete removes the .bak sidecar too",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    storage.save({ name: "del-bak", description: "d", script: "s" });
+    const path = join(workflowProjectPaths(cwd).savedDir, "del-bak.json");
+    assert.ok(existsSync(`${path}.bak`), ".bak exists before delete");
+    storage.delete("del-bak");
+    assert.equal(existsSync(path), false);
+    assert.equal(existsSync(`${path}.bak`), false, ".bak cleaned up too");
+  }),
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Unguarded directory read: list() must degrade to "no files" for a missing
+// or unreadable directory instead of throwing (same guard run-persistence.ts
+// uses, via the shared listJsonFilesSafe()).
+// ═══════════════════════════════════════════════════════════════════════════
+
+test(
+  "createWorkflowStorage list returns empty (not throw) when a saved-workflow directory is unreadable",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd, {
+      readdirSync: () => {
+        throw new Error("EACCES: permission denied, scandir");
+      },
+    });
+    // Make sure the directory actually exists, so the throwing readdirSync
+    // path (not the pre-existing existsSync-false path) is what's exercised.
+    mkdirSync(workflowProjectPaths(cwd).savedDir, { recursive: true });
+
+    assert.deepEqual(storage.list(), [], "an unreadable directory degrades to an empty list, not a thrown error");
+  }),
+);
+
+test(
+  "createWorkflowStorage list returns empty for a project directory that was never created",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    assert.equal(existsSync(workflowProjectPaths(cwd).savedDir), false, "directory really doesn't exist yet");
+    assert.deepEqual(storage.list(), []);
+  }),
+);


### PR DESCRIPTION
## What

Three retention/persistence fixes in the workflow run manager and storage layers:

1. **In-memory run retention is now bounded.** Terminal (completed/failed/aborted) runs were kept in the manager's in-memory map forever, so a long-lived session grew monotonically — the run-level analog of the recently-fixed subagent memory retention. Terminal runs now become eviction-eligible only after their execution has fully settled, persisted, and released its lease; a FIFO keeps the most recent ones (default 20, configurable) and evicts the oldest. Paused and running runs are never evicted, eviction re-validates a run's current status before removing it (a run resumed back to life is untouched), and every consumer falls back to the persisted view — resuming an evicted run works exactly like resuming across a process restart. Stopping an already-paused run now also marks it eviction-eligible (previously it lingered in memory with nothing left to reap it). The full lifecycle contract is documented on the map itself.

2. **On-disk run retention is capped and listing scales.** Persisted runs had no retention cap, and every listing cache miss re-parsed every historical run file — with the active panel polling every ~300ms, long-term use degraded steadily. Terminal runs on disk are now capped (default 300, oldest evicted first, active runs never touched, sidecar files cleaned up), and the listing keeps a per-file mtime+size+inode cache so unchanged files are never re-parsed. The inode check matters on coarse-mtime filesystems, where two same-length writes can land in one mtime tick; the atomic tmp+rename write allocates a fresh inode every save, so it disambiguates for free.

3. **Saved workflows get the same crash-safety as runs.** Saved-workflow files were written non-atomically with no backup, and listing them hit an unguarded directory read. The atomic tmp+rename+backup write, corrupt-file backup recovery, and guarded directory listing are now a single shared module (`src/fs-persistence.ts`) used by both run persistence and saved-workflow storage — one implementation, no parallel copies.

## Verification

- New regression tests cover: eviction bounding under single-manager queue pressure (including a failed→resumed run surviving pressure from sibling terminations, and a usage-limit-paused run's immunity), stop-on-paused reaping, resume-after-eviction, the disk cap sparing active runs saved before newer terminal ones, no-reparse of unchanged files, the same-tick/same-size inode disambiguation, atomic-write crash simulation, backup recovery, and missing/unreadable directory handling. Each was verified to fail with its guard reverted.
- Full suite: 1098/1098 pass; lint, typecheck, docs/context checks, and the release gate all clean.
