### PR TITLE
fix: correct resume caching for nested workflows, isolate retry store writes, complete checkpoint identity hash

### DIFF
--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -70,8 +70,21 @@ export interface PersistedRunState {
     cacheRead?: number;
     cacheWrite?: number;
   };
-  /** Cached agent results for resume, keyed by deterministic call index. */
-  journal?: Array<{ index: number; hash: string; result: unknown }>;
+  /**
+   * Cached agent/checkpoint results for resume, keyed by deterministic call
+   * index. `runId` namespaces `index` (a nested workflow() call restarts its
+   * own callSeq at 0) — absent on journals persisted before that namespacing
+   * existed; see JournalEntry.runId in workflow.ts for the resume-time
+   * legacy-degradation behavior. `storeDelta` is this call's SharedStore
+   * write delta, replayed additively on resume.
+   */
+  journal?: Array<{
+    index: number;
+    runId?: string;
+    hash: string;
+    result: unknown;
+    storeDelta?: Record<string, unknown>;
+  }>;
   /**
    * Opt-out of auto-resume for this run (default true, i.e. eligible unless
    * explicitly set to false via ExecOptions.autoResume). Set once at run start

--- a/src/shared-store.ts
+++ b/src/shared-store.ts
@@ -116,6 +116,16 @@ export class SharedStore {
    * inconsistent. Each key touched during this delta window is restored to
    * whatever it held immediately before the window started (or deleted, if
    * it did not exist yet) — never to some other attempt's or caller's value.
+   *
+   * Per-key guard: a key is only rolled back if the store STILL holds this
+   * attempt's own last write to it (checked with `Object.is` against the
+   * value recorded in `delta`). If a concurrently-running sibling (a
+   * different `deltaKey`, e.g. another agent in the same parallel() batch)
+   * legitimately overwrote the same key AFTER this attempt wrote it but
+   * BEFORE it failed, that sibling's write is left untouched — rolling back
+   * unconditionally would silently erase a live, unrelated write that this
+   * attempt never made and has no business undoing.
+   *
    * A no-op if `deltaKey` never wrote anything (nothing to roll back).
    */
   discardDelta(deltaKey: string): void {
@@ -123,6 +133,9 @@ export class SharedStore {
     if (!delta) return;
     const priors = this.priorValues.get(deltaKey);
     for (const key of Object.keys(delta)) {
+      // Someone else already overwrote this key since our last write to it —
+      // leave their write in place instead of clobbering it with our rollback.
+      if (!Object.is(this.map.get(key), delta[key])) continue;
       const prior = priors?.get(key);
       if (prior?.existed) this.map.set(key, prior.value);
       else this.map.delete(key);

--- a/src/shared-store.ts
+++ b/src/shared-store.ts
@@ -32,6 +32,15 @@ export class SharedStore {
   // `${runId}:${callIndex}` string (see class doc) so nested workflow() runs
   // sharing this store can't collide on a bare callIndex.
   private readonly agentDeltas = new Map<string, Record<string, unknown>>();
+  // Pre-write shadow values for the CURRENT delta-key's in-progress writes,
+  // so a failed retry attempt's mutations can be rolled back (see
+  // `discardDelta`) instead of leaking into the live store or a later
+  // successful attempt's recorded delta. Populated lazily by `trackPut` (only
+  // the first write to a given key within the current delta window is
+  // shadowed — later writes to the same key within the same attempt are
+  // already covered by that first shadow) and cleared whenever the delta is
+  // finalized, either way, via `commitDelta`/`discardDelta`.
+  private readonly priorValues = new Map<string, Map<string, { existed: boolean; value: unknown }>>();
 
   /** Store a value under `key`. Overwrites any existing value. */
   put(key: string, value: unknown): void {
@@ -45,6 +54,20 @@ export class SharedStore {
    * writes can be journaled and replayed independently.
    */
   trackPut(key: string, value: unknown, deltaKey: string): void {
+    let priors = this.priorValues.get(deltaKey);
+    if (!priors) {
+      priors = new Map();
+      this.priorValues.set(deltaKey, priors);
+    }
+    // Only shadow the value from BEFORE this delta window started writing to
+    // this key — a second write to the same key within the same attempt must
+    // not overwrite the shadow with its own (already-in-window) value.
+    if (!priors.has(key)) {
+      priors.set(
+        key,
+        this.map.has(key) ? { existed: true, value: this.map.get(key) } : { existed: false, value: undefined },
+      );
+    }
     this.map.set(key, value);
     let delta = this.agentDeltas.get(deltaKey);
     if (!delta) {
@@ -76,7 +99,36 @@ export class SharedStore {
   commitDelta(deltaKey: string): Record<string, unknown> {
     const delta = this.agentDeltas.get(deltaKey) ?? {};
     this.agentDeltas.delete(deltaKey);
+    this.priorValues.delete(deltaKey);
     return delta;
+  }
+
+  /**
+   * Undo the writes recorded for `deltaKey` and discard its bookkeeping,
+   * without touching any other key. Used when a retry attempt fails: that
+   * attempt's writes must not remain visible in the live store (e.g. to a
+   * concurrently-running sibling agent's store_get, or to script code reading
+   * `store.get` directly) and must not merge into the delta eventually
+   * recorded when a later attempt of the SAME call succeeds — otherwise a
+   * failed attempt's mutations would silently survive into the run's live
+   * state while being absent from the journaled delta that resume replay
+   * reconstructs from, leaving live execution and replay permanently
+   * inconsistent. Each key touched during this delta window is restored to
+   * whatever it held immediately before the window started (or deleted, if
+   * it did not exist yet) — never to some other attempt's or caller's value.
+   * A no-op if `deltaKey` never wrote anything (nothing to roll back).
+   */
+  discardDelta(deltaKey: string): void {
+    const delta = this.agentDeltas.get(deltaKey);
+    if (!delta) return;
+    const priors = this.priorValues.get(deltaKey);
+    for (const key of Object.keys(delta)) {
+      const prior = priors?.get(key);
+      if (prior?.existed) this.map.set(key, prior.value);
+      else this.map.delete(key);
+    }
+    this.agentDeltas.delete(deltaKey);
+    this.priorValues.delete(deltaKey);
   }
 
   /**
@@ -105,6 +157,7 @@ export class SharedStore {
   dispose(): void {
     this.map.clear();
     this.agentDeltas.clear();
+    this.priorValues.clear();
   }
 }
 

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -112,8 +112,12 @@ export interface ManagedRun {
 
 /** Per-execution options shared by sync, background, and resume runs. */
 export interface ExecOptions {
-  /** Replay these journaled agent results for the unchanged prefix (resume). */
-  resumeJournal?: Map<number, JournalEntry>;
+  /**
+   * Replay these journaled agent/checkpoint results for the unchanged prefix
+   * (resume), keyed by `${runId}:${index}` — see
+   * WorkflowRunOptions.resumeJournal in workflow.ts.
+   */
+  resumeJournal?: Map<string, JournalEntry>;
   /** Cap on total agents for this run. */
   maxAgents?: number;
   /** Per-agent timeout in milliseconds. null/omitted means no hard timeout. */
@@ -640,12 +644,16 @@ export class WorkflowManager extends EventEmitter {
           this.accumulateTokenUsage(managed, tokens);
         },
         onAgentJournal: (entry) => {
-          // Append (crash-safe-ish): keep the latest entry per index, then persist.
-          // This is the high-frequency progress persist (fires once per completed
-          // agent, can burst under concurrency) — throttled (trailing edge). Every
+          // Append (crash-safe-ish): keep the latest entry per (runId, index)
+          // pair, then persist. Matching on index ALONE would let a nested
+          // workflow()'s callIndex-0 entry evict the parent's own
+          // callIndex-0 entry (and vice versa) — they're only distinguished
+          // by runId (see JournalEntry.runId). This is the high-frequency
+          // progress persist (fires once per completed agent, can burst
+          // under concurrency) — throttled (trailing edge). Every
           // lifecycle-critical persist below (status transitions, run end,
           // pause/resume/stop) still calls persistRun() directly and flushes this.
-          managed.journal = managed.journal.filter((e) => e.index !== entry.index);
+          managed.journal = managed.journal.filter((e) => !(e.index === entry.index && e.runId === entry.runId));
           managed.journal.push(entry);
           this.schedulePersist(managed);
         },
@@ -1189,7 +1197,14 @@ export class WorkflowManager extends EventEmitter {
     // lifecycle status, while getRun() supplies the live in-memory snapshot.
     this.persistRun(managed);
 
-    const resumeJournal = new Map((persisted.journal ?? []).map((e) => [e.index, e] as const));
+    // Namespace by (runId, index) exactly like the live onAgentJournal dedup
+    // above and like SharedStore's deltaKey — see JournalEntry.runId. A
+    // legacy entry persisted before namespacing existed has no `runId`; it is
+    // assumed to belong to this run's own top-level runId (the only frame
+    // that existed before nested workflow() journaling was namespaced), so it
+    // still resume-hits for a top-level call and safely cache-misses (re-runs
+    // live, does not misapply) for what was actually a nested-run entry.
+    const resumeJournal = new Map((persisted.journal ?? []).map((e) => [`${e.runId ?? runId}:${e.index}`, e] as const));
     this.emit("resumed", { runId });
     // Run in the background; executeRun records status/errors on the managed run.
     // initialTokenUsage seeds the resumed execution's fresh SharedRuntime.spent

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -968,23 +968,31 @@ export async function runWorkflow<T = unknown>(
     options.onRuntimeEvent?.({ type: "workflow", stage: "start", name: workflowName, args: childArgs });
     shared.depth++;
     try {
+      // Propagate the resumeJournal into the child frame ONLY while the
+      // parent's own longest-unchanged-prefix is still intact at the moment
+      // of this workflow() call (state.firstMiss === Infinity, i.e. every
+      // parent agent()/checkpoint() call BEFORE this one was a cache hit).
+      // This is namespacing-safe (see JournalEntry.runId) but namespacing
+      // alone is NOT sufficient: SharedStore content itself is not part of
+      // any call's hash, so a cached child result was computed against
+      // whatever store state the UPSTREAM parent calls had written at the
+      // time it originally ran live. If an upstream parent call misses
+      // (edited script) and re-runs live, it may write different store
+      // values than it did originally — a child cached under the OLD store
+      // state would then be replaying a result that's stale with respect to
+      // the NEW live state, even though the child's own hash still matches.
+      // The prefix contract already treats "this call sits after a miss" as
+      // "must run live" for calls within one frame; a nested workflow() is
+      // no exception; once anything upstream in the parent has missed, cut
+      // the child off from the journal entirely so it runs fully live.
+      const prefixIntact = state.firstMiss === Number.POSITIVE_INFINITY;
       const child = await runWorkflow(childScript, {
         ...options,
         args: childArgs,
         sharedRuntime: shared,
         // Propagate the parent's store so nested agents share the same key-value space.
         sharedStore: store,
-        // Propagate the SAME resumeJournal Map down into the child frame. This
-        // is safe (and required for nested resume caching to work at all) now
-        // that entries are namespaced by runId: the child looks itself up
-        // under `${childRunId}:${index}`, which can never collide with the
-        // parent's `${runId}:${index}` entries in the same Map — see
-        // JournalEntry.runId. Previously this was unconditionally cleared to
-        // `undefined` specifically BECAUSE the un-namespaced Map made a
-        // shared journal unsafe to reuse across nesting levels; that
-        // workaround also meant a nested workflow() call could never cache-hit
-        // on resume at all, which this fix corrects.
-        resumeJournal: options.resumeJournal,
+        resumeJournal: prefixIntact ? options.resumeJournal : undefined,
         resumeFromRunId: undefined,
         // shared.nestedCallSeq, not shared.depth — see its doc comment: depth
         // returns to 0 between sequential sibling calls, which would otherwise

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -60,6 +60,19 @@ export interface WorkflowMeta {
 /** One cached agent() result, keyed by its deterministic call index. */
 export interface JournalEntry {
   index: number;
+  /**
+   * The runId of the frame (top-level run, or a nested workflow()'s own run)
+   * this entry's `index` is scoped to. A nested workflow() restarts its own
+   * callSeq at 0, so `index` alone collides between a parent's and a child's
+   * same-numbered calls — see `resumeJournal`'s key format, which namespaces
+   * on this the same way SharedStore's deltaKey already does. Absent on
+   * journal entries persisted before this field existed; such legacy entries
+   * are treated as belonging to the run's own top-level runId (see
+   * WorkflowManager.resume()) — a legacy entry that actually belonged to a
+   * nested frame simply cache-misses on resume (safe degradation: it re-runs
+   * live, it does not apply to the wrong call).
+   */
+  runId?: string;
   /** sha256 of the call's identity (prompt + model + phase + agentType + schema). */
   hash: string;
   result: unknown;
@@ -166,8 +179,15 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   persistLogs?: boolean;
   /** Run ID for persistence. Auto-generated if not provided. */
   runId?: string;
-  /** Resume: cached agent results keyed by deterministic call index. */
-  resumeJournal?: Map<number, JournalEntry>;
+  /**
+   * Resume: cached agent/checkpoint results keyed by `${runId}:${callIndex}`
+   * — the same namespacing SharedStore's deltaKey uses — so a nested
+   * workflow() call's callIndex-0 (its callSeq restarts at 0) can never
+   * collide with the parent's own callIndex-0 entry. A legacy entry with no
+   * `runId` (persisted before namespacing existed) is looked up under the
+   * run's own top-level runId only; see `JournalEntry.runId`.
+   */
+  resumeJournal?: Map<string, JournalEntry>;
   /** Resume: the run being resumed (informational; enables resume mode). */
   resumeFromRunId?: string;
   /** Called after each live agent completes so the caller can persist the journal. */
@@ -626,7 +646,11 @@ export async function runWorkflow<T = unknown>(
     // call. Once any call misses, it AND everything after it run live (matching
     // Claude Code's contract), so an edited upstream call never leaves stale
     // downstream results served from the journal.
-    const cached = options.resumeJournal?.get(callIndex);
+    // Namespaced the same way as SharedStore's deltaKey (deltaKey IS this
+    // exact `${runId}:${callIndex}` string) so a nested workflow()'s
+    // callIndex-0 can never accidentally replay the parent's callIndex-0
+    // entry, or vice versa (see JournalEntry.runId).
+    const cached = options.resumeJournal?.get(deltaKey);
     const hashMatches = cached != null && cached.hash === callHash;
     const cachedEmptyOutput = hashMatches && isEmptyTextAgentResult(cached.result, agentOptions.schema);
     if (hashMatches && !cachedEmptyOutput && callIndex < state.firstMiss) {
@@ -770,6 +794,7 @@ export async function runWorkflow<T = unknown>(
             const tokens = recordTokens(result);
             options.onAgentJournal?.({
               index: callIndex,
+              runId,
               hash: callHash,
               result,
               storeDelta: store.commitDelta(deltaKey),
@@ -791,6 +816,17 @@ export async function runWorkflow<T = unknown>(
             const workflowError = wrapError(error, { agentLabel: label });
             logger.error(`agent ${label} attempt ${attempt}/${maxAttempts} failed: ${workflowError.message}`);
             const tokens = recordTokens(null);
+            // This attempt's store writes must not survive it — a failed
+            // attempt shares this call's deltaKey with every other attempt
+            // (retried or not), so without rolling back here its writes would
+            // stay live in the store (visible to concurrently-running sibling
+            // agents) and merge into whatever a later, successful attempt
+            // commits — corrupting both the live run's state and the delta
+            // that resume replay reconstructs from. Unconditional: this
+            // covers the about-to-retry case AND the exhausted/non-recoverable
+            // case, since neither leaves behind a call that "produced" a
+            // result this attempt's writes should be attributed to.
+            store.discardDelta(deltaKey);
 
             if (workflowError.recoverable && attempt < maxAttempts) {
               log(
@@ -938,8 +974,17 @@ export async function runWorkflow<T = unknown>(
         sharedRuntime: shared,
         // Propagate the parent's store so nested agents share the same key-value space.
         sharedStore: store,
-        // A nested run is its own script; never reuse the parent's resume journal.
-        resumeJournal: undefined,
+        // Propagate the SAME resumeJournal Map down into the child frame. This
+        // is safe (and required for nested resume caching to work at all) now
+        // that entries are namespaced by runId: the child looks itself up
+        // under `${childRunId}:${index}`, which can never collide with the
+        // parent's `${runId}:${index}` entries in the same Map — see
+        // JournalEntry.runId. Previously this was unconditionally cleared to
+        // `undefined` specifically BECAUSE the un-namespaced Map made a
+        // shared journal unsafe to reuse across nesting levels; that
+        // workaround also meant a nested workflow() call could never cache-hit
+        // on resume at all, which this fix corrects.
+        resumeJournal: options.resumeJournal,
         resumeFromRunId: undefined,
         // shared.nestedCallSeq, not shared.depth — see its doc comment: depth
         // returns to 0 between sequential sibling calls, which would otherwise
@@ -1140,7 +1185,9 @@ export async function runWorkflow<T = unknown>(
     }
     const callIndex = state.callSeq++;
     const callHash = hashCheckpoint(promptText, checkpointOptions);
-    const cached = options.resumeJournal?.get(callIndex);
+    // Namespaced by runId like agent()'s deltaKey — see JournalEntry.runId.
+    const journalKey = `${runId}:${callIndex}`;
+    const cached = options.resumeJournal?.get(journalKey);
     if (cached != null && cached.hash === callHash && callIndex < state.firstMiss) {
       shared.agentCount++;
       return cached.result; // replay the journaled human reply
@@ -1161,7 +1208,7 @@ export async function runWorkflow<T = unknown>(
       reply = checkpointOptions.default ?? true;
     }
     throwIfAborted();
-    options.onAgentJournal?.({ index: callIndex, hash: callHash, result: reply });
+    options.onAgentJournal?.({ index: callIndex, runId, hash: callHash, result: reply });
     return reply;
   };
 
@@ -1428,12 +1475,32 @@ function defaultAgentLabel(phase: string | undefined, index: number): string {
   return phase ? `${phase} agent ${index}` : `agent ${index}`;
 }
 
-/** Stable identity hash for an agent() call — a cache miss on resume when anything changes. */
+/**
+ * Stable identity hash for a checkpoint() call — a cache miss on resume when
+ * anything that could change its outcome changes. Must cover every
+ * CheckpointOptions field that participates in the outcome, not just
+ * promptText/kind/choices:
+ *   - `default` and `headless` decide the reply in the headless (no `confirm`
+ *     threaded in) path — a script edited to change either must not resume
+ *     with the OLD default/behavior's stale journaled reply.
+ *   - `timeoutMs` bounds the interactive prompt; a host `confirm` may itself
+ *     fall back to `default` when the human doesn't answer in time, so it can
+ *     also affect the outcome and is included for the same reason.
+ * NOTE: widening this hash is a one-time invalidation of any checkpoint
+ * answers already persisted under the old (narrower) hash — on the first
+ * resume after upgrading, those checkpoints will cache-miss and re-prompt (or
+ * re-apply the default) once, live. That's intentional: a silently-stale
+ * cached decision from before the identity surface was fixed is worse than a
+ * one-time re-ask.
+ */
 function hashCheckpoint(promptText: string, options: CheckpointOptions): string {
   const identity = JSON.stringify({
     promptText,
     kind: options.kind ?? "confirm",
     choices: options.choices ?? null,
+    default: options.default ?? null,
+    headless: options.headless ?? "default",
+    timeoutMs: options.timeoutMs ?? null,
   });
   return createHash("sha256").update(identity).digest("hex");
 }

--- a/tests/agent-registry.test.ts
+++ b/tests/agent-registry.test.ts
@@ -486,6 +486,7 @@ return r`;
     await runWorkflow(script, {
       agent: first.runner,
       persistLogs: false,
+      runId: "agenttype-edit-run",
       agentRegistry: registry,
       onAgentJournal: (e) => journal.push(e),
     });
@@ -501,8 +502,9 @@ return r`;
     await runWorkflow(script, {
       agent: second.runner,
       persistLogs: false,
+      runId: "agenttype-edit-run",
       agentRegistry: editedRegistry,
-      resumeJournal: new Map(journal.map((e) => [e.index, e])),
+      resumeJournal: new Map(journal.map((e) => [`${e.runId}:${e.index}`, e])),
     });
     assert.equal(second.seen.length, 1, "edited definition busts the cache and re-runs live");
     assert.equal(second.seen[0].model, "vendor/changed-model");
@@ -517,6 +519,7 @@ return r`;
     await runWorkflow(script, {
       agent: first.runner,
       persistLogs: false,
+      runId: "agenttype-unchanged-run",
       agentRegistry: registry,
       onAgentJournal: (e) => journal.push(e),
     });
@@ -524,8 +527,9 @@ return r`;
     await runWorkflow(script, {
       agent: second.runner,
       persistLogs: false,
+      runId: "agenttype-unchanged-run",
       agentRegistry: registry,
-      resumeJournal: new Map(journal.map((e) => [e.index, e])),
+      resumeJournal: new Map(journal.map((e) => [`${e.runId}:${e.index}`, e])),
     });
     assert.equal(second.seen.length, 0, "unchanged definition → cache hit → no live run");
   });

--- a/tests/checkpoint.test.ts
+++ b/tests/checkpoint.test.ts
@@ -52,12 +52,13 @@ test("checkpoint(): replays the journaled reply on resume (no re-prompt)", async
   const script = `export const meta = { name: 'c', description: 'checkpoint' }
 const r = await checkpoint('Approve?', {})
 return { r }`;
-  const journal = new Map<number, JournalEntry>();
+  const journal = new Map<string, JournalEntry>();
   const first = await runWorkflow<{ r: string }>(script, {
     agent: noopAgent,
     persistLogs: false,
+    runId: "checkpoint-resume-run",
     confirm: async () => "approved",
-    onAgentJournal: (e) => journal.set(e.index, e),
+    onAgentJournal: (e) => journal.set(`${e.runId}:${e.index}`, e),
   });
   assert.equal(first.result.r, "approved");
 
@@ -65,6 +66,7 @@ return { r }`;
   const second = await runWorkflow<{ r: string }>(script, {
     agent: noopAgent,
     persistLogs: false,
+    runId: "checkpoint-resume-run",
     resumeJournal: journal,
     confirm: async () => {
       calledAgain = true;
@@ -82,4 +84,91 @@ await checkpoint('b', { default: 1 })
 await checkpoint('c', { default: 1 })
 return 1`;
   await assert.rejects(() => runWorkflow(script, { agent: noopAgent, persistLogs: false, maxAgents: 2 }), /limit/i);
+});
+
+// ─── Checkpoint resume-identity hash coverage ─────────────────────────────────
+
+test("checkpoint(): resume cache misses (re-applies the NEW default) when only `default` changes", async () => {
+  const script = (def: string) => `export const meta = { name: 'c', description: 'checkpoint' }
+const r = await checkpoint('Approve?', { default: ${JSON.stringify(def)} })
+return { r }`;
+  const journal = new Map<string, JournalEntry>();
+  const first = await runWorkflow<{ r: string }>(script("A"), {
+    agent: noopAgent,
+    persistLogs: false,
+    runId: "checkpoint-default-run",
+    onAgentJournal: (e) => journal.set(`${e.runId}:${e.index}`, e),
+  });
+  assert.equal(first.result.r, "A");
+
+  // Edited script: same prompt/kind/choices, only `default` changed. Before
+  // this fix, `default` was not part of the checkpoint hash, so this would
+  // wrongly cache-hit and resume with the STALE journaled "A" reply instead
+  // of the new default "B".
+  const second = await runWorkflow<{ r: string }>(script("B"), {
+    agent: noopAgent,
+    persistLogs: false,
+    runId: "checkpoint-default-run",
+    resumeJournal: journal,
+  });
+  assert.equal(second.result.r, "B", "changed default busts the cache and takes the NEW default live");
+});
+
+test("checkpoint(): resume cache misses (throws live) when only `headless` changes to 'abort'", async () => {
+  const script = `export const meta = { name: 'c', description: 'checkpoint' }
+const r = await checkpoint('Approve?', { default: true, headless: 'default' })
+return { r }`;
+  const journal = new Map<string, JournalEntry>();
+  const first = await runWorkflow<{ r: string }>(script, {
+    agent: noopAgent,
+    persistLogs: false,
+    runId: "checkpoint-headless-run",
+    onAgentJournal: (e) => journal.set(`${e.runId}:${e.index}`, e),
+  });
+  assert.equal(first.result.r, true);
+
+  // Edited script: same prompt/default, only `headless` changed to "abort".
+  // Before this fix, `headless` was not part of the hash, so this would
+  // wrongly cache-hit and silently keep replaying the old "default" reply
+  // instead of ever exercising the new abort behavior.
+  const abortScript = script.replace("headless: 'default'", "headless: 'abort'");
+  await assert.rejects(
+    () =>
+      runWorkflow(abortScript, {
+        agent: noopAgent,
+        persistLogs: false,
+        runId: "checkpoint-headless-run",
+        resumeJournal: journal,
+      }),
+    /headless/i,
+    "changed headless mode busts the cache and re-evaluates live instead of replaying the stale reply",
+  );
+});
+
+test("checkpoint(): resume cache HITS when nothing (including default/headless/timeoutMs) changes", async () => {
+  const script = `export const meta = { name: 'c', description: 'checkpoint' }
+const r = await checkpoint('Approve?', { default: true, headless: 'default', timeoutMs: 5000 })
+return { r }`;
+  const journal = new Map<string, JournalEntry>();
+  await runWorkflow<{ r: string }>(script, {
+    agent: noopAgent,
+    persistLogs: false,
+    runId: "checkpoint-stable-run",
+    confirm: async () => "human-said-yes",
+    onAgentJournal: (e) => journal.set(`${e.runId}:${e.index}`, e),
+  });
+
+  let confirmCalledOnResume = false;
+  const second = await runWorkflow<{ r: string }>(script, {
+    agent: noopAgent,
+    persistLogs: false,
+    runId: "checkpoint-stable-run",
+    resumeJournal: journal,
+    confirm: async () => {
+      confirmCalledOnResume = true;
+      return "different";
+    },
+  });
+  assert.equal(confirmCalledOnResume, false, "identical options must still cache-hit — no re-prompt");
+  assert.equal(second.result.r, "human-said-yes", "the journaled reply replays unchanged");
 });

--- a/tests/shared-store.test.ts
+++ b/tests/shared-store.test.ts
@@ -76,6 +76,85 @@ test("SharedStore.dispose clears map and agent deltas", () => {
   assert.deepEqual(store.commitDelta("run-1:1"), {});
 });
 
+test("SharedStore.discardDelta rolls back to the pre-window value, not an intermediate write", () => {
+  // Load-bearing guard: trackPut only shadows a key's value the FIRST time it
+  // is written within the current delta window — a second write to the SAME
+  // key within that window must not overwrite the shadow with the first
+  // write's (still in-window) value. If it did, discardDelta would roll back
+  // to the intermediate write "w1" instead of the true pre-window value
+  // "pre" — an in-window leak of a value that was never meant to survive
+  // either.
+  const store = new SharedStore();
+  store.put("k", "pre");
+  store.trackPut("k", "w1", "run-1:0");
+  store.trackPut("k", "w2", "run-1:0"); // second write to the SAME key, same window
+  store.discardDelta("run-1:0");
+  assert.equal(store.get("k"), "pre", "rollback must restore the true pre-window value, not the first in-window write");
+  assert.deepEqual(store.commitDelta("run-1:0"), {}, "the delta must be fully discarded, including the first write");
+});
+
+test("SharedStore.discardDelta deletes a key that did not exist before the window", () => {
+  const store = new SharedStore();
+  store.trackPut("brandNew", "w1", "run-1:0");
+  assert.equal(store.has("brandNew"), true);
+  store.discardDelta("run-1:0");
+  assert.equal(
+    store.has("brandNew"),
+    false,
+    "a key with no pre-window value must be deleted on rollback, not left as undefined",
+  );
+});
+
+test("SharedStore.discardDelta on a deltaKey with no writes is a no-op", () => {
+  const store = new SharedStore();
+  store.put("k", "v");
+  store.discardDelta("run-1:never-wrote");
+  assert.equal(store.get("k"), "v");
+});
+
+test("SharedStore.discardDelta must not clobber a concurrent sibling's legitimate overwrite of the same key", () => {
+  // A failed attempt ("run-1:0") writes key "k", then — before it's rolled
+  // back — a concurrently-running SIBLING call ("run-1:1", e.g. another
+  // agent in the same parallel() batch) legitimately overwrites the same
+  // key. Rolling back "run-1:0" unconditionally to its pre-window value
+  // would erase the sibling's write, which "run-1:0" never made and has no
+  // business undoing.
+  const store = new SharedStore();
+  store.put("k", "pre");
+  store.trackPut("k", "poisoned", "run-1:0");
+  store.trackPut("k", "sibling-value", "run-1:1");
+  store.discardDelta("run-1:0");
+  assert.equal(
+    store.get("k"),
+    "sibling-value",
+    "the sibling's legitimate write must survive the failed attempt's rollback",
+  );
+});
+
+test("SharedStore.discardDelta still rolls back a key untouched by any concurrent sibling", () => {
+  const store = new SharedStore();
+  store.put("k", "pre");
+  store.put("other", "pre-other");
+  store.trackPut("k", "poisoned", "run-1:0");
+  store.trackPut("other", "sibling-value", "run-1:1"); // sibling touches a DIFFERENT key
+  store.discardDelta("run-1:0");
+  assert.equal(store.get("k"), "pre", "a key no sibling touched still rolls back normally");
+  assert.equal(
+    store.get("other"),
+    "sibling-value",
+    "the sibling's own key is untouched by the other deltaKey's rollback",
+  );
+});
+
+test("SharedStore.commitDelta (success) does not roll back — the discardDelta shadow is cleared, not applied", () => {
+  const store = new SharedStore();
+  store.put("k", "pre");
+  store.trackPut("k", "w1", "run-1:0");
+  const delta = store.commitDelta("run-1:0");
+  assert.deepEqual(delta, { k: "w1" });
+  assert.equal(store.get("k"), "w1", "a successful commit keeps the write live — commitDelta must not roll back");
+});
+
 // ─── Delta-key collision regression (defect: nested workflow() shares a store
 // but restarts callSeq at 0) ───────────────────────────────────────────────────
 
@@ -375,6 +454,77 @@ test("resume degrades gracefully (never corrupts) when replaying a pre-namespaci
     JSON.stringify(first.result),
     "no corruption: the final result still matches a live run's",
   );
+});
+
+const prefixNestedScript = (aPrompt: string) => `
+  export const meta = { name: "prefix-nested-outer", description: "outer" };
+  const a = await agent(${JSON.stringify(aPrompt)}, {});
+  const inner = await workflow(\`
+    export const meta = { name: "prefix-nested-inner", description: "inner" };
+    const x = await agent("inner-call", {});
+    return x;
+  \`, {});
+  return { a, inner };
+`;
+
+test("resume: an upstream parent-call miss cuts the nested child off from the journal (child re-runs live)", async () => {
+  // Regression test for a correctness gap introduced by namespacing the
+  // journal: propagating resumeJournal into a nested workflow() call is only
+  // safe while the PARENT's own longest-unchanged-prefix is still intact.
+  // SharedStore content is not part of any call's hash — a cached child
+  // result was computed against whatever the store held when it originally
+  // ran, which depended on the (now-edited) upstream parent call's live
+  // output. If the parent's agent('A') call misses and re-runs live, a stale
+  // cached child result must NOT be wholesale-replayed just because the
+  // child's own hash still matches; the child must run fully live too.
+  const journal: import("../src/workflow.js").JournalEntry[] = [];
+  const firstCalls = { count: 0 };
+  await runWorkflow<{ a: string; inner: string }>(prefixNestedScript("A-v1"), {
+    agent: countingRunnerFor(firstCalls),
+    persistLogs: false,
+    runId: "prefix-nested-run",
+    onAgentJournal: (e) => journal.push(e),
+  });
+  assert.equal(firstCalls.count, 2, "one live call for the parent's agent('A'), one for the nested child");
+
+  const resumeJournal = new Map(journal.map((e) => [`${e.runId}:${e.index}`, e] as const));
+
+  // Edit ONLY the parent's agent('A-v1') call to 'A-v2'. The child script is
+  // byte-identical, so the child's own callHash still matches its journaled
+  // entry — the only thing that changed is upstream of it.
+  const editedCalls = { count: 0 };
+  const edited = await runWorkflow<{ a: string; inner: string }>(prefixNestedScript("A-v2"), {
+    agent: countingRunnerFor(editedCalls),
+    persistLogs: false,
+    runId: "prefix-nested-run",
+    resumeJournal,
+  });
+  assert.equal(editedCalls.count, 2, "both the edited parent call AND the downstream child call must re-run live");
+  assert.equal(edited.result.a, "ran:A-v2", "the parent call reflects the edit");
+  assert.equal(edited.result.inner, "ran:inner-call", "the child re-ran live rather than replaying a stale cache hit");
+});
+
+test("resume: nested child still cache-hits when nothing upstream of it changed (positive control)", async () => {
+  const journal: import("../src/workflow.js").JournalEntry[] = [];
+  const firstCalls = { count: 0 };
+  const first = await runWorkflow<{ a: string; inner: string }>(prefixNestedScript("A-v1"), {
+    agent: countingRunnerFor(firstCalls),
+    persistLogs: false,
+    runId: "prefix-nested-stable-run",
+    onAgentJournal: (e) => journal.push(e),
+  });
+  assert.equal(firstCalls.count, 2);
+
+  const resumeJournal = new Map(journal.map((e) => [`${e.runId}:${e.index}`, e] as const));
+  const secondCalls = { count: 0 };
+  const second = await runWorkflow<{ a: string; inner: string }>(prefixNestedScript("A-v1"), {
+    agent: countingRunnerFor(secondCalls),
+    persistLogs: false,
+    runId: "prefix-nested-stable-run",
+    resumeJournal,
+  });
+  assert.equal(secondCalls.count, 0, "nothing changed upstream — both parent and child cache-hit, no live re-run");
+  assert.equal(JSON.stringify(second.result), JSON.stringify(first.result));
 });
 
 // ─── Retry-attempt store-delta isolation ──────────────────────────────────────

--- a/tests/shared-store.test.ts
+++ b/tests/shared-store.test.ts
@@ -262,6 +262,253 @@ test("nested workflow() concurrent with its parent does not collide on shared-st
   assert.ok(allDeltaKeys.includes("nestedKey"), "journal must contain a delta for nestedKey");
 });
 
+// ─── Nested workflow() journal-index collision (resume) ──────────────────────
+
+/** Agent runner that counts real invocations and echoes a per-call result. */
+function countingRunnerFor(calls: { count: number }) {
+  return {
+    async run(prompt: string) {
+      calls.count++;
+      return `ran:${prompt}`;
+    },
+  };
+}
+
+const nestedResumeScript = `
+  export const meta = { name: "nested-resume-outer", description: "outer" };
+  const inner = await workflow(\`
+    export const meta = { name: "nested-resume-inner", description: "inner" };
+    const x = await agent("inner-call", {});
+    return x;
+  \`, {});
+  const outer = await agent("outer-call", {});
+  return { inner, outer };
+`;
+
+test("resume after nested workflow(): parent and child journal entries cache-hit independently despite both indexing at 0", async () => {
+  // Regression test for the journal-index-collision bug: a nested workflow()
+  // call restarts its own callSeq at 0, so its journal entry's `index` equals
+  // the parent's own callIndex-0 entry. Before namespacing, the manager's
+  // per-index journal map meant whichever entry was recorded LAST clobbered
+  // the other, so a resume could never cache-hit both frames — often it could
+  // not correctly cache-hit either, since the hash of the surviving entry
+  // would only match one of the two calls.
+  const journal: import("../src/workflow.js").JournalEntry[] = [];
+  const firstCalls = { count: 0 };
+  const first = await runWorkflow<{ inner: string; outer: string }>(nestedResumeScript, {
+    agent: countingRunnerFor(firstCalls),
+    persistLogs: false,
+    runId: "nested-resume-run",
+    onAgentJournal: (e) => journal.push(e),
+  });
+  assert.equal(firstCalls.count, 2, "one live call for the child, one for the parent");
+  assert.equal(journal.length, 2);
+  // Both entries share callIndex 0 (each frame's own callSeq restarts at 0)
+  // but must carry DISTINCT runId — that's what makes them distinguishable.
+  assert.deepEqual(journal.map((e) => e.index).sort(), [0, 0]);
+  const runIds = new Set(journal.map((e) => e.runId));
+  assert.equal(runIds.size, 2, "the parent's and child's entries must carry distinct runId");
+
+  const resumeJournal = new Map(journal.map((e) => [`${e.runId}:${e.index}`, e] as const));
+  const secondCalls = { count: 0 };
+  const second = await runWorkflow<{ inner: string; outer: string }>(nestedResumeScript, {
+    agent: countingRunnerFor(secondCalls),
+    persistLogs: false,
+    runId: "nested-resume-run",
+    resumeJournal,
+  });
+  assert.equal(secondCalls.count, 0, "both the parent's AND the child's calls must cache-hit — neither re-runs live");
+  // JSON-compare (not assert.deepEqual): the two runs execute in separate vm
+  // realms, so their plain-object results have different (but structurally
+  // identical) prototypes — deepStrictEqual would spuriously fail on that.
+  assert.equal(JSON.stringify(second.result), JSON.stringify(first.result));
+});
+
+test("resume degrades gracefully (never corrupts) when replaying a pre-namespacing legacy journal", async () => {
+  // Simulate a journal persisted by a version before JournalEntry.runId
+  // existed: both the parent's and the child's index-0 entries have no
+  // `runId` field on disk, exactly like WorkflowManager's on-disk format did
+  // before this fix. WorkflowManager.resume() falls back to the run's own
+  // top-level runId for such entries (see its resumeJournal construction),
+  // which this test replicates directly against runWorkflow.
+  const journal: import("../src/workflow.js").JournalEntry[] = [];
+  const firstCalls = { count: 0 };
+  const first = await runWorkflow<{ inner: string; outer: string }>(nestedResumeScript, {
+    agent: countingRunnerFor(firstCalls),
+    persistLogs: false,
+    runId: "legacy-resume-run",
+    onAgentJournal: (e) => journal.push(e),
+  });
+
+  // Strip `runId`, as a legacy on-disk journal would lack it.
+  const legacyEntries = journal.map((e) => {
+    const { runId: _runId, ...rest } = e;
+    return rest as import("../src/workflow.js").JournalEntry;
+  });
+  const legacyResumeJournal = new Map(
+    legacyEntries.map((e) => [`${e.runId ?? "legacy-resume-run"}:${e.index}`, e] as const),
+  );
+  // The two legacy entries collapse onto the SAME map key ("legacy-resume-run:0"),
+  // since neither carries a runId to distinguish them — only one can survive
+  // (the child's is journaled first, so the parent's, journaled second,
+  // overwrites it in the Map).
+  assert.equal(legacyResumeJournal.size, 1, "both legacy entries collapse onto one key");
+
+  const secondCalls = { count: 0 };
+  const second = await runWorkflow<{ inner: string; outer: string }>(nestedResumeScript, {
+    agent: countingRunnerFor(secondCalls),
+    persistLogs: false,
+    runId: "legacy-resume-run",
+    resumeJournal: legacyResumeJournal,
+  });
+
+  // Graceful degradation, not corruption: the surviving legacy entry belongs
+  // to the parent's call (its hash matches "outer-call"'s hash under the
+  // collapsed key), so the parent cache-hits and the child — whose own entry
+  // was lost in the collapse — safely re-runs live instead of replaying the
+  // parent's (wrong) cached value. The end result is still correct.
+  assert.equal(secondCalls.count, 1, "the frame that lost its slot in the collapse re-runs live, not corrupted");
+  // JSON-compare — see the note in the previous test about cross-vm-realm
+  // prototypes tripping up assert.deepEqual.
+  assert.equal(
+    JSON.stringify(second.result),
+    JSON.stringify(first.result),
+    "no corruption: the final result still matches a live run's",
+  );
+});
+
+// ─── Retry-attempt store-delta isolation ──────────────────────────────────────
+
+test("a failed retry attempt's store writes are rolled back: absent from the recorded delta and from the live store", async () => {
+  // Regression test: all attempts of one agent() call share the same
+  // SharedStore deltaKey. A failed first attempt that writes to the store
+  // before throwing must not leave that write visible to the rest of the live
+  // run, and must not merge into the delta recorded for the eventual
+  // successful attempt. The failed and successful attempts deliberately write
+  // DIFFERENT keys ("poisonedOnly" vs "shared") — if they wrote the same key,
+  // the successful attempt's write would naturally overwrite the failed one's
+  // in both the live map and the delta, masking the leak entirely.
+  let callAttempts = 0;
+  const agent = {
+    async run(
+      prompt: string,
+      opts: { systemTools?: Array<{ name: string; execute: (id: string, p: unknown) => Promise<unknown> }> },
+    ) {
+      if (prompt === "call") {
+        callAttempts++;
+        if (callAttempts === 1) {
+          await opts.systemTools
+            ?.find((t) => t.name === "store_put")
+            ?.execute("", { key: "poisonedOnly", value: "should-never-survive" });
+          throw new Error("transient failure");
+        }
+        await opts.systemTools?.find((t) => t.name === "store_put")?.execute("", { key: "shared", value: "good" });
+        return "call-done";
+      }
+      // "check": read the live store from a SEPARATE, later agent() call —
+      // proves the failed attempt's write is gone from the LIVE store, not
+      // merely absent from the journaled delta.
+      const found = (await opts.systemTools
+        ?.find((t) => t.name === "store_get")
+        ?.execute("", {
+          key: "poisonedOnly",
+        })) as { details?: { found?: boolean } };
+      return found?.details?.found;
+    },
+  };
+  const journal: import("../src/workflow.js").JournalEntry[] = [];
+  const script = `export const meta = { name: 'retry-isolation', description: 'retry isolation' }
+  const r = await agent('call', {})
+  const check = await agent('check', {})
+  return { r, check }`;
+  const result = await runWorkflow<{ r: string; check: boolean }>(script, {
+    agent,
+    agentRetries: 1,
+    persistLogs: false,
+    onAgentJournal: (e) => journal.push(e),
+  });
+
+  assert.equal(callAttempts, 2, "first attempt fails, the retried second attempt succeeds");
+  assert.equal(result.result.r, "call-done");
+  assert.equal(
+    result.result.check,
+    false,
+    "the live store must NOT contain the failed attempt's key — it must be rolled back, not merely left uncommitted",
+  );
+  const callEntry = journal.find((e) => e.result === "call-done");
+  assert.deepEqual(
+    callEntry?.storeDelta,
+    { shared: "good" },
+    "the recorded delta must reflect only the successful attempt, not the failed one's poisoned key",
+  );
+});
+
+test("a failed retry attempt's rolled-back write matches what resume replay reconstructs", async () => {
+  // The live run and a later resume's replay must agree exactly: replaying
+  // the journal must additively reconstruct the SAME store state the live
+  // run ended up with — not a state polluted by a discarded failed attempt.
+  let callAttempts = 0;
+  const agent = {
+    async run(
+      prompt: string,
+      opts: { systemTools?: Array<{ name: string; execute: (id: string, p: unknown) => Promise<unknown> }> },
+    ) {
+      if (prompt === "call") {
+        callAttempts++;
+        if (callAttempts === 1) {
+          await opts.systemTools
+            ?.find((t) => t.name === "store_put")
+            ?.execute("", { key: "poisonedOnly", value: "should-never-survive" });
+          throw new Error("transient failure");
+        }
+        await opts.systemTools?.find((t) => t.name === "store_put")?.execute("", { key: "shared", value: "good" });
+        return "call-done";
+      }
+      const found = (await opts.systemTools
+        ?.find((t) => t.name === "store_get")
+        ?.execute("", {
+          key: "poisonedOnly",
+        })) as { details?: { found?: boolean } };
+      return found?.details?.found;
+    },
+  };
+  const journal: import("../src/workflow.js").JournalEntry[] = [];
+  const script = `export const meta = { name: 'retry-isolation-resume', description: 'retry isolation resume' }
+  const r = await agent('call', {})
+  const check = await agent('check', {})
+  return { r, check }`;
+  await runWorkflow(script, {
+    agent,
+    agentRetries: 1,
+    persistLogs: false,
+    runId: "retry-isolation-resume-run",
+    onAgentJournal: (e) => journal.push(e),
+  });
+
+  // Resume: replay everything from the journal (no live calls at all), and
+  // verify the "check" call's cached result — captured against the LIVE
+  // store during the original run — shows the poisoned key was never present.
+  const resumeJournal = new Map(journal.map((e) => [`${e.runId}:${e.index}`, e] as const));
+  let liveCallsOnResume = 0;
+  const second = await runWorkflow<{ r: string; check: boolean }>(script, {
+    agent: {
+      async run() {
+        liveCallsOnResume++;
+        return "should-not-run";
+      },
+    },
+    persistLogs: false,
+    runId: "retry-isolation-resume-run",
+    resumeJournal,
+  });
+  assert.equal(liveCallsOnResume, 0, "fully cached — resume must not re-run anything live");
+  assert.equal(
+    second.result.check,
+    false,
+    "replay must reconstruct the same rolled-back state as the live run (the poisoned key stays absent)",
+  );
+});
+
 // ─── Resume under fan-out (integration) ──────────────────────────────────────
 
 test("resume replays parallel-agent deltas additively so no writes are lost", async () => {
@@ -312,6 +559,7 @@ test("resume replays parallel-agent deltas additively so no writes are lost", as
   await runWorkflow(script, {
     agent,
     cwd: process.cwd(),
+    runId: "fan-out-resume-run",
     onAgentJournal: (e) => journal.push(e),
   });
 
@@ -327,11 +575,12 @@ test("resume replays parallel-agent deltas additively so no writes are lost", as
   // The get agents are intentionally absent so they run live against the rebuilt store,
   // which is how we verify the delta replay correctness.
   const resumeJournal = new Map(
-    journal.filter((e) => Object.keys(e.storeDelta ?? {}).length > 0).map((e) => [e.index, e]),
+    journal.filter((e) => Object.keys(e.storeDelta ?? {}).length > 0).map((e) => [`${e.runId}:${e.index}`, e] as const),
   );
   await runWorkflow(script, {
     agent,
     cwd: process.cwd(),
+    runId: "fan-out-resume-run",
     resumeJournal,
     onAgentJournal: () => {},
   });

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -3104,6 +3104,100 @@ test(
   }),
 );
 
+/** Runner that records prompts and pauses (usage limit) on a third, later call. */
+function nestedPauseResumeRunner() {
+  const seen: string[] = [];
+  const state = { failThird: true };
+  return {
+    seen,
+    state,
+    runner: {
+      async run(prompt: string) {
+        seen.push(prompt);
+        if (prompt === "third-call" && state.failThird) {
+          throw new WorkflowError("usage limit reached", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, {
+            recoverable: false,
+            resetHint: "Resets soon",
+          });
+        }
+        return `ran:${prompt}`;
+      },
+    },
+  };
+}
+
+test(
+  "manager resume: both a nested child's AND the parent's own index-0 journal entries cache-hit, not re-run live (M6)",
+  withTempCwd(async (cwd) => {
+    // Regression coverage for the manager-level journal dedup keying. The
+    // nested child's agent('inner-call') and the parent's own
+    // agent('outer-call') both land at callIndex 0 in their respective
+    // frames and BOTH journal successfully during the SAME live execution —
+    // this is exactly the shape that collides if managed.journal's dedup
+    // filter matched on `index` alone (not `(index, runId)`): whichever of
+    // the two journals SECOND would evict the other from managed.journal,
+    // so the persisted journal silently ends up with only one of the two
+    // entries. A third call then fails (usage limit) to force a pause with
+    // that (possibly corrupted) journal on disk, and resume must show BOTH
+    // completed calls cache-hitting — not just whichever survived a buggy
+    // dedup.
+    const { seen, state, runner } = nestedPauseResumeRunner();
+    const manager = new WorkflowManager({ cwd, agent: runner });
+    manager.on("paused", () => {});
+    manager.on("error", () => {});
+
+    const script = `export const meta = { name: 'nested_pause_resume', description: 'nested resume' }
+const inner = await workflow(\`
+  export const meta = { name: 'nested_pause_resume_inner', description: 'inner' }
+  const x = await agent('inner-call', { label: 'inner' })
+  return x
+\`, {})
+const outer = await agent('outer-call', { label: 'outer' })
+const third = await agent('third-call', { label: 'third' })
+return { inner, outer, third }`;
+
+    // First run: the nested child's index-0 call AND the parent's own
+    // index-0 call both complete and journal; the parent's third call hits
+    // a usage limit -> run pauses.
+    const { runId, promise } = manager.startInBackground(script);
+    await promise.catch(() => {});
+    assert.equal(manager.getRun(runId)?.status, "paused", "run pauses on the third call's usage limit");
+    assert.equal(seen.filter((p) => p === "inner-call").length, 1, "the nested child's agent ran once before pause");
+    assert.equal(seen.filter((p) => p === "outer-call").length, 1, "the parent's own agent ran once before pause");
+
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.equal(
+      persisted?.journal?.length,
+      2,
+      "BOTH the child's and the parent's completed index-0 calls must be journaled — neither may have evicted the other",
+    );
+
+    // Resume: let the third call succeed this time.
+    state.failThird = false;
+    const seenBeforeResume = seen.length;
+    const resumed = await manager.resume(runId);
+    assert.equal(resumed, true);
+    await new Promise((r) => setTimeout(r, 80));
+
+    const finalRun = manager.getRun(runId);
+    assert.equal(finalRun?.status, "completed", "resumed run completes");
+    assert.equal(finalRun?.result?.result?.inner, "ran:inner-call");
+    assert.equal(finalRun?.result?.result?.outer, "ran:outer-call");
+    assert.equal(finalRun?.result?.result?.third, "ran:third-call");
+
+    const promptsDuringResume = seen.slice(seenBeforeResume);
+    assert.ok(
+      !promptsDuringResume.includes("inner-call"),
+      "the nested child's journaled call must cache-hit on resume, not re-run live",
+    );
+    assert.ok(
+      !promptsDuringResume.includes("outer-call"),
+      "the parent's own journaled call must cache-hit on resume, not re-run live",
+    );
+    assert.ok(promptsDuringResume.includes("third-call"), "the parent's previously-failed third call re-runs live");
+  }),
+);
+
 // ═══════════════════════════════════════════════════════════════════════════
 // `runs` map eviction (run-level analog of the subagent memory-retention
 // mitigation): terminal runs' in-memory ManagedRun (agents array, journal,

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -345,6 +345,7 @@ test("resume replays cached results without re-running agents", async () => {
   const r1 = await runWorkflow(resumeScript, {
     agent: first.runner,
     persistLogs: false,
+    runId: "resume-run",
     onAgentJournal: (e) => journal.push(e),
   });
   assert.equal(first.state.calls, 2);
@@ -358,7 +359,8 @@ test("resume replays cached results without re-running agents", async () => {
   const r2 = await runWorkflow(resumeScript, {
     agent: second.runner,
     persistLogs: false,
-    resumeJournal: new Map(journal.map((e) => [e.index, e])),
+    runId: "resume-run",
+    resumeJournal: new Map(journal.map((e) => [`${e.runId}:${e.index}`, e])),
   });
   assert.equal(second.state.calls, 0, "no live runs on a full cache hit");
   assert.equal(JSON.stringify(r2.result), JSON.stringify(r1.result));
@@ -370,6 +372,7 @@ test("resume re-runs only the changed call (hash mismatch)", async () => {
   await runWorkflow(resumeScript, {
     agent: first.runner,
     persistLogs: false,
+    runId: "resume-run-2",
     onAgentJournal: (e) => journal.push(e),
   });
 
@@ -378,7 +381,8 @@ test("resume re-runs only the changed call (hash mismatch)", async () => {
   await runWorkflow(editedScript, {
     agent: second.runner,
     persistLogs: false,
-    resumeJournal: new Map(journal.map((e) => [e.index, e])),
+    runId: "resume-run-2",
+    resumeJournal: new Map(journal.map((e) => [`${e.runId}:${e.index}`, e])),
   });
   assert.equal(second.state.calls, 1, "only the edited call re-runs");
 });
@@ -395,6 +399,7 @@ test("resume re-runs the changed call AND everything after it (longest-unchanged
   await runWorkflow(threeCallScript, {
     agent: first.runner,
     persistLogs: false,
+    runId: "prefix-run",
     onAgentJournal: (e) => journal.push(e),
   });
   assert.equal(first.state.calls, 3);
@@ -407,7 +412,8 @@ test("resume re-runs the changed call AND everything after it (longest-unchanged
   await runWorkflow(editedScript, {
     agent: second.runner,
     persistLogs: false,
-    resumeJournal: new Map(journal.map((e) => [e.index, e])),
+    runId: "prefix-run",
+    resumeJournal: new Map(journal.map((e) => [`${e.runId}:${e.index}`, e])),
   });
   assert.equal(second.state.calls, 2, "edited call (1) + its suffix (2) re-run; only the prefix (0) is cached");
 });
@@ -427,6 +433,7 @@ test("resume in parallel(): editing one thunk re-runs that index and every later
   await runWorkflow(script("x"), {
     agent: first.runner,
     persistLogs: false,
+    runId: "par-prefix-run",
     onAgentJournal: (e) => journal.push(e),
   });
   assert.equal(first.state.calls, 3);
@@ -435,7 +442,8 @@ test("resume in parallel(): editing one thunk re-runs that index and every later
   await runWorkflow(script("x-edited"), {
     agent: second.runner,
     persistLogs: false,
-    resumeJournal: new Map(journal.map((e) => [e.index, e])),
+    runId: "par-prefix-run",
+    resumeJournal: new Map(journal.map((e) => [`${e.runId}:${e.index}`, e])),
   });
   assert.equal(second.state.calls, 2, "changed thunk (index 1) + later index (2) re-run; index 0 cached");
 });
@@ -1288,11 +1296,12 @@ test("an un-awaited agent() call replays deterministically from the journal on r
 agent('stray', { label: 'stray' })
 const main = await agent('main', { label: 'main' })
 return main`;
-  const journalEntries = new Map<number, JournalEntry>();
+  const journalEntries = new Map<string, JournalEntry>();
   const first = await runWorkflow<string>(script, {
     agent: runner,
     persistLogs: false,
-    onAgentJournal: (entry) => journalEntries.set(entry.index, entry),
+    runId: "prior-run",
+    onAgentJournal: (entry) => journalEntries.set(`${entry.runId}:${entry.index}`, entry),
   });
   assert.equal(first.result, "main-done");
   assert.equal(calls.stray, 1);
@@ -1301,6 +1310,7 @@ return main`;
   const second = await runWorkflow<string>(script, {
     agent: runner,
     persistLogs: false,
+    runId: "prior-run",
     resumeJournal: journalEntries,
     resumeFromRunId: "prior-run",
   });


### PR DESCRIPTION
## What

Three determinism/resume fixes in the workflow runtime and store:

1. **Resume caching now works correctly for nested `workflow()` calls.** Journal entries were keyed only by call index, so a nested child's index-0 entry collided with the parent's in the persisted journal — resume caching was silently broken for any script using nesting (the old code worked around it by disabling the child's journal entirely). Entries are now namespaced by run id (the same convention the shared store's delta keys already use), the parent's journal propagates into nested frames, and both parent and child calls genuinely cache-hit across resume. Two guardrails: propagation is gated on the parent's unchanged-prefix still being intact at the `workflow()` call — once an upstream call misses (e.g. an edited script), the child runs fully live rather than replaying results computed against stale store state — and journals persisted by older versions degrade to a safe cache-miss instead of corrupting.

2. **A failed retry attempt's store writes no longer leak into the recorded state.** All attempts of one `agent()` call share a delta window; a failed attempt's `store.put` writes previously stayed live and merged into the successful attempt's committed delta (and thus into what replay applies). The store now shadows each key's pre-window value on first write and rolls back a failed attempt's writes before the retry — with a per-key identity check so a concurrent sibling's legitimate overwrite of the same key survives the rollback. Live state and replayed state stay exactly consistent, verified by test.

3. **The checkpoint identity hash covers every input that affects its outcome.** It previously hashed only the prompt, kind, and choices — changing `default`, `headless`, or `timeoutMs` between runs did not invalidate a cached checkpoint decision, so an edited script could resume with a stale answer. All five option fields now participate. This invalidates existing persisted checkpoints once on upgrade; a one-time re-ask beats a silently wrong cached decision.

## Verification

- New regression tests: parent+child journal round-trip with cache hits verified across a real manager pause/resume (both index-0 entries persisted and hit), legacy-journal graceful degradation, upstream-edit cuts the child off from the journal (with a positive control), double-write rollback restores the pre-window value, sibling-overwrite survival, retry-isolation live-equals-replay agreement, and checkpoint cache-miss on each newly hashed field plus a stability control. Each was verified to fail with its guard reverted.
- Full suite run twice: 1123/1123 both times; lint, typecheck, docs/context checks, and the release gate all clean.
