### PR TITLE
fix: pause stranded runs when reload handoff expires

### DIFF
--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -3,7 +3,7 @@ import {
   claimWorkflowRuntime,
   discardWorkflowRuntime,
   handoffWorkflowRuntime,
-  pauseVersionMismatchWorkflowRuntime,
+  pauseStrandedWorkflowRuntime,
   WORKFLOW_EXTENSION_VERSION,
   type WorkflowReloadRuntime,
 } from "../src/extension-reload.js";
@@ -56,7 +56,7 @@ export default function extension(pi: ExtensionAPI) {
   const runtimeClaim = claimWorkflowRuntime(cwd);
   const previousRuntime = runtimeClaim.compatible;
   const pausedForVersionChange = runtimeClaim.versionMismatch
-    ? pauseVersionMismatchWorkflowRuntime(runtimeClaim.versionMismatch)
+    ? pauseStrandedWorkflowRuntime(runtimeClaim.versionMismatch)
     : 0;
   const manager = previousRuntime?.manager ?? new WorkflowManager({ cwd, ...managerOptions });
   if (previousRuntime) manager.reconfigureAfterReload(managerOptions);

--- a/src/extension-reload.ts
+++ b/src/extension-reload.ts
@@ -40,8 +40,13 @@ function handoffs(): Map<string, HandoffEntry> {
   return created;
 }
 
-/** Stage a live runtime immediately before Pi tears down the old extension runner. */
-export function handoffWorkflowRuntime(runtime: WorkflowReloadRuntime): void {
+/**
+ * Stage a live runtime immediately before Pi tears down the old extension runner.
+ *
+ * `ttlMs` is only ever overridden by tests; production callers rely on the
+ * default so a slow/failed reload doesn't strand a staged runtime forever.
+ */
+export function handoffWorkflowRuntime(runtime: WorkflowReloadRuntime, ttlMs: number = RELOAD_HANDOFF_TTL_MS): void {
   const store = handoffs();
   const previous = store.get(runtime.cwd);
   if (previous) clearTimeout(previous.timer);
@@ -49,8 +54,14 @@ export function handoffWorkflowRuntime(runtime: WorkflowReloadRuntime): void {
   const entry = {} as HandoffEntry;
   entry.runtime = runtime;
   entry.timer = setTimeout(() => {
-    if (store.get(runtime.cwd) === entry) store.delete(runtime.cwd);
-  }, RELOAD_HANDOFF_TTL_MS);
+    if (store.get(runtime.cwd) !== entry) return;
+    // No new extension generation ever claimed this runtime. Anything still
+    // "running" in it would otherwise burn tokens to completion and deliver
+    // its result into a manager nobody can reach anymore, so pause it onto
+    // the same journal-recovery path a version-mismatch reload uses.
+    pauseStrandedWorkflowRuntime(runtime);
+    store.delete(runtime.cwd);
+  }, ttlMs);
   entry.timer.unref?.();
   store.set(runtime.cwd, entry);
 }
@@ -79,10 +90,11 @@ export function claimWorkflowRuntime(cwd: string): WorkflowRuntimeClaim {
 }
 
 /**
- * Move live runs from a replaced extension version onto the existing journal
- * recovery path before the fresh manager is constructed.
+ * Move a runtime's live runs onto the existing journal recovery path when no
+ * compatible manager will carry them forward — a replaced extension version,
+ * or a staged handoff that expired unclaimed.
  */
-export function pauseVersionMismatchWorkflowRuntime(runtime: WorkflowReloadRuntime): number {
+export function pauseStrandedWorkflowRuntime(runtime: WorkflowReloadRuntime): number {
   let paused = 0;
   for (const run of runtime.manager.listRuns()) {
     if (run.status === "running" && runtime.manager.pause(run.runId)) paused++;

--- a/tests/extension-reload.test.ts
+++ b/tests/extension-reload.test.ts
@@ -1,14 +1,55 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import {
   claimWorkflowRuntime,
   discardWorkflowRuntime,
   handoffWorkflowRuntime,
-  pauseVersionMismatchWorkflowRuntime,
+  pauseStrandedWorkflowRuntime,
   takeWorkflowRuntime,
   WORKFLOW_EXTENSION_VERSION,
   type WorkflowReloadRuntime,
 } from "../src/extension-reload.js";
+import { WorkflowManager } from "../src/workflow-manager.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+/** Agent that stays running until a deferred resolve is called externally. */
+function deferredAgent() {
+  const pending = new Map<number, { resolve: (v: unknown) => void }>();
+  let callIndex = 0;
+  return {
+    resolve: (index: number, value: unknown = "done") => pending.get(index)?.resolve(value),
+    runner: {
+      async run(_prompt: string, _options?: { onUsage?: (u: unknown) => void }) {
+        const index = callIndex++;
+        return new Promise((resolve) => {
+          pending.set(index, { resolve });
+        });
+      },
+    },
+  };
+}
+
+const twoAgentScript = `export const meta = { name: 'two_agent_ttl', description: 'two agents' }
+const a = await agent('first', { label: 'first' })
+const b = await agent('second', { label: 'second' })
+return { a, b }`;
+
+/** Run with isolated cwd + HOME so the real manager's persistence stays sandboxed. */
+function withTempCwd(fn: (cwd: string) => Promise<void>) {
+  return async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-dw-reload-ttl-"));
+    const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-reload-home-"));
+    try {
+      await withFakeHomeAsync(fakeHome, () => fn(cwd));
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  };
+}
 
 function runtime(cwd: string): WorkflowReloadRuntime {
   return {
@@ -55,9 +96,69 @@ test("a changed package version is rejected and its live runs are paused for rec
   assert.equal(claim.compatible, undefined);
   assert.ok(claim.versionMismatch);
   assert.equal(claim.versionMismatch, value);
-  assert.equal(pauseVersionMismatchWorkflowRuntime(claim.versionMismatch), 1);
+  assert.equal(pauseStrandedWorkflowRuntime(claim.versionMismatch), 1);
   assert.deepEqual(paused, ["running-1"]);
 });
+
+test("a handoff nobody claims before its TTL expires pauses any still-running run", async () => {
+  const cwd = `/tmp/reload-handoff-${process.pid}-ttl-expiry`;
+  const paused: string[] = [];
+  const value: WorkflowReloadRuntime = {
+    ...runtime(cwd),
+    manager: {
+      listRuns: () => [
+        { runId: "running-1", status: "running" },
+        { runId: "done-1", status: "completed" },
+      ],
+      pause: (runId: string) => {
+        paused.push(runId);
+        return true;
+      },
+    } as unknown as WorkflowReloadRuntime["manager"],
+  };
+  discardWorkflowRuntime(cwd);
+
+  handoffWorkflowRuntime(value, 10);
+  // Nobody ever claims it (simulating a reload that failed or never happened).
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  assert.deepEqual(paused, ["running-1"], "the stranded running run must be paused, not left to burn tokens");
+  assert.equal(takeWorkflowRuntime(cwd), undefined, "the expired entry must be gone so it can't be claimed later");
+});
+
+test(
+  "a real in-flight run left stranded past the TTL is paused with its journal persisted",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId } = manager.startInBackground(twoAgentScript);
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Let agent 1 finish so it lands in the journal; agent 2 stays pending
+    // forever, so the run is still "running" when the handoff expires.
+    da.resolve(0, "first-result");
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(manager.getRun(runId)?.status, "running", "run must still be in flight when the TTL fires");
+
+    const value: WorkflowReloadRuntime = {
+      cwd,
+      extensionVersion: WORKFLOW_EXTENSION_VERSION,
+      manager: manager as unknown as WorkflowReloadRuntime["manager"],
+      effort: { level: "high" },
+    };
+    discardWorkflowRuntime(cwd);
+    handoffWorkflowRuntime(value, 10);
+
+    // Nobody ever claims it (simulating a reload that failed or never started).
+    await new Promise((r) => setTimeout(r, 60));
+
+    assert.equal(manager.getRun(runId)?.status, "paused", "stranded run must be paused, not left running forever");
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.ok(persisted?.journal && persisted.journal.length >= 1, "agent 1's result must be journaled to disk");
+    assert.equal(takeWorkflowRuntime(cwd), undefined, "expired entry must be gone so it can't be claimed later");
+  }),
+);
 
 test("reload handoffs are isolated by cwd and identity-guarded on cleanup", () => {
   const cwdA = `/tmp/reload-handoff-${process.pid}-a`;

--- a/tests/workflow-tools-available.test.ts
+++ b/tests/workflow-tools-available.test.ts
@@ -19,7 +19,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, mock } from "node:test";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { handoffWorkflowRuntime, takeWorkflowRuntime } from "../src/extension-reload.js";
+import { discardWorkflowRuntime, handoffWorkflowRuntime, takeWorkflowRuntime } from "../src/extension-reload.js";
 import { buildArmedWorkflowPrompt, WORKFLOW_TOOL_NAME, type WorkflowModeState } from "../src/workflow-editor.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
@@ -417,6 +417,62 @@ describe("workflow extension - control tool availability", () => {
         const restaged = takeWorkflowRuntime(process.cwd());
         assert.equal(restaged?.manager, staged.manager, "a compatible generation keeps the exact live manager");
         assert.equal(restaged?.effort.level, "high", "session effort survives with the compatible runtime");
+      });
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  it("discards the runtime on a non-reload shutdown so nothing is left to claim", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-control-extension-discard-"));
+    try {
+      await withFakeHomeAsync(fakeHome, async () => {
+        discardWorkflowRuntime(process.cwd());
+
+        const activeTools = ["bash", "read"];
+        const handlers: Record<string, Array<(...args: any[]) => any>> = {};
+        const pi = {
+          registerTool: () => {},
+          registerCommand: () => {},
+          getCommands: () => [],
+          on: (event: string, handler: (...args: any[]) => any) => {
+            if (!handlers[event]) handlers[event] = [];
+            handlers[event].push(handler);
+          },
+          getActiveTools: () => [...activeTools],
+          setActiveTools: (tools: string[]) => {
+            activeTools.splice(0, activeTools.length, ...tools);
+          },
+          sendMessage: () => {},
+        } as unknown as ExtensionAPI;
+        const { default: installExtension } = await import("../extensions/workflow.js");
+
+        installExtension(pi);
+        handlers.session_start[0](
+          {},
+          {
+            model: undefined,
+            modelRegistry: {},
+            sessionManager: { getSessionId: () => "session-1" },
+            ui: { setWidget: () => {} },
+          },
+        );
+
+        // No reason at all, and an explicit non-"reload" reason: neither may
+        // stage a handoff for the next extension generation to claim.
+        handlers.session_shutdown?.[0]?.();
+        assert.equal(
+          takeWorkflowRuntime(process.cwd()),
+          undefined,
+          "session_shutdown with no reason must not stage a handoff",
+        );
+
+        handlers.session_shutdown?.[0]?.({ reason: "manual" });
+        assert.equal(
+          takeWorkflowRuntime(process.cwd()),
+          undefined,
+          "session_shutdown(reason !== 'reload') must not stage a handoff",
+        );
       });
     } finally {
       rmSync(fakeHome, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- A staged reload handoff that no new extension generation claims before its 30s TTL previously just deleted the entry — any still-running run kept burning tokens to completion and delivered its result into a manager nothing could reach.
- The TTL expiry now routes those runs through the same pause path a version-mismatch reload uses (abort → journal flush → lease release), so they land as `paused` and are resumable. The helper is renamed `pauseStrandedWorkflowRuntime` to cover both callers.
- Adds a regression test pinning the reload-only staging guard: `session_shutdown` without `reason: "reload"` must discard the handoff, which nothing previously asserted.

## Test plan

- [x] `npm test` — 1149 passing, release gate 0 warnings
- [x] New unit + end-to-end coverage: TTL expiry pauses a running run with its journal flushed and the entry removed; non-reload shutdown leaves nothing to claim