### PR TITLE
fix: stop siblings on run-fatal errors; key agent events by id; drain un-awaited agents

### DIFF
--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -975,6 +975,23 @@ export class WorkflowManager extends EventEmitter {
     // it, or deleteRun() removed it), not an error: writing anyway would
     // resurrect a torn-down run's file, or clobber a newer execution's
     // in-progress/completed state with this stale one's.
+    //
+    // This check is redundant with persistRun()'s own early-return for every
+    // CURRENT call site — it earns its keep solely for schedulePersist()'s
+    // deferred setTimeout callback, the one path into this method that skips
+    // persistRun() entirely. That callback only fires from onAgentJournal, and
+    // onAgentJournal only fires for a call that got PAST agent()'s
+    // throwIfAborted() check (see workflow.ts) — which, since run-fatal abort
+    // (SharedRuntime.runFatalController) now seals every top-level run's
+    // shared runtime the instant any error escapes it uncaught, means a
+    // genuinely superseded-but-never-aborted execution (the only kind that
+    // could previously still journal a stray call after resume() replaced it)
+    // is structurally impossible to construct anymore — see the "unreachable
+    // defense-in-depth (#2)" test in workflow-manager.test.ts for the worked
+    // example and its own note. This check is KEPT anyway: it costs nothing,
+    // and removing it would silently reopen a stale-write path the moment any
+    // future change (e.g. a new way to journal without throwIfAborted()'s
+    // gate) reintroduces a producer for it.
     if (!this.isCurrent(managed)) return;
     try {
       this.persistence.save({

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -5,7 +5,7 @@
 import { EventEmitter } from "node:events";
 import type { ModelRegistry, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { WorkflowAgent } from "./agent.js";
-import { preview, type WorkflowSnapshot } from "./display.js";
+import { preview, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
 import { isProviderUsageLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import {
   createRunPersistence,
@@ -67,6 +67,19 @@ export interface ManagedRun {
    * every agent with the run's startedAt / "now".
    */
   agentTimestamps: Map<number, { startedAt: string; endedAt?: string }>;
+  /**
+   * Live snapshot-agent lookup keyed by the agent CALL's unique id (see
+   * WorkflowRunOptions.onAgentStart/onAgentEnd/onAgentHistory's `id` field in
+   * workflow.ts — unique per call, never per label). onAgentEnd/onAgentHistory
+   * must resolve the snapshot entry to update through this map, never by
+   * scanning managed.snapshot.agents for a label match: two concurrent agents
+   * routinely share a label (e.g. parallel()'s default `"${phase} agent N"`
+   * labeling, or an author-supplied label reused across a fan-out), and a
+   * label+status scan would update whichever same-label entry it happens to
+   * find first — misattributing one agent's end/history event to a different,
+   * still-running sibling.
+   */
+  agentsById: Map<string, WorkflowAgentSnapshot>;
   /**
    * The run's cap on total agents (per-run value, else left undefined so
    * runWorkflow applies its own MAX_AGENTS_PER_RUN default), fixed at run
@@ -423,6 +436,7 @@ export class WorkflowManager extends EventEmitter {
       concurrency: exec.concurrency !== undefined ? exec.concurrency : this.concurrency,
       agentRetries: exec.agentRetries !== undefined ? exec.agentRetries : this.defaultAgentRetries,
       agentTimestamps: new Map(),
+      agentsById: new Map(),
     };
 
     this.runs.set(runId, managed);
@@ -524,6 +538,7 @@ export class WorkflowManager extends EventEmitter {
       journal: [],
       background: false,
       agentTimestamps: new Map(),
+      agentsById: new Map(),
     };
   }
 
@@ -649,14 +664,19 @@ export class WorkflowManager extends EventEmitter {
         },
         onAgentStart: (event) => {
           const id = managed.snapshot.agents.length + 1;
-          managed.snapshot.agents.push({
+          const agentSnapshot: WorkflowAgentSnapshot = {
             id,
             label: event.label,
             phase: event.phase,
             prompt: event.prompt,
             status: "running",
             model: event.model,
-          });
+          };
+          managed.snapshot.agents.push(agentSnapshot);
+          // Index by the call's unique id (never label — see agentsById's doc
+          // comment) so onAgentEnd/onAgentHistory can resolve back to exactly
+          // THIS entry even when a concurrent sibling shares its label.
+          managed.agentsById.set(event.id, agentSnapshot);
           // Real per-agent start time, captured the moment the agent actually
           // starts (not the run's startedAt) — see agentTimestamps.
           managed.agentTimestamps.set(id, { startedAt: new Date().toISOString() });
@@ -664,9 +684,7 @@ export class WorkflowManager extends EventEmitter {
           progress();
         },
         onAgentEnd: (event) => {
-          const agent = [...managed.snapshot.agents]
-            .reverse()
-            .find((a) => a.label === event.label && a.status === "running");
+          const agent = managed.agentsById.get(event.id);
           if (agent) {
             agent.status = event.result === null ? "error" : "done";
             agent.resultPreview = preview(event.result);
@@ -699,9 +717,7 @@ export class WorkflowManager extends EventEmitter {
           progress();
         },
         onAgentHistory: (event) => {
-          const agent = [...managed.snapshot.agents]
-            .reverse()
-            .find((a) => a.label === event.label && a.status === "running");
+          const agent = managed.agentsById.get(event.id);
           if (agent) {
             agent.history = event.history;
           }
@@ -1149,6 +1165,7 @@ export class WorkflowManager extends EventEmitter {
       // onAgentStart/onAgentEnd fire again for this attempt (see `agents: []`
       // above); the journal, not this map, is what makes replayed agents cheap.
       agentTimestamps: new Map(),
+      agentsById: new Map(),
     };
     this.runs.set(runId, managed);
     // Persist before notifying renderers: listRuns() is their source of truth for

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -83,6 +83,32 @@ export interface SharedRuntime {
   spent: number;
   tokenUsage: { input: number; output: number; total: number; cost: number; cacheRead: number; cacheWrite: number };
   depth: number;
+  /**
+   * Fires exactly once a run-fatal error is determined: an error that escaped
+   * the TOP-level script's own execution completely uncaught (see runWorkflow's
+   * catch below) — i.e. nothing anywhere in the call chain, at any nesting
+   * depth, caught it, so the run really is failing. Shared (not per-nesting-
+   * level) so a nested workflow()'s in-flight siblings wind down too, the
+   * instant the fate of the WHOLE run is sealed — not the instant any single
+   * fan-out rejects, which would break parallel()'s null-on-recoverable-error
+   * contract and a script's own try/catch around agent()/workflow(). Every
+   * agent() call (this level and any nested workflow()) links its per-attempt
+   * AbortController to this signal, alongside the caller's own options.signal,
+   * so already-in-flight sibling subagent sessions actually abort instead of
+   * running to completion on a run whose outcome is already decided. Wrapped
+   * in an AbortController (not a bare boolean) purely so workflow.ts never
+   * needs write access to the caller-owned options.signal/AbortController.
+   */
+  runFatalController: AbortController;
+  /**
+   * Every agent() promise spawned anywhere in this run (this level's script
+   * and any nested workflow()'s), added on call and removed on settle. Drained
+   * (awaited to completion) by the TOP-level runWorkflow's finally, before the
+   * SharedStore is disposed — so a script that forgets to `await agent(...)`
+   * can never have that call still mutating the store (or reporting results)
+   * after the run has been marked complete and torn down. See the drain below.
+   */
+  inFlight: Set<Promise<unknown>>;
 }
 
 /** Runtime instrumentation for workflow boundaries, quality helpers, and control attempts. */
@@ -180,8 +206,17 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   onPhase?: (title: string) => void;
   /** Runtime behavior trace used by diagnostics and comprehension evidence. */
   onRuntimeEvent?: (event: WorkflowRuntimeEvent) => void;
-  onAgentStart?: (event: { label: string; phase?: string; prompt: string; model?: string }) => void;
+  onAgentStart?: (event: { id: string; label: string; phase?: string; prompt: string; model?: string }) => void;
   onAgentEnd?: (event: {
+    /**
+     * Unique per agent() CALL (not per label — concurrent agents routinely
+     * share a label, e.g. parallel()'s default `"${phase} agent N"` labels or
+     * an author-supplied label reused across a fan-out). Stable across this
+     * call's start/end/history events. Callers must key any per-agent
+     * bookkeeping on this, never on label, to avoid misattributing a
+     * concurrent same-label agent's event to the wrong entry.
+     */
+    id: string;
     label: string;
     phase?: string;
     result: unknown;
@@ -193,7 +228,7 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
     errorCode?: WorkflowErrorCode;
     recoverable?: boolean;
   }) => void;
-  onAgentHistory?: (event: { label: string; phase?: string; history: AgentHistoryEntry[] }) => void;
+  onAgentHistory?: (event: { id: string; label: string; phase?: string; history: AgentHistoryEntry[] }) => void;
   onTokenUsage?: (usage: {
     input: number;
     output: number;
@@ -394,8 +429,17 @@ export async function runWorkflow<T = unknown>(
       ? { ...options.initialTokenUsage }
       : { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
     depth: 0,
+    runFatalController: new AbortController(),
+    inFlight: new Set<Promise<unknown>>(),
   };
   const limiter = shared.limiter;
+  // This frame created `shared` fresh (rather than inheriting a parent
+  // workflow()'s) — i.e. it's the true top-level run, the only frame allowed
+  // to declare the run's fate sealed (see SharedRuntime.runFatalController) or
+  // drain/dispose the SharedStore. A nested workflow() call always passes both
+  // sharedRuntime and sharedStore together (see workflowFn below), so this is
+  // equivalent to `!options.sharedStore` — used at both choke points below.
+  const isTopLevelRun = !options.sharedRuntime;
 
   // One store instance per run; nested workflow() calls inherit the parent's store
   // so all agents across nesting levels share the same key-value space.
@@ -437,13 +481,34 @@ export async function runWorkflow<T = unknown>(
       { recoverable: false },
     );
 
+  // True on an intentional external abort (pause/stop/Esc, via options.signal)
+  // OR once this run's fate has been sealed (shared.runFatalController — see
+  // its doc comment). Every abort check in this file goes through this so the
+  // two sources compose identically everywhere instead of only some call
+  // sites remembering to check the second one.
+  const isAborted = () => Boolean(options.signal?.aborted || shared.runFatalController.signal.aborted);
+
   const throwIfAborted = () => {
-    if (options.signal?.aborted) {
+    if (isAborted()) {
       throw new WorkflowError("workflow aborted", WorkflowErrorCode.WORKFLOW_ABORTED, { recoverable: true });
     }
   };
 
-  const agent = async (prompt: string, agentOptions: AgentOptions = {}) => {
+  const agent = (prompt: string, agentOptions: AgentOptions = {}): Promise<unknown> => {
+    // Track every call (awaited or not) so the top-level run can drain
+    // outstanding calls before completing (see SharedRuntime.inFlight and the
+    // drain in the finally below) — this is what stops a forgotten `await`
+    // from letting an agent mutate state after the run is torn down.
+    const call = agentImpl(prompt, agentOptions);
+    shared.inFlight.add(call);
+    // Attaching a handler here (independent of whatever the script itself does
+    // with the returned promise) also means an un-awaited call's eventual
+    // rejection never becomes a process-crashing unhandled rejection.
+    call.catch(() => {}).finally(() => shared.inFlight.delete(call));
+    return call;
+  };
+
+  const agentImpl = async (prompt: string, agentOptions: AgentOptions = {}) => {
     throwIfAborted();
 
     // Capture the enclosing parallel()/pipeline() fan-out's cancellation batch
@@ -542,8 +607,15 @@ export async function runWorkflow<T = unknown>(
     const hashMatches = cached != null && cached.hash === callHash;
     const cachedEmptyOutput = hashMatches && isEmptyTextAgentResult(cached.result, agentOptions.schema);
     if (hashMatches && !cachedEmptyOutput && callIndex < state.firstMiss) {
-      options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
-      options.onAgentEnd?.({ label, phase: assignedPhase, result: cached.result, tokens: 0, model: displayModel });
+      options.onAgentStart?.({ id: deltaKey, label, phase: assignedPhase, prompt, model: displayModel });
+      options.onAgentEnd?.({
+        id: deltaKey,
+        label,
+        phase: assignedPhase,
+        result: cached.result,
+        tokens: 0,
+        model: displayModel,
+      });
       // Apply this agent's write delta so live agents later in the run see a
       // consistent store. Additive apply preserves parallel-agent writes that
       // came from higher-callIndex agents finishing before this one.
@@ -559,7 +631,7 @@ export async function runWorkflow<T = unknown>(
       const retryAttempts = normalizeAgentRetries(agentOptions.retries ?? options.agentRetries ?? 0);
       const maxAttempts = retryAttempts + 1;
 
-      options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
+      options.onAgentStart?.({ id: deltaKey, label, phase: assignedPhase, prompt, model: displayModel });
 
       // Optional per-agent worktree isolation (deterministic name -> stable resume keys).
       // Precedence: explicit call-site isolation > agentDef isolation.
@@ -597,6 +669,7 @@ export async function runWorkflow<T = unknown>(
           usage = undefined;
           const externalSignal = options.signal;
           let onExternalAbort: (() => void) | undefined;
+          let onRunFatal: (() => void) | undefined;
           try {
             throwIfAborted();
             // This agent's own fan-out already breached maxAgents while this
@@ -607,16 +680,23 @@ export async function runWorkflow<T = unknown>(
             // Per-attempt abort: on timeout we abort THIS agent so its session is
             // disposed and its heavy state (messages, etc.) released, instead of
             // leaving it streaming in the background — retries would otherwise
-            // stack live sessions on top of each other (#109). Linked to the run's
-            // external signal so an outer abort still cancels the agent too; the
-            // link is torn down per attempt in finally so listeners don't accrue.
+            // stack live sessions on top of each other (#109). Linked to BOTH the
+            // run's external signal (outer abort — pause/stop/Esc) AND
+            // shared.runFatalController (this run's fate has been sealed by a
+            // sibling's non-recoverable error escaping the top-level script — see
+            // SharedRuntime.runFatalController) so an in-flight sibling actually
+            // winds down instead of running to completion on a doomed run. Both
+            // links are torn down per attempt in finally so listeners don't accrue.
             const agentController = new AbortController();
-            if (externalSignal) {
-              if (externalSignal.aborted) agentController.abort();
-              else {
+            if (isAborted()) {
+              agentController.abort();
+            } else {
+              if (externalSignal) {
                 onExternalAbort = () => agentController.abort();
                 externalSignal.addEventListener("abort", onExternalAbort, { once: true });
               }
+              onRunFatal = () => agentController.abort();
+              shared.runFatalController.signal.addEventListener("abort", onRunFatal, { once: true });
             }
             const runPromise = agentRunner.run(prompt, {
               label,
@@ -647,7 +727,7 @@ export async function runWorkflow<T = unknown>(
                 usage = u;
               },
               onHistory: (history: AgentHistoryEntry[]) => {
-                options.onAgentHistory?.({ label, phase: assignedPhase, history });
+                options.onAgentHistory?.({ id: deltaKey, label, phase: assignedPhase, history });
               },
             });
             // After a timeout the run() promise still settles later, rejecting with
@@ -672,6 +752,7 @@ export async function runWorkflow<T = unknown>(
               storeDelta: store.commitDelta(deltaKey),
             });
             options.onAgentEnd?.({
+              id: deltaKey,
               label,
               phase: assignedPhase,
               result,
@@ -682,7 +763,7 @@ export async function runWorkflow<T = unknown>(
             });
             return result;
           } catch (error) {
-            if (options.signal?.aborted) throw error;
+            if (isAborted()) throw error;
 
             const workflowError = wrapError(error, { agentLabel: label });
             logger.error(`agent ${label} attempt ${attempt}/${maxAttempts} failed: ${workflowError.message}`);
@@ -701,6 +782,7 @@ export async function runWorkflow<T = unknown>(
             }
 
             options.onAgentEnd?.({
+              id: deltaKey,
               label,
               phase: assignedPhase,
               result: null,
@@ -721,9 +803,11 @@ export async function runWorkflow<T = unknown>(
             }
             throw workflowError;
           } finally {
-            // Drop this attempt's external-abort listener so it doesn't accrue one
-            // entry per attempt on the run's signal for the whole run (#109 hygiene).
+            // Drop this attempt's abort listeners so they don't accrue one entry
+            // per attempt on the run's signal / runFatalController for the whole
+            // run (#109 hygiene).
             if (onExternalAbort) externalSignal?.removeEventListener("abort", onExternalAbort);
+            if (onRunFatal) shared.runFatalController.signal.removeEventListener("abort", onRunFatal);
           }
         }
         return null;
@@ -751,7 +835,7 @@ export async function runWorkflow<T = unknown>(
           try {
             return await thunk();
           } catch (error) {
-            if (options.signal?.aborted) throw error;
+            if (isAborted()) throw error;
             const workflowError = wrapError(error);
             // Non-recoverable failures (token budget / agent limit exhausted) must
             // halt the whole run, exactly like a directly-awaited agent() — not be
@@ -793,7 +877,7 @@ export async function runWorkflow<T = unknown>(
               value = await stage(value, item, index);
               throwIfAborted();
             } catch (error) {
-              if (options.signal?.aborted) throw error;
+              if (isAborted()) throw error;
               const workflowError = wrapError(error);
               // Non-recoverable failures halt the whole run (see parallel()).
               if (!workflowError.recoverable) {
@@ -1113,10 +1197,42 @@ export async function runWorkflow<T = unknown>(
       runId,
       tokenUsage: shared.tokenUsage,
     };
+  } catch (error) {
+    // This error just escaped THIS frame's own vm script execution completely
+    // uncaught. For the top-level frame that means nothing anywhere in the
+    // whole call chain (this script, any enclosing try/catch around a nested
+    // workflow()/parallel()/agent()) caught it — the run's fate is genuinely
+    // sealed now (see SharedRuntime.runFatalController). Sealing it here, not
+    // inside agent()/parallel(), is what preserves parallel()'s "a thrown
+    // thunk resolves to null without failing the others" contract and a
+    // script's own try/catch around agent()/workflow(): both those cases are
+    // swallowed well before an error would ever reach this catch. A NESTED
+    // frame reaching here does NOT seal anything — the parent script may still
+    // catch workflow()'s rejection and continue, so only isTopLevelRun acts.
+    // Idempotent: if this is already an intentional pause/stop (options.signal
+    // aborted) or a second escape after the fatal signal already fired,
+    // aborting an already-aborted controller is a no-op.
+    if (isTopLevelRun) shared.runFatalController.abort();
+    throw error;
   } finally {
-    // Dispose the store only when this run created it; nested runs inherit the
-    // parent's store and must not tear it down while the parent is still running.
-    if (!options.sharedStore) store.dispose();
+    // Only the top-level frame drains/disposes (see isTopLevelRun) — a nested
+    // workflow()'s in-flight agents are still tracked in this SAME shared set
+    // and get drained once, here, when the whole run finishes.
+    if (isTopLevelRun) {
+      // Wait out every agent() call spawned anywhere in this run — including
+      // ones the script never awaited — before the store goes away. Without
+      // this, a forgotten `await agent(...)` could keep mutating store/journal
+      // state after the run is marked complete/failed and torn down. Loop
+      // (not a single Promise.allSettled) because draining can itself let a
+      // still-running call schedule further work that adds to the set.
+      if (shared.inFlight.size > 0) {
+        log(`waiting for ${shared.inFlight.size} outstanding agent() call(s) to settle before this run completes`);
+      }
+      while (shared.inFlight.size > 0) {
+        await Promise.allSettled(Array.from(shared.inFlight));
+      }
+      store.dispose();
+    }
   }
 }
 

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -84,6 +84,24 @@ export interface SharedRuntime {
   tokenUsage: { input: number; output: number; total: number; cost: number; cacheRead: number; cacheWrite: number };
   depth: number;
   /**
+   * Monotonic count of every workflow() call anywhere in this run tree,
+   * regardless of nesting depth — used (instead of `depth`) to build each
+   * nested run's runId suffix (see workflowFn below). `depth` alone is NOT
+   * enough: it returns to 0 after each nested call finishes, so two
+   * SEQUENTIAL nested workflow() calls at the same depth (`await
+   * workflow('a'); await workflow('b')`) would otherwise both compute the
+   * exact same `${runId}-nested1` suffix. That collision matters because a
+   * child's own callSeq restarts at 0, so its deltaKey (`${childRunId}:
+   * ${callIndex}`) — the same id used as SharedStore's delta key AND as the
+   * onAgentStart/onAgentEnd/onAgentHistory event id (see item 2's identity
+   * model) — would collide between the two children's same-callIndex calls.
+   * That's a real, not just theoretical, collision risk: an un-awaited
+   * stray agent() call from the first child (still in SharedRuntime.inFlight,
+   * not yet drained — only the top-level frame drains) can still be pending
+   * when the second child starts and mints the very same id.
+   */
+  nestedCallSeq: number;
+  /**
    * Fires exactly once a run-fatal error is determined: an error that escaped
    * the TOP-level script's own execution completely uncaught (see runWorkflow's
    * catch below) — i.e. nothing anywhere in the call chain, at any nesting
@@ -429,6 +447,7 @@ export async function runWorkflow<T = unknown>(
       ? { ...options.initialTokenUsage }
       : { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
     depth: 0,
+    nestedCallSeq: 0,
     runFatalController: new AbortController(),
     inFlight: new Set<Promise<unknown>>(),
   };
@@ -583,10 +602,14 @@ export async function runWorkflow<T = unknown>(
     // Store delta key: callIndex alone is NOT run-unique. A nested workflow()
     // call (see workflowFn below) shares this run's SharedStore instance but
     // restarts its own callSeq at 0, so a parent agent and a concurrently
-    // running nested-run agent can both get callIndex 0 and collide in
-    // SharedStore.agentDeltas — whichever commits last steals/overwrites the
-    // other's journaled delta. Composing the run's own runId (unique per
-    // top-level run AND per nested run, see `${runId}-nested${shared.depth}`
+    // running nested-run agent — or two SEQUENTIAL sibling nested runs, whose
+    // depth alone would otherwise repeat — can both get callIndex 0 and
+    // collide in SharedStore.agentDeltas — whichever commits last
+    // steals/overwrites the other's journaled delta (and, via this same
+    // deltaKey doubling as the onAgentStart/onAgentEnd/onAgentHistory event
+    // id, misattributes one agent's events to the other — see item 2's
+    // identity model). Composing the run's own runId (unique per top-level
+    // run AND per nested run, see `${runId}-nested${++shared.nestedCallSeq}`
     // below) with callIndex makes the key unique across the whole store.
     const deltaKey = `${runId}:${callIndex}`;
 
@@ -918,7 +941,11 @@ export async function runWorkflow<T = unknown>(
         // A nested run is its own script; never reuse the parent's resume journal.
         resumeJournal: undefined,
         resumeFromRunId: undefined,
-        runId: `${runId}-nested${shared.depth}`,
+        // shared.nestedCallSeq, not shared.depth — see its doc comment: depth
+        // returns to 0 between sequential sibling calls, which would otherwise
+        // mint the same child runId (and hence colliding deltaKeys/event ids)
+        // for two different children.
+        runId: `${runId}-nested${++shared.nestedCallSeq}`,
         persistLogs: false,
       });
       return child.result;
@@ -1212,6 +1239,15 @@ export async function runWorkflow<T = unknown>(
     // Idempotent: if this is already an intentional pause/stop (options.signal
     // aborted) or a second escape after the fatal signal already fired,
     // aborting an already-aborted controller is a no-op.
+    //
+    // This also fires on a PROVIDER_USAGE_LIMIT escape (a quota/rate-limit
+    // hit), not just a genuine bug — that error is non-recoverable too (see
+    // errors.ts), so it escapes exactly like any other run-fatal error and
+    // seals the same way. Deliberate tradeoff: any sibling still in flight
+    // when the quota was hit gets aborted rather than allowed to finish and
+    // journal — this stops burning an already-exhausted budget right now, at
+    // the cost of that sibling's work being thrown away and re-run live when
+    // the paused run resumes (it was never journaled, so it isn't cached).
     if (isTopLevelRun) shared.runFatalController.abort();
     throw error;
   } finally {
@@ -1225,6 +1261,16 @@ export async function runWorkflow<T = unknown>(
       // state after the run is marked complete/failed and torn down. Loop
       // (not a single Promise.allSettled) because draining can itself let a
       // still-running call schedule further work that adds to the set.
+      //
+      // Caveat: this can block indefinitely. A run-fatal abort (see the catch
+      // above) aborts the AbortSignal passed to each in-flight agent, but that
+      // is cooperative — an agent runner that ignores its signal (or one still
+      // waiting out a real subagent process that won't die) never settles on
+      // its own. Combined with agentTimeoutMs: null (no hard timeout, the
+      // default), a single hung, signal-ignoring, un-awaited agent() call can
+      // wedge this drain — and therefore the whole run's completion — forever.
+      // Configure a finite agentTimeoutMs (run- or per-agent-level) for any
+      // workflow where this is a real risk; there is no drain-side timeout.
       if (shared.inFlight.size > 0) {
         log(`waiting for ${shared.inFlight.size} outstanding agent() call(s) to settle before this run completes`);
       }

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -2008,32 +2008,40 @@ test(
 );
 
 test(
-  "resume() superseding a NEVER-ABORTED failed run suppresses a stray sibling agent's later agentEnd event (#1)",
+  "resume() superseding a run-fatal-aborted failed run never delivers a stray sibling agent's agentEnd event (#1)",
   withTempCwd(async (cwd) => {
-    // Key insight: pause()/stop()/deleteRun() all abort the run's shared
-    // signal before/while superseding it — so a straggling agent, once it
-    // resolves, hits agent()'s own throwIfAborted() and never reaches
-    // onAgentEnd at all (aborted-and-superseded is already covered by the
-    // A3/A4 disk/lease guard, and never emits events in the first place).
-    // The REAL gap is a run that reaches "failed" WITHOUT any abort — e.g. a
-    // parallel() fan-out where one sibling ('failer') throws a plain
-    // non-recoverable error while another ('straggler') is still in flight:
-    // Promise.all rejects immediately (failing the whole run) but does NOT
-    // cancel 'straggler', and nothing ever aborts the run's signal. resume()
-    // is then callable on this "failed" run (no abort needed) and builds a
-    // BRAND NEW managed/controller — leaving the OLD 'straggler' running
-    // against the OLD (now superseded) managed with a signal that will NEVER
-    // trip throwIfAborted(). When it finally resolves, it WILL reach
-    // onAgentEnd — this must be suppressed because the old managed is no
-    // longer current, not because of any abort.
+    // Historical note: this test used to document a genuine gap — a run that
+    // reached "failed" WITHOUT managed.controller ever aborting (a parallel()
+    // fan-out where one sibling ('failer') throws a non-recoverable error
+    // while another ('straggler') is still in flight: Promise.all rejects
+    // immediately but does NOT cancel 'straggler'). That gap is now closed at
+    // the ROOT — runWorkflow's own run-fatal handling (SharedRuntime.
+    // runFatalController, see workflow.ts) fires the instant 'failer's error
+    // escapes the top-level script, and every in-flight agent (including
+    // 'straggler') links its abort controller to that signal. So 'straggler'
+    // still runs to completion here (the fake agent below doesn't check its
+    // signal, simulating a real subagent process that doesn't cooperate with
+    // abort) — stragglerSettles below proves that — but once it resolves,
+    // agentImpl's OWN throwIfAborted() now trips before onAgentEnd is ever
+    // called, for BOTH the old (never-resumed) execution and the new
+    // (resumed) one, since 'failer' fails identically on replay. So
+    // onAgentEnd for "straggler" is never delivered at all — a strictly
+    // stronger guarantee than the old isCurrent()-based suppression this test
+    // originally probed (that guard remains in place as defense-in-depth for
+    // OTHER supersede paths — pause()/stop()/deleteRun() — see the tests
+    // below), it just never has to fire for THIS scenario anymore.
+    // managed.controller.signal itself still never aborts here (asserted
+    // below) — the two abort signals are deliberately independent (see
+    // SharedRuntime.runFatalController's doc comment).
     let stragglerSettles = 0;
     const agent = {
       async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
         if (prompt === "failer") {
           throw new WorkflowError("boom", WorkflowErrorCode.AGENT_EXECUTION_ERROR, { recoverable: false });
         }
-        // "straggler": a real delay, entirely unrelated to the sibling's
-        // failure or to abort — it just takes time to answer.
+        // "straggler": a real delay, and deliberately ignores any abort
+        // signal — simulating a real subagent process that doesn't
+        // cooperate with cancellation.
         await new Promise((resolve) => setTimeout(resolve, 60));
         stragglerSettles++;
         options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
@@ -2059,16 +2067,18 @@ return xs`;
     for (let i = 0; i < 200 && manager.getRun(runId)?.status !== "failed"; i++) {
       await new Promise((resolve) => setTimeout(resolve, 5));
     }
-    assert.equal(manager.getRun(runId)?.status, "failed", "the run must fail (via 'failer') without ever aborting");
+    assert.equal(manager.getRun(runId)?.status, "failed", "the run must fail (via 'failer')");
     assert.equal(
       manager.getRun(runId)?.controller.signal.aborted,
       false,
-      "confirms this failure path never aborts — the real gap this test targets",
+      "managed.controller (options.signal) itself is never aborted by a run-fatal error — only the internal runFatalController is",
     );
     const oldManaged = manager.getRun(runId);
 
     // Resume: builds a brand-new managed/controller for this runId. The OLD
-    // managed's 'straggler' call is still in flight, entirely unaffected.
+    // execution's 'straggler' call is still in flight (its run-fatal abort
+    // only discards its RESULT once it settles — it doesn't forcibly kill a
+    // signal-ignoring runner mid-call), entirely unaffected by resume().
     assert.equal(await manager.resume(runId), true);
     assert.notEqual(manager.getRun(runId), oldManaged, "resume() must have replaced the managed run object");
 
@@ -2079,8 +2089,8 @@ return xs`;
     assert.equal(stragglerSettles, 2, "both the old (stale) and new (current) straggler calls actually ran");
     assert.equal(
       agentEndsByLabel.get("straggler"),
-      1,
-      "only the current execution's straggler should emit agentEnd — the stale one must be suppressed",
+      undefined,
+      "run-fatal abort suppresses BOTH stragglers' agentEnd before the manager ever sees them",
     );
   }),
 );
@@ -2156,6 +2166,66 @@ return xs`;
       beforeStaleWrite?.updatedAt,
       "the stray schedulePersist timer (from the stale execution's straggler) must not write to disk",
     );
+  }),
+);
+
+test(
+  "concurrent agents sharing a label get correctly attributed onAgentEnd results (never swapped)",
+  withTempCwd(async (cwd) => {
+    // Two agents in the same parallel() fan-out share a label ('x') — a
+    // routine pattern (parallel()'s own default label is phase-scoped, not
+    // per-call-unique, and authors often reuse a label across a fan-out). 'A'
+    // (started first) finishes quickly; 'B' (started second) finishes much
+    // later. Before keying snapshot lookups on the agent CALL's unique id
+    // (see WorkflowRunOptions.onAgentEnd's `id` field in workflow.ts), the
+    // manager resolved an onAgentEnd event by reverse-scanning
+    // managed.snapshot.agents for the last-pushed entry with a matching label
+    // AND status "running" — which, for two concurrently-running same-label
+    // agents, picks whichever entry the scan happens to land on rather than
+    // the one THIS event actually belongs to. Here that would misattribute
+    // A's (fast) result onto B's snapshot slot (B is the last-pushed
+    // still-"running" entry when A's event fires), and later attribute B's
+    // (slow) result onto A's slot — a full swap.
+    const agent = {
+      async run(prompt: string) {
+        if (prompt === "A") {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return "result-A";
+        }
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        return "result-B";
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent });
+    manager.on("error", () => {});
+
+    const script = `export const meta = { name: 'shared_label_demo', description: 'same-label concurrency' }
+const xs = await parallel([
+  () => agent('A', { label: 'x' }),
+  () => agent('B', { label: 'x' }),
+])
+return xs`;
+
+    const { runId, promise } = manager.startInBackground(script);
+    promise.catch(() => {});
+
+    // Wait past A's ~5ms completion but well before B's ~150ms one.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const midSnapshot = manager.getSnapshot(runId);
+    assert.ok(midSnapshot, "run must still be live at this point");
+    if (!midSnapshot) throw new Error("unreachable");
+    const [firstAgent, secondAgent] = midSnapshot.agents;
+    assert.equal(firstAgent.label, "x");
+    assert.equal(secondAgent.label, "x");
+    assert.equal(firstAgent.status, "done", "the first-started agent (A) has already finished");
+    assert.equal(firstAgent.resultPreview, "result-A", "A's own result must land on A's own snapshot entry");
+    assert.equal(secondAgent.status, "running", "the second-started agent (B) is still genuinely in flight");
+
+    // Wait past B's completion too, then verify final attribution is still correct.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    const finalSnapshot = manager.getSnapshot(runId);
+    assert.equal(finalSnapshot?.agents[0].resultPreview, "result-A", "A's slot must still hold A's result");
+    assert.equal(finalSnapshot?.agents[1].resultPreview, "result-B", "B's slot must hold B's own result, not A's");
   }),
 );
 

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -2008,6 +2008,74 @@ test(
 );
 
 test(
+  "pause() -> immediate resume(): the stale (paused) execution's delayed agent rejection never emits a stray 'error' event (emitLive gate)",
+  withTempCwd(async (cwd) => {
+    // Same race as #A4 (pause() then immediately resume(), the OLD execution's
+    // 'second' agent hangs until aborted and only rejects ~40ms later), but
+    // this test targets emitLive()'s isCurrent() gate directly rather than
+    // persisted status: executeRun()'s own catch tail (reached when the stale
+    // execution's runWorkflow() promise finally rejects) unconditionally
+    // computes `usageLimitPaused` and, when it's false and an "error" listener
+    // is attached, calls `this.emitLive(managed, "error", ...)`. With the gate
+    // intact, isCurrent(managed) is false by then (resume() already replaced
+    // this.runs's entry for runId with a brand-new managed/controller), so
+    // that emit is silently dropped. Removing the isCurrent() check inside
+    // emitLive() (the exact mutation this test targets) would let that stale
+    // "error" event reach every listener — including, in production, the task
+    // panel's failure-delivery path — for a run that has already resumed (and,
+    // as asserted below, completed successfully).
+    let secondAttempts = 0;
+    const agent = {
+      async run(prompt: string, options?: { signal?: AbortSignal; onUsage?: (u: AgentUsage) => void }) {
+        if (prompt === "first") {
+          options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
+          return "first-result";
+        }
+        secondAttempts++;
+        if (secondAttempts === 1) {
+          return new Promise((_resolve, reject) => {
+            const fire = () => setTimeout(() => reject(new Error("stale agent rejected")), 40);
+            if (options?.signal?.aborted) fire();
+            else options?.signal?.addEventListener("abort", fire, { once: true });
+          });
+        }
+        options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
+        return "second-result";
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent });
+    const errorEvents: unknown[] = [];
+    manager.on("error", (e) => errorEvents.push(e));
+
+    const { runId, promise } = manager.startInBackground(twoAgentScript);
+    promise.catch(() => {});
+    for (let i = 0; i < 200 && secondAttempts === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(secondAttempts, 1, "'second' should be in flight before pausing");
+
+    assert.equal(manager.pause(runId), true);
+    assert.equal(await manager.resume(runId), true);
+
+    for (let i = 0; i < 200 && manager.getRun(runId)?.status === "running"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(manager.getPersistence().load(runId)?.status, "completed", "the resumed execution completes");
+
+    // Wait past the stale execution's delayed (40ms) rejection settling —
+    // this is when its executeRun() catch tail runs and attempts the stray
+    // emitLive("error", ...).
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    assert.equal(
+      errorEvents.length,
+      0,
+      "the stale (paused, superseded) execution's delayed rejection must never reach an 'error' listener",
+    );
+  }),
+);
+
+test(
   "resume() superseding a run-fatal-aborted failed run never delivers a stray sibling agent's agentEnd event (#1)",
   withTempCwd(async (cwd) => {
     // Historical note: this test used to document a genuine gap — a run that
@@ -2096,41 +2164,53 @@ return xs`;
 );
 
 test(
-  "writeRunToDisk's own isCurrent guard is independently load-bearing: a stale schedulePersist deferred timer must not write (#2)",
+  "writeRunToDisk's isCurrent guard is unreachable defense-in-depth: run-fatal abort now stops a stale straggler from ever journaling (#2)",
   withTempCwd(async (cwd) => {
-    // persistRun() early-returns on a stale `managed` before it would clear
-    // any pending throttled timer — so mutation testing showed removing
-    // writeRunToDisk's OWN isCurrent check survives the suite: every OTHER
-    // test's stale write happens to arrive via a direct persistRun() call
-    // (already guarded there). The one path that funnels straight into
-    // writeRunToDisk WITHOUT ever going through persistRun() is
-    // schedulePersist()'s deferred setTimeout callback — reachable only when
-    // a stale (never-aborted, superseded) execution's onAgentJournal fires
-    // AFTER supersede and schedules a BRAND NEW timer for a runId that
-    // nothing else currently has one pending for (see the "stray sibling"
-    // test above for why resume() on a never-aborted failed run is the way
-    // to get a genuinely stale-but-still-running agent call).
+    // HISTORY: this test used to drive a stale schedulePersist() deferred
+    // timer (the one path into writeRunToDisk() that skips persistRun()'s own
+    // isCurrent guard) by having a superseded-but-never-aborted execution's
+    // straggler settle and journal AFTER resume() replaced it. That trigger
+    // required a run to reach "failed" WITHOUT managed.controller ever
+    // aborting AND its straggler's onAgentJournal still firing after the
+    // fact — exactly the gap item 1 (run-fatal abort, see
+    // SharedRuntime.runFatalController in workflow.ts) closes: ANY error that
+    // fails a top-level run now seals that SAME execution's shared runtime
+    // before its own catch returns, so a sibling straggler within THAT
+    // execution — like 'straggler' below — trips throwIfAborted() the moment
+    // it resolves and NEVER reaches onAgentJournal (see the flow proven
+    // below). Since onAgentJournal is schedulePersist()'s only call site,
+    // there is no longer a way to construct a genuinely stale (superseded,
+    // un-aborted) execution whose straggler still journals afterward — every
+    // status transition that would make a run resumable (paused OR failed)
+    // is now, structurally, always preceded by at least one abort signal
+    // (managed.controller for pause()/stop(), or shared.runFatalController
+    // for a run-fatal escape) tripping for that same execution first.
     //
-    // Timing: the OLD execution's 'straggler' (its first invocation) settles
-    // quickly (30ms) and alone registers the stray timer; the NEW
-    // execution's OWN 'straggler' (second invocation) is deliberately much
-    // slower (500ms) so it can't interfere with or mask the stray timer's
-    // ~400ms throttle window.
-    let stragglerCalls = 0;
+    // The isCurrent() check inside writeRunToDisk() (independent of, and
+    // additional to, persistRun()'s own early-return) is KEPT as
+    // defense-in-depth — it costs nothing, and protects against a future
+    // change that reopens a stale-journal path without anyone re-deriving
+    // this whole chain of reasoning. This test now asserts the structural
+    // closure directly (the straggler's result never reaches the journal at
+    // all) instead of asserting a disk-write side effect that no longer has
+    // a way to occur — a test that only proved "nothing happened" for a path
+    // that can no longer be exercised would silently stop meaning anything.
     const agent = {
-      async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+      async run(prompt: string) {
         if (prompt === "failer") {
           throw new WorkflowError("boom", WorkflowErrorCode.AGENT_EXECUTION_ERROR, { recoverable: false });
         }
-        stragglerCalls++;
-        const delayMs = stragglerCalls === 1 ? 30 : 500;
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-        options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 });
-        return `straggler-${stragglerCalls}`;
+        // "straggler": settles well after 'failer' has already failed the run.
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return "straggler-stale";
       },
     };
     const manager = new WorkflowManager({ cwd, agent });
     manager.on("error", () => {});
+    const journaledResults: unknown[] = [];
+    manager.on("agentEnd", (e: { label: string; result: unknown }) => {
+      if (e.label === "straggler") journaledResults.push(e.result);
+    });
 
     const script = `export const meta = { name: 'stray_timer_demo', description: 'stray schedulePersist timer' }
 const xs = await parallel([
@@ -2145,27 +2225,30 @@ return xs`;
       await new Promise((resolve) => setTimeout(resolve, 5));
     }
     assert.equal(manager.getRun(runId)?.status, "failed");
-    assert.equal(manager.getRun(runId)?.controller.signal.aborted, false, "never aborted — the real gap");
+    assert.equal(manager.getRun(runId)?.controller.signal.aborted, false, "managed.controller itself is never aborted");
 
-    assert.equal(await manager.resume(runId), true);
-
-    // Wait past the OLD straggler's 30ms settle (registers the stray timer)
-    // but stay well before its ~400ms throttle fires, and well before the
-    // NEW straggler's own 500ms settle.
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    const beforeStaleWrite = manager.getPersistence().load(runId);
-    assert.ok(beforeStaleWrite, "run should still be persisted at this point");
-
-    // Wait past the stray timer's ~400ms throttle window, but still short of
-    // the NEW execution's own straggler settling at ~500ms.
-    await new Promise((resolve) => setTimeout(resolve, 350));
-
-    const afterStaleWindow = manager.getPersistence().load(runId);
+    // Wait well past the OLD straggler's 30ms settle. Its result must NEVER
+    // reach an agentEnd event — throwIfAborted() (tripped by run-fatal abort,
+    // sealed the instant 'failer' escaped) discards it before onAgentJournal
+    // (and therefore schedulePersist) is ever called.
+    await new Promise((resolve) => setTimeout(resolve, 80));
     assert.equal(
-      afterStaleWindow?.updatedAt,
-      beforeStaleWrite?.updatedAt,
-      "the stray schedulePersist timer (from the stale execution's straggler) must not write to disk",
+      journaledResults.includes("straggler-stale"),
+      false,
+      "the old (never-aborted-by-controller) execution's straggler must never journal — run-fatal abort discards it first",
     );
+
+    const persisted = manager.getPersistence().load(runId);
+    const journal = persisted?.journal ?? [];
+    assert.ok(
+      !journal.some((entry) => entry.result === "straggler-stale"),
+      "the persisted journal must never contain the stale straggler's result either — schedulePersist() is only ever " +
+        "called from onAgentJournal, so if the journal never sees it, no stray timer was ever scheduled for it",
+    );
+    // (resume()'s own correctness — including a genuinely resumed execution's
+    // writes landing normally — is covered by #A3/#A4 and the other resume
+    // tests above; this test's whole point is the pre-resume structural
+    // closure proven above, not resume() itself.)
   }),
 );
 

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -497,6 +497,60 @@ return { err }`;
   assert.match(result.result.err, /one level deep/);
 });
 
+test("sequential nested workflow() calls at the same depth get distinct child run ids (no cross-child id/deltaKey collision)", async () => {
+  // `shared.depth` alone would give BOTH of these sequential children the
+  // same `${runId}-nested1` suffix (depth returns to 0 between them, since
+  // only one level of nesting is ever live at a time) — and each child's own
+  // callSeq restarts at 0, so their first agent() calls would then compute
+  // the identical deltaKey (also used as the onAgentStart/onAgentEnd event
+  // id — see item 2's identity model), corrupting SharedStore deltas and
+  // misattributing events. child1's agent() call is deliberately left
+  // un-awaited — realistically, that's exactly when the collision bites:
+  // the stray can still be in SharedRuntime.inFlight (only the top-level
+  // frame drains, not each nested frame) when child2 starts and mints an id.
+  const seenIds = new Set<string>();
+  let duplicateId: string | undefined;
+  const runner = {
+    async run(prompt: string) {
+      if (prompt === "child1-stray") {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return "child1-stray-done";
+      }
+      return `ran:${prompt}`;
+    },
+  };
+  const scripts: Record<string, string> = {
+    child1: `export const meta = { name: 'child1', description: 'c1' }
+// Deliberately NOT awaited.
+agent('child1-stray', { label: 'stray' })
+return 'child1-done'`,
+    child2: `export const meta = { name: 'child2', description: 'c2' }
+const r = await agent('child2-live', { label: 'live' })
+return r`,
+  };
+  const parent = `export const meta = { name: 'parent', description: 'p' }
+const a = await workflow('child1')
+const b = await workflow('child2')
+return { a, b }`;
+
+  const result = await runWorkflow<{ a: string; b: string }>(parent, {
+    agent: runner,
+    persistLogs: false,
+    loadSavedWorkflow: (name) => scripts[name],
+    onAgentStart: (event) => {
+      if (seenIds.has(event.id)) duplicateId = event.id;
+      seenIds.add(event.id);
+    },
+  });
+  assert.equal(result.result.a, "child1-done");
+  assert.equal(result.result.b, "ran:child2-live");
+  assert.equal(
+    duplicateId,
+    undefined,
+    "child1's un-awaited stray and child2's live call must never share an id/deltaKey",
+  );
+});
+
 test("runWorkflow budget gates on accumulated tokens", async () => {
   const script = `export const meta = { name: 'budget_demo', description: 'budget' }
 const a = await agent('first', { label: 'a' })
@@ -1145,6 +1199,41 @@ return xs`;
   assert.deepEqual(result.result, [null, "done:sib"], "the thrown thunk resolves to null; the sibling still succeeds");
   assert.equal(state.aborted, 0, "a recoverable, swallowed-to-null error must never trigger a run-fatal abort");
   assert.equal(state.completed, 1);
+});
+
+test("a parent script that catches a nested workflow()'s uncaught child error can still run agents afterward (isTopLevelRun gate)", async () => {
+  // Only the TOP-level frame is allowed to seal shared.runFatalController (see
+  // isTopLevelRun in runWorkflow's catch) — a NESTED frame reaching its own
+  // catch must never seal it, because the error hasn't finished propagating
+  // yet: the parent script may still catch workflow()'s rejection and
+  // continue normally. If a nested frame sealed it too (the mutation this
+  // test targets — dropping the isTopLevelRun guard), the shared runtime
+  // (shared between parent and child via sharedRuntime) would already be
+  // aborted by the time control returns to the parent's catch block, so the
+  // parent's own SUBSEQUENT agent() call would be aborted before it could
+  // even start — even though the parent legitimately handled the failure.
+  const { state, runner } = abortAwareAgent(20);
+  const child = `export const meta = { name: 'child', description: 'c' }
+await agent('failer', { label: 'child-failer' })
+return 1`;
+  const parent = `export const meta = { name: 'parent', description: 'p' }
+let caught = false
+try {
+  await workflow('child')
+} catch (e) {
+  caught = true
+}
+const after = await agent('after', { label: 'after' })
+return { caught, after }`;
+
+  const result = await runWorkflow<{ caught: boolean; after: string }>(parent, {
+    agent: runner,
+    persistLogs: false,
+    loadSavedWorkflow: (name) => (name === "child" ? child : undefined),
+  });
+  assert.equal(result.result.caught, true, "the parent's own try/catch saw the child workflow's escaping error");
+  assert.equal(result.result.after, "done:after", "a later agent() call must still run normally after the catch");
+  assert.equal(state.aborted, 0, "sealing at the child (nested) level must never abort the parent's own later agent");
 });
 
 // ── Un-awaited agent() calls must not outlive the run: the run drains every

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -669,9 +669,14 @@ test("a fan-out past maxAgents cancels queued agents instead of draining the res
 const xs = await parallel(Array.from({ length: ${fanout} }, (_, i) => () => agent('x' + i, { label: 'a' + i })))
 return xs`;
   const run = runWorkflow(script, { agent: runner, maxAgents, concurrency, persistLogs: false });
+  // The run now drains every in-flight agent() call (including these
+  // gate-blocked ones) before its own promise settles — see the run-fatal
+  // drain in runWorkflow's finally — so `run` will NOT reject until `gate`
+  // resolves. Release it concurrently instead of after awaiting the
+  // rejection (which would deadlock: nothing else ever calls release()).
+  const releaseSoon = new Promise<void>((r) => setTimeout(r, 20)).then(() => release());
   await assert.rejects(run, /limit/i);
-  release();
-  await new Promise((r) => setTimeout(r, 50)); // let any queued agents drain
+  await releaseSoon;
   // Deterministically exactly `concurrency`: the limiter runs the first
   // `concurrency` submissions' bodies synchronously during the reservation
   // pass (each immediately calls runner.run() and then suspends on `gate`);
@@ -1044,4 +1049,175 @@ return { escaped, arr, j, s }`;
   // ({}).constructor.constructor is the vm Function; its code runs in the vm realm
   // where Date.now is neutered -> blocked (the old host-object escape is closed).
   assert.match(r.result.escaped, /blocked/, "constructor escape via vm objects is closed");
+});
+
+// ── Run-fatal abort: a non-recoverable error that will fail the whole run
+// must stop in-flight siblings from continuing to spend, while preserving
+// parallel()'s null-on-recoverable-error contract and a script's own
+// try/catch around agent()/parallel(). ──
+
+/** An agent runner whose in-flight calls actually respect an abort signal. */
+function abortAwareAgent(delayMs: number) {
+  const state = { started: 0, completed: 0, aborted: 0 };
+  return {
+    state,
+    runner: {
+      async run(prompt: string, options: { signal?: AbortSignal } = {}) {
+        state.started++;
+        if (prompt === "failer") {
+          throw new WorkflowError("boom", WorkflowErrorCode.AGENT_EXECUTION_ERROR, { recoverable: false });
+        }
+        return await new Promise((resolve, reject) => {
+          const timer = setTimeout(() => {
+            state.completed++;
+            resolve(`done:${prompt}`);
+          }, delayMs);
+          options.signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              state.aborted++;
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        });
+      },
+    },
+  };
+}
+
+test("a run-fatal error aborts in-flight parallel() siblings instead of letting them run to completion", async () => {
+  const { state, runner } = abortAwareAgent(200);
+  const script = `export const meta = { name: 'fatal_abort', description: 'sibling abort' }
+const xs = await parallel([
+  () => agent('failer', { label: 'failer' }),
+  () => agent('sib1', { label: 'sib1' }),
+  () => agent('sib2', { label: 'sib2' }),
+])
+return xs`;
+  await assert.rejects(runWorkflow(script, { agent: runner, persistLogs: false }), /boom/);
+  // Both in-flight siblings must have been aborted before their (200ms)
+  // delay would otherwise have let them complete and return a result.
+  assert.equal(state.started, 3, "all three agent() calls actually started");
+  assert.equal(state.aborted, 2, "both siblings were aborted once the run's fate was sealed");
+  assert.equal(state.completed, 0, "no sibling ran to completion on a run that's already failing");
+});
+
+test("a script's own try/catch around parallel() preserves in-flight siblings — no run-fatal abort", async () => {
+  const { state, runner } = abortAwareAgent(20);
+  const script = `export const meta = { name: 'fatal_abort_caught', description: 'sibling survives caught failure' }
+let caught = false
+try {
+  await parallel([
+    () => agent('failer', { label: 'failer' }),
+    () => agent('sib1', { label: 'sib1' }),
+  ])
+} catch (e) {
+  caught = true
+}
+// A later agent() call must still work normally — the run's fate was never
+// sealed because the script caught parallel()'s escaping error.
+const after = await agent('after', { label: 'after' })
+return { caught, after }`;
+  const result = await runWorkflow<{ caught: boolean; after: string }>(script, {
+    agent: runner,
+    persistLogs: false,
+  });
+  assert.equal(result.result.caught, true, "the script's own try/catch saw parallel()'s escaping error");
+  assert.equal(result.result.after, "done:after", "a later agent() call still runs normally, unaborted");
+  assert.equal(state.aborted, 0, "the caught sibling was never aborted — the run's fate was never sealed");
+  assert.equal(state.completed, 2, "the caught sibling and the later agent() both ran to completion");
+});
+
+test("parallel()'s recoverable-error-to-null contract does not seal the run's fate (siblings unaffected)", async () => {
+  const { state, runner } = abortAwareAgent(20);
+  // A plain (non-WorkflowError) throw from a thunk is classified recoverable by
+  // wrapError()'s default — parallel() must swallow it to null, not rethrow,
+  // and must NOT abort the sibling still in flight.
+  const script = `export const meta = { name: 'recoverable_null', description: 'recoverable swallowed' }
+const xs = await parallel([
+  () => { throw new Error('plain failure') },
+  () => agent('sib', { label: 'sib' }),
+])
+return xs`;
+  const result = await runWorkflow<Array<unknown>>(script, { agent: runner, persistLogs: false });
+  assert.deepEqual(result.result, [null, "done:sib"], "the thrown thunk resolves to null; the sibling still succeeds");
+  assert.equal(state.aborted, 0, "a recoverable, swallowed-to-null error must never trigger a run-fatal abort");
+  assert.equal(state.completed, 1);
+});
+
+// ── Un-awaited agent() calls must not outlive the run: the run drains every
+// spawned agent() call (awaited or not) before it is allowed to complete. ──
+
+test("an un-awaited agent() call is drained before the run completes", async () => {
+  let strayCompleted = false;
+  const runner = {
+    async run(prompt: string) {
+      if (prompt === "stray") {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        strayCompleted = true;
+        return "stray-done";
+      }
+      return "main-done";
+    },
+  };
+  const script = `export const meta = { name: 'stray_demo', description: 'un-awaited agent' }
+// Deliberately NOT awaited — a script bug the run must tolerate without
+// letting this call outlive the run's completion.
+agent('stray', { label: 'stray' })
+const main = await agent('main', { label: 'main' })
+return main`;
+  const journal: JournalEntry[] = [];
+  const result = await runWorkflow<string>(script, {
+    agent: runner,
+    persistLogs: false,
+    onAgentJournal: (entry) => journal.push(entry),
+  });
+  assert.equal(result.result, "main-done");
+  assert.equal(strayCompleted, true, "the run must not complete until the un-awaited agent has settled");
+  assert.ok(
+    journal.some((e) => e.result === "stray-done"),
+    "the stray agent's completion must be journaled before the run ends",
+  );
+});
+
+test("an un-awaited agent() call replays deterministically from the journal on resume", async () => {
+  const calls = { stray: 0, main: 0 };
+  const runner = {
+    async run(prompt: string) {
+      if (prompt === "stray") {
+        calls.stray++;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return "stray-done";
+      }
+      calls.main++;
+      return "main-done";
+    },
+  };
+  const script = `export const meta = { name: 'stray_resume_demo', description: 'un-awaited agent replay' }
+agent('stray', { label: 'stray' })
+const main = await agent('main', { label: 'main' })
+return main`;
+  const journalEntries = new Map<number, JournalEntry>();
+  const first = await runWorkflow<string>(script, {
+    agent: runner,
+    persistLogs: false,
+    onAgentJournal: (entry) => journalEntries.set(entry.index, entry),
+  });
+  assert.equal(first.result, "main-done");
+  assert.equal(calls.stray, 1);
+  assert.equal(calls.main, 1);
+
+  const second = await runWorkflow<string>(script, {
+    agent: runner,
+    persistLogs: false,
+    resumeJournal: journalEntries,
+    resumeFromRunId: "prior-run",
+  });
+  assert.equal(second.result, "main-done");
+  // Resume replays BOTH cached calls (including the un-awaited 'stray') from
+  // the journal — neither runner.run() is invoked again.
+  assert.equal(calls.stray, 1, "the un-awaited agent's cached result must replay, not re-run, on resume");
+  assert.equal(calls.main, 1, "the awaited agent's cached result must replay, not re-run, on resume");
 });


### PR DESCRIPTION
## What

Three concurrency/fan-out fixes in the workflow runtime:

1. **A run-fatal error now stops in-flight sibling agents.** When a script error escapes completely uncaught and seals the run's fate, sibling agents in a `parallel()`/`pipeline()` fan-out previously kept executing to completion — burning tokens and API calls on a run whose outcome was already decided. A run-scoped fatal signal now aborts in-flight agent sessions the moment the run's failure is determined. The semantics are deliberately narrow: `parallel()`'s contract that a thrown thunk resolves its item to `null` without failing the others is untouched, a script's own `try/catch` around agents or nested `workflow()` calls still allows it to continue (covered by tests), and the recoverable-retry path never triggers it. This also applies to provider usage-limit escapes: in-flight siblings stop consuming an already-exhausted quota, at the cost of re-running them on resume (documented inline).

2. **Agent events are attributed by unique id, not label.** Concurrent agents sharing a label previously collided in the run snapshot's bookkeeping — end/history events could update the wrong agent's entry. Every agent event now carries the call's unique id and all snapshot lookups key on it. Sequential nested `workflow()` calls also minted colliding child-run ids (each restarted at the same suffix); a monotonic per-run-tree counter now keeps them distinct, with resume/replay determinism verified.

3. **Un-awaited `agent()` calls can no longer outlive the run.** A script that forgot to `await` an agent promise could let the run complete and dispose its shared store while the agent was still executing and mutating state. Every spawned agent promise is now tracked and drained before the run is allowed to settle, making post-completion mutation structurally impossible rather than merely diagnosed; a completed-but-un-awaited agent's journal entry is recorded before settle, so resume replays deterministically (covered by a test). A hung agent that ignores the abort signal can delay completion if no `agentTimeoutMs` is configured — noted inline with guidance.

## Verification

- New regression tests: siblings actually stop on run-fatal errors (counted via a fake agent layer), script-catch and swallow-to-null contracts preserved, parent-catches-nested-child-error can continue, same-label concurrent attribution, sequential-nested id distinctness under an un-awaited stray overlap, drain-before-completion, replay determinism for a completed un-awaited agent, and a pause→immediate-resume race asserting a stale execution's late failure emits no spurious error event. Each was verified to fail with its guard reverted.
- Full suite run twice: 1107/1107 both times; lint, typecheck, docs/context checks, and the release gate all clean.
