### PR TITLE
chore(release): 3.4.0 — version bump and generated surfaces

### DIFF
--- a/docs/workflow-guidance-baseline.json
+++ b/docs/workflow-guidance-baseline.json
@@ -3,6 +3,6 @@
   "algorithm": "sha256",
   "surfaces": {
     "compactGuidance": "6db7b76e4e4017674cbad91c28c51132cef03121da20e1a23d3561f5652945cf",
-    "detailedProse": "22fccb6ce35da667e7d57ed884d445e88b214f3c1d1890c3237f3c905c944da7"
+    "detailedProse": "7485668b8b814e50dad371df9e9da5ff5decc6c6e62e08aa783dec765091f91c"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintinshaw/pi-dynamic-workflows",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintinshaw/pi-dynamic-workflows",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintinshaw/pi-dynamic-workflows",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Claude-Code-style dynamic workflows for Pi — fan a task out across 100s of subagents with real model routing, token/cost accounting, resume, git-worktree isolation, an interactive /workflows TUI, and a real /deep-research.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/workflow-authoring/SKILL.md
+++ b/skills/workflow-authoring/SKILL.md
@@ -2,7 +2,7 @@
 name: workflow-authoring
 description: Guidance for writing, editing, reviewing, and debugging JavaScript workflow code for pi-dynamic-workflows. Use when authoring or changing workflow scripts; not for merely running an existing workflow.
 metadata:
-  version: "3.3.0"
+  version: "3.4.0"
 ---
 
 # Workflow authoring

--- a/skills/workflow-authoring/references/capabilities.md
+++ b/skills/workflow-authoring/references/capabilities.md
@@ -2,7 +2,7 @@
 # Workflow capability index
 
 Contract format: `1.0.0`<br>
-Contract content / skill / extension: `3.3.0`
+Contract content / skill / extension: `3.4.0`
 
 This compact generated index covers supported runtime globals and workflow-tool inputs. For constraints, compatibility behavior, internal boundaries, and dynamic-reference ownership, follow the [exhaustive generated facts](capability-details.md).
 

--- a/skills/workflow-authoring/references/capability-details.md
+++ b/skills/workflow-authoring/references/capability-details.md
@@ -2,7 +2,7 @@
 # Exhaustive workflow capability facts
 
 Contract format: `1.0.0`<br>
-Contract content / skill / extension: `3.3.0`
+Contract content / skill / extension: `3.4.0`
 
 Every exact fact below is projected from the installed extension's capability contract. Explanatory judgment belongs in the hand-written references next to this file.
 

--- a/skills/workflow-patterns/SKILL.md
+++ b/skills/workflow-patterns/SKILL.md
@@ -2,7 +2,7 @@
 name: workflow-patterns
 description: Argument shapes for the 5 built-in workflow patterns — deep-research, adversarial-review, code-review, multi-perspective, codebase-audit — runnable via the `workflow` tool's `name` input, without slash-command syntax. Use for requests like "research X", "fact-check/adversarially review this", "review this diff/PR", "analyze from multiple perspectives", or "audit the codebase for Y". Not for authoring a new workflow script — see workflow-authoring.
 metadata:
-  version: "3.3.0"
+  version: "3.4.0"
 ---
 
 # Built-in workflow patterns

--- a/src/workflow-authoring-coverage.ts
+++ b/src/workflow-authoring-coverage.ts
@@ -33,7 +33,7 @@ export const WORKFLOW_COMPREHENSION_SCENARIO_IDS = COMPREHENSION_SCENARIOS.map((
 export const WORKFLOW_AUTHORING_FROZEN_FILES = [
   {
     path: "skills/workflow-authoring/SKILL.md",
-    sha256: "d2843c4d928b6f622271c65bf4cf5d54cb219efca0ce92d8c5f4d8204365bf91",
+    sha256: "cfd6de08089a3e234ee5168b59d9e18d5ecf18931820df559bcf90a6d8a697bc",
   },
   {
     path: "skills/workflow-authoring/references/runtime.md",


### PR DESCRIPTION
## Summary

- Bump package version to 3.4.0 and sync both skills' frontmatter versions.
- Regenerate the tracked capability docs, context-measurement, and guidance-baseline surfaces for the new version.

## Test plan

- [x] `npm test` — 1149 passing, release gate 0 warnings