### PR TITLE
fix: preserve active workflows across Pi reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Subagents are in-memory by default. Set `persistAgentSessions: true` to retain f
 
 Completed background runs persist their full result in the project run JSON. The conversation delivery includes a pointer to that file when the visible summary is shortened.
 
+Pi's `/reload` keeps the live workflow manager in-process when the installed extension version has not changed. Active background runs therefore continue streaming progress, remain controllable, and deliver their result through the freshly loaded extension; session-local `/effort` also survives the reload. If the package version changes, active runs are paused and a fresh manager loads, leaving them safely resumable through the journal instead of mixing extension versions. This handoff applies only to `/reload`. A process restart still uses the same durable journal path, recovering an interrupted running workflow as paused so it can be resumed safely.
+
 Finished runs (completed, failed, or aborted) are retained in full on disk, capped at the 300 most recent per project — older ones are evicted first, and a running or paused run is never touched. Only a smaller number (20 by default) also stay fully loaded in memory for instant access right after they finish; older finished runs still show up in `/workflows` and `workflow_control list`, just read back from disk instead of memory. Library embedders can tune both caps — `maxTerminalRunsInMemory` on `WorkflowManager` and `maxTerminalRunsOnDisk` on the run-persistence layer.
 
 </details>

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -1,5 +1,13 @@
 import { createCodingTools, type ExtensionAPI, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
+  claimWorkflowRuntime,
+  discardWorkflowRuntime,
+  handoffWorkflowRuntime,
+  pauseVersionMismatchWorkflowRuntime,
+  WORKFLOW_EXTENSION_VERSION,
+  type WorkflowReloadRuntime,
+} from "../src/extension-reload.js";
+import {
   createEffortState,
   createWebTools,
   createWorkflowControlTool,
@@ -20,14 +28,16 @@ import {
 } from "../src/index.js";
 
 export default function extension(pi: ExtensionAPI) {
-  // Single manager/storage shared by the workflow tool and the /workflows command,
-  // so background runs started by the tool are reachable from the command.
+  // Single manager shared by the workflow tool and /workflows command. Pi loads
+  // a fresh extension factory for /reload, so explicitly claim the old live
+  // manager when session_shutdown staged one; otherwise in-flight promises,
+  // controls, event delivery, and live UI updates would stay on an unreachable
+  // manager even though their persisted snapshots remained visible on disk.
   const cwd = process.cwd();
   const storage = createWorkflowStorage(cwd);
   const settings = loadWorkflowSettings({ cwd });
-  const manager = new WorkflowManager({
-    cwd,
-    loadSavedWorkflow: (name) => storage.load(name)?.script,
+  const managerOptions = {
+    loadSavedWorkflow: (name: string) => storage.load(name)?.script,
     // Named toolsets survive on the persisted run (the tag, not the functions),
     // so a resumed run re-resolves the tools it started with — e.g. a paused
     // /deep-research keeps web access instead of degrading to coding tools.
@@ -42,7 +52,27 @@ export default function extension(pi: ExtensionAPI) {
     concurrency: settings.defaultConcurrency,
     defaultAgentRetries: settings.defaultAgentRetries,
     persistAgentSessions: settings.persistAgentSessions,
-  });
+  };
+  const runtimeClaim = claimWorkflowRuntime(cwd);
+  const previousRuntime = runtimeClaim.compatible;
+  const pausedForVersionChange = runtimeClaim.versionMismatch
+    ? pauseVersionMismatchWorkflowRuntime(runtimeClaim.versionMismatch)
+    : 0;
+  const manager = previousRuntime?.manager ?? new WorkflowManager({ cwd, ...managerOptions });
+  if (previousRuntime) manager.reconfigureAfterReload(managerOptions);
+  // /effort is independent of the manager implementation and can safely
+  // survive an extension-version fallback to a fresh manager.
+  const effort = (previousRuntime ?? runtimeClaim.versionMismatch)?.effort ?? createEffortState();
+  const runtime: WorkflowReloadRuntime = {
+    cwd,
+    extensionVersion: WORKFLOW_EXTENSION_VERSION,
+    manager,
+    effort,
+  };
+  // Refresh the delivery holder immediately after claiming the manager. On a
+  // reload handoff its listener survives, but Pi invalidates the old ExtensionAPI
+  // before loading this generation.
+  installResultDelivery(pi, manager, { loadSettings: () => loadWorkflowSettings({ cwd }) });
 
   const workflowTool = createWorkflowTool({ cwd, manager, storage });
   const workflowControlTool = createWorkflowControlTool({ manager });
@@ -54,13 +84,18 @@ export default function extension(pi: ExtensionAPI) {
   // re-arms any run that was already paused-on-usage_limit before this process
   // started (cold start), so restarting pi doesn't strand a paused run.
   const usageLimitScheduler = new UsageLimitScheduler(manager);
-  pi.on("session_shutdown", () => {
+  pi.on("session_shutdown", (event?: { reason?: string }) => {
     usageLimitScheduler.dispose();
+    if (event?.reason === "reload") {
+      handoffWorkflowRuntime(runtime);
+    } else {
+      discardWorkflowRuntime(cwd, runtime);
+    }
   });
   // Standing /effort opt-in (off|high|ultra): auto-arms a workflow for substantive
   // messages, like CC's ultracode. Shared with the editor's input hook below and
-  // with the explicit /workflows run <prompt> manual trigger.
-  const effort = createEffortState();
+  // with the explicit /workflows run <prompt> manual trigger. It is part of the
+  // reload handoff so /reload does not silently turn the selected effort off.
   registerWorkflowCommands(pi, manager, { storage, cwd, effort });
   registerWorkflowModelsCommand(pi);
   registerBuiltinWorkflows(pi, { cwd, manager, storage });
@@ -72,6 +107,12 @@ export default function extension(pi: ExtensionAPI) {
   let armingInstalled = false;
 
   pi.on("session_start", (_event: unknown, ctx: ExtensionContext) => {
+    if (pausedForVersionChange > 0) {
+      ctx.ui.notify(
+        `Workflow extension updated during /reload; paused ${pausedForVersionChange} active workflow(s) for safe resume.`,
+        "warning",
+      );
+    }
     // Tell the manager the session's main model so "explore" agents auto-tier
     // down to a lighter same-family sibling (e.g. Claude → Haiku).
     manager.setMainModel(ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined);
@@ -93,10 +134,6 @@ export default function extension(pi: ExtensionAPI) {
     } catch {
       // sessionManager may be unavailable in some contexts — fall back to global history.
     }
-    // Deliver a background run's result into the conversation when it finishes.
-    // The live settings loader lets `deliveredResultMaxChars` take effect without
-    // a restart.
-    installResultDelivery(pi, manager, { loadSettings: () => loadWorkflowSettings({ cwd }) });
     // Live "workflows running" panel below the input (focus + enter to open).
     // Pass a live settings loader so /workflows-progress (compact|detailed) takes
     // effect without a restart.

--- a/src/extension-reload.ts
+++ b/src/extension-reload.ts
@@ -1,0 +1,100 @@
+import packageJson from "../package.json" with { type: "json" };
+import type { EffortState } from "./effort-command.js";
+import type { WorkflowManager } from "./workflow-manager.js";
+
+/**
+ * Live extension state that Pi may hand from one extension generation to the
+ * next during `/reload`. This deliberately stays process-local: run snapshots
+ * and journals already provide the durable cold-start path, while the live
+ * manager is what owns in-flight promises, abort controllers, and event streams.
+ */
+export const WORKFLOW_EXTENSION_VERSION = packageJson.version;
+
+export interface WorkflowReloadRuntime {
+  cwd: string;
+  /** Package version that created this manager. Only an exact match is retained. */
+  extensionVersion: string;
+  manager: WorkflowManager;
+  effort: EffortState;
+}
+
+export interface WorkflowRuntimeClaim {
+  compatible?: WorkflowReloadRuntime;
+  versionMismatch?: WorkflowReloadRuntime;
+}
+
+interface HandoffEntry {
+  runtime: WorkflowReloadRuntime;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const RELOAD_HANDOFF_KEY = Symbol.for("@quintinshaw/pi-dynamic-workflows:reload-handoffs");
+const RELOAD_HANDOFF_TTL_MS = 30_000;
+
+function handoffs(): Map<string, HandoffEntry> {
+  const root = globalThis as typeof globalThis & { [RELOAD_HANDOFF_KEY]?: Map<string, HandoffEntry> };
+  const existing = root[RELOAD_HANDOFF_KEY];
+  if (existing) return existing;
+  const created = new Map<string, HandoffEntry>();
+  root[RELOAD_HANDOFF_KEY] = created;
+  return created;
+}
+
+/** Stage a live runtime immediately before Pi tears down the old extension runner. */
+export function handoffWorkflowRuntime(runtime: WorkflowReloadRuntime): void {
+  const store = handoffs();
+  const previous = store.get(runtime.cwd);
+  if (previous) clearTimeout(previous.timer);
+
+  const entry = {} as HandoffEntry;
+  entry.runtime = runtime;
+  entry.timer = setTimeout(() => {
+    if (store.get(runtime.cwd) === entry) store.delete(runtime.cwd);
+  }, RELOAD_HANDOFF_TTL_MS);
+  entry.timer.unref?.();
+  store.set(runtime.cwd, entry);
+}
+
+/** Claim a staged runtime from the extension generation that `/reload` just stopped. */
+export function takeWorkflowRuntime(cwd: string): WorkflowReloadRuntime | undefined {
+  const store = handoffs();
+  const entry = store.get(cwd);
+  if (!entry) return undefined;
+  clearTimeout(entry.timer);
+  store.delete(cwd);
+  return entry.runtime;
+}
+
+/**
+ * Claim a staged runtime and compare its package version with this extension
+ * generation. Any package update falls back to a fresh manager; only reloads
+ * within the exact same installed version retain live workflow state.
+ */
+export function claimWorkflowRuntime(cwd: string): WorkflowRuntimeClaim {
+  const runtime = takeWorkflowRuntime(cwd);
+  if (!runtime) return {};
+  return runtime.extensionVersion === WORKFLOW_EXTENSION_VERSION
+    ? { compatible: runtime }
+    : { versionMismatch: runtime };
+}
+
+/**
+ * Move live runs from a replaced extension version onto the existing journal
+ * recovery path before the fresh manager is constructed.
+ */
+export function pauseVersionMismatchWorkflowRuntime(runtime: WorkflowReloadRuntime): number {
+  let paused = 0;
+  for (const run of runtime.manager.listRuns()) {
+    if (run.status === "running" && runtime.manager.pause(run.runId)) paused++;
+  }
+  return paused;
+}
+
+/** Test/cleanup helper; identity guard avoids deleting a newer handoff. */
+export function discardWorkflowRuntime(cwd: string, runtime?: WorkflowReloadRuntime): void {
+  const store = handoffs();
+  const entry = store.get(cwd);
+  if (!entry || (runtime && entry.runtime !== runtime)) return;
+  clearTimeout(entry.timer);
+  store.delete(cwd);
+}

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -154,15 +154,22 @@ export function installResultDelivery(
   manager: WorkflowManager,
   opts: { loadSettings?: () => WorkflowSettings } = {},
 ): void {
-  // Mutable holder on manager so shared across re-calls (e.g. session_start after /reload).
-  const m = manager as unknown as { __deliveryInstalled?: boolean; __holder?: { pi: ExtensionAPI } };
+  // Mutable holder on the manager shared by extension generations across /reload.
+  const m = manager as unknown as {
+    __deliveryInstalled?: boolean;
+    __holder?: { pi: ExtensionAPI; loadSettings?: () => WorkflowSettings };
+  };
   if (m.__deliveryInstalled) {
-    // Refresh pi reference only — listeners stay registered.
-    if (m.__holder) m.__holder.pi = pi;
+    // The manager and listeners survive /reload. Refresh every generation-bound
+    // dependency while leaving listener registration exactly-once.
+    if (m.__holder) {
+      m.__holder.pi = pi;
+      m.__holder.loadSettings = opts.loadSettings;
+    }
     return;
   }
   m.__deliveryInstalled = true;
-  m.__holder = { pi };
+  m.__holder = { pi, loadSettings: opts.loadSettings };
 
   const deliver = (content: string) => {
     try {
@@ -184,7 +191,12 @@ export function installResultDelivery(
     // Only background/resumed runs are delivered: a foreground (sync) run already
     // returns its result inline as the tool result, so re-delivering would dup it.
     if (run?.background) {
-      deliver(deliverText(run, { resultPath: persistedResultPath(manager, runId), maxChars: deliveredMaxChars(opts) }));
+      deliver(
+        deliverText(run, {
+          resultPath: persistedResultPath(manager, runId),
+          maxChars: deliveredMaxChars({ loadSettings: m.__holder?.loadSettings }),
+        }),
+      );
     }
   });
   manager.on("error", ({ runId, error }: { runId: string; error?: { message?: string } }) => {

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -223,6 +223,21 @@ export interface WorkflowManagerOptions {
   maxTerminalRunsInMemory?: number;
 }
 
+/** Options that a fresh extension generation may safely refresh on a live
+ * manager handed across `/reload`. Execution identity (`cwd`, persistence,
+ * injected agent, and in-memory runs) is intentionally excluded. */
+export type WorkflowManagerReloadOptions = Pick<
+  WorkflowManagerOptions,
+  | "concurrency"
+  | "loadSavedWorkflow"
+  | "defaultAgentTimeoutMs"
+  | "defaultAgentRetries"
+  | "defaultTokenBudget"
+  | "toolsets"
+  | "excludeSubagentTools"
+  | "persistAgentSessions"
+>;
+
 /**
  * Statuses in which a run's execution has genuinely settled — no promise is
  * still pending, no lease is still held, nothing will asynchronously mutate
@@ -364,6 +379,23 @@ export class WorkflowManager extends EventEmitter {
     } catch {
       // Recovery is best-effort; never let it block manager construction.
     }
+  }
+
+  /**
+   * Refresh host configuration after Pi reloads the extension while retaining
+   * this manager's live runs, controllers, leases, and event listeners.
+   * Existing executions keep the options they captured at start; subsequent
+   * runs and resumes use these refreshed defaults.
+   */
+  reconfigureAfterReload(options: WorkflowManagerReloadOptions): void {
+    this.concurrency = options.concurrency ?? 8;
+    this.loadSavedWorkflow = options.loadSavedWorkflow;
+    this.defaultAgentTimeoutMs = options.defaultAgentTimeoutMs ?? null;
+    this.defaultAgentRetries = options.defaultAgentRetries ?? 0;
+    this.defaultTokenBudget = options.defaultTokenBudget ?? null;
+    this.toolsets = options.toolsets;
+    this.excludeSubagentTools = options.excludeSubagentTools;
+    this.persistAgentSessions = options.persistAgentSessions ?? false;
   }
 
   /** Set the session's main model (provider/id). Used to auto-tier explore agents. */

--- a/tests/extension-reload.test.ts
+++ b/tests/extension-reload.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  claimWorkflowRuntime,
+  discardWorkflowRuntime,
+  handoffWorkflowRuntime,
+  pauseVersionMismatchWorkflowRuntime,
+  takeWorkflowRuntime,
+  WORKFLOW_EXTENSION_VERSION,
+  type WorkflowReloadRuntime,
+} from "../src/extension-reload.js";
+
+function runtime(cwd: string): WorkflowReloadRuntime {
+  return {
+    cwd,
+    extensionVersion: WORKFLOW_EXTENSION_VERSION,
+    manager: { marker: cwd } as unknown as WorkflowReloadRuntime["manager"],
+    effort: { level: "high" },
+  };
+}
+
+test("reload handoff transfers the exact live runtime once", () => {
+  const cwd = `/tmp/reload-handoff-${process.pid}-once`;
+  const value = runtime(cwd);
+  discardWorkflowRuntime(cwd);
+
+  handoffWorkflowRuntime(value);
+  assert.equal(takeWorkflowRuntime(cwd), value);
+  assert.equal(takeWorkflowRuntime(cwd), undefined, "a second extension generation cannot claim it twice");
+});
+
+test("a changed package version is rejected and its live runs are paused for recovery", () => {
+  const cwd = `/tmp/reload-handoff-${process.pid}-version`;
+  const paused: string[] = [];
+  const value: WorkflowReloadRuntime = {
+    ...runtime(cwd),
+    extensionVersion: `${WORKFLOW_EXTENSION_VERSION}-next`,
+    manager: {
+      listRuns: () => [
+        { runId: "running-1", status: "running" },
+        { runId: "paused-1", status: "paused" },
+        { runId: "done-1", status: "completed" },
+      ],
+      pause: (runId: string) => {
+        paused.push(runId);
+        return true;
+      },
+    } as unknown as WorkflowReloadRuntime["manager"],
+  };
+  discardWorkflowRuntime(cwd);
+
+  handoffWorkflowRuntime(value);
+  const claim = claimWorkflowRuntime(cwd);
+
+  assert.equal(claim.compatible, undefined);
+  assert.ok(claim.versionMismatch);
+  assert.equal(claim.versionMismatch, value);
+  assert.equal(pauseVersionMismatchWorkflowRuntime(claim.versionMismatch), 1);
+  assert.deepEqual(paused, ["running-1"]);
+});
+
+test("reload handoffs are isolated by cwd and identity-guarded on cleanup", () => {
+  const cwdA = `/tmp/reload-handoff-${process.pid}-a`;
+  const cwdB = `/tmp/reload-handoff-${process.pid}-b`;
+  const first = runtime(cwdA);
+  const replacement = runtime(cwdA);
+  const other = runtime(cwdB);
+  discardWorkflowRuntime(cwdA);
+  discardWorkflowRuntime(cwdB);
+
+  handoffWorkflowRuntime(first);
+  handoffWorkflowRuntime(replacement);
+  handoffWorkflowRuntime(other);
+  discardWorkflowRuntime(cwdA, first);
+
+  assert.equal(takeWorkflowRuntime(cwdA), replacement, "stale cleanup cannot delete a newer generation");
+  assert.equal(takeWorkflowRuntime(cwdB), other);
+});

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -417,6 +417,23 @@ describe("installResultDelivery", () => {
     assert.equal(calls1.length, 0, "pi1 should not be used after refresh");
     assert.equal(calls2.length, 1, "pi2 should receive the delivery");
   });
+
+  it("refreshes the live delivery settings loader across reload generations", () => {
+    const pi1 = createMockPi();
+    const pi2 = createMockPi();
+    const manager = createMockManager(makeRun({ result: { result: { note: "z".repeat(200) } } }));
+
+    mod.installResultDelivery(pi1 as unknown as ExtensionAPI, manager, {
+      loadSettings: () => ({ deliveredResultMaxChars: 400 }),
+    });
+    mod.installResultDelivery(pi2 as unknown as ExtensionAPI, manager, {
+      loadSettings: () => ({ deliveredResultMaxChars: 40 }),
+    });
+    manager.emit("complete", { runId: "test-run-1" });
+
+    const content = (pi2 as unknown as { _calls: { content: string }[] })._calls[0]?.content ?? "";
+    assert.match(content, /truncated/, "the reused listener reads settings from the fresh generation");
+  });
 });
 
 // ─── installTaskPanel ─────────────────────────────────────────────────────────

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -170,6 +170,19 @@ test(
 );
 
 test(
+  "reconfigureAfterReload refreshes defaults without replacing the live manager",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: delayedAgent(25), defaultAgentTimeoutMs: 5 });
+
+    manager.reconfigureAfterReload({ defaultAgentTimeoutMs: 100 });
+    const result = await manager.runSync(oneAgentScript);
+
+    assert.equal((result.result as { a: unknown }).a, "slow");
+    assert.equal(manager.listRuns()[0]?.agents[0]?.status, "done");
+  }),
+);
+
+test(
   "an agent timeout aborts the subagent so its session can be released (#109)",
   withTempCwd(async (cwd) => {
     // A subagent whose run() never resolves on its own — only an abort ends it.

--- a/tests/workflow-tools-available.test.ts
+++ b/tests/workflow-tools-available.test.ts
@@ -19,6 +19,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, mock } from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { handoffWorkflowRuntime, takeWorkflowRuntime } from "../src/extension-reload.js";
 import { buildArmedWorkflowPrompt, WORKFLOW_TOOL_NAME, type WorkflowModeState } from "../src/workflow-editor.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
@@ -353,7 +354,7 @@ describe("installWorkflowKeywordArming - tool availability", () => {
 });
 
 describe("workflow extension - control tool availability", () => {
-  it("registers and activates workflow and workflow_control together", async () => {
+  it("registers both control tools and hands the live runtime across reload", async () => {
     const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-control-extension-"));
     try {
       await withFakeHomeAsync(fakeHome, async () => {
@@ -394,7 +395,28 @@ describe("workflow extension - control tool availability", () => {
 
         assert.ok(activeTools.includes("workflow"));
         assert.ok(activeTools.includes("workflow_control"));
-        handlers.session_shutdown?.[0]?.();
+
+        handlers.session_shutdown?.[0]?.({ reason: "reload" });
+        const staged = takeWorkflowRuntime(process.cwd());
+        assert.ok(staged, "session_shutdown(reload) stages the live manager for the next extension generation");
+        staged.effort.level = "high";
+        handoffWorkflowRuntime(staged);
+
+        const secondHandlers: Record<string, Array<(...args: any[]) => any>> = {};
+        const secondPi = {
+          ...pi,
+          on: (event: string, handler: (...args: any[]) => any) => {
+            if (!secondHandlers[event]) secondHandlers[event] = [];
+            secondHandlers[event].push(handler);
+          },
+        } as unknown as ExtensionAPI;
+        installExtension(secondPi);
+        assert.equal(takeWorkflowRuntime(process.cwd()), undefined, "the fresh factory consumes the staged runtime");
+
+        secondHandlers.session_shutdown?.[0]?.({ reason: "reload" });
+        const restaged = takeWorkflowRuntime(process.cwd());
+        assert.equal(restaged?.manager, staged.manager, "a compatible generation keeps the exact live manager");
+        assert.equal(restaged?.effort.level, "high", "session effort survives with the compatible runtime");
       });
     } finally {
       rmSync(fakeHome, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- keep the live `WorkflowManager` and session `/effort` state across Pi `/reload`
- refresh generation-bound dependencies, including the `ExtensionAPI`, delivery settings loader, toolsets, and manager defaults
- guard the handoff with the package version, pausing live runs for journal recovery after any extension update
- limit handoff to in-process reloads so process restarts continue using durable journal recovery

## Implementation

Pi creates a fresh extension generation during `/reload`, but active workflows still depend on the old manager's in-memory promises, abort controllers, leases, and event streams. This change stages that live runtime in a process-local, cwd-keyed handoff during `session_shutdown` when the reason is `reload`, then claims and reconfigures it from the fresh extension factory.

The handoff is single-use and expires after 30 seconds. Reloads within the same package version retain the exact live manager. If the installed package version changes, running workflows are paused and a fresh manager is loaded, avoiding mixed-version execution while leaving those runs safely resumable. Non-reload shutdowns discard the handoff. Existing durable restart behavior is unchanged: interrupted workflows recover from the journal as paused.

## Test plan

- [x] `npm test` (1,128 tests passed; release verification passed)
- [x] reload handoff is single-use, cwd-isolated, identity-guarded, and package-version guarded
- [x] the extension reuses the live manager across reload generations
- [x] manager defaults and result-delivery dependencies refresh after reload
- [x] interactive smoke test: start a background workflow, run `/reload`, then verify progress, controls, completion delivery, and `/effort`
