### PR TITLE
fix: declare args as an explicit object schema, not typeless Type.Any()

### DIFF
--- a/docs/workflow-context-surfaces.json
+++ b/docs/workflow-context-surfaces.json
@@ -13,7 +13,7 @@
     },
     "providerVisibleWorkflowToolDefinition": {
       "serialization": "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
-      "bytes": 4267
+      "bytes": 4283
     },
     "registeredSkillsDiscovery": {
       "serialization": "sum of UTF-8 bytes of normalized Pi skill XML (name + description + location) across every root in package.json's pi.skills",
@@ -33,7 +33,7 @@
     },
     "ordinaryWorkflowOwnedAlwaysOn": {
       "serialization": "sum of permanent prompt, provider-visible tool definition, and every registered skill's discovery bytes",
-      "bytes": 5940
+      "bytes": 5956
     },
     "workflowAuthoringSkillCorpus": {
       "serialization": "sum of UTF-8 bytes for every file under skills/workflow-authoring",

--- a/docs/workflow-guidance-baseline.json
+++ b/docs/workflow-guidance-baseline.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "algorithm": "sha256",
   "surfaces": {
-    "compactGuidance": "aff3c746a9180ec9551030606d328008704234f62f3dade489a031fd4dbc8731",
+    "compactGuidance": "6db7b76e4e4017674cbad91c28c51132cef03121da20e1a23d3561f5652945cf",
     "detailedProse": "22fccb6ce35da667e7d57ed884d445e88b214f3c1d1890c3237f3c905c944da7"
   }
 }

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -49,7 +49,23 @@ const workflowToolSchema = Type.Object({
     }),
   ),
   args: Type.Optional(
-    Type.Any({ description: "Optional JSON value exposed to the workflow script as global `args`." }),
+    // Must be an explicitly typed object schema, not Type.Any(). Type.Any()
+    // compiles to a schema with no "type" keyword at all (just
+    // `{ description }`), and at least one MCP/tool-calling bridge observed
+    // in the wild does not treat a typeless property as "accept any JSON
+    // value" — it coerces/flattens it before the handler ever sees it, so
+    // `args.scope` (etc.) arrives as `undefined` and every built-in pattern
+    // that requires an args field fails validation regardless of what the
+    // caller actually sent. Every built-in pattern's `args` is a JSON object
+    // at the top level, so declaring `type: "object"` is lossless and fixes
+    // the coercion. Type.Unsafe keeps the emitted schema minimal (no
+    // `properties`/`additionalProperties` boilerplate — JSON Schema already
+    // allows additional properties by default) to stay inside the
+    // provider-visible tool definition's byte budget.
+    Type.Unsafe<Record<string, unknown>>({
+      type: "object",
+      description: "Optional JSON value exposed to the workflow script as global `args`.",
+    }),
   ),
   background: Type.Optional(
     Type.Boolean({
@@ -101,7 +117,7 @@ const workflowToolSchema = Type.Object({
 export type WorkflowToolInput = {
   script?: string;
   name?: string;
-  args?: unknown;
+  args?: Record<string, unknown>;
   background?: boolean;
   maxAgents?: number;
   concurrency?: number;

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -38,7 +38,21 @@ const RENDERED_PROMPT_BUDGET_BYTES = 800;
 // approximately 349 (this tool definition) + 593 (skill discovery) ≈ 942
 // bytes — well short of loading the skill's full body, which only happens
 // on demand.
-const TOOL_DEFINITION_BUDGET_BYTES = 4_267;
+//
+// `args` was `Type.Any()`, which TypeBox compiles to a schema with no
+// "type" keyword at all (just `{ description }`). At least one MCP/tool-
+// calling bridge does not treat a typeless property as "accept any JSON
+// value" — it coerces/flattens the value before the handler sees it, so
+// every named built-in pattern's required `args` field (e.g. `args.scope`
+// for codebase-audit) silently arrives as `undefined` regardless of what
+// the caller sent, making `name`-based invocation of all 5 built-in
+// patterns unusable end-to-end on that bridge. Every built-in pattern's
+// `args` is a JSON object at the top level, so `args` is now declared
+// `Type.Unsafe<Record<string, unknown>>({ type: "object", description })`
+// — an explicit, minimal, JSON-Schema-valid object type (additional
+// properties are allowed by default without needing to spell that out) —
+// increasing this compact definition from 4,267 to 4,283 bytes (+16).
+const TOOL_DEFINITION_BUDGET_BYTES = 4_283;
 
 test("rendered workflow prompt contribution stays within its accepted size", async () => {
   await withRenderedWorkflow(async ({ systemPrompt, promptLines }) => {

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -144,6 +144,30 @@ test("createWorkflowTool keeps script syntax in the parameter schema", () => {
   assert.doesNotMatch(guidance, /each stage receives.*previousValue.*originalItem.*index/i);
 });
 
+test("createWorkflowTool declares `args` as an explicitly typed object, not a typeless Type.Any() schema", () => {
+  // Regression test: `args` used to be `Type.Any()`, which compiles to a
+  // schema with no "type" keyword at all (just `{ description }`). At least
+  // one MCP/tool-calling bridge does not treat a typeless property as
+  // "accept any JSON value" — it coerces/flattens the value before the
+  // handler ever sees it, so every named built-in pattern's required args
+  // field (e.g. `args.scope` for codebase-audit, `args.question` for
+  // deep-research) silently arrives as `undefined`, regardless of what the
+  // caller actually sent — making name-based invocation of every built-in
+  // pattern fail on that bridge. Every built-in pattern's `args` is a JSON
+  // object at the top level, so it must be declared `type: "object"`.
+  const tool = createWorkflowTool();
+  const parameters = tool.parameters as { properties: Record<string, unknown> };
+  const argsSchema = parameters.properties.args as Record<string, unknown> | undefined;
+
+  assert.ok(argsSchema, "tool.parameters.properties.args should exist");
+  assert.equal(argsSchema?.type, "object", "args schema must declare an explicit object type");
+  assert.equal(
+    typeof argsSchema?.description,
+    "string",
+    "args schema should keep its description alongside the explicit type",
+  );
+});
+
 test("createWorkflowTool keeps background behavior in the parameter schema", () => {
   const tool = createWorkflowTool();
   const description = parameterDescription(tool, "background");


### PR DESCRIPTION
## Bug

The `workflow` tool's `args` parameter — used to pass arguments to the 5 named built-in patterns (e.g. `{ scope, checks }` for `codebase-audit`, `{ question }` for `deep-research`) — is declared with `Type.Any()`:

```ts
args: Type.Optional(
  Type.Any({ description: "Optional JSON value exposed to the workflow script as global `args`." }),
),
```

`Type.Any()` compiles to a JSON Schema with **no `"type"` keyword at all** — just `{ "description": "..." }`. Confirmed directly:

```js
const { Type } = require("@sinclair/typebox");
JSON.stringify(Type.Any({ description: "x" }));
// => {"description":"x"}
```

At least one MCP/tool-calling bridge does not treat a typeless property as "accept any JSON value" — it coerces/flattens the value before the tool handler ever sees it. The object a caller sends for `args` never reaches `resolveWorkflowInvocation()` intact:

```ts
function asRecord(args: unknown): Record<string, unknown> {
  return args && typeof args === "object" ? (args as Record<string, unknown>) : {};
}
```

`typeof args === "object"` fails, `asRecord` silently returns `{}`, and every built-in pattern's required-field validation throws — e.g.:

```
Built-in workflow "codebase-audit" requires args.scope to be a non-empty string.
```

...regardless of what was actually sent. Reproduced identically on `deep-research` with a single trivial `{"question": "test question"}` arg, so it's not pattern-specific — it makes `name`-based invocation of **all 5 built-in patterns** unusable end-to-end on that bridge. Only the `script` path (a plain typed `string` parameter, unaffected by this) still worked, which is exactly the workaround I used before digging into root cause.

This surfaced right after #117 made the 5 built-in patterns reachable via `name` + `args` from the tool itself (previously only via slash commands, whose args arrive as a plain string and go through a different parsing path — `tokenizeArgs` — untouched by this).

## Fix

Every built-in pattern's `args` is a JSON object at the top level (never a bare string/array/number), so this declares it as an explicit, minimal object schema instead of leaving it typeless:

```ts
Type.Unsafe<Record<string, unknown>>({
  type: "object",
  description: "Optional JSON value exposed to the workflow script as global `args`.",
}),
```

`Type.Unsafe` avoids `Type.Object({}, { additionalProperties: true })`'s extra `"properties":{}` boilerplate (JSON Schema already permits additional properties by default), keeping the byte cost to the provider-visible tool definition as small as possible: **+16 bytes** (4,267 → 4,283).

## Other changes required to keep the repo's own guardrails green

- `WorkflowToolInput.args` widened from `unknown` to `Record<string, unknown>` to match the now-typed schema (TS compile error otherwise).
- `TOOL_DEFINITION_BUDGET_BYTES` in `tests/workflow-prompt-budget.test.ts` bumped 4,267 → 4,283 (+16), documented inline in the same ratchet-comment style as the existing #105/#117 entries.
- Regenerated `docs/workflow-context-surfaces.json` (byte-size snapshot) and `docs/workflow-guidance-baseline.json` (content-hash snapshot) via their existing `npm run context:generate` / `npm run guidance:generate` scripts — both are generated artifacts tracked for drift detection.
- Added a regression test (`tests/workflow-tool.test.ts`) asserting `tool.parameters.properties.args.type === "object"`, so this can't silently regress back to a typeless schema.

## Verification

- `npm run build` — clean, no type errors.
- `npm run check` — clean (pre-existing lint infos unrelated to this change, untouched files).
- `npm test` (build + docs:check + context:check + full unit suite + release:verify) — **1124/1124 passing**, release gate green.