### PR TITLE
[C-19457] [Pi Workflows] Retain isolated worktrees across agent steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ The installed extension generates this compact index from its executable capabil
 <!-- BEGIN GENERATED SUPPORTED WORKFLOW CAPABILITIES -->
 | Name | Classification | Signature | Options and defaults |
 | --- | --- | --- | --- |
-| agent | runtime-global | `agent(prompt, options?) => Promise<string \| structured value \| null>` | `label`: string (optional; default: derived from phase and call count)<br>`phase`: string (optional; default: current phase)<br>`schema`: plain JSON Schema (optional)<br>`model`: string (optional)<br>`tier`: string (optional)<br>`isolation`: "worktree" (optional)<br>`agentType`: string (optional)<br>`timeoutMs`: number \| null (optional; default: run timeout; null disables)<br>`retries`: number (optional; default: run retry count) |
+| agent | runtime-global | `agent(prompt, options?) => Promise<string \| structured value \| null>` | `label`: string (optional; default: derived from phase and call count)<br>`phase`: string (optional; default: current phase)<br>`schema`: plain JSON Schema (optional)<br>`model`: string (optional)<br>`tier`: string (optional)<br>`isolation`: "worktree" (optional)<br>`retainWorktree`: boolean (optional; default: false)<br>`worktree`: opaque retained-worktree handle (optional)<br>`agentType`: string (optional)<br>`timeoutMs`: number \| null (optional; default: run timeout; null disables)<br>`retries`: number (optional; default: run retry count) |
+| releaseWorktree | runtime-global | `releaseWorktree(handle) => Promise<void>` | — |
 | parallel | runtime-global | `parallel(thunks) => Promise<Array<unknown \| null>>` | — |
 | pipeline | runtime-global | `pipeline(items, ...stages) => Promise<Array<unknown \| null>>` | — |
 | workflow | runtime-global | `workflow(savedName, childArgs?) => Promise<unknown>` | — |
@@ -185,6 +186,7 @@ Agent details use a compact summary by default: completed agents show their fina
 | `loopUntilDry` / `completenessCheck` | Repeat discovery until no new findings remain |
 | `workflow(name, args)` | Run a saved workflow inline |
 | `checkpoint(prompt, opts)` | Add a journaled human-approval gate |
+| `releaseWorktree(handle)` | Idempotently release a runtime-issued retained worktree |
 | `budget` | Inspect real tokens spent and remaining |
 
 | Agent option | Description |
@@ -193,6 +195,8 @@ Agent details use a compact summary by default: completed agents show their fina
 | `model` | Exact `provider/modelId` or `provider/modelId:thinking`; overrides `tier` |
 | `agentType` | Named role, tool, and model definition |
 | `isolation` | Use `"worktree"` for conflict-free parallel edits |
+| `retainWorktree` | With worktree isolation, return `{ result, worktree }` and retain it for later steps |
+| `worktree` | Bind to a retained producer's opaque handle; cannot be combined with isolation or `retainWorktree: true` |
 | `schema` | JSON Schema for a validated structured result |
 | `label` / `phase` | Display label and phase override |
 | `timeoutMs` / `retries` | Optional per-agent timeout and recoverable-failure retries |
@@ -277,6 +281,22 @@ The default `workflow` also matches `workflows`; a custom word matches exactly. 
 Workflow scripts run in a Node `vm` sandbox. `Date.now()`, `Math.random()`, `new Date()`, `require`, `import`, filesystem access, and network access are unavailable inside the orchestration script. Subagents use their assigned tools; keeping the orchestrator deterministic is what makes journal replay reliable.
 
 Journal replay — including edit-and-resume via `resumeFromRunId` — matches cached agent results by **positional call index** (the order in which `agent()` calls execute), the same contract Claude Code uses. Editing an `agent()` prompt in place reuses the cache up to that call and re-runs it and everything after. Inserting, removing, or reordering an `agent()` call before others shifts their positions and invalidates the cache from that point on (mismatched calls simply re-run — no crash). To preserve the cached prefix, keep the earlier still-good `agent()` calls unchanged and in the same order.
+
+Retained worktrees are root-run-owned, in-memory capabilities. A producer uses `{ isolation: "worktree", retainWorktree: true }` and returns `{ result, worktree }`; consumers pass only that opaque handle as `{ worktree: handle }`. Consumers are FIFO-exclusive. `releaseWorktree(handle)` closes admission, waits already-admitted consumers, and removes the runtime-created checkout; successful repeated release is a no-op. Root settlement performs fallback cleanup after success, failure, abort, stop, or provider-limit pause. Producer and consumer calls are noncacheable, and nested retained use invalidates its dependent parent suffix on resume.
+
+Cleanup uses proof-bound checkout, Git-registration, branch, and repository identities plus a cross-process repository-operation lock. Identity mismatches fail closed instead of deleting an unverified path. Cleanup failures never replace the workflow result or original error: direct and managed successful results expose a bounded, path-free `worktreeCleanupFailures` list, and persistence replaces issued handles with inert scalar markers. Handles, paths, private registration markers, and process-local descriptor proofs are never serialized as reusable capabilities.
+
+```js
+const produced = await agent("Edit the generated client.", {
+  isolation: "worktree",
+  retainWorktree: true,
+})
+const verified = await agent("Test those uncommitted edits.", {
+  worktree: produced.worktree,
+})
+await releaseWorktree(produced.worktree)
+return { generated: produced.result, verified }
+```
 
 ## Upgrading to 3.0
 

--- a/docs/workflow-authoring.md
+++ b/docs/workflow-authoring.md
@@ -11,7 +11,8 @@ See [Workflow prompt guidance rationale](workflow-prompt-guidance-rationale.md) 
 <!-- BEGIN GENERATED SUPPORTED WORKFLOW CAPABILITIES -->
 | Name | Classification | Signature | Options and defaults |
 | --- | --- | --- | --- |
-| agent | runtime-global | `agent(prompt, options?) => Promise<string \| structured value \| null>` | `label`: string (optional; default: derived from phase and call count)<br>`phase`: string (optional; default: current phase)<br>`schema`: plain JSON Schema (optional)<br>`model`: string (optional)<br>`tier`: string (optional)<br>`isolation`: "worktree" (optional)<br>`agentType`: string (optional)<br>`timeoutMs`: number \| null (optional; default: run timeout; null disables)<br>`retries`: number (optional; default: run retry count) |
+| agent | runtime-global | `agent(prompt, options?) => Promise<string \| structured value \| null>` | `label`: string (optional; default: derived from phase and call count)<br>`phase`: string (optional; default: current phase)<br>`schema`: plain JSON Schema (optional)<br>`model`: string (optional)<br>`tier`: string (optional)<br>`isolation`: "worktree" (optional)<br>`retainWorktree`: boolean (optional; default: false)<br>`worktree`: opaque retained-worktree handle (optional)<br>`agentType`: string (optional)<br>`timeoutMs`: number \| null (optional; default: run timeout; null disables)<br>`retries`: number (optional; default: run retry count) |
+| releaseWorktree | runtime-global | `releaseWorktree(handle) => Promise<void>` | — |
 | parallel | runtime-global | `parallel(thunks) => Promise<Array<unknown \| null>>` | — |
 | pipeline | runtime-global | `pipeline(items, ...stages) => Promise<Array<unknown \| null>>` | — |
 | workflow | runtime-global | `workflow(savedName, childArgs?) => Promise<unknown>` | — |

--- a/docs/workflow-context-surfaces.json
+++ b/docs/workflow-context-surfaces.json
@@ -13,7 +13,7 @@
     },
     "providerVisibleWorkflowToolDefinition": {
       "serialization": "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
-      "bytes": 4283
+      "bytes": 4551
     },
     "registeredSkillsDiscovery": {
       "serialization": "sum of UTF-8 bytes of normalized Pi skill XML (name + description + location) across every root in package.json's pi.skills",
@@ -33,12 +33,12 @@
     },
     "ordinaryWorkflowOwnedAlwaysOn": {
       "serialization": "sum of permanent prompt, provider-visible tool definition, and every registered skill's discovery bytes",
-      "bytes": 5956
+      "bytes": 6224
     },
     "workflowAuthoringSkillCorpus": {
       "serialization": "sum of UTF-8 bytes for every file under skills/workflow-authoring",
       "files": 27,
-      "bytes": 67450
+      "bytes": 68197
     },
     "representativeAuthoringProfiles": {
       "serialization": "sum of UTF-8 bytes for each profile's declared package-relative files",

--- a/docs/workflow-guidance-baseline.json
+++ b/docs/workflow-guidance-baseline.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "algorithm": "sha256",
   "surfaces": {
-    "compactGuidance": "6db7b76e4e4017674cbad91c28c51132cef03121da20e1a23d3561f5652945cf",
+    "compactGuidance": "03e815e0e2e32f31f21b42f4cddcb79c73e3cc50f098c29e2870ca40ff5f88d7",
     "detailedProse": "7485668b8b814e50dad371df9e9da5ff5decc6c6e62e08aa783dec765091f91c"
   }
 }

--- a/skills/workflow-authoring/references/capabilities.md
+++ b/skills/workflow-authoring/references/capabilities.md
@@ -11,7 +11,8 @@ This compact generated index covers supported runtime globals and workflow-tool 
 <!-- BEGIN GENERATED SUPPORTED WORKFLOW CAPABILITIES -->
 | Name | Classification | Signature | Options and defaults |
 | --- | --- | --- | --- |
-| agent | runtime-global | `agent(prompt, options?) => Promise<string \| structured value \| null>` | `label`: string (optional; default: derived from phase and call count)<br>`phase`: string (optional; default: current phase)<br>`schema`: plain JSON Schema (optional)<br>`model`: string (optional)<br>`tier`: string (optional)<br>`isolation`: "worktree" (optional)<br>`agentType`: string (optional)<br>`timeoutMs`: number \| null (optional; default: run timeout; null disables)<br>`retries`: number (optional; default: run retry count) |
+| agent | runtime-global | `agent(prompt, options?) => Promise<string \| structured value \| null>` | `label`: string (optional; default: derived from phase and call count)<br>`phase`: string (optional; default: current phase)<br>`schema`: plain JSON Schema (optional)<br>`model`: string (optional)<br>`tier`: string (optional)<br>`isolation`: "worktree" (optional)<br>`retainWorktree`: boolean (optional; default: false)<br>`worktree`: opaque retained-worktree handle (optional)<br>`agentType`: string (optional)<br>`timeoutMs`: number \| null (optional; default: run timeout; null disables)<br>`retries`: number (optional; default: run retry count) |
+| releaseWorktree | runtime-global | `releaseWorktree(handle) => Promise<void>` | — |
 | parallel | runtime-global | `parallel(thunks) => Promise<Array<unknown \| null>>` | — |
 | pipeline | runtime-global | `pipeline(items, ...stages) => Promise<Array<unknown \| null>>` | — |
 | workflow | runtime-global | `workflow(savedName, childArgs?) => Promise<unknown>` | — |

--- a/skills/workflow-authoring/references/capability-details.md
+++ b/skills/workflow-authoring/references/capability-details.md
@@ -19,6 +19,8 @@ Every exact fact below is projected from the installed extension's capability co
 - `model`: string (optional; highest-priority exact model selector)
 - `tier`: string (optional; configured route name; dynamic reference: model-routes)
 - `isolation`: "worktree" (optional)
+- `retainWorktree`: boolean (optional; default: false; requires resolved worktree isolation)
+- `worktree`: opaque retained-worktree handle (optional; cannot be combined with isolation or retainWorktree: true)
 - `agentType`: string (optional; must come from provided context; dynamic reference: agent-types)
 - `timeoutMs`: number | null (optional; default: run timeout; null disables)
 - `retries`: number (optional; default: run retry count; finite values are floored and clamped to 0..3)
@@ -29,6 +31,15 @@ Every exact fact below is projected from the installed extension's capability co
 - Constraint: selector priority is explicit model > agentType model > tier > phase model > metadata model > implicit medium > session default
 - Constraint: if the selected model or route is unavailable, execution falls directly to the session default rather than trying lower-priority selectors
 - Constraint: worktree isolation is best-effort; failure logs that isolation was ignored and continues without an isolated working directory
+
+<a id="releaseworktree"></a>
+## releaseWorktree
+
+- Classification: `runtime-global`
+- Support: `supported`
+- Signature: `releaseWorktree(handle) => Promise<void>`
+- Constraint: accepts only opaque handles issued by the current root run
+- Constraint: closes consumer admission, waits admitted consumers, and is idempotent after success
 
 <a id="parallel"></a>
 ## parallel

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,5 +172,14 @@ export {
   type ViewKind,
 } from "./workflow-ui.js";
 export { registerWorkflowModelsCommand } from "./workflows-models-command.js";
-export type { Worktree } from "./worktree.js";
+export type {
+  RetainedWorktreeResult,
+  Worktree,
+  WorktreeCleanupFailure,
+  WorktreeCleanupMetadata,
+  WorktreeCleanupStage,
+  WorktreeHandle,
+  WorktreeIdentity,
+  WorktreeOperations,
+} from "./worktree.js";
 export { createWorktree, removeWorktree } from "./worktree.js";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -21,8 +21,8 @@ export interface WorkflowLoggerOptions {
   cwd?: string;
   /** Whether to persist logs to disk. */
   persist?: boolean;
-  /** Callback for each log entry. */
-  onLog?: (message: string) => void;
+  /** Callback for each log entry. Observer failures are diagnostic-only. */
+  onLog?: (message: string) => void | PromiseLike<void>;
 }
 
 export function createWorkflowLogger(options: WorkflowLoggerOptions = {}): WorkflowLogger {
@@ -37,7 +37,12 @@ export function createWorkflowLogger(options: WorkflowLoggerOptions = {}): Workf
     const timestamp = new Date().toISOString();
     const entry = `[${timestamp}] [${level}] ${message}`;
     logs.push(entry);
-    options.onLog?.(message);
+    try {
+      const callbackResult = options.onLog?.(message);
+      if (callbackResult !== undefined) void Promise.resolve(callbackResult).catch(() => undefined);
+    } catch {
+      // Logging observers are never allowed to replace the workflow outcome.
+    }
 
     if (persistLogs && logFile) {
       try {

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -16,8 +16,57 @@ import {
   writeJsonAtomicWithBackup,
 } from "./fs-persistence.js";
 import { workflowProjectPaths } from "./workflow-paths.js";
+import {
+  sanitizeRetainedWorktreeCapabilitiesForPersistence,
+  sanitizeWorktreeCleanupFailure,
+  type WorktreeCleanupFailure,
+} from "./worktree.js";
 
 export type RunStatus = "pending" | "running" | "paused" | "completed" | "failed" | "aborted";
+
+export const MAX_WORKTREE_CLEANUP_FAILURES = 20;
+
+/** Bound and redact durable/public cleanup diagnostics while preserving opaque recovery identity. */
+export function boundWorktreeCleanupFailure(failure: WorktreeCleanupFailure): WorktreeCleanupFailure {
+  return sanitizeWorktreeCleanupFailure(failure);
+}
+
+export function mergeWorktreeCleanupFailures(
+  ...groups: ReadonlyArray<readonly WorktreeCleanupFailure[] | undefined>
+): WorktreeCleanupFailure[] | undefined {
+  const merged: WorktreeCleanupFailure[] = [];
+  const seen = new Set<string>();
+  for (const group of groups) {
+    for (const failure of group ?? []) {
+      const bounded = boundWorktreeCleanupFailure(failure);
+      const key = JSON.stringify([
+        bounded.stage,
+        bounded.message,
+        bounded.identity.recoveryId,
+        bounded.identity.branchRef,
+        bounded.identity.baseSha,
+      ]);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      merged.push(bounded);
+      if (merged.length === MAX_WORKTREE_CLEANUP_FAILURES) return merged;
+    }
+  }
+  return merged.length > 0 ? merged : undefined;
+}
+
+export function boundedWorktreeCleanupFailures(
+  failures: readonly WorktreeCleanupFailure[] | undefined,
+): WorktreeCleanupFailure[] | undefined {
+  return mergeWorktreeCleanupFailures(failures);
+}
+
+export function worktreeCleanupWarning(failures: readonly WorktreeCleanupFailure[] | undefined): string | undefined {
+  const bounded = boundedWorktreeCleanupFailures(failures);
+  if (!bounded) return undefined;
+  const stages = [...new Set(bounded.map((failure) => failure.stage))].join(", ");
+  return `Cleanup warning: ${bounded.length} retained worktree cleanup failure(s) at stage(s): ${stages}. Workflow computation still completed.`;
+}
 
 export interface PersistedAgentState {
   id: number;
@@ -142,6 +191,8 @@ export interface PersistedRunState {
    * auto-resume attempt has been recorded yet.
    */
   autoResumeAttempts?: number;
+  /** Bounded retained-worktree cleanup recovery diagnostics; never contains a handle. */
+  worktreeCleanupFailures?: WorktreeCleanupFailure[];
 }
 
 export interface RunPersistence {
@@ -383,10 +434,11 @@ export function createRunPersistence(
       ensureDir();
       state.updatedAt = new Date().toISOString();
       const path = primaryRunPath(state.runId);
+      const persistenceSafeState = sanitizeRetainedWorktreeCapabilitiesForPersistence(state) as PersistedRunState;
       // Atomic write: a crash mid-write can't corrupt the live file (tmp+rename is
       // atomic on the same filesystem). A .bak from the previous good save is the
       // recovery fallback if the primary is somehow truncated.
-      writeJsonAtomicWithBackup(fs, path, state);
+      writeJsonAtomicWithBackup(fs, path, persistenceSafeState);
       invalidateListCache();
       // Only a terminal write can grow the terminal-run count, so only check
       // the cap then — a "running"/"paused" save is on the hot path (every

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -19,6 +19,7 @@ import {
   type WorkflowAgentSnapshot,
   type WorkflowSnapshot,
 } from "./display.js";
+import { boundedWorktreeCleanupFailures, worktreeCleanupWarning } from "./run-persistence.js";
 import type { ManagedRun, WorkflowManager } from "./workflow-manager.js";
 import type { WorkflowStorage } from "./workflow-saved.js";
 import type { WorkflowSettings } from "./workflow-settings.js";
@@ -106,8 +107,13 @@ export function deliverText(run: ManagedRun, opts: { resultPath?: string; maxCha
   const tokens = `${segment ? ` · ${segment}` : ""}${cost}`;
   const agents = run.result?.agentCount ?? run.snapshot.agentCount;
   const duration = run.result?.durationMs ? ` · ${(run.result.durationMs / 1000).toFixed(1)}s` : "";
+  const cleanupFailures = boundedWorktreeCleanupFailures(
+    run.worktreeCleanupFailures ?? run.result?.worktreeCleanupFailures,
+  );
+  const cleanupWarning = worktreeCleanupWarning(cleanupFailures);
   const lines = [
-    `✓ Background workflow "${run.snapshot.name}" finished (${agents} agents${tokens}${duration}).`,
+    `${cleanupWarning ? "⚠" : "✓"} Background workflow "${run.snapshot.name}" finished (${agents} agents${tokens}${duration}).`,
+    ...(cleanupWarning ? [cleanupWarning] : []),
     "",
     summary,
   ];

--- a/src/workflow-capability-contract.ts
+++ b/src/workflow-capability-contract.ts
@@ -112,6 +112,7 @@ export interface RuntimeBindingAssembly {
 /** Project-owned implementations required to assemble the workflow VM context. */
 export interface WorkflowRuntimeImplementations {
   agent: unknown;
+  releaseWorktree: unknown;
   parallel: unknown;
   pipeline: unknown;
   workflow: unknown;
@@ -180,6 +181,10 @@ const AGENT_OPTIONS: OptionShape = {
     option("model", "string", true, null, ["highest-priority exact model selector"]),
     option("tier", "string", true, null, ["configured route name"], "model-routes"),
     option("isolation", '"worktree"', true),
+    option("retainWorktree", "boolean", true, "false", ["requires resolved worktree isolation"]),
+    option("worktree", "opaque retained-worktree handle", true, null, [
+      "cannot be combined with isolation or retainWorktree: true",
+    ]),
     option("agentType", "string", true, null, ["must come from provided context"], "agent-types"),
     option("timeoutMs", "number | null", true, "run timeout; null disables"),
     option("retries", "number", true, "run retry count", ["finite values are floored and clamped to 0..3"]),
@@ -313,6 +318,14 @@ const capabilities: readonly CapabilityDescriptor[] = [
       "worktree isolation is best-effort; failure logs that isolation was ignored and continues without an isolated working directory",
     ],
     evidence: ["tests/workflow-runtime.test.ts", "tests/agent-registry.test.ts", "tests/structured-output.test.ts"],
+  }),
+  runtimeGlobal("releaseWorktree", {
+    signature: "releaseWorktree(handle) => Promise<void>",
+    constraints: [
+      "accepts only opaque handles issued by the current root run",
+      "closes consumer admission, waits admitted consumers, and is idempotent after success",
+    ],
+    evidence: ["tests/retained-worktree.test.ts"],
   }),
   runtimeGlobal("parallel", {
     signature: "parallel(thunks) => Promise<Array<unknown | null>>",

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -8,14 +8,17 @@ import type { WorkflowAgent } from "./agent.js";
 import { preview, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
 import { isProviderUsageLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import {
+  boundWorktreeCleanupFailure,
   createRunPersistence,
   generateRunId,
+  mergeWorktreeCleanupFailures,
   type PersistedRunState,
   type RunLease,
   type RunPersistence,
   type RunStatus,
 } from "./run-persistence.js";
 import { type JournalEntry, parseWorkflowScript, runWorkflow, type WorkflowRunResult } from "./workflow.js";
+import type { WorktreeCleanupFailure, WorktreeOperations } from "./worktree.js";
 
 export interface ManagedRun {
   runId: string;
@@ -32,6 +35,10 @@ export interface ManagedRun {
   journal: JournalEntry[];
   /** Cross-process execution lease for this run, when it is actively executing. */
   lease?: RunLease;
+  /** Active execution retained for compatibility and safe lifecycle fencing. */
+  execution?: Promise<WorkflowRunResult>;
+  /** Settlement of this execution generation. */
+  settlement?: Promise<WorkflowRunResult>;
   /**
    * True when the run was started in the background (or resumed) and the caller is
    * not awaiting its result inline. Only background runs deliver their result back
@@ -108,6 +115,8 @@ export interface ManagedRun {
    * tokenBudget.
    */
   agentRetries?: number;
+  /** Bounded cleanup recovery diagnostics for retained worktrees. */
+  worktreeCleanupFailures?: WorktreeCleanupFailure[];
 }
 
 /** Per-execution options shared by sync, background, and resume runs. */
@@ -194,6 +203,8 @@ export interface WorkflowManagerOptions {
   defaultAgentRetries?: number;
   /** Default hard token budget when a run does not pass tokenBudget. null/omitted means no budget. */
   defaultTokenBudget?: number | null;
+  /** Internal/injectable retained-worktree filesystem operations. */
+  worktreeOperations?: WorktreeOperations;
   /**
    * Named toolsets resolvable by ExecOptions.toolset — e.g.
    * `{ "web-research": () => [...createCodingTools(cwd), ...createWebTools()] }`.
@@ -330,6 +341,7 @@ export class WorkflowManager extends EventEmitter {
   private toolsets?: Record<string, () => ToolDefinition[]>;
   private excludeSubagentTools?: string[];
   private persistAgentSessions: boolean;
+  private worktreeOperations?: WorktreeOperations;
 
   constructor(options: WorkflowManagerOptions = {}) {
     super();
@@ -346,6 +358,7 @@ export class WorkflowManager extends EventEmitter {
     this.toolsets = options.toolsets;
     this.excludeSubagentTools = options.excludeSubagentTools;
     this.persistAgentSessions = options.persistAgentSessions ?? false;
+    this.worktreeOperations = options.worktreeOperations;
     this.maxTerminalRunsInMemory = options.maxTerminalRunsInMemory ?? DEFAULT_MAX_TERMINAL_RUNS_IN_MEMORY;
     this.persistence = createRunPersistence(this.cwd);
     this.recoverStaleRuns();
@@ -511,6 +524,8 @@ export class WorkflowManager extends EventEmitter {
     // already records status/event/persist, but the promise still rejects.
     // The original promise is returned so callers can await it in try/catch.
     const promise = this.executeRun(managed, script, args, exec);
+    managed.execution = promise;
+    managed.settlement = promise;
     promise.catch(() => {});
 
     return { runId, promise };
@@ -539,7 +554,10 @@ export class WorkflowManager extends EventEmitter {
     // Persist the initial state immediately so listRuns()/the task panel can see
     // the run the moment it starts, not only after the first agent journals.
     this.persistRun(managed);
-    return this.executeRun(managed, script, args, exec);
+    const execution = this.executeRun(managed, script, args, exec);
+    managed.execution = execution;
+    managed.settlement = execution;
+    return execution;
   }
 
   /** Build a fresh managed run with an empty snapshot. */
@@ -597,6 +615,7 @@ export class WorkflowManager extends EventEmitter {
       tools,
       initialTokenUsage,
     } = exec;
+    const priorCleanupFailures = managed.worktreeCleanupFailures?.map((failure) => structuredClone(failure));
     // maxAgents/agentTimeoutMs/concurrency/agentRetries were resolved (per-run
     // value, else the manager default at the time) and frozen on the managed
     // run at start/resume (see ManagedRun doc comments) — read them from there
@@ -661,6 +680,12 @@ export class WorkflowManager extends EventEmitter {
         loadSavedWorkflow: this.loadSavedWorkflow,
         resumeJournal,
         resumeFromRunId: resumeJournal ? managed.runId : undefined,
+        worktreeOperations: this.worktreeOperations,
+        onWorktreeCleanupFailure: (failure) => {
+          if (!this.isCurrent(managed)) return;
+          managed.worktreeCleanupFailures = mergeWorktreeCleanupFailures(managed.worktreeCleanupFailures, [failure]);
+          this.persistRun(managed);
+        },
         // Seed the fresh SharedRuntime's spend counter from the persisted total
         // (resume()) so the hard tokenBudget cap holds cumulatively across a
         // pause/resume cycle instead of resetting to zero each time (see A2 —
@@ -691,7 +716,7 @@ export class WorkflowManager extends EventEmitter {
         },
         onLog: (message) => {
           managed.snapshot.logs.push(message);
-          this.emitLive(managed, "log", { runId: managed.runId, message });
+          this.emitNonMaskingLive(managed, "log", { runId: managed.runId, message });
           progress();
         },
         onPhase: (title) => {
@@ -775,6 +800,22 @@ export class WorkflowManager extends EventEmitter {
         },
       });
 
+      const cleanupFailures = mergeWorktreeCleanupFailures(
+        priorCleanupFailures,
+        managed.worktreeCleanupFailures,
+        result.worktreeCleanupFailures,
+      );
+      managed.worktreeCleanupFailures = cleanupFailures;
+      result.worktreeCleanupFailures = cleanupFailures;
+      if (priorCleanupFailures?.length && cleanupFailures?.length) {
+        const stages = [...new Set(cleanupFailures.map((failure) => failure.stage))].join(", ");
+        const warning = `Cleanup warning: ${cleanupFailures.length} retained worktree cleanup failure(s) at stage(s): ${stages}. Workflow computation still completed.`;
+        if (!managed.snapshot.logs.includes(warning)) {
+          managed.snapshot.logs.push(warning);
+          this.emitNonMaskingLive(managed, "log", { runId: managed.runId, message: warning });
+          progress();
+        }
+      }
       managed.status = "completed";
       managed.result = result;
       // Gated the same way as disk/lease below (see emitLive()): a stale
@@ -890,6 +931,18 @@ export class WorkflowManager extends EventEmitter {
    */
   private emitLive(managed: ManagedRun, event: string, payload: unknown): void {
     if (this.isCurrent(managed)) this.emit(event, payload);
+  }
+
+  private emitNonMaskingLive(managed: ManagedRun, event: string, payload: unknown): void {
+    if (!this.isCurrent(managed)) return;
+    for (const listener of this.rawListeners(event)) {
+      try {
+        const result = Reflect.apply(listener, this, [payload]) as unknown;
+        if (result !== undefined) void Promise.resolve(result).catch(() => undefined);
+      } catch {
+        // Cleanup/log observers never replace the workflow outcome.
+      }
+    }
   }
 
   /**
@@ -1101,6 +1154,7 @@ export class WorkflowManager extends EventEmitter {
         updatedAt: new Date().toISOString(),
         completedAt: managed.status === "completed" ? new Date().toISOString() : undefined,
         durationMs: managed.result?.durationMs,
+        worktreeCleanupFailures: managed.worktreeCleanupFailures?.map((failure) => structuredClone(failure)),
       });
     } catch (err) {
       // Persistence is best-effort: the run is still healthy in memory.
@@ -1235,6 +1289,7 @@ export class WorkflowManager extends EventEmitter {
       // above); the journal, not this map, is what makes replayed agents cheap.
       agentTimestamps: new Map(),
       agentsById: new Map(),
+      worktreeCleanupFailures: persisted.worktreeCleanupFailures?.map((failure) => structuredClone(failure)),
     };
     this.runs.set(runId, managed);
     // Persist before notifying renderers: listRuns() is their source of truth for
@@ -1263,7 +1318,10 @@ export class WorkflowManager extends EventEmitter {
     // correct cumulative count inside this fresh SharedRuntime by the time any
     // new live agent runs — so maxAgents (via A1) is already a genuine
     // cumulative cap across resume with no extra seeding required.
-    void this.executeRun(managed, script, args, { resumeJournal, initialTokenUsage: priorTokenUsage }).catch(() => {});
+    const execution = this.executeRun(managed, script, args, { resumeJournal, initialTokenUsage: priorTokenUsage });
+    managed.execution = execution;
+    managed.settlement = execution;
+    void execution.catch(() => {});
     return true;
   }
 
@@ -1328,11 +1386,32 @@ export class WorkflowManager extends EventEmitter {
     return true;
   }
 
-  /**
-   * Get status of a specific run.
-   */
+  /** Get live/in-memory status for a run owned by this manager instance. */
   getRun(runId: string): ManagedRun | undefined {
     return this.runs.get(runId);
+  }
+
+  /** Canonical execution cwd owned by this manager. */
+  getCwd(): string {
+    return this.cwd;
+  }
+
+  /** Bounded persisted metadata, including cold terminal cleanup diagnostics. */
+  getRunMetadata(runId: string): PersistedRunState | undefined {
+    const state = this.persistence.load(runId);
+    if (!state) return undefined;
+    return {
+      ...state,
+      worktreeCleanupFailures: state.worktreeCleanupFailures?.map((failure) => boundWorktreeCleanupFailure(failure)),
+    };
+  }
+
+  /** Bounded cross-session persisted metadata. */
+  listRunMetadata(): PersistedRunState[] {
+    return this.persistence.list().map((state) => ({
+      ...state,
+      worktreeCleanupFailures: state.worktreeCleanupFailures?.map((failure) => boundWorktreeCleanupFailure(failure)),
+    }));
   }
 
   /**

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -14,6 +14,7 @@ import {
   type WorkflowSnapshot,
 } from "./display.js";
 import { WorkflowError, WorkflowErrorCode } from "./errors.js";
+import { boundedWorktreeCleanupFailures, worktreeCleanupWarning } from "./run-persistence.js";
 import { parseWorkflowScript, type WorkflowRunResult } from "./workflow.js";
 import { WorkflowManager } from "./workflow-manager.js";
 import { createWorkflowStorage, type WorkflowStorage } from "./workflow-saved.js";
@@ -34,7 +35,8 @@ const workflowToolSchema = Type.Object({
         "Optional control helpers include retry() and gate(); budget exposes total, spent(), and remaining(), and phase('Name', { budget: N }) sets a phase token limit.",
         "The optional `agentType` option selects a named user or project definition that can bind tools, a model, and role instructions; use it only when its name and purpose are provided in context. Its bound model overrides `tier`; an explicit `model` overrides both.",
         "Use plain JavaScript only; imports, require(), filesystem modules, Date.now(), Math.random(), and new Date() are unavailable.",
-        "Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, cwd, process.cwd(), and budget. The workflow must call agent() at least once.",
+        "Use phase('Name'), agent(prompt, opts), releaseWorktree(handle), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, cwd, process.cwd(), and budget. The workflow must call agent() at least once.",
+        "For a retained handoff, call agent(..., { isolation: 'worktree', retainWorktree: true }), pass only its opaque worktree handle to a consumer as { worktree: handle }, and call releaseWorktree(handle). Root settlement provides fallback cleanup.",
         "parallel() requires functions, not promises, and returns results in input order: await parallel(items.map(item => () => agent(...))).",
         "pipeline(items, ...stages) runs stages sequentially for each item while items proceed concurrently; each stage receives (previousValue, originalItem, index).",
       ].join(" "),
@@ -313,12 +315,15 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
 
       const formattedResult =
         result.result !== undefined ? `\n\`\`\`json\n${JSON.stringify(result.result, null, 2)}\n\`\`\`` : "";
+      const cleanupFailures = boundedWorktreeCleanupFailures(result.worktreeCleanupFailures);
+      const cleanupWarning = worktreeCleanupWarning(cleanupFailures);
+      const cleanupInfo = cleanupWarning ? `\n\n> **Warning:** ${cleanupWarning}` : "";
 
       return {
         content: [
           {
             type: "text",
-            text: `Workflow **${result.meta.name}** completed with **${result.agentCount}** agent(s).${tokenInfo}\n\n## Result${formattedResult}\n\n${reviseHint(result.runId)}`,
+            text: `Workflow **${result.meta.name}** completed with **${result.agentCount}** agent(s).${cleanupInfo}${tokenInfo}\n\n## Result${formattedResult}\n\n${reviseHint(result.runId)}`,
           },
         ],
         details: {
@@ -329,6 +334,7 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
           result: result.result,
           durationMs: result.durationMs,
           tokenUsage: result.tokenUsage,
+          worktreeCleanupFailures: cleanupFailures,
           runId: result.runId,
         },
       };

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import vm from "node:vm";
 import type { Node } from "acorn";
 import { parse } from "acorn";
@@ -18,9 +18,19 @@ import { DEFAULT_AGENT_TIMEOUT_MS, MAX_AGENT_RETRIES, MAX_AGENTS_PER_RUN, MAX_CO
 import { WorkflowError, WorkflowErrorCode, wrapError } from "./errors.js";
 import { createWorkflowLogger } from "./logger.js";
 import { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.js";
+import { boundWorktreeCleanupFailure, MAX_WORKTREE_CLEANUP_FAILURES } from "./run-persistence.js";
 import { createAgentStoreTools, SharedStore } from "./shared-store.js";
 import { WORKFLOW_CAPABILITY_CONTRACT, type WorkflowRuntimeImplementations } from "./workflow-capability-contract.js";
-import { createWorktree, removeWorktree, type Worktree } from "./worktree.js";
+import {
+  DEFAULT_WORKTREE_OPERATIONS,
+  type RetainedWorktreeLease,
+  RetainedWorktreeRegistry,
+  type RetainedWorktreeResult,
+  type Worktree,
+  type WorktreeCleanupFailure,
+  type WorktreeHandle,
+  type WorktreeOperations,
+} from "./worktree.js";
 
 /**
  * Batch-scoped cancellation for a single parallel()/pipeline() fan-out. When a
@@ -154,6 +164,35 @@ export interface WorkflowAgentRunner {
   run(prompt: string, options?: AgentRunOptions<TSchema>): Promise<unknown>;
 }
 
+interface CleanupFailureCollectionResult {
+  /** Immutable detached value admitted to the canonical bounded root collection. */
+  admittedFailure?: WorktreeCleanupFailure;
+  /** Bounded diagnostic produced when the external callback itself throws. */
+  callbackFailure?: WorktreeCleanupFailure;
+}
+
+interface RootOperationAdmission {
+  readonly owner: symbol;
+}
+
+interface RootExecutionContext {
+  retainedWorktrees: RetainedWorktreeRegistry;
+  admitOperation(parent?: RootOperationAdmission): RootOperationAdmission;
+  completeOperationAdmission(admission: RootOperationAdmission): void;
+  closeOperationAdmission(): void;
+  retainedWorktreeUseScopes: Set<string>;
+  /** Bounded diagnostics accumulated across ordinary, explicit-release, and terminal cleanup. */
+  worktreeCleanupFailures: WorktreeCleanupFailure[];
+  /** Deduplicated root collection plus the single external callback dispatch point. */
+  reportWorktreeCleanupFailure(failure: WorktreeCleanupFailure): CleanupFailureCollectionResult;
+  /** Ordinary failed cleanups whose proof authority ends at root terminal settlement. */
+  terminalProofWorktrees: Set<Worktree>;
+  /** Failed creation rollbacks that receive one root-owned terminal cleanup retry. */
+  terminalRetryWorktrees: Set<Worktree>;
+  /** Operations owned by this root, including nested workflows and retained consumers. */
+  liveOperations: Set<Promise<unknown>>;
+}
+
 export interface WorkflowRunOptions extends WorkflowAgentOptions {
   args?: unknown;
   agent?: WorkflowAgentRunner;
@@ -275,6 +314,18 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
     cacheRead?: number;
     cacheWrite?: number;
   }) => void;
+  /** Internal/injectable worktree operations (primarily for deterministic tests). */
+  worktreeOperations?: WorktreeOperations;
+  /** Receives best-effort retained-worktree cleanup diagnostics. */
+  onWorktreeCleanupFailure?: (failure: WorktreeCleanupFailure) => void | PromiseLike<void>;
+  /** Internal root-scoped retained-worktree and terminal-admission ownership. */
+  executionContext?: RootExecutionContext;
+  /** Internal admission inherited by an already-admitted nested wrapper. */
+  operationAdmission?: RootOperationAdmission;
+  /** Internal owner key used to drain operations spawned by this workflow frame. */
+  operationScopeKey?: string;
+  /** Internal immutable nesting level (0 = top-level, 1 = child). */
+  nestingDepth?: number;
 }
 
 export interface WorkflowRunResult<T = unknown> {
@@ -293,6 +344,8 @@ export interface WorkflowRunResult<T = unknown> {
     cacheRead?: number;
     cacheWrite?: number;
   };
+  /** Bounded retained-worktree cleanup failures. Successful cleanup omits this field. */
+  worktreeCleanupFailures?: WorktreeCleanupFailure[];
 }
 
 export interface AgentOptions<TSchemaDef extends TSchema | undefined = TSchema | undefined> {
@@ -314,6 +367,10 @@ export interface AgentOptions<TSchemaDef extends TSchema | undefined = TSchema |
    */
   tier?: string;
   isolation?: "worktree";
+  /** Keep a newly isolated worktree alive and return `{ result, worktree }`. */
+  retainWorktree?: boolean;
+  /** Bind this agent exclusively to a runtime-issued retained-worktree handle. */
+  worktree?: WorktreeHandle;
   /**
    * Name of a registered subagent definition (`.pi/agents/<name>.md`, project >
    * user). Binds that definition's tool allow/denylist, model, and body prompt
@@ -382,6 +439,35 @@ const DETERMINISM_BLOCKLIST = /\bDate\s*\.\s*now\b|\bMath\s*\.\s*random\b|\bnew\
  * script could bypass this. The guard is best-effort against ACCIDENTAL
  * nondeterminism from trusted (user / guided-LLM) scripts, not a security wall.
  */
+const MAX_WORKTREE_CLEANUP_DIAGNOSTIC_LENGTH = 1024;
+
+function worktreeCleanupDispatchFailure(worktree: Worktree, error: unknown): WorktreeCleanupFailure {
+  return {
+    stage: "cleanup_dispatch",
+    message: (error instanceof Error ? error.message : String(error)).slice(0, MAX_WORKTREE_CLEANUP_DIAGNOSTIC_LENGTH),
+    identity: {
+      repoRoot: worktree.repoRoot ?? "",
+      worktreePath: worktree.cwd,
+      branchRef: worktree.branchRef ?? (worktree.branch ? `refs/heads/${worktree.branch}` : ""),
+      baseSha: worktree.baseSha ?? "",
+    },
+  };
+}
+
+async function disposeWorktreeProofsSafely(
+  operations: WorktreeOperations,
+  worktree: Worktree,
+  reportFailure: (failure: WorktreeCleanupFailure) => void,
+): Promise<void> {
+  try {
+    await Promise.resolve().then(() =>
+      (operations.disposeWorktreeProofs ?? DEFAULT_WORKTREE_OPERATIONS.disposeWorktreeProofs)?.(worktree),
+    );
+  } catch (error) {
+    reportFailure(worktreeCleanupDispatchFailure(worktree, error));
+  }
+}
+
 const DETERMINISM_PRELUDE = [
   '"use strict";',
   'Math.random = () => { throw new Error("Math.random() is unavailable in a workflow (it breaks resume); pass randomness via args or vary by index"); };',
@@ -411,7 +497,7 @@ export async function runWorkflow<T = unknown>(
   const routingConfig = parseModelRoutingFromMeta(meta.phases, meta.model);
   const maxAgents = options.maxAgents ?? MAX_AGENTS_PER_RUN;
   const agentTimeoutMs = options.agentTimeoutMs !== undefined ? options.agentTimeoutMs : DEFAULT_AGENT_TIMEOUT_MS;
-  const runId = options.runId ?? `run-${started.toString(36)}`;
+  const runId = options.runId ?? `run-${randomUUID()}`;
   const baseCwd = options.cwd ?? process.cwd();
   // Snapshot the agentType registry ONCE per run so two agent() calls can't
   // observe a mid-run edit (determinism); a later resume re-reads it.
@@ -471,13 +557,24 @@ export async function runWorkflow<T = unknown>(
     runFatalController: new AbortController(),
     inFlight: new Set<Promise<unknown>>(),
   };
+  // Compatibility with callers that constructed SharedRuntime before the
+  // upstream fatal/drain fields were introduced.
+  shared.nestedCallSeq ??= 0;
+  shared.runFatalController ??= new AbortController();
+  shared.inFlight ??= new Set<Promise<unknown>>();
   const limiter = shared.limiter;
+  // Retained capabilities and terminal admission are root-scoped separately
+  // from SharedRuntime so concurrent direct roots cannot accidentally share
+  // handles even when a legacy caller shares counters.
+  const ownsExecutionContext = options.executionContext === undefined;
+  const executionContext =
+    options.executionContext ??
+    createRootExecutionContext(options.worktreeOperations, options.onWorktreeCleanupFailure);
+  const operationScopeKey = options.operationScopeKey ?? `root:${runId}`;
+  const nestingDepth = options.nestingDepth ?? 0;
   // This frame created `shared` fresh (rather than inheriting a parent
-  // workflow()'s) — i.e. it's the true top-level run, the only frame allowed
-  // to declare the run's fate sealed (see SharedRuntime.runFatalController) or
-  // drain/dispose the SharedStore. A nested workflow() call always passes both
-  // sharedRuntime and sharedStore together (see workflowFn below), so this is
-  // equivalent to `!options.sharedStore` — used at both choke points below.
+  // workflow()'s) — i.e. it's the true top-level run for upstream fatal-signal
+  // and store ownership behavior. Retained cleanup uses ownsExecutionContext.
   const isTopLevelRun = !options.sharedRuntime;
 
   // One store instance per run; nested workflow() calls inherit the parent's store
@@ -533,43 +630,43 @@ export async function runWorkflow<T = unknown>(
     }
   };
 
-  const agent = (prompt: string, agentOptions: AgentOptions = {}): Promise<unknown> => {
-    // Track every call (awaited or not) so the top-level run can drain
-    // outstanding calls before completing (see SharedRuntime.inFlight and the
-    // drain in the finally below) — this is what stops a forgotten `await`
-    // from letting an agent mutate state after the run is torn down.
-    const call = agentImpl(prompt, agentOptions);
-    shared.inFlight.add(call);
-    // Attaching a handler here (independent of whatever the script itself does
-    // with the returned promise) also means an un-awaited call's eventual
-    // rejection never becomes a process-crashing unhandled rejection.
-    call.catch(() => {}).finally(() => shared.inFlight.delete(call));
-    return call;
+  const reportWorktreeCleanupFailure = (failure: WorktreeCleanupFailure): void => {
+    const collected = executionContext.reportWorktreeCleanupFailure(failure);
+    if (collected.callbackFailure) {
+      logger.error(`worktree cleanup diagnostic callback failed: ${collected.callbackFailure.message}`);
+    }
+    if (!collected.admittedFailure) return;
+    try {
+      log(`worktree cleanup failed at ${collected.admittedFailure.stage}: ${collected.admittedFailure.message}`);
+    } catch {
+      // Cleanup observability is best-effort and must never replace the primary outcome.
+    }
   };
 
-  const agentImpl = async (prompt: string, agentOptions: AgentOptions = {}) => {
+  const agent = (prompt: string, callerOptions: unknown = {}): Promise<unknown> => {
+    try {
+      if (typeof prompt !== "string") throw invalidAgentOptions("prompt must be a string");
+      const agentOptions = snapshotAgentOptions(callerOptions);
+      const admission = executionContext.admitOperation(options.operationAdmission);
+      const batch = fanoutScope.getStore();
+      return trackRuntimeOperation(
+        shared,
+        executionContext,
+        runAgent(admission, prompt, agentOptions, batch),
+        admission,
+      );
+    } catch (error) {
+      return safelyRejectedOperation(error);
+    }
+  };
+
+  const runAgent = async (
+    operationAdmission: RootOperationAdmission,
+    prompt: string,
+    agentOptions: Readonly<AgentOptions>,
+    batch: { cancelled: boolean } | undefined,
+  ) => {
     throwIfAborted();
-
-    // Capture the enclosing parallel()/pipeline() fan-out's cancellation batch
-    // (if any) synchronously, while the ALS context of the caller is still
-    // active — i.e. before suspending on the limiter below. The limiter body
-    // closes over this so a still-queued agent can bail once its OWN fan-out
-    // breaches the cap, without affecting sibling or outer fan-outs.
-    const batch = fanoutScope.getStore();
-
-    // Check agent limit. A fan-out that overshoots the cap has already reserved
-    // and queued up to `maxAgents` agents; the breaching call throws here, and
-    // parallel()/pipeline() mark their own batch cancelled so the already-queued
-    // agents short-circuit before their real API call (see the limiter body).
-    if (shared.agentCount >= maxAgents) {
-      throw agentLimitError();
-    }
-
-    if (budget.total !== null && budget.remaining() <= 0) {
-      throw new WorkflowError("workflow token budget exhausted", WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED, {
-        recoverable: false,
-      });
-    }
 
     const assignedPhase = agentOptions.phase ?? state.currentPhase;
 
@@ -602,6 +699,15 @@ export async function runWorkflow<T = unknown>(
     if (agentOptions.agentType && !agentDef) {
       log(`unknown agentType "${agentOptions.agentType}"; using default tools/model`);
     }
+    const resolvedIsolation = agentOptions.isolation ?? agentDef?.isolation;
+    if (agentOptions.worktree !== undefined && resolvedIsolation !== undefined) {
+      throw new TypeError("agent({ worktree }) cannot be combined with isolation, including agentType isolation");
+    }
+    if (agentOptions.retainWorktree && resolvedIsolation !== "worktree") {
+      throw new TypeError("retainWorktree requires isolation: 'worktree'");
+    }
+    const capabilityCall = agentOptions.retainWorktree === true || agentOptions.worktree !== undefined;
+    if (capabilityCall) markRetainedWorktreeUse(executionContext, operationScopeKey);
 
     // Model precedence: explicit agentOptions.model > agentType.model > tier > phase model.
     // The "explicit-level" model is opts.model, else the definition's model — either
@@ -633,11 +739,36 @@ export async function runWorkflow<T = unknown>(
     // below) with callIndex makes the key unique across the whole store.
     const deltaKey = `${runId}:${callIndex}`;
 
-    // Reserve the agent slot synchronously — atomic with the limit/budget gate
-    // above (no await in between) — so a parallel() fan-out can't all observe the
-    // same agentCount and overshoot maxAgents. (Token budget stays a soft gate:
-    // spent accrues after each agent, matching Claude Code; in-flight agents may
-    // push slightly past total, then further agent() calls throw.)
+    // Retained consumers validate and reserve FIFO admission before they charge
+    // maxAgents. Invalid/released/cross-root handles therefore cannot consume a
+    // slot. A valid lease is released below if any later admission gate fails.
+    const admittedRetainedLease =
+      agentOptions.worktree === undefined
+        ? undefined
+        : executionContext.retainedWorktrees.acquire(agentOptions.worktree, operationAdmission);
+
+    const releaseAdmittedLease = () => {
+      if (admittedRetainedLease !== undefined) {
+        void admittedRetainedLease.then(
+          (lease) => lease.release(),
+          () => undefined,
+        );
+      }
+    };
+    if (shared.agentCount >= maxAgents) {
+      releaseAdmittedLease();
+      throw agentLimitError();
+    }
+    if (budget.total !== null && budget.remaining() <= 0) {
+      releaseAdmittedLease();
+      throw new WorkflowError("workflow token budget exhausted", WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED, {
+        recoverable: false,
+      });
+    }
+
+    // Reserve the agent slot synchronously — atomic with the limit gate above —
+    // so a parallel() fan-out cannot overshoot maxAgents. Token budget remains a
+    // soft gate because delayed telemetry may arrive after concurrent admission.
     shared.agentCount++;
     const label = requestedLabel || defaultAgentLabel(assignedPhase, shared.agentCount);
 
@@ -650,7 +781,7 @@ export async function runWorkflow<T = unknown>(
     // exact `${runId}:${callIndex}` string) so a nested workflow()'s
     // callIndex-0 can never accidentally replay the parent's callIndex-0
     // entry, or vice versa (see JournalEntry.runId).
-    const cached = options.resumeJournal?.get(deltaKey);
+    const cached = capabilityCall ? undefined : options.resumeJournal?.get(deltaKey);
     const hashMatches = cached != null && cached.hash === callHash;
     const cachedEmptyOutput = hashMatches && isEmptyTextAgentResult(cached.result, agentOptions.schema);
     if (hashMatches && !cachedEmptyOutput && callIndex < state.firstMiss) {
@@ -673,25 +804,15 @@ export async function runWorkflow<T = unknown>(
     // unchanged prefix ends; this call and every later one then run live.
     if (!hashMatches || cachedEmptyOutput) state.firstMiss = Math.min(state.firstMiss, callIndex);
 
-    return limiter(async () => {
+    let limiterStarted = false;
+    const invocation = limiter(async () => {
+      limiterStarted = true;
       const timeout = agentOptions.timeoutMs !== undefined ? agentOptions.timeoutMs : agentTimeoutMs;
       const retryAttempts = normalizeAgentRetries(agentOptions.retries ?? options.agentRetries ?? 0);
       const maxAttempts = retryAttempts + 1;
-
-      options.onAgentStart?.({ id: deltaKey, label, phase: assignedPhase, prompt, model: displayModel });
-
-      // Optional per-agent worktree isolation (deterministic name -> stable resume keys).
-      // Precedence: explicit call-site isolation > agentDef isolation.
-      // Note: passing { isolation: undefined } falls through ?? to the def's value — there
-      // is no sentinel to suppress a def's isolation at the call site. Remove the agentType
-      // or override with a def that has no isolation field if opt-out is needed.
       let worktree: Worktree | undefined;
-      const resolvedIsolation = agentOptions.isolation ?? agentDef?.isolation;
-      if (resolvedIsolation === "worktree") {
-        worktree = await createWorktree(baseCwd, `${runId}-${callIndex}-${label}`);
-        if (!worktree.isolated) log(`isolation ignored for "${label}" (${worktree.reason})`);
-      }
-      const runCwd = worktree?.isolated ? worktree.cwd : undefined;
+      let retainedHandle: WorktreeHandle | undefined;
+      let retainedLease: RetainedWorktreeLease | undefined;
 
       // Captured from the subagent's real session usage; falls back to an
       // estimate when the provider reports no usage (total === 0). Usage is reset
@@ -712,6 +833,47 @@ export async function runWorkflow<T = unknown>(
       };
 
       try {
+        if (admittedRetainedLease !== undefined) {
+          retainedLease = await admittedRetainedLease;
+          worktree = retainedLease.worktree;
+        } else if (resolvedIsolation === "worktree") {
+          worktree = await (options.worktreeOperations ?? DEFAULT_WORKTREE_OPERATIONS).createWorktree(
+            baseCwd,
+            `${runId}-${callIndex}`,
+          );
+          if (!worktree.isolated) {
+            if (worktree.creationRecoveryWorktree) {
+              executionContext.terminalRetryWorktrees.add(worktree.creationRecoveryWorktree);
+            }
+            if (worktree.recoveryFailures && worktree.recoveryFailures.length > 0) {
+              const safeFailures = worktree.recoveryFailures.map(boundWorktreeCleanupFailure);
+              log("isolation ignored because worktree creation recovery failed");
+              for (const failure of safeFailures) reportWorktreeCleanupFailure(failure);
+              throw new WorkflowError(
+                "Worktree creation recovery failed; inspect bounded cleanup diagnostics",
+                WorkflowErrorCode.AGENT_EXECUTION_ERROR,
+                { recoverable: false, details: safeFailures },
+              );
+            }
+            log(`isolation ignored for "${label}" (${worktree.reason})`);
+            if (agentOptions.retainWorktree) {
+              throw new WorkflowError(
+                `Cannot retain worktree for "${label}": ${worktree.reason ?? "isolation unavailable"}`,
+                WorkflowErrorCode.AGENT_EXECUTION_ERROR,
+                { recoverable: false },
+              );
+            }
+          } else if (agentOptions.retainWorktree) {
+            retainedHandle = executionContext.retainedWorktrees.register(worktree, operationAdmission);
+          }
+        }
+        const runCwd = worktree?.isolated ? worktree.cwd : undefined;
+        options.onAgentStart?.({ id: deltaKey, label, phase: assignedPhase, prompt, model: displayModel });
+        const publicResult = (result: unknown): unknown =>
+          retainedHandle === undefined
+            ? result
+            : ({ result, worktree: retainedHandle } satisfies RetainedWorktreeResult<unknown>);
+
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
           usage = undefined;
           const externalSignal = options.signal;
@@ -792,24 +954,29 @@ export async function runWorkflow<T = unknown>(
             }
 
             const tokens = recordTokens(result);
-            options.onAgentJournal?.({
-              index: callIndex,
-              runId,
-              hash: callHash,
-              result,
-              storeDelta: store.commitDelta(deltaKey),
-            });
+            const returnedResult = publicResult(result);
+            if (!capabilityCall) {
+              options.onAgentJournal?.({
+                index: callIndex,
+                runId,
+                hash: callHash,
+                result,
+                storeDelta: store.commitDelta(deltaKey),
+              });
+            } else {
+              store.commitDelta(deltaKey);
+            }
             options.onAgentEnd?.({
               id: deltaKey,
               label,
               phase: assignedPhase,
-              result,
+              result: returnedResult,
               tokens,
               tokenUsage: usage,
               worktree: runCwd,
               model: displayModel,
             });
-            return result;
+            return returnedResult;
           } catch (error) {
             if (isAborted()) throw error;
 
@@ -858,7 +1025,7 @@ export async function runWorkflow<T = unknown>(
               log(
                 `agent "${label}" exhausted ${maxAttempts} attempt${maxAttempts === 1 ? "" : "s"}: ${workflowError.code} ${workflowError.message}`,
               );
-              return null;
+              return publicResult(null);
             }
             throw workflowError;
           } finally {
@@ -869,11 +1036,30 @@ export async function runWorkflow<T = unknown>(
             if (onRunFatal) shared.runFatalController.signal.removeEventListener("abort", onRunFatal);
           }
         }
-        return null;
+        return publicResult(null);
       } finally {
-        // Always tear down the worktree, even on timeout/abort.
-        if (worktree?.isolated) await removeWorktree(worktree);
+        retainedLease?.release();
+        // Retained producers are root-owned after registration. Ordinary isolated
+        // calls preserve the historical immediate teardown behavior.
+        if (worktree?.isolated && retainedHandle === undefined && agentOptions.worktree === undefined) {
+          try {
+            const failures =
+              (await (options.worktreeOperations ?? DEFAULT_WORKTREE_OPERATIONS).removeWorktree(worktree)) ?? [];
+            for (const failure of failures) reportWorktreeCleanupFailure(failure);
+            if (failures.length > 0) executionContext.terminalProofWorktrees.add(worktree);
+          } catch (error) {
+            reportWorktreeCleanupFailure(worktreeCleanupDispatchFailure(worktree, error));
+            executionContext.terminalProofWorktrees.add(worktree);
+          }
+        }
       }
+    });
+    return invocation.catch(async (error: unknown) => {
+      if (!limiterStarted && admittedRetainedLease !== undefined) {
+        const lease = await admittedRetainedLease;
+        lease.release();
+      }
+      throw error;
     });
   };
 
@@ -955,9 +1141,33 @@ export async function runWorkflow<T = unknown>(
 
   // Nested workflow(): run a saved workflow (or a raw script) inline, sharing this
   // run's limiter/counters/budget so the global caps hold. One level deep only.
-  const workflowFn = async (nameOrScript: string, childArgs?: unknown) => {
+  const workflowFn = (nameOrScript: string, childArgs?: unknown): Promise<unknown> => {
+    try {
+      if (typeof nameOrScript !== "string") {
+        throw new WorkflowError("workflow() nameOrScript must be a string", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
+          recoverable: false,
+        });
+      }
+      const snapshottedArgs = snapshotNestedWorkflowArgs(childArgs, executionContext.retainedWorktrees).value;
+      const admission = executionContext.admitOperation(options.operationAdmission);
+      return trackRuntimeOperation(
+        shared,
+        executionContext,
+        runNestedWorkflow(admission, nameOrScript, snapshottedArgs),
+        admission,
+      );
+    } catch (error) {
+      return safelyRejectedOperation(error);
+    }
+  };
+
+  const runNestedWorkflow = async (
+    admission: RootOperationAdmission,
+    nameOrScript: string,
+    childArgs?: unknown,
+  ): Promise<unknown> => {
     throwIfAborted();
-    if (shared.depth >= 1) {
+    if (nestingDepth >= 1) {
       throw new WorkflowError("workflow() can nest only one level deep", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
         recoverable: false,
       });
@@ -986,10 +1196,16 @@ export async function runWorkflow<T = unknown>(
       // no exception; once anything upstream in the parent has missed, cut
       // the child off from the journal entirely so it runs fully live.
       const prefixIntact = state.firstMiss === Number.POSITIVE_INFINITY;
+      const childSequence = ++shared.nestedCallSeq;
+      const childOperationScope = `${operationScopeKey}/nested:${childSequence}`;
       const child = await runWorkflow(childScript, {
         ...options,
         args: childArgs,
         sharedRuntime: shared,
+        executionContext,
+        operationAdmission: admission,
+        operationScopeKey: childOperationScope,
+        nestingDepth: nestingDepth + 1,
         // Propagate the parent's store so nested agents share the same key-value space.
         sharedStore: store,
         resumeJournal: prefixIntact ? options.resumeJournal : undefined,
@@ -998,9 +1214,13 @@ export async function runWorkflow<T = unknown>(
         // returns to 0 between sequential sibling calls, which would otherwise
         // mint the same child runId (and hence colliding deltaKeys/event ids)
         // for two different children.
-        runId: `${runId}-nested${++shared.nestedCallSeq}`,
+        runId: `${runId}-nested${childSequence}`,
         persistLogs: false,
       });
+      if (executionContext.retainedWorktreeUseScopes.delete(childOperationScope)) {
+        markRetainedWorktreeUse(executionContext, operationScopeKey);
+        state.firstMiss = Math.min(state.firstMiss, state.callSeq);
+      }
       return child.result;
     } finally {
       shared.depth--;
@@ -1185,7 +1405,25 @@ export async function runWorkflow<T = unknown>(
   // replays by callIndex exactly like a cached agent() — the genuine edge over CC,
   // whose steering is in-session only. Headless (no UI threaded in): takes the
   // declared default and journals THAT, so a detached/background run never hangs.
-  const checkpoint = async (promptText: string, checkpointOptions: CheckpointOptions = {}) => {
+  const checkpoint = (promptText: string, checkpointOptions: CheckpointOptions = {}): Promise<unknown> => {
+    try {
+      const admission = executionContext.admitOperation(options.operationAdmission);
+      return trackRuntimeOperation(
+        shared,
+        executionContext,
+        runCheckpoint(admission, promptText, snapshotCheckpointOptions(checkpointOptions)),
+        admission,
+      );
+    } catch (error) {
+      return safelyRejectedOperation(error);
+    }
+  };
+
+  const runCheckpoint = async (
+    _admission: RootOperationAdmission,
+    promptText: string,
+    checkpointOptions: CheckpointOptions,
+  ): Promise<unknown> => {
     throwIfAborted();
     if (typeof promptText !== "string") throw new TypeError("checkpoint(promptText, options?) needs a prompt string");
     if (shared.agentCount >= maxAgents) {
@@ -1220,8 +1458,23 @@ export async function runWorkflow<T = unknown>(
     return reply;
   };
 
+  const releaseWorktree = (handle: unknown): Promise<void> => {
+    try {
+      const admission = executionContext.admitOperation(options.operationAdmission);
+      return trackRuntimeOperation(
+        shared,
+        executionContext,
+        executionContext.retainedWorktrees.release(handle, admission),
+        admission,
+      );
+    } catch (error) {
+      return safelyRejectedOperation(error);
+    }
+  };
+
   const runtimeImplementations = {
     agent,
+    releaseWorktree,
     parallel,
     pipeline,
     workflow: workflowFn,
@@ -1257,6 +1510,7 @@ export async function runWorkflow<T = unknown>(
   });
 
   const wrapped = `${DETERMINISM_PRELUDE}\n(async () => {\n${body}\n})()`;
+  let completedResult: WorkflowRunResult<T> | undefined;
   try {
     const result = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context);
 
@@ -1269,7 +1523,7 @@ export async function runWorkflow<T = unknown>(
     // Emit final token usage
     options.onTokenUsage?.(shared.tokenUsage);
 
-    return {
+    completedResult = {
       meta,
       result: result as T,
       logs: state.logs,
@@ -1306,6 +1560,7 @@ export async function runWorkflow<T = unknown>(
     if (isTopLevelRun) shared.runFatalController.abort();
     throw error;
   } finally {
+    if (ownsExecutionContext) executionContext.closeOperationAdmission();
     // Only the top-level frame drains/disposes (see isTopLevelRun) — a nested
     // workflow()'s in-flight agents are still tracked in this SAME shared set
     // and get drained once, here, when the whole run finishes.
@@ -1329,12 +1584,58 @@ export async function runWorkflow<T = unknown>(
       if (shared.inFlight.size > 0) {
         log(`waiting for ${shared.inFlight.size} outstanding agent() call(s) to settle before this run completes`);
       }
-      while (shared.inFlight.size > 0) {
+      do {
         await Promise.allSettled(Array.from(shared.inFlight));
-      }
+        // Let native Promise continuations register (or reject through) the
+        // terminal admission barrier before declaring the root stably drained.
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      } while (shared.inFlight.size > 0);
       store.dispose();
     }
+
+    if (ownsExecutionContext) {
+      executionContext.retainedWorktrees.closeAdmission();
+      await executionContext.retainedWorktrees.cleanupAll();
+      const operations = options.worktreeOperations ?? DEFAULT_WORKTREE_OPERATIONS;
+      await Promise.all(
+        [...executionContext.terminalRetryWorktrees].map(async (worktree) => {
+          try {
+            const failures = (await operations.removeWorktree(worktree)) ?? [];
+            for (const failure of failures) reportWorktreeCleanupFailure(failure);
+            if (failures.length > 0)
+              await disposeWorktreeProofsSafely(operations, worktree, reportWorktreeCleanupFailure);
+          } catch (error) {
+            reportWorktreeCleanupFailure(worktreeCleanupDispatchFailure(worktree, error));
+          }
+        }),
+      );
+      executionContext.terminalRetryWorktrees.clear();
+      await Promise.all(
+        [...executionContext.terminalProofWorktrees].map((worktree) =>
+          disposeWorktreeProofsSafely(operations, worktree, reportWorktreeCleanupFailure),
+        ),
+      );
+      executionContext.terminalProofWorktrees.clear();
+      if (executionContext.worktreeCleanupFailures.length > 0) {
+        for (const failure of executionContext.worktreeCleanupFailures) {
+          const warning = `retained worktree cleanup failed at ${failure.stage} (recovery ID ${failure.identity.recoveryId ?? "unavailable"}); inspect worktreeCleanupFailures metadata`;
+          if (!state.logs.includes(warning)) {
+            try {
+              log(warning);
+            } catch {
+              // Terminal cleanup observability never replaces the primary outcome.
+            }
+          }
+        }
+        if (completedResult) {
+          completedResult.worktreeCleanupFailures = executionContext.worktreeCleanupFailures.map((failure) =>
+            boundWorktreeCleanupFailure(failure),
+          );
+        }
+      }
+    }
   }
+  return completedResult as WorkflowRunResult<T>;
 }
 
 export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body: string } {
@@ -1477,6 +1778,289 @@ function createLimiter(limit: number) {
       next();
     }
   };
+}
+
+function detachedWorktreeCleanupFailure(failure: WorktreeCleanupFailure): WorktreeCleanupFailure {
+  return { stage: failure.stage, message: failure.message, identity: { ...failure.identity } };
+}
+
+function immutableWorktreeCleanupFailure(failure: WorktreeCleanupFailure): WorktreeCleanupFailure {
+  return Object.freeze({
+    stage: failure.stage,
+    message: failure.message,
+    identity: Object.freeze({ ...failure.identity }),
+  });
+}
+
+function createRootExecutionContext(
+  operations: WorktreeOperations | undefined,
+  onCleanupFailure: ((failure: WorktreeCleanupFailure) => void | PromiseLike<void>) | undefined,
+): RootExecutionContext {
+  const worktreeCleanupFailures: WorktreeCleanupFailure[] = [];
+  const worktreeCleanupFailureKeys = new Set<string>();
+  const admissionOwner = Symbol("root-operation-admission");
+  const activeAdmissions = new WeakSet<RootOperationAdmission>();
+  let operationAdmissionOpen = true;
+  const validAdmission = (candidate: unknown): candidate is RootOperationAdmission =>
+    typeof candidate === "object" &&
+    candidate !== null &&
+    (candidate as RootOperationAdmission).owner === admissionOwner &&
+    activeAdmissions.has(candidate as RootOperationAdmission);
+  const admitOperation = (parent?: RootOperationAdmission): RootOperationAdmission => {
+    if (parent !== undefined ? !validAdmission(parent) : !operationAdmissionOpen) {
+      throw new WorkflowError(
+        "Root execution admission is closed after script settlement",
+        WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+        { recoverable: false },
+      );
+    }
+    const admission = Object.freeze({ owner: admissionOwner });
+    activeAdmissions.add(admission);
+    return admission;
+  };
+  const reportCleanupFailure = (failure: WorktreeCleanupFailure): CleanupFailureCollectionResult => {
+    const bounded = boundWorktreeCleanupFailure(failure);
+    const key = JSON.stringify(bounded);
+    if (worktreeCleanupFailureKeys.has(key) || worktreeCleanupFailures.length >= MAX_WORKTREE_CLEANUP_FAILURES) {
+      return {};
+    }
+    worktreeCleanupFailureKeys.add(key);
+    const stored = immutableWorktreeCleanupFailure(detachedWorktreeCleanupFailure(bounded));
+    worktreeCleanupFailures.push(stored);
+    const admittedFailure = immutableWorktreeCleanupFailure(detachedWorktreeCleanupFailure(stored));
+    try {
+      const callbackResult = onCleanupFailure?.(detachedWorktreeCleanupFailure(stored));
+      if (callbackResult !== undefined) void Promise.resolve(callbackResult).catch(() => undefined);
+      return { admittedFailure };
+    } catch (error) {
+      return {
+        admittedFailure,
+        callbackFailure: boundWorktreeCleanupFailure({
+          stage: "cleanup_dispatch",
+          message: error instanceof Error ? error.message : String(error),
+          identity: detachedWorktreeCleanupFailure(stored).identity,
+        }),
+      };
+    }
+  };
+  return {
+    retainedWorktrees: new RetainedWorktreeRegistry(
+      operations ?? DEFAULT_WORKTREE_OPERATIONS,
+      reportCleanupFailure,
+      validAdmission,
+    ),
+    admitOperation,
+    completeOperationAdmission: (admission) => activeAdmissions.delete(admission),
+    closeOperationAdmission: () => {
+      operationAdmissionOpen = false;
+    },
+    retainedWorktreeUseScopes: new Set<string>(),
+    worktreeCleanupFailures,
+    reportWorktreeCleanupFailure: reportCleanupFailure,
+    terminalProofWorktrees: new Set<Worktree>(),
+    terminalRetryWorktrees: new Set<Worktree>(),
+    liveOperations: new Set<Promise<unknown>>(),
+  };
+}
+
+function markRetainedWorktreeUse(context: RootExecutionContext, operationScopeKey: string): void {
+  context.retainedWorktreeUseScopes.add(operationScopeKey);
+}
+
+function safelyRejectedOperation(error: unknown): Promise<never> {
+  const rejection = Promise.reject(error);
+  void rejection.catch(() => undefined);
+  return rejection;
+}
+
+function trackRuntimeOperation<T>(
+  shared: SharedRuntime,
+  executionContext: RootExecutionContext,
+  operation: Promise<T>,
+  admission?: RootOperationAdmission,
+): Promise<T> {
+  shared.inFlight.add(operation);
+  executionContext.liveOperations.add(operation);
+  const release = () => {
+    if (admission) executionContext.completeOperationAdmission(admission);
+    shared.inFlight.delete(operation);
+    executionContext.liveOperations.delete(operation);
+  };
+  void operation.then(release, release);
+  return operation;
+}
+
+function invalidAgentOptions(message: string): WorkflowError {
+  return new WorkflowError(`Invalid agent options: ${message}`, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
+    recoverable: false,
+  });
+}
+
+function snapshotAgentOptions(value: unknown): Readonly<AgentOptions> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw invalidAgentOptions("agent() second argument must be an options object");
+  }
+  const source = value as AgentOptions;
+  const read = <K extends keyof AgentOptions>(key: K): AgentOptions[K] => {
+    try {
+      return source[key];
+    } catch {
+      throw invalidAgentOptions(`${key} property accessor could not be read`);
+    }
+  };
+  const options: AgentOptions = {
+    label: read("label"),
+    phase: read("phase"),
+    schema: read("schema"),
+    model: read("model"),
+    tier: read("tier"),
+    isolation: read("isolation"),
+    retainWorktree: read("retainWorktree"),
+    worktree: read("worktree"),
+    agentType: read("agentType"),
+    timeoutMs: read("timeoutMs"),
+    retries: read("retries"),
+  };
+  for (const key of ["label", "phase", "model", "tier", "agentType"] as const) {
+    if (options[key] !== undefined && typeof options[key] !== "string") {
+      throw invalidAgentOptions(`${key} must be a string`);
+    }
+  }
+  if (
+    options.schema !== undefined &&
+    (options.schema === null || typeof options.schema !== "object" || Array.isArray(options.schema))
+  ) {
+    throw invalidAgentOptions("schema must be an object");
+  }
+  if (options.isolation !== undefined && options.isolation !== "worktree") {
+    throw invalidAgentOptions("isolation must be 'worktree'");
+  }
+  if (options.retainWorktree !== undefined && typeof options.retainWorktree !== "boolean") {
+    throw invalidAgentOptions("retainWorktree must be a boolean");
+  }
+  if (
+    options.worktree !== undefined &&
+    (options.worktree === null || typeof options.worktree !== "object" || Array.isArray(options.worktree))
+  ) {
+    throw invalidAgentOptions("worktree must be a runtime-issued handle object");
+  }
+  if (
+    options.timeoutMs !== undefined &&
+    options.timeoutMs !== null &&
+    (typeof options.timeoutMs !== "number" || !Number.isFinite(options.timeoutMs) || options.timeoutMs < 0)
+  ) {
+    throw invalidAgentOptions("timeoutMs must be a non-negative finite number or null");
+  }
+  if (
+    options.retries !== undefined &&
+    (typeof options.retries !== "number" || !Number.isFinite(options.retries) || options.retries < 0)
+  ) {
+    throw invalidAgentOptions("retries must be a non-negative finite number");
+  }
+  if (options.worktree !== undefined && (options.isolation !== undefined || options.retainWorktree === true)) {
+    throw invalidAgentOptions("worktree cannot be combined with isolation or retainWorktree: true");
+  }
+  return Object.freeze(options);
+}
+
+function snapshotCheckpointOptions(value: unknown): CheckpointOptions {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new WorkflowError("checkpoint() options must be an object", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
+      recoverable: false,
+    });
+  }
+  const source = value as CheckpointOptions;
+  const read = <K extends keyof CheckpointOptions>(key: K): CheckpointOptions[K] => {
+    try {
+      return source[key];
+    } catch {
+      throw new WorkflowError(
+        `checkpoint() ${key} property accessor could not be read`,
+        WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+        { recoverable: false },
+      );
+    }
+  };
+  return Object.freeze({
+    default: read("default"),
+    headless: read("headless"),
+    kind: read("kind"),
+    choices: read("choices") ? [...(read("choices") ?? [])] : undefined,
+    timeoutMs: read("timeoutMs"),
+  });
+}
+
+function snapshotNestedWorkflowArgs(
+  value: unknown,
+  retainedWorktrees: RetainedWorktreeRegistry,
+): { value: unknown; carriesRetainedWorktree: boolean } {
+  const ancestors = new WeakSet<object>();
+  let carriesRetainedWorktree = false;
+  const clone = (item: unknown, path: string): unknown => {
+    if (
+      item === null ||
+      item === undefined ||
+      typeof item === "string" ||
+      typeof item === "boolean" ||
+      typeof item === "number"
+    ) {
+      return item;
+    }
+    if (typeof item === "bigint" || typeof item === "function" || typeof item === "symbol") {
+      throw invalidNestedIdentity(`${path} contains unsupported ${typeof item}; pass data-only JSON-like values`);
+    }
+    if (typeof item !== "object") throw invalidNestedIdentity(`${path} contains unsupported value`);
+    const retainedIdentity = retainedWorktrees.canonicalIdentity(item);
+    if (retainedIdentity !== undefined) {
+      carriesRetainedWorktree = true;
+      return item;
+    }
+    if (ancestors.has(item)) throw invalidNestedIdentity(`${path} is cyclic; nested workflow args must be acyclic`);
+    ancestors.add(item);
+    try {
+      if (Array.isArray(item)) {
+        const descriptors = Object.getOwnPropertyDescriptors(item);
+        const result = new Array<unknown>(item.length);
+        for (const key of Reflect.ownKeys(descriptors)) {
+          if (typeof key === "symbol") throw invalidNestedIdentity(`${path} contains symbol properties`);
+          if (key === "length") continue;
+          const descriptor = descriptors[key];
+          if (!("value" in descriptor) || !descriptor.enumerable) {
+            throw invalidNestedIdentity(`${path}[${key}] must be an enumerable data property`);
+          }
+          const index = Number(key);
+          if (!Number.isSafeInteger(index) || index < 0 || index >= item.length) {
+            throw invalidNestedIdentity(`${path} array contains custom property ${JSON.stringify(key)}`);
+          }
+          result[index] = clone(descriptor.value, `${path}[${key}]`);
+        }
+        return result;
+      }
+      const prototype = Object.getPrototypeOf(item);
+      if (prototype !== null && Object.prototype.toString.call(item) !== "[object Object]") {
+        throw invalidNestedIdentity(`${path} must contain plain data objects`);
+      }
+      const result: Record<string, unknown> = prototype === null ? Object.create(null) : {};
+      for (const key of Reflect.ownKeys(Object.getOwnPropertyDescriptors(item))) {
+        if (typeof key === "symbol") throw invalidNestedIdentity(`${path} contains symbol properties`);
+        const descriptor = Object.getOwnPropertyDescriptor(item, key);
+        if (!descriptor || !("value" in descriptor) || !descriptor.enumerable) {
+          throw invalidNestedIdentity(`${path}.${key} must be an enumerable data property`);
+        }
+        result[key] = clone(descriptor.value, `${path}.${key}`);
+      }
+      return result;
+    } finally {
+      ancestors.delete(item);
+    }
+  };
+  return { value: clone(value, "workflow args"), carriesRetainedWorktree };
+}
+
+function invalidNestedIdentity(message: string): WorkflowError {
+  return new WorkflowError(`Invalid nested workflow args: ${message}`, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
+    recoverable: false,
+  });
 }
 
 function defaultAgentLabel(phase: string | undefined, index: number): string {

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,15 +1,130 @@
 /**
- * Per-agent git worktree isolation. When an agent requests `isolation: "worktree"`,
- * it runs in a throwaway worktree on its own branch so parallel agents can edit the
- * same files without conflict. Results are NOT auto-merged — the path is surfaced for
- * the caller to inspect. Falls back to a logged no-op when isolation isn't possible.
+ * Per-agent git worktree isolation and retained-worktree ownership.
+ * Ordinary isolation is removed by the caller immediately. Retained isolation is
+ * registered here behind an opaque, run-scoped handle and removed only by release
+ * or root-run terminal cleanup.
  */
 
 import { execFile } from "node:child_process";
-import { join } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import {
+  type FileHandle,
+  link,
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readdir,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  rmdir,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 
 const exec = promisify(execFile);
+
+export interface WorktreeCleanupMetadataV1 {
+  /** Legacy schema retained for safe in-place cleanup upgrades. */
+  version: 1;
+  gitCommonRoot: string;
+  gitDir: string;
+  registrationMarker: string;
+}
+
+export interface WorktreeCleanupMetadataV2 {
+  /** Legacy cloneable schema retained for safe in-place identity upgrades. */
+  version: 2;
+  registrationMarker: string;
+  repoRoot: string;
+  worktreePath: string;
+  branch: string;
+  branchRef: string;
+  baseSha: string;
+  gitCommonRoot: string;
+  gitDir: string;
+}
+
+export interface WorktreeFilesystemIdentity {
+  /** Decimal device ID captured with bigint stat. */
+  dev: string;
+  /** Decimal inode captured with bigint stat. */
+  ino: string;
+}
+
+export interface WorktreeCleanupMetadataV3 {
+  /** Prior current schema retained for same-process cleanup only; never freshly adopted. */
+  version: 3;
+  /** Random token binding this complete record to one issued cleanup identity. */
+  registrationMarker: string;
+  /** Original canonical repository root. */
+  repoRoot: string;
+  /** Original canonical worktree checkout path. */
+  worktreePath: string;
+  /** Original checkout device/inode; never refreshed for current-version cleanup. */
+  checkoutIdentity: WorktreeFilesystemIdentity;
+  /** Original temporary branch name. */
+  branch: string;
+  /** Original full temporary branch ref. */
+  branchRef: string;
+  /** Exact commit from which the worktree was created. */
+  baseSha: string;
+  /** Original canonical Git common directory. */
+  gitCommonRoot: string;
+  /** Original canonical per-worktree Git directory. */
+  gitDir: string;
+}
+
+export type WorktreeCheckoutProof =
+  | { kind: "descriptor" }
+  | {
+      kind: "sentinel";
+      fileName: string;
+      token: string;
+      excludeLeadingNewline: boolean;
+      excludeIdentity: WorktreeFilesystemIdentity;
+    };
+
+export type WorktreeGitDirectoryProof =
+  | { kind: "descriptor" }
+  | {
+      kind: "sentinel";
+      fileName: string;
+      token: string;
+      identity: WorktreeFilesystemIdentity;
+    };
+
+export interface WorktreeCleanupMetadataV4 {
+  /** Current schema binds inode metadata to a durable process descriptor or sentinel. */
+  version: 4;
+  registrationMarker: string;
+  repoRoot: string;
+  worktreePath: string;
+  checkoutIdentity: WorktreeFilesystemIdentity;
+  checkoutProof: WorktreeCheckoutProof;
+  /** Original per-worktree Git registration directory identity. */
+  gitDirIdentity: WorktreeFilesystemIdentity;
+  /** Durable ownership proof. Absent only on already-issued v4 compatibility records. */
+  gitDirProof?: WorktreeGitDirectoryProof;
+  branch: string;
+  branchRef: string;
+  baseSha: string;
+  gitCommonRoot: string;
+  gitDir: string;
+}
+
+export type WorktreeCleanupMetadata =
+  | WorktreeCleanupMetadataV1
+  | WorktreeCleanupMetadataV2
+  | WorktreeCleanupMetadataV3
+  | WorktreeCleanupMetadataV4;
 
 export interface Worktree {
   /** True when a real worktree was created; false means "ran in the shared tree". */
@@ -17,60 +132,4589 @@ export interface Worktree {
   /** cwd the agent should run in (worktree path when isolated, else the base cwd). */
   cwd: string;
   branch?: string;
+  /** Full temporary branch ref. */
+  branchRef?: string;
+  /** Exact commit from which the worktree was created. */
+  baseSha?: string;
   /** Repo root the worktree was added to (for teardown). */
   repoRoot?: string;
+  /**
+   * Cloneable low-level identity required by removeWorktree(). Preserve this
+   * object unchanged when copying or serializing a Worktree. It is deliberately
+   * separate from the opaque high-level WorktreeHandle capability.
+   */
+  cleanupMetadata?: WorktreeCleanupMetadata;
   /** Why isolation was skipped, when isolated === false. */
   reason?: string;
+  /**
+   * Bounded recovery diagnostics when creation succeeded but identity
+   * finalization and rollback did not. This is recovery metadata, not a
+   * reusable retained-worktree capability.
+   */
+  recoveryFailures?: WorktreeCleanupFailure[];
+  /** @internal Root-owned exact identity for terminal retry after creation rollback failed. */
+  creationRecoveryWorktree?: Worktree;
+  /** @internal Creation-only branch deletion authority retained across terminal retries. */
+  creationRollbackExpectedOid?: string;
 }
 
-function slug(name: string): string {
-  return (
-    name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "")
-      .slice(0, 32) || "agent"
-  );
+export interface WorktreeIdentity {
+  /** Opaque deterministic identity for operator correlation and recovery. */
+  recoveryId?: string;
+  branchRef: string;
+  baseSha: string;
+  /** @deprecated Accepted only as untrusted input to the public diagnostic sanitizer. */
+  repoRoot?: string;
+  /** @deprecated Accepted only as untrusted input to the public diagnostic sanitizer. */
+  worktreePath?: string;
+}
+
+export type WorktreeCleanupStage =
+  | "identity_verification"
+  | "worktree_remove"
+  | "branch_delete"
+  | "cleanup_dispatch"
+  | "unknown";
+
+export interface WorktreeCleanupFailure {
+  stage: WorktreeCleanupStage;
+  message: string;
+  identity: WorktreeIdentity;
+}
+
+export interface WorktreeOperations {
+  createWorktree(baseCwd: string, name: string): Promise<Worktree>;
+  removeWorktree(worktree: Worktree): Promise<undefined | WorktreeCleanupFailure[]>;
+  /** Terminally release process-local ownership proofs when no retry authority remains. */
+  disposeWorktreeProofs?(worktree: Worktree): Promise<void>;
+}
+
+declare const WORKTREE_HANDLE_BRAND: unique symbol;
+/** Opaque runtime-issued capability. It deliberately contains no path or ref data. */
+export type WorktreeHandle = Readonly<{ [WORKTREE_HANDLE_BRAND]: true }>;
+
+export interface RetainedWorktreeResult<T> {
+  result: T;
+  worktree: WorktreeHandle;
+}
+
+export interface RetainedWorktreeLease {
+  worktree: Worktree;
+  release(): void;
+}
+
+interface RetainedEntry {
+  handle: WorktreeHandle;
+  canonicalIdentity: string;
+  worktree: Worktree;
+  tail: Promise<void>;
+  releaseRequested: boolean;
+  released: boolean;
+  releasePromise?: Promise<void>;
+}
+
+const issuedHandleOwners = new WeakMap<object, symbol>();
+
+/** Durable scalar used in place of runtime-only retained-worktree capabilities. */
+export const RETAINED_WORKTREE_PERSISTENCE_MARKER = "[retained-worktree-handle]";
+const PERSISTENCE_CIRCULAR_MARKER = "[circular]";
+const PERSISTENCE_ACCESSOR_MARKER = "[accessor omitted]";
+
+/**
+ * Clone arbitrary persistence input without carrying runtime capabilities into
+ * durable state. Capability recognition is registry-backed rather than based on
+ * the deliberately empty public shape. Cycles and accessors become inert scalar
+ * markers so the clone remains JSON serializable without invoking user code.
+ */
+export function sanitizeRetainedWorktreeCapabilitiesForPersistence(value: unknown): unknown {
+  const ancestors = new WeakSet<object>();
+  const visit = (current: unknown): unknown => {
+    if ((typeof current !== "object" && typeof current !== "function") || current === null) return current;
+    if (issuedHandleOwners.has(current as object)) return RETAINED_WORKTREE_PERSISTENCE_MARKER;
+    if (ancestors.has(current as object)) return PERSISTENCE_CIRCULAR_MARKER;
+
+    ancestors.add(current as object);
+    try {
+      if (Array.isArray(current)) {
+        const descriptors = Object.getOwnPropertyDescriptors(current);
+        return Array.from({ length: current.length }, (_, index) => {
+          const descriptor = descriptors[String(index)];
+          if (!descriptor) return null;
+          return "value" in descriptor ? visit(descriptor.value) : PERSISTENCE_ACCESSOR_MARKER;
+        });
+      }
+      const objectTag = Object.prototype.toString.call(current);
+      if (objectTag === "[object Map]") {
+        return Array.from(Map.prototype.entries.call(current) as MapIterator<[unknown, unknown]>, ([key, item]) => [
+          visit(key),
+          visit(item),
+        ]);
+      }
+      if (objectTag === "[object Set]") {
+        return Array.from(Set.prototype.values.call(current) as SetIterator<unknown>, (item) => visit(item));
+      }
+      if (objectTag === "[object Date]") {
+        const timestamp = Date.prototype.getTime.call(current) as number;
+        return Number.isNaN(timestamp) ? null : new Date(timestamp).toISOString();
+      }
+
+      const clone: Record<string, unknown> = {};
+      const descriptors = Object.getOwnPropertyDescriptors(current);
+      for (const key of Object.keys(descriptors)) {
+        const descriptor = descriptors[key];
+        if (!descriptor?.enumerable) continue;
+        clone[key] = "value" in descriptor ? visit(descriptor.value) : PERSISTENCE_ACCESSOR_MARKER;
+      }
+      return clone;
+    } catch {
+      // Hostile proxies and exotic cross-realm values are never allowed to make
+      // a runtime capability durable or break best-effort persistence.
+      return "[unserializable value omitted]";
+    } finally {
+      ancestors.delete(current as object);
+    }
+  };
+  return visit(value);
+}
+
+const MAX_WORKTREE_ID_LENGTH = 32;
+const WORKTREE_ID_HASH_LENGTH = 10;
+const MAX_CLEANUP_DIAGNOSTIC_LENGTH = 1024;
+const REGISTRATION_MARKER_FILE = "pi-dynamic-workflows-registration";
+const LEGACY_CHECKOUT_SENTINEL_FILE = ".pi-dynamic-workflows-checkout-identity";
+const CHECKOUT_SENTINEL_PREFIX = `${LEGACY_CHECKOUT_SENTINEL_FILE}-`;
+const GIT_DIRECTORY_SENTINEL_PREFIX = ".pi-dynamic-workflows-registration-identity-";
+const DIRECT_CLEANUP_CLAIM_PREFIX = ".pi-dynamic-workflows";
+const LEGACY_CHECKOUT_QUARANTINE_ROOT = "pi-dynamic-workflows-checkout-cleanup";
+const LEGACY_REGISTRATION_QUARANTINE_ROOT = "pi-dynamic-workflows-cleanup";
+const REPOSITORY_OPERATION_LOCK = "pi-dynamic-workflows-operation-lock";
+const REPOSITORY_OPERATION_LOCK_TIMEOUT_MS = 500;
+const REPOSITORY_OPERATION_LOCK_ACQUISITION_DEADLINE_MS = 30_000;
+const REPOSITORY_OPERATION_LOCK_STALE_MS = 30_000;
+const REPOSITORY_OPERATION_LOCK_RETRY_MS = 25;
+const RUNTIME_WORKTREE_PREFIX = "pi-workflow-checkout-";
+const LEGACY_DIRECT_WORKTREE_PREFIX = ".pi-worktree-";
+const PENDING_CLEANUP_RECORD_VERSION = 1;
+const CREATION_ADVANCED_BRANCH_PRESERVED = "creation rollback preserved advanced temporary branch";
+
+interface RuntimeWorktreeIdentity {
+  version: 3 | 4;
+  repoRoot: string;
+  worktreePath: string;
+  checkoutIdentity: FileIdentity;
+  checkoutProof?: WorktreeCheckoutProof;
+  gitDirIdentity?: FileIdentity;
+  gitDirProof?: WorktreeGitDirectoryProof;
+  branch: string;
+  branchRef: string;
+  baseSha: string;
+  gitCommonRoot: string;
+  gitDir: string;
+  marker: string;
+}
+
+/** Successful identities are remembered process-locally so cloned repeated cleanup is idempotent. */
+const MAX_CLEANED_RUNTIME_WORKTREES = 1024;
+const cleanedRuntimeWorktrees = new Set<string>();
+/** Non-serializable ownership proofs retained from final creation until successful cleanup. */
+const checkoutDirectoryHandles = new Map<string, FileHandle>();
+let allocationDescriptorCount = 0;
+const gitDirectoryHandles = new Map<string, FileHandle>();
+const sentinelExcludeHandles = new Map<string, FileHandle>();
+type CreationRegistrationAuthority = "persisted" | "in-memory";
+/** Same-object, process-local authority; it cannot be cloned or serialized into cleanup power. */
+const creationRecoveryAuthorities = new WeakMap<object, CreationRegistrationAuthority>();
+
+interface RepositoryGitMetadataQueue {
+  tail: Promise<void>;
 }
 
 /**
- * Create an isolated worktree under `<repoRoot>/.pi/worktrees/<name>` on branch
- * `pi/wf/<name>`. The `name` must be deterministic (derived from runId + call index,
- * never wall-clock) so resume keys stay stable. Returns a no-op Worktree on any failure.
+ * Git's worktree registry is repository-global. In particular, `git worktree
+ * list` can enumerate a registration immediately before another cleanup moves
+ * that directory and then fail while opening it. Keep only the destructive
+ * registration interval FIFO-serialized per canonical common Git directory;
+ * unrelated repositories and the rest of each agent cleanup remain parallel.
  */
-export async function createWorktree(baseCwd: string, name: string): Promise<Worktree> {
-  const id = slug(name);
-  let repoRoot: string;
+const repositoryGitMetadataQueues = new Map<string, RepositoryGitMetadataQueue>();
+
+interface RepositoryOperationLockOwner {
+  version: 1;
+  token: string;
+  pid: number;
+  createdAtMs: number;
+}
+
+interface RepositoryOperationLockClaim {
+  lockPath: string;
+  uniquePath: string;
+  identity: FileIdentity;
+  owner: RepositoryOperationLockOwner;
+}
+
+function parseRepositoryOperationLockOwner(contents: string): RepositoryOperationLockOwner {
+  let value: unknown;
   try {
-    const { stdout } = await exec("git", ["-C", baseCwd, "rev-parse", "--show-toplevel"]);
-    repoRoot = stdout.trim();
+    value = JSON.parse(contents);
+  } catch {
+    throw new Error("repository operation lock owner is not valid JSON");
+  }
+  if (!value || typeof value !== "object") throw new Error("repository operation lock owner is malformed");
+  const owner = value as Partial<RepositoryOperationLockOwner>;
+  if (
+    owner.version !== 1 ||
+    typeof owner.token !== "string" ||
+    !/^[0-9a-f]{64}$/.test(owner.token) ||
+    typeof owner.pid !== "number" ||
+    !Number.isSafeInteger(owner.pid) ||
+    owner.pid <= 0 ||
+    typeof owner.createdAtMs !== "number" ||
+    !Number.isSafeInteger(owner.createdAtMs) ||
+    owner.createdAtMs <= 0
+  ) {
+    throw new Error("repository operation lock owner is malformed");
+  }
+  return owner as RepositoryOperationLockOwner;
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+function repositoryOperationLockUniquePath(gitCommonRoot: string, token: string): string {
+  return join(gitCommonRoot, `.${REPOSITORY_OPERATION_LOCK}-owner-${token}`);
+}
+
+async function inspectRepositoryOperationLock(lockPath: string): Promise<RepositoryOperationLockClaim> {
+  const lockStats = await lstat(lockPath, { bigint: true });
+  if (lockStats.isSymbolicLink() || !lockStats.isFile()) {
+    if (lockStats.isDirectory()) {
+      throw new Error(
+        "legacy repository operation lock directory requires manual removal after verifying no live owner",
+      );
+    }
+    throw new Error("repository operation lock is not a regular owner file");
+  }
+  const owner = parseRepositoryOperationLockOwner(await readRegistrationFile(lockPath));
+  const uniquePath = repositoryOperationLockUniquePath(dirname(lockPath), owner.token);
+  const uniqueStats = await lstat(uniquePath, { bigint: true });
+  if (
+    uniqueStats.isSymbolicLink() ||
+    !uniqueStats.isFile() ||
+    !hasFileIdentity(uniqueStats, fileIdentity(lockStats)) ||
+    (await readRegistrationFile(uniquePath)) !== (await readRegistrationFile(lockPath))
+  ) {
+    throw new Error("repository operation lock unique owner identity changed");
+  }
+  return { lockPath, uniquePath, identity: fileIdentity(lockStats), owner };
+}
+
+async function verifyRepositoryOperationLockClaim(claim: RepositoryOperationLockClaim): Promise<void> {
+  const [lockStats, uniqueStats, lockContents, uniqueContents] = await Promise.all([
+    lstat(claim.lockPath, { bigint: true }),
+    lstat(claim.uniquePath, { bigint: true }),
+    readRegistrationFile(claim.lockPath),
+    readRegistrationFile(claim.uniquePath),
+  ]);
+  const owner = parseRepositoryOperationLockOwner(lockContents);
+  if (
+    !lockStats.isFile() ||
+    lockStats.isSymbolicLink() ||
+    !uniqueStats.isFile() ||
+    uniqueStats.isSymbolicLink() ||
+    !hasFileIdentity(lockStats, claim.identity) ||
+    !hasFileIdentity(uniqueStats, claim.identity) ||
+    lockContents !== uniqueContents ||
+    owner.token !== claim.owner.token ||
+    owner.pid !== claim.owner.pid ||
+    owner.createdAtMs !== claim.owner.createdAtMs
+  ) {
+    throw new Error("repository operation lock identity changed");
+  }
+}
+
+async function removeClaimedRepositoryOperationLock(
+  claim: RepositoryOperationLockClaim,
+  hooks: WorktreeCleanupTestHooks = {},
+): Promise<void> {
+  await hooks.beforeRepositoryOperationLockUnlink?.(claim.lockPath, claim.owner.token);
+  try {
+    await verifyRepositoryOperationLockClaim(claim);
+    await unlink(claim.lockPath);
+  } finally {
+    const [fixedStats, uniqueStats] = await Promise.all([
+      lstat(claim.lockPath, { bigint: true }).catch(() => undefined),
+      lstat(claim.uniquePath, { bigint: true }).catch(() => undefined),
+    ]);
+    if (
+      uniqueStats?.isFile() &&
+      !uniqueStats.isSymbolicLink() &&
+      hasFileIdentity(uniqueStats, claim.identity) &&
+      (!fixedStats || !hasFileIdentity(fixedStats, claim.identity))
+    ) {
+      await unlink(claim.uniquePath);
+    }
+  }
+}
+
+async function acquireRepositoryOperationLock(
+  gitCommonRoot: string,
+  hooks: WorktreeCleanupTestHooks = {},
+): Promise<RepositoryOperationLockClaim> {
+  const canonicalRoot = await realDirectory(gitCommonRoot, false);
+  if (canonicalRoot !== gitCommonRoot) throw new Error("repository operation lock parent is not canonical");
+  const lockPath = join(canonicalRoot, REPOSITORY_OPERATION_LOCK);
+  const startedAt = Date.now();
+  const acquisitionDeadlineMs = Math.max(
+    1,
+    hooks.repositoryOperationLockAcquisitionDeadlineMs ?? REPOSITORY_OPERATION_LOCK_ACQUISITION_DEADLINE_MS,
+  );
+  const retryMs = Math.max(1, hooks.repositoryOperationLockRetryMs ?? REPOSITORY_OPERATION_LOCK_RETRY_MS);
+  const owner: RepositoryOperationLockOwner = {
+    version: 1,
+    token: randomUUID().replaceAll("-", "") + randomUUID().replaceAll("-", ""),
+    pid: process.pid,
+    createdAtMs: Date.now(),
+  };
+
+  const uniquePath = repositoryOperationLockUniquePath(canonicalRoot, owner.token);
+  await writeFile(uniquePath, `${JSON.stringify(owner)}\n`, { encoding: "utf8", flag: "wx", mode: 0o600 });
+  try {
+    const uniqueStats = await lstat(uniquePath, { bigint: true });
+    if (uniqueStats.isSymbolicLink() || !uniqueStats.isFile()) {
+      throw new Error("repository operation lock unique owner is not a regular file");
+    }
+    const uniqueIdentity = fileIdentity(uniqueStats);
+    while (true) {
+      try {
+        await link(uniquePath, lockPath);
+        const claim = await inspectRepositoryOperationLock(lockPath);
+        if (claim.owner.token !== owner.token || !hasFileIdentity(claim.identity, uniqueIdentity)) {
+          throw new Error("repository operation lock ownership changed during atomic claim");
+        }
+        return claim;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        let existing: RepositoryOperationLockClaim;
+        try {
+          existing = await inspectRepositoryOperationLock(lockPath);
+        } catch (inspectionError) {
+          if ((inspectionError as NodeJS.ErrnoException).code === "ENOENT") {
+            const fixedStillExists = await lstat(lockPath).then(
+              () => true,
+              (error: NodeJS.ErrnoException) => {
+                if (error.code === "ENOENT") return false;
+                throw error;
+              },
+            );
+            if (fixedStillExists && Date.now() - startedAt > REPOSITORY_OPERATION_LOCK_TIMEOUT_MS) {
+              throw new Error("repository operation lock has no initialized unique owner file");
+            }
+            await delay(retryMs);
+            continue;
+          }
+          throw inspectionError;
+        }
+        const age = Date.now() - existing.owner.createdAtMs;
+        const ownerAlive = processIsAlive(existing.owner.pid);
+        if (!ownerAlive && age >= REPOSITORY_OPERATION_LOCK_STALE_MS) {
+          try {
+            await removeClaimedRepositoryOperationLock(existing, hooks);
+          } catch (reclaimError) {
+            const current = await inspectRepositoryOperationLock(lockPath).catch(
+              (inspectionError: NodeJS.ErrnoException) => {
+                if (inspectionError.code === "ENOENT") return undefined;
+                throw reclaimError;
+              },
+            );
+            if (current && hasFileIdentity(current.identity, existing.identity)) throw reclaimError;
+            await delay(retryMs);
+          }
+          continue;
+        }
+        if (!ownerAlive && Date.now() - startedAt > REPOSITORY_OPERATION_LOCK_TIMEOUT_MS) {
+          throw new Error("repository operation lock acquisition timed out");
+        }
+        if (ownerAlive && Date.now() - startedAt >= acquisitionDeadlineMs) {
+          throw new Error("repository operation lock acquisition deadline exceeded for a verified live owner");
+        }
+        await delay(retryMs);
+      }
+    }
+  } catch (error) {
+    const fixedStats = await lstat(lockPath, { bigint: true }).catch(() => undefined);
+    const uniqueStats = await lstat(uniquePath, { bigint: true }).catch(() => undefined);
+    if (
+      fixedStats?.isFile() &&
+      uniqueStats?.isFile() &&
+      !fixedStats.isSymbolicLink() &&
+      !uniqueStats.isSymbolicLink() &&
+      hasFileIdentity(fixedStats, fileIdentity(uniqueStats))
+    ) {
+      await unlink(lockPath).catch(() => undefined);
+    }
+    await unlink(uniquePath).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function withRepositoryGitMetadataCleanup<T>(
+  gitCommonRoot: string,
+  operation: () => Promise<T>,
+  hooks: WorktreeCleanupTestHooks = {},
+): Promise<T> {
+  let queue = repositoryGitMetadataQueues.get(gitCommonRoot);
+  if (!queue) {
+    queue = { tail: Promise.resolve() };
+    repositoryGitMetadataQueues.set(gitCommonRoot, queue);
+  }
+
+  const previous = queue.tail;
+  let releaseTurn!: () => void;
+  const turn = new Promise<void>((resolveTurn) => {
+    releaseTurn = resolveTurn;
+  });
+  const completion = previous.then(() => turn);
+  queue.tail = completion;
+
+  await previous;
+  let lock: RepositoryOperationLockClaim | undefined;
+  try {
+    lock = await acquireRepositoryOperationLock(gitCommonRoot, hooks);
+    return await operation();
+  } finally {
+    try {
+      if (lock) await removeClaimedRepositoryOperationLock(lock, hooks);
+    } finally {
+      releaseTurn();
+      if (queue.tail === completion) repositoryGitMetadataQueues.delete(gitCommonRoot);
+    }
+  }
+}
+
+function rememberCleanedRuntimeWorktree(identityKey: string): void {
+  if (cleanedRuntimeWorktrees.has(identityKey)) return;
+  cleanedRuntimeWorktrees.add(identityKey);
+  if (cleanedRuntimeWorktrees.size <= MAX_CLEANED_RUNTIME_WORKTREES) return;
+  const oldest = cleanedRuntimeWorktrees.values().next().value;
+  if (oldest !== undefined) cleanedRuntimeWorktrees.delete(oldest);
+}
+
+function slug(name: string): string {
+  const normalized =
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "agent";
+  if (normalized.length <= MAX_WORKTREE_ID_LENGTH) return normalized;
+
+  // Keep the readable prefix while reserving room for identity that truncation
+  // cannot erase (notably the workflow call index and label).
+  const suffix = createHash("sha256").update(name).digest("hex").slice(0, WORKTREE_ID_HASH_LENGTH);
+  const prefixLength = MAX_WORKTREE_ID_LENGTH - WORKTREE_ID_HASH_LENGTH - 1;
+  const prefix = normalized.slice(0, prefixLength).replace(/-+$/g, "") || "agent";
+  return `${prefix}-${suffix}`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function redactAbsolutePaths(message: string): string {
+  return message
+    .replace(/(?:[A-Za-z]:[\\/]|\\\\)[^\s"'`<>{}|]+/g, "<redacted-path>")
+    .replace(/(^|[\s"'`(=:[])(\/(?:[^\s"'`<>{}|;,()[\]]+\/?)+)/g, "$1<redacted-path>");
+}
+
+function boundedDiagnostic(message: string): string {
+  return redactAbsolutePaths(message).slice(0, MAX_CLEANUP_DIAGNOSTIC_LENGTH);
+}
+
+function validDiagnosticBranchRef(value: string): boolean {
+  return /^refs\/heads\/pi\/wf\/[A-Za-z0-9_-]{1,256}$/.test(value);
+}
+
+function validDiagnosticBaseSha(value: string): boolean {
+  return /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(value);
+}
+
+function opaqueCleanupIdentity(input: WorktreeIdentity): WorktreeIdentity {
+  const raw = {
+    recoveryId: input.recoveryId,
+    repoRoot: input.repoRoot,
+    worktreePath: input.worktreePath,
+    branchRef: input.branchRef,
+    baseSha: input.baseSha,
+  };
+  const suppliedRecoveryId = typeof input.recoveryId === "string" ? input.recoveryId : "";
+  return {
+    recoveryId: /^[0-9a-f]{64}$/i.test(suppliedRecoveryId)
+      ? suppliedRecoveryId.toLowerCase()
+      : createHash("sha256").update(JSON.stringify(raw)).digest("hex"),
+    branchRef: validDiagnosticBranchRef(input.branchRef) ? input.branchRef : "<redacted-ref>",
+    baseSha: validDiagnosticBaseSha(input.baseSha) ? input.baseSha.toLowerCase() : "<unknown>",
+  };
+}
+
+/**
+ * Synthesize every public/durable cleanup diagnostic exclusively from allowlisted
+ * structured fields. Raw filesystem/Git errors are deliberately discarded here:
+ * regex path removal cannot safely preserve arbitrary prose.
+ */
+export function sanitizeWorktreeCleanupFailure(failure: WorktreeCleanupFailure): WorktreeCleanupFailure {
+  const identity = opaqueCleanupIdentity(failure.identity);
+  const stage: WorktreeCleanupStage = (
+    ["identity_verification", "worktree_remove", "branch_delete", "cleanup_dispatch"] as unknown[]
+  ).includes(failure.stage)
+    ? failure.stage
+    : "unknown";
+  return {
+    stage,
+    message: `Worktree cleanup failed at ${stage}; recovery ID ${identity.recoveryId}.`,
+    identity,
+  };
+}
+
+function creationFailureReason(code: string, failures: readonly WorktreeCleanupFailure[] = []): string {
+  if (failures.length === 0) return `Worktree creation failed safely (${code}).`;
+  const stages = [...new Set(failures.map((failure) => failure.stage))].join(", ");
+  const recoveryIds = failures
+    .map((failure) => failure.identity.recoveryId)
+    .filter(Boolean)
+    .join(", ");
+  return `Worktree creation failed safely (${code}); ${failures.length} cleanup failure(s) at stage(s): ${stages}; recovery ID(s): ${recoveryIds}.`;
+}
+
+async function realDirectory(path: string, create: boolean): Promise<string> {
+  if (create) {
+    try {
+      await mkdir(path, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
+  }
+  const pathStats = await lstat(path);
+  if (pathStats.isSymbolicLink()) throw new Error(`refusing symbolic-link directory: ${path}`);
+  if (!pathStats.isDirectory()) throw new Error(`expected a real directory: ${path}`);
+  const canonicalPath = await realpath(path);
+  if (canonicalPath !== path) throw new Error(`directory is not canonical: ${path}`);
+  return canonicalPath;
+}
+
+async function secureChildDirectory(parent: string, childName: string, create: boolean): Promise<string> {
+  const canonicalParent = await realDirectory(parent, false);
+  const requestedChild = join(canonicalParent, childName);
+  const canonicalChild = await realDirectory(requestedChild, create);
+  const containedPath = relative(canonicalParent, canonicalChild);
+  if (containedPath !== childName || canonicalChild !== requestedChild) {
+    throw new Error(`directory is not an exact child of its canonical parent: ${requestedChild}`);
+  }
+  return canonicalChild;
+}
+
+async function secureWorktreeRoot(repoRoot: string, create: boolean): Promise<string> {
+  const canonicalRepoRoot = await realDirectory(repoRoot, false);
+  if (canonicalRepoRoot !== repoRoot) throw new Error("repository root is not canonical");
+  const piRoot = await secureChildDirectory(canonicalRepoRoot, ".pi", create);
+  return secureChildDirectory(piRoot, "worktrees", create);
+}
+
+function isExactPrefixedChild(parent: string, childPath: string, prefix: string): boolean {
+  const child = relative(parent, childPath);
+  return (
+    child.length > prefix.length &&
+    !child.startsWith("..") &&
+    !isAbsolute(child) &&
+    !child.includes("/") &&
+    !child.includes("\\") &&
+    child.startsWith(prefix) &&
+    resolve(parent, child) === childPath
+  );
+}
+
+function isExactRuntimeWorktreeChild(gitCommonRoot: string, worktreePath: string): boolean {
+  return isExactPrefixedChild(gitCommonRoot, worktreePath, RUNTIME_WORKTREE_PREFIX);
+}
+
+function isExactLegacyDirectWorktreeChild(repoRoot: string, worktreePath: string): boolean {
+  return isExactPrefixedChild(repoRoot, worktreePath, LEGACY_DIRECT_WORKTREE_PREFIX);
+}
+
+async function verifyRuntimeWorktreeContainment(
+  repoRoot: string,
+  gitCommonRoot: string,
+  worktreePath: string,
+): Promise<void> {
+  if (isExactRuntimeWorktreeChild(gitCommonRoot, worktreePath)) return;
+  if (isExactLegacyDirectWorktreeChild(repoRoot, worktreePath)) return;
+  const legacyRoot = await secureWorktreeRoot(repoRoot, false);
+  const child = relative(legacyRoot, worktreePath);
+  if (
+    !child ||
+    child.startsWith("..") ||
+    isAbsolute(child) ||
+    child.includes("/") ||
+    child.includes("\\") ||
+    resolve(legacyRoot, child) !== worktreePath
+  ) {
+    throw new Error(
+      "runtime worktree path is neither an exact Git-common-dir runtime child nor a trusted legacy worktree child",
+    );
+  }
+}
+
+interface GitExecutionResult {
+  stdout: string;
+}
+
+type GitExecutor = (args: string[]) => Promise<GitExecutionResult>;
+
+const executeGit: GitExecutor = async (args) => {
+  const { stdout } = await exec("git", args);
+  return { stdout: String(stdout) };
+};
+
+async function resolveGitDirectory(
+  commandCwd: string,
+  option: "--git-common-dir" | "--git-dir",
+  gitExec: GitExecutor = executeGit,
+): Promise<string> {
+  const { stdout } = await gitExec(["-C", commandCwd, "rev-parse", option]);
+  const output = stdout.trim();
+  return realpath(isAbsolute(output) ? output : resolve(commandCwd, output));
+}
+
+async function secureCleanupClaimParent(expected: RuntimeWorktreeIdentity): Promise<string> {
+  const canonicalRepoRoot = await realDirectory(expected.repoRoot, false);
+  if (canonicalRepoRoot !== expected.repoRoot) throw new Error("repository root is not canonical");
+  const canonicalGitCommonRoot = await realDirectory(expected.gitCommonRoot, false);
+  if (canonicalGitCommonRoot !== expected.gitCommonRoot) throw new Error("Git common root is not canonical");
+  return canonicalGitCommonRoot;
+}
+
+function legacyQuarantineRoot(expected: RuntimeWorktreeIdentity, kind: DirectoryClaimKind): string {
+  return join(
+    expected.gitCommonRoot,
+    kind === "checkout" ? LEGACY_CHECKOUT_QUARANTINE_ROOT : LEGACY_REGISTRATION_QUARANTINE_ROOT,
+  );
+}
+
+function isCurrentSentinelFileName(fileName: string): boolean {
+  return new RegExp(`^${CHECKOUT_SENTINEL_PREFIX.replaceAll(".", "\\.")}[0-9a-f]{64}$`).test(fileName);
+}
+
+function sentinelExcludeTag(proof: Extract<WorktreeCheckoutProof, { kind: "sentinel" }>): string {
+  const ownership = createHash("sha256").update(`${proof.fileName}\0${proof.token}`).digest("hex");
+  return `# pi-dynamic-workflows-owned-sentinel:${ownership}`;
+}
+
+function sentinelExcludeBlock(proof: Extract<WorktreeCheckoutProof, { kind: "sentinel" }>): string {
+  return `${proof.excludeLeadingNewline ? "\n" : ""}${sentinelExcludeTag(proof)}\n/${proof.fileName}\n`;
+}
+
+async function readBoundedFile(handle: FileHandle): Promise<Buffer> {
+  const stats = await handle.stat({ bigint: true });
+  if (!stats.isFile() || stats.size > 1_048_576n) throw new Error("Git exclude file is not a bounded regular file");
+  const size = Number(stats.size);
+  const contents = Buffer.alloc(size);
+  let offset = 0;
+  while (offset < size) {
+    const { bytesRead } = await handle.read(contents, offset, size - offset, offset);
+    if (bytesRead === 0) throw new Error("Git exclude file changed during descriptor read");
+    offset += bytesRead;
+  }
+  return contents;
+}
+
+function locateOwnedSentinelBlock(
+  contents: Buffer,
+  proof: Extract<WorktreeCheckoutProof, { kind: "sentinel" }>,
+): { offset: number; block: Buffer } | undefined {
+  const block = Buffer.from(sentinelExcludeBlock(proof), "utf8");
+  const offset = contents.indexOf(block);
+  if (offset < 0) {
+    const hasTag = contents.indexOf(Buffer.from(sentinelExcludeTag(proof), "utf8")) >= 0;
+    const hasFileName = contents.indexOf(Buffer.from(proof.fileName, "utf8")) >= 0;
+    if (!hasTag && !hasFileName) return undefined;
+    throw new Error("owned sentinel exclude block is incomplete or changed");
+  }
+  if (contents.indexOf(block, offset + block.length) >= 0) {
+    throw new Error("owned sentinel exclude block is duplicated");
+  }
+  return { offset, block };
+}
+
+function neutralizedSentinelBlock(block: Buffer): Buffer {
+  const neutralized = Buffer.alloc(block.length, 0x20);
+  let lineStart = true;
+  for (let index = 0; index < block.length; index++) {
+    if (block[index] === 0x0a) {
+      neutralized[index] = 0x0a;
+      lineStart = true;
+    } else if (lineStart) {
+      neutralized[index] = 0x23;
+      lineStart = false;
+    }
+  }
+  return neutralized;
+}
+
+async function appendSentinelExclude(
+  gitCommonRoot: string,
+  marker: string,
+  proof: Pick<Extract<WorktreeCheckoutProof, { kind: "sentinel" }>, "kind" | "fileName" | "token">,
+  repositoryLockHeld = false,
+): Promise<Extract<WorktreeCheckoutProof, { kind: "sentinel" }>> {
+  const operation = async () => {
+    const infoRoot = await secureChildDirectory(gitCommonRoot, "info", true);
+    const excludePath = join(infoRoot, "exclude");
+    const handle = await open(excludePath, constants.O_CREAT | constants.O_RDWR | constants.O_NOFOLLOW, 0o600);
+    try {
+      const [pathStats, handleStats] = await Promise.all([
+        lstat(excludePath, { bigint: true }),
+        handle.stat({ bigint: true }),
+      ]);
+      const excludeIdentity = fileIdentity(handleStats);
+      if (
+        pathStats.isSymbolicLink() ||
+        !pathStats.isFile() ||
+        !handleStats.isFile() ||
+        !hasFileIdentity(pathStats, excludeIdentity)
+      ) {
+        throw new Error("Git exclude file identity changed during sentinel append");
+      }
+      const existing = await readBoundedFile(handle);
+      const excludeLeadingNewline = existing.length > 0 && existing[existing.length - 1] !== 0x0a;
+      const completedProof = { ...proof, excludeLeadingNewline, excludeIdentity };
+      const block = Buffer.from(sentinelExcludeBlock(completedProof), "utf8");
+      await appendToVerifiedExcludePath(excludePath, excludeIdentity, block, "sentinel append");
+      const [finalPathStats, finalHandleStats] = await Promise.all([
+        lstat(excludePath, { bigint: true }),
+        handle.stat({ bigint: true }),
+      ]);
+      if (
+        finalPathStats.isSymbolicLink() ||
+        !finalPathStats.isFile() ||
+        !finalHandleStats.isFile() ||
+        !hasFileIdentity(finalPathStats, excludeIdentity) ||
+        !hasFileIdentity(finalHandleStats, excludeIdentity)
+      ) {
+        throw new Error("Git exclude file identity changed after sentinel append");
+      }
+      const previous = sentinelExcludeHandles.get(marker);
+      sentinelExcludeHandles.set(marker, handle);
+      if (previous && previous !== handle) await previous.close().catch(() => undefined);
+      return completedProof;
+    } catch (error) {
+      await handle.close().catch(() => undefined);
+      throw error;
+    }
+  };
+  return repositoryLockHeld ? operation() : withRepositoryGitMetadataCleanup(gitCommonRoot, operation);
+}
+
+async function appendToVerifiedExcludePath(
+  excludePath: string,
+  expectedIdentity: FileIdentity,
+  contents: Buffer,
+  operation: string,
+): Promise<void> {
+  const appendHandle = await open(excludePath, constants.O_WRONLY | constants.O_APPEND | constants.O_NOFOLLOW);
+  try {
+    const [pathStats, handleStats] = await Promise.all([
+      lstat(excludePath, { bigint: true }),
+      appendHandle.stat({ bigint: true }),
+    ]);
+    if (
+      pathStats.isSymbolicLink() ||
+      !pathStats.isFile() ||
+      !handleStats.isFile() ||
+      !hasFileIdentity(pathStats, expectedIdentity) ||
+      !hasFileIdentity(handleStats, expectedIdentity)
+    ) {
+      throw new Error(`Git exclude file identity changed before ${operation}`);
+    }
+    const { bytesWritten } = await appendHandle.write(contents, 0, contents.length, null);
+    if (bytesWritten !== contents.length) throw new Error(`Git exclude ${operation} was incomplete`);
+  } finally {
+    await appendHandle.close();
+  }
+}
+
+async function verifiedSentinelExcludeHandle(
+  gitCommonRoot: string,
+  marker: string,
+  proof: Extract<WorktreeCheckoutProof, { kind: "sentinel" }>,
+  simulateReusedIdentity = false,
+): Promise<{ handle: FileHandle; excludePath: string }> {
+  const handle = sentinelExcludeHandles.get(marker);
+  if (!handle) throw new Error("process-local Git exclude descriptor is unavailable for current-version cleanup");
+  const infoRoot = await secureChildDirectory(gitCommonRoot, "info", false);
+  const excludePath = join(infoRoot, "exclude");
+  const [pathStats, handleStats] = await Promise.all([
+    lstat(excludePath, { bigint: true }),
+    handle.stat({ bigint: true }),
+  ]);
+  if (
+    pathStats.isSymbolicLink() ||
+    !pathStats.isFile() ||
+    !handleStats.isFile() ||
+    (!simulateReusedIdentity && !hasFileIdentity(pathStats, proof.excludeIdentity)) ||
+    !hasFileIdentity(handleStats, proof.excludeIdentity) ||
+    !hasFileIdentity(pathStats, fileIdentity(handleStats))
+  ) {
+    throw new Error("Git exclude file no longer matches its original descriptor identity");
+  }
+  return { handle, excludePath };
+}
+
+async function restoreSentinelExclude(
+  gitCommonRoot: string,
+  marker: string,
+  proof: Extract<WorktreeCheckoutProof, { kind: "sentinel" }>,
+  repositoryLockHeld = false,
+): Promise<void> {
+  if (!isCurrentSentinelFileName(proof.fileName)) return;
+  const operation = async () => {
+    const { handle, excludePath } = await verifiedSentinelExcludeHandle(gitCommonRoot, marker, proof);
+    const existing = await readBoundedFile(handle);
+    if (locateOwnedSentinelBlock(existing, proof)) return;
+    const blockBytes = Buffer.from(sentinelExcludeBlock(proof), "utf8");
+    await appendToVerifiedExcludePath(excludePath, proof.excludeIdentity, blockBytes, "sentinel restore append");
+  };
+  if (repositoryLockHeld) await operation();
+  else await withRepositoryGitMetadataCleanup(gitCommonRoot, operation);
+}
+
+async function removeSentinelExclude(
+  gitCommonRoot: string,
+  marker: string,
+  proof: Extract<WorktreeCheckoutProof, { kind: "sentinel" }>,
+  hooks: WorktreeCleanupTestHooks = {},
+  repositoryLockHeld = false,
+): Promise<void> {
+  if (!isCurrentSentinelFileName(proof.fileName)) return;
+  const operation = async () => {
+    const { handle, excludePath } = await verifiedSentinelExcludeHandle(
+      gitCommonRoot,
+      marker,
+      proof,
+      hooks.simulateReusedExcludeIdentity,
+    );
+    const initial = await readBoundedFile(handle);
+    if (!locateOwnedSentinelBlock(initial, proof)) {
+      throw new Error("owned sentinel exclude block cannot be uniquely located");
+    }
+    await hooks.beforeSentinelExcludeNeutralize?.();
+
+    const [currentPathStats, currentHandleStats] = await Promise.all([
+      lstat(excludePath, { bigint: true }),
+      handle.stat({ bigint: true }),
+    ]);
+    if (
+      currentPathStats.isSymbolicLink() ||
+      !currentPathStats.isFile() ||
+      !currentHandleStats.isFile() ||
+      (!hooks.simulateReusedExcludeIdentity && !hasFileIdentity(currentPathStats, proof.excludeIdentity)) ||
+      !hasFileIdentity(currentHandleStats, proof.excludeIdentity) ||
+      !hasFileIdentity(currentPathStats, fileIdentity(currentHandleStats))
+    ) {
+      throw new Error("Git exclude file identity changed before owned block neutralization");
+    }
+    const fresh = await readBoundedFile(handle);
+    const owned = locateOwnedSentinelBlock(fresh, proof);
+    if (!owned) throw new Error("owned sentinel exclude block disappeared before neutralization");
+    const neutralized = neutralizedSentinelBlock(owned.block);
+    const { bytesWritten } = await handle.write(neutralized, 0, neutralized.length, owned.offset);
+    if (bytesWritten !== neutralized.length)
+      throw new Error("owned sentinel exclude block neutralization was incomplete");
+  };
+  if (repositoryLockHeld) await operation();
+  else await withRepositoryGitMetadataCleanup(gitCommonRoot, operation);
+}
+
+async function verifySentinelCheckoutPath(
+  worktreePath: string,
+  expectedIdentity: FileIdentity,
+  requiredHandle?: FileHandle,
+): Promise<void> {
+  const [pathStats, canonicalPath, handleStats] = await Promise.all([
+    lstat(worktreePath, { bigint: true }),
+    realpath(worktreePath),
+    requiredHandle?.stat({ bigint: true }),
+  ]);
+  if (
+    canonicalPath !== worktreePath ||
+    pathStats.isSymbolicLink() ||
+    !pathStats.isDirectory() ||
+    !hasFileIdentity(pathStats, expectedIdentity) ||
+    (requiredHandle !== undefined &&
+      (!handleStats?.isDirectory() ||
+        !hasFileIdentity(handleStats, expectedIdentity) ||
+        !hasFileIdentity(handleStats, fileIdentity(pathStats))))
+  ) {
+    throw new Error("portable sentinel checkout path does not match its allocated descriptor identity");
+  }
+}
+
+async function createCheckoutSentinel(
+  worktreePath: string,
+  gitCommonRoot: string,
+  marker: string,
+  expectedIdentity: FileIdentity,
+  requiredHandle: FileHandle,
+  repositoryLockHeld = false,
+  writeOptions: DescriptorRelativeWriteOptions = {},
+): Promise<WorktreeCheckoutProof> {
+  await verifySentinelCheckoutPath(worktreePath, expectedIdentity, requiredHandle);
+  const token = randomUUID().replaceAll("-", "") + randomUUID().replaceAll("-", "");
+  const fileName = `${CHECKOUT_SENTINEL_PREFIX}${randomUUID().replaceAll("-", "")}${randomUUID().replaceAll("-", "")}`;
+  const initialProof = { kind: "sentinel", fileName, token } as const;
+  const proof = await appendSentinelExclude(gitCommonRoot, marker, initialProof, repositoryLockHeld);
+  try {
+    await verifySentinelCheckoutPath(worktreePath, expectedIdentity, requiredHandle);
+    await writeExclusiveDescriptorRelative(
+      worktreePath,
+      requiredHandle,
+      expectedIdentity,
+      fileName,
+      `${token}\n`,
+      "checkout",
+      writeOptions,
+    );
+    return proof;
+  } catch (error) {
+    await removeSentinelExclude(gitCommonRoot, marker, proof, {}, repositoryLockHeld).catch(() => undefined);
+    const held = sentinelExcludeHandles.get(marker);
+    sentinelExcludeHandles.delete(marker);
+    await held?.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+interface CreateWorktreeOptions {
+  /** Narrow test seam: portable sentinel mode still pins the directory for safe relative creation. */
+  directoryDescriptorMode?: "supported" | "unsupported" | "open-unsupported";
+  /** Narrow test seam for a platform with directory descriptors but no verified descriptor aliases. */
+  descriptorAliasMode?: "supported" | "unsupported";
+  /** Simulate a pathname-only rollback accepting a replacement with a reused numeric identity. */
+  simulateReusedAllocationPathIdentity?: boolean;
+  /** Runs after alias identity verification and before an exclusive descriptor-relative proof write. */
+  beforeDescriptorRelativeWrite?: (kind: DescriptorRelativeWriteKind, directoryPath: string) => void | Promise<void>;
+  /** Narrow test seam for portable Git-registration-directory finalization. */
+  gitDirectoryDescriptorErrorCode?: "EISDIR" | "ENOTSUP";
+  /** Narrow test seam for failures after git has created the worktree. */
+  canonicalizePath?: (path: string) => Promise<string>;
+  /** Narrow test seam for simulating older Git command support. */
+  execGit?: GitExecutor;
+  /** Runs after the private direct-child directory is atomically allocated and identity-bound. */
+  afterAtomicDirectoryCreation?: (gitCommonRoot: string, worktreePath: string) => void | Promise<void>;
+  /** Runs after branch creation and immediately before the final path identity check. */
+  afterBranchCreationBeforeGitAdd?: (gitCommonRoot: string, worktreePath: string) => void | Promise<void>;
+  /** Narrow test seam for unsuccessful exact-identity post-create cleanup. */
+  rollbackFinalizedWorktree?: (worktree: Worktree) => Promise<WorktreeCleanupFailure[]>;
+  /** Narrow test seam for partial `git worktree add` transactional recovery. */
+  creationCleanupHooks?: WorktreeCleanupTestHooks;
+  /** Narrow test seam for registration persistence failures during identity finalization. */
+  beforeRegistrationRecordWrite?: (metadata: WorktreeCleanupMetadataV4) => void | Promise<void>;
+  /** Runs after registration persistence and immediately before final ownership revalidation. */
+  afterRegistrationRecordWrite?: (metadata: WorktreeCleanupMetadataV4) => void | Promise<void>;
+}
+
+interface AllocatedCheckoutRollback {
+  gitCommonRoot: string;
+  worktreePath: string;
+  allocatedIdentity?: FileIdentity;
+  allocatedHandle?: FileHandle;
+  simulateReusedPathIdentity?: boolean;
+}
+
+async function closeAllocationDescriptor(handle: FileHandle | undefined): Promise<void> {
+  if (!handle) return;
+  allocationDescriptorCount -= 1;
+  await handle.close().catch(() => undefined);
+}
+
+async function rollbackAllocatedCheckoutDirectory(
+  allocated: AllocatedCheckoutRollback,
+): Promise<WorktreeCleanupFailure[]> {
+  const identity = opaqueCleanupIdentity({
+    repoRoot: allocated.gitCommonRoot,
+    worktreePath: allocated.worktreePath,
+    branchRef: "",
+    baseSha: "",
+  });
+  if (!allocated.worktreePath || !allocated.allocatedIdentity) return [];
+
+  try {
+    const [pathStats, handleStats] = await Promise.all([
+      lstat(allocated.worktreePath, { bigint: true }).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return undefined;
+        throw error;
+      }),
+      allocated.allocatedHandle?.stat({ bigint: true }),
+    ]);
+    if (!pathStats) return [];
+    const pathMatchesRecordedIdentity =
+      allocated.simulateReusedPathIdentity || hasFileIdentity(pathStats, allocated.allocatedIdentity);
+    const descriptorMatchesPath = handleStats === undefined || hasFileIdentity(pathStats, fileIdentity(handleStats));
+    if (
+      pathStats.isSymbolicLink() ||
+      !pathStats.isDirectory() ||
+      !pathMatchesRecordedIdentity ||
+      (!handleStats?.isDirectory() && allocated.allocatedHandle !== undefined) ||
+      !descriptorMatchesPath
+    ) {
+      return [
+        {
+          stage: "worktree_remove",
+          message: boundedDiagnostic(
+            "allocated checkout pathname no longer matches its retained descriptor; replacement preserved and descriptor-owned state requires bounded recovery",
+          ),
+          identity,
+        },
+      ];
+    }
+
+    const claimPath = join(allocated.gitCommonRoot, `.pi-dynamic-workflows-allocation-rollback-${randomUUID()}`);
+    await rename(allocated.worktreePath, claimPath);
+    const [claimedStats, finalHandleStats] = await Promise.all([
+      lstat(claimPath, { bigint: true }),
+      allocated.allocatedHandle?.stat({ bigint: true }),
+    ]);
+    const claimedIdentity = fileIdentity(claimedStats);
+    if (
+      claimedStats.isSymbolicLink() ||
+      !claimedStats.isDirectory() ||
+      !hasFileIdentity(claimedStats, allocated.allocatedIdentity) ||
+      (allocated.allocatedHandle !== undefined &&
+        (!finalHandleStats?.isDirectory() || !hasFileIdentity(claimedStats, fileIdentity(finalHandleStats))))
+    ) {
+      const restoration = await restoreUnexpectedClaim(allocated.worktreePath, claimPath, claimedIdentity);
+      return [
+        {
+          stage: "worktree_remove",
+          message: boundedDiagnostic(`allocated checkout rollback captured a replacement; ${restoration}`),
+          identity,
+        },
+      ];
+    }
+    await rmdir(claimPath);
+    return [];
+  } catch (error) {
+    return [
+      {
+        stage: "worktree_remove",
+        message: boundedDiagnostic(`allocated checkout rollback stopped safely: ${errorMessage(error)}`),
+        identity,
+      },
+    ];
+  }
+}
+
+/**
+ * Create an isolated worktree in an atomically allocated runtime-only direct
+ * child of the canonical Git common directory, on branch `pi/wf/<name>`. This
+ * keeps checkouts outside the repository status namespace and avoids the
+ * historically shared `.pi/worktrees` parent. The exact HEAD SHA is retained
+ * as identity metadata. Returns a no-op Worktree on failure.
+ */
+export async function createWorktree(
+  baseCwd: string,
+  name: string,
+  options: CreateWorktreeOptions = {},
+): Promise<Worktree> {
+  const id = slug(name);
+  const canonicalizePath = options.canonicalizePath ?? realpath;
+  const gitExec = options.execGit ?? executeGit;
+  let repoRoot: string;
+  let gitCommonRoot: string;
+  let baseSha: string;
+  try {
+    const [{ stdout: rootOutput }, { stdout: shaOutput }, commonRoot] = await Promise.all([
+      gitExec(["-C", baseCwd, "rev-parse", "--show-toplevel"]),
+      gitExec(["-C", baseCwd, "rev-parse", "HEAD"]),
+      resolveGitDirectory(baseCwd, "--git-common-dir", gitExec),
+    ]);
+    repoRoot = await canonicalizePath(rootOutput.trim());
+    gitCommonRoot = await realDirectory(commonRoot, false);
+    baseSha = shaOutput.trim();
+    if (!/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i.test(baseSha)) {
+      throw new Error("HEAD does not have a supported object ID");
+    }
   } catch {
     return { isolated: false, cwd: baseCwd, reason: "not a git repository" };
   }
 
-  const path = join(repoRoot, ".pi", "worktrees", id);
   const branch = `pi/wf/${id}`;
+  const branchRef = `refs/heads/${branch}`;
+  const nullOid = "0".repeat(baseSha.length);
+  let requestedPath = "";
+  let allocatedIdentity: FileIdentity | undefined;
+  let allocatedHandle: FileHandle | undefined;
   try {
-    await exec("git", ["-C", repoRoot, "worktree", "add", "-b", branch, path, "HEAD"]);
-    return { isolated: true, cwd: path, branch, repoRoot };
-  } catch (error) {
-    return { isolated: false, cwd: baseCwd, reason: error instanceof Error ? error.message : String(error) };
+    requestedPath = await mkdtemp(join(gitCommonRoot, `${RUNTIME_WORKTREE_PREFIX}${id}-`));
+    const allocatedStats = await lstat(requestedPath, { bigint: true });
+    if (!allocatedStats.isDirectory() || allocatedStats.isSymbolicLink()) {
+      throw new Error("atomically allocated worktree path is not a real directory");
+    }
+    allocatedIdentity = fileIdentity(allocatedStats);
+    if (options.directoryDescriptorMode === "open-unsupported") {
+      throw forcedDirectoryDescriptorError("ENOTSUP");
+    }
+    allocatedHandle = await open(requestedPath, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+    allocationDescriptorCount += 1;
+    if (allocatedHandle) {
+      const allocatedHandleStats = await allocatedHandle.stat({ bigint: true });
+      if (!allocatedHandleStats.isDirectory() || !hasFileIdentity(allocatedHandleStats, allocatedIdentity)) {
+        throw new Error("atomically allocated worktree descriptor does not match its path identity");
+      }
+    }
+    if (!isExactRuntimeWorktreeChild(gitCommonRoot, requestedPath)) {
+      throw new Error("atomically allocated worktree path is not an exact Git-common-dir child");
+    }
+    await options.afterAtomicDirectoryCreation?.(gitCommonRoot, requestedPath);
+    const beforeGitStats = await lstat(requestedPath, { bigint: true });
+    if (!beforeGitStats.isDirectory() || !hasFileIdentity(beforeGitStats, allocatedIdentity)) {
+      throw new Error("atomically allocated worktree identity changed before Git creation");
+    }
+  } catch {
+    const boundedFailures = (
+      await rollbackAllocatedCheckoutDirectory({
+        gitCommonRoot,
+        worktreePath: requestedPath,
+        allocatedIdentity,
+        allocatedHandle,
+        simulateReusedPathIdentity: options.simulateReusedAllocationPathIdentity,
+      })
+    ).map(sanitizeWorktreeCleanupFailure);
+    await closeAllocationDescriptor(allocatedHandle);
+    allocatedHandle = undefined;
+    return {
+      isolated: false,
+      cwd: baseCwd,
+      reason: creationFailureReason("unsafe_allocation", boundedFailures),
+      ...(boundedFailures.length > 0 ? { recoveryFailures: boundedFailures } : {}),
+    };
+  }
+
+  try {
+    await gitExec(["-C", repoRoot, "update-ref", "--no-deref", branchRef, baseSha, nullOid]);
+  } catch {
+    const boundedFailures = (
+      await rollbackAllocatedCheckoutDirectory({
+        gitCommonRoot,
+        worktreePath: requestedPath,
+        allocatedIdentity,
+        allocatedHandle,
+        simulateReusedPathIdentity: options.simulateReusedAllocationPathIdentity,
+      })
+    ).map(sanitizeWorktreeCleanupFailure);
+    await closeAllocationDescriptor(allocatedHandle);
+    allocatedHandle = undefined;
+    return {
+      isolated: false,
+      cwd: baseCwd,
+      reason: creationFailureReason("branch_create", boundedFailures),
+      ...(boundedFailures.length > 0 ? { recoveryFailures: boundedFailures } : {}),
+    };
+  }
+
+  try {
+    await options.afterBranchCreationBeforeGitAdd?.(gitCommonRoot, requestedPath);
+    const [preAddStats, preAddCanonicalPath, preAddHandleStats] = await Promise.all([
+      lstat(requestedPath, { bigint: true }),
+      realpath(requestedPath),
+      allocatedHandle?.stat({ bigint: true }),
+    ]);
+    if (
+      preAddCanonicalPath !== requestedPath ||
+      preAddStats.isSymbolicLink() ||
+      !preAddStats.isDirectory() ||
+      !allocatedIdentity ||
+      (allocatedHandle !== undefined &&
+        (!preAddHandleStats?.isDirectory() || !hasFileIdentity(preAddHandleStats, allocatedIdentity))) ||
+      !hasFileIdentity(preAddStats, allocatedIdentity) ||
+      !isExactRuntimeWorktreeChild(gitCommonRoot, preAddCanonicalPath)
+    ) {
+      throw new Error("atomically allocated worktree identity changed before Git worktree add");
+    }
+  } catch {
+    const boundedFailures = (
+      await recoverFailedWorktreeCreation(
+        {
+          repoRoot,
+          gitCommonRoot,
+          worktreePath: requestedPath,
+          branch,
+          branchRef,
+          baseSha,
+          nullOid,
+          allocatedIdentity,
+          allocatedHandle,
+        },
+        options.creationCleanupHooks ?? {},
+      )
+    ).map(sanitizeWorktreeCleanupFailure);
+    await closeAllocationDescriptor(allocatedHandle);
+    allocatedHandle = undefined;
+    return {
+      isolated: false,
+      cwd: baseCwd,
+      reason: creationFailureReason("pre_add_verification", boundedFailures),
+      ...(boundedFailures.length > 0 ? { recoveryFailures: boundedFailures } : {}),
+    };
+  }
+
+  try {
+    await withRepositoryGitMetadataCleanup(gitCommonRoot, () =>
+      gitExec(["-C", repoRoot, "worktree", "add", requestedPath, branch]),
+    );
+  } catch {
+    const boundedFailures = (
+      await recoverFailedWorktreeCreation(
+        {
+          repoRoot,
+          gitCommonRoot,
+          worktreePath: requestedPath,
+          branch,
+          branchRef,
+          baseSha,
+          nullOid,
+          allocatedIdentity,
+          allocatedHandle,
+        },
+        options.creationCleanupHooks ?? {},
+      )
+    ).map(sanitizeWorktreeCleanupFailure);
+    await closeAllocationDescriptor(allocatedHandle);
+    allocatedHandle = undefined;
+    return {
+      isolated: false,
+      cwd: baseCwd,
+      reason: creationFailureReason("git_add", boundedFailures),
+      ...(boundedFailures.length > 0 ? { recoveryFailures: boundedFailures } : {}),
+    };
+  }
+
+  let finalizedWorktree: Worktree | undefined;
+  let finalizingWorktree: Worktree | undefined;
+  let finalizingRecoveryIdentity: FailedWorktreeCreationIdentity | undefined;
+  let finalizingMarker: string | undefined;
+  let finalizingGitDirHandle: FileHandle | undefined;
+  let finalizingGitDirSentinel: Extract<WorktreeGitDirectoryProof, { kind: "sentinel" }> | undefined;
+  let finalizingGitDirIdentity: FileIdentity | undefined;
+  let finalizingGitDir = "";
+  let registrationPersisted = false;
+  let creationRecoveryWorktree: Worktree | undefined;
+  try {
+    const cwd = await realpath(requestedPath);
+    const createdStats = await lstat(cwd, { bigint: true });
+    if (
+      cwd !== requestedPath ||
+      !allocatedIdentity ||
+      !createdStats.isDirectory() ||
+      !hasFileIdentity(createdStats, allocatedIdentity) ||
+      !isExactRuntimeWorktreeChild(gitCommonRoot, cwd)
+    ) {
+      throw new Error("created worktree no longer matches its atomically allocated Git-common-dir identity");
+    }
+    const [createdCommonRoot, gitDir, expectedCommonRoot] = await Promise.all([
+      resolveGitDirectory(cwd, "--git-common-dir", gitExec),
+      resolveGitDirectory(cwd, "--git-dir", gitExec),
+      resolveGitDirectory(repoRoot, "--git-common-dir", gitExec),
+    ]);
+    if (createdCommonRoot !== expectedCommonRoot || createdCommonRoot !== gitCommonRoot) {
+      throw new Error("created worktree has an unexpected Git common root");
+    }
+
+    const registrationMarker = randomUUID();
+    finalizingMarker = registrationMarker;
+    finalizingGitDir = gitDir;
+    // Establish exact path, branch, checkout-inode, and descriptor authority
+    // before either portable proof can create a sentinel side effect.
+    finalizingRecoveryIdentity = {
+      repoRoot,
+      gitCommonRoot: createdCommonRoot,
+      worktreePath: cwd,
+      branch,
+      branchRef,
+      baseSha,
+      nullOid,
+      allocatedIdentity,
+      allocatedHandle,
+    };
+    const descriptorWriteOptions: DescriptorRelativeWriteOptions = {
+      aliasMode: options.descriptorAliasMode,
+      beforeWrite: options.beforeDescriptorRelativeWrite,
+    };
+    const gitDirectoryOwnership = await createGitDirectoryOwnershipProof(
+      gitDir,
+      options.gitDirectoryDescriptorErrorCode,
+      descriptorWriteOptions,
+    );
+    finalizingGitDirHandle = gitDirectoryOwnership.handle;
+    finalizingGitDirIdentity = gitDirectoryOwnership.identity;
+    if (gitDirectoryOwnership.proof.kind === "sentinel") {
+      finalizingGitDirSentinel = gitDirectoryOwnership.proof;
+    }
+    if (!allocatedHandle) throw new Error("safe checkout-directory descriptor is unavailable");
+    const checkoutProof =
+      options.directoryDescriptorMode === "unsupported"
+        ? await createCheckoutSentinel(
+            cwd,
+            createdCommonRoot,
+            registrationMarker,
+            allocatedIdentity,
+            allocatedHandle,
+            false,
+            descriptorWriteOptions,
+          )
+        : ({ kind: "descriptor" } as const);
+    const cleanupMetadata: WorktreeCleanupMetadataV4 = Object.freeze({
+      version: 4,
+      registrationMarker,
+      repoRoot,
+      worktreePath: cwd,
+      checkoutIdentity: { ...allocatedIdentity },
+      checkoutProof,
+      gitDirIdentity: gitDirectoryOwnership.identity,
+      gitDirProof: gitDirectoryOwnership.proof,
+      branch,
+      branchRef,
+      baseSha,
+      gitCommonRoot: createdCommonRoot,
+      gitDir,
+    });
+    finalizingWorktree = { isolated: true, cwd, branch, branchRef, baseSha, repoRoot, cleanupMetadata };
+    // Transfer every proof into process-local root authority before persistence.
+    // A marker write failure can therefore roll back without trusting a pathname.
+    if (allocatedHandle && checkoutProof.kind === "descriptor") {
+      checkoutDirectoryHandles.set(registrationMarker, allocatedHandle);
+      allocationDescriptorCount -= 1;
+      allocatedHandle = undefined;
+    }
+    if (finalizingGitDirHandle && gitDirectoryOwnership.proof.kind === "descriptor") {
+      gitDirectoryHandles.set(registrationMarker, finalizingGitDirHandle);
+      finalizingGitDirHandle = undefined;
+    }
+    creationRecoveryAuthorities.set(finalizingWorktree, "in-memory");
+    await options.beforeRegistrationRecordWrite?.(cleanupMetadata);
+    const registrationHandle = gitDirectoryHandles.get(registrationMarker) ?? finalizingGitDirHandle;
+    if (!registrationHandle) throw new Error("safe Git registration-directory descriptor is unavailable");
+    await writeRegistrationRecord(
+      gitDir,
+      cleanupMetadata,
+      { handle: registrationHandle, identity: gitDirectoryOwnership.identity },
+      descriptorWriteOptions,
+    );
+    registrationPersisted = true;
+    if (gitDirectoryOwnership.proof.kind === "sentinel") {
+      await finalizingGitDirHandle?.close().catch(() => undefined);
+      finalizingGitDirHandle = undefined;
+    }
+    creationRecoveryAuthorities.set(finalizingWorktree, "persisted");
+    finalizingGitDirSentinel = undefined;
+    finalizedWorktree = finalizingWorktree;
+
+    // This deterministic final hook is deliberately after marker persistence.
+    // No agent can observe the checkout until every current proof is revalidated.
+    await options.afterRegistrationRecordWrite?.(cleanupMetadata);
+    if ((await canonicalizePath(requestedPath)) !== cwd) {
+      throw new Error("created worktree path changed during final ownership revalidation");
+    }
+    const finalVerification = await verifyCleanupIdentity(finalizedWorktree);
+    if (
+      typeof finalVerification === "string" ||
+      finalVerification.checkoutPath !== cwd ||
+      finalVerification.branchOid !== baseSha
+    ) {
+      throw new Error(
+        typeof finalVerification === "string"
+          ? `created worktree final ownership revalidation failed: ${finalVerification}`
+          : "created worktree identity changed during final ownership revalidation",
+      );
+    }
+    creationRecoveryAuthorities.delete(finalizedWorktree);
+    await closeAllocationDescriptor(allocatedHandle);
+    allocatedHandle = undefined;
+    return finalizedWorktree;
+  } catch {
+    const recoveryIdentity = opaqueCleanupIdentity({ repoRoot, worktreePath: requestedPath, branchRef, baseSha });
+    const recoveryFailures: WorktreeCleanupFailure[] = [];
+    const rollbackFinalized = async (value: Worktree): Promise<boolean> => {
+      try {
+        const customRollback = options.rollbackFinalizedWorktree;
+        const failures = customRollback
+          ? await customRollback(value)
+          : await removeWorktreeWithDiagnostics(value, {
+              ...(options.creationCleanupHooks ?? {}),
+              creationRollbackExpectedOid: baseSha,
+            });
+        for (const failure of failures) {
+          recoveryFailures.push({ ...failure, message: boundedDiagnostic(failure.message) });
+        }
+        if (
+          failures.length === 0 ||
+          (!customRollback &&
+            failures.length === 1 &&
+            failures[0]?.message.startsWith(CREATION_ADVANCED_BRANCH_PRESERVED))
+        ) {
+          return true;
+        }
+      } catch (rollbackError) {
+        recoveryFailures.push({
+          stage: "cleanup_dispatch",
+          message: boundedDiagnostic(
+            `exact-identity worktree creation rollback failed: ${errorMessage(rollbackError)}`,
+          ),
+          identity: recoveryIdentity,
+        });
+      }
+      value.creationRollbackExpectedOid = baseSha;
+      creationRecoveryWorktree = value;
+      return false;
+    };
+    if (finalizedWorktree) {
+      await rollbackFinalized(finalizedWorktree);
+    } else if (finalizingWorktree) {
+      if (!registrationPersisted) {
+        recoveryFailures.push({
+          stage: "cleanup_dispatch",
+          message: "registration persistence failed; exact in-memory creation identity authorized immediate rollback",
+          identity: recoveryIdentity,
+        });
+      }
+      await rollbackFinalized(finalizingWorktree);
+      if (!creationRecoveryWorktree) {
+        // A successful rollback is a clean isolation fallback, not a recovery failure.
+        recoveryFailures.length = 0;
+      }
+    } else if (finalizingRecoveryIdentity) {
+      for (const failure of await recoverFailedWorktreeCreation(
+        finalizingRecoveryIdentity,
+        options.creationCleanupHooks ?? {},
+      )) {
+        recoveryFailures.push({ ...failure, message: boundedDiagnostic(failure.message) });
+      }
+    } else {
+      recoveryFailures.push(
+        {
+          stage: "worktree_remove",
+          message: "worktree creation rollback lacks a complete exact recovery identity",
+          identity: recoveryIdentity,
+        },
+        {
+          stage: "branch_delete",
+          message: "temporary branch remains reachable with the preserved exact worktree registration",
+          identity: recoveryIdentity,
+        },
+      );
+    }
+    if (creationRecoveryWorktree && allocatedHandle && finalizingMarker) {
+      checkoutDirectoryHandles.set(finalizingMarker, allocatedHandle);
+      allocationDescriptorCount -= 1;
+      allocatedHandle = undefined;
+    }
+    if (!creationRecoveryWorktree) {
+      await closeAllocationDescriptor(allocatedHandle);
+      allocatedHandle = undefined;
+      await finalizingGitDirHandle?.close().catch(() => undefined);
+      finalizingGitDirHandle = undefined;
+      if (finalizingGitDirSentinel && finalizingGitDir) {
+        const currentGitDir = await lstat(finalizingGitDir, { bigint: true }).catch(() => undefined);
+        if (
+          currentGitDir?.isDirectory() &&
+          finalizingGitDirIdentity &&
+          hasFileIdentity(currentGitDir, finalizingGitDirIdentity)
+        ) {
+          await rm(join(finalizingGitDir, finalizingGitDirSentinel.fileName), { force: true }).catch(() => undefined);
+        }
+      }
+      const finalizedMarker = finalizedWorktree?.cleanupMetadata?.registrationMarker ?? finalizingMarker;
+      if (finalizedMarker) await closeRuntimeIdentityHandles(finalizedMarker);
+    }
+    const publicRecoveryFailures = recoveryFailures.map(sanitizeWorktreeCleanupFailure);
+    return {
+      isolated: false,
+      cwd: baseCwd,
+      reason: creationFailureReason("identity_finalization", publicRecoveryFailures),
+      ...(publicRecoveryFailures.length > 0 ? { recoveryFailures: publicRecoveryFailures } : {}),
+      ...(creationRecoveryWorktree ? { creationRecoveryWorktree } : {}),
+    };
   }
 }
 
-/** Remove a worktree and its branch. Best-effort; safe to call on a no-op Worktree. */
-export async function removeWorktree(wt: Worktree): Promise<void> {
-  if (!wt.isolated || !wt.repoRoot) return;
+interface FailedWorktreeCreationIdentity {
+  repoRoot: string;
+  gitCommonRoot: string;
+  worktreePath: string;
+  branch: string;
+  branchRef: string;
+  baseSha: string;
+  nullOid: string;
+  allocatedIdentity: FileIdentity;
+  allocatedHandle?: FileHandle;
+}
+
+async function findExactPartialRegistrationGitDir(
+  gitCommonRoot: string,
+  worktreePath: string,
+): Promise<string | undefined> {
+  let worktreesRoot: string;
   try {
-    await exec("git", ["-C", wt.repoRoot, "worktree", "remove", "--force", wt.cwd]);
-  } catch {
-    // already gone / locked — fall through
+    worktreesRoot = await secureChildDirectory(gitCommonRoot, "worktrees", false);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
   }
-  if (wt.branch) {
+
+  const matches: string[] = [];
+  for (const entry of await readdir(worktreesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    const candidate = join(worktreesRoot, entry.name);
+    let canonicalCandidate: string;
     try {
-      await exec("git", ["-C", wt.repoRoot, "branch", "-D", wt.branch]);
+      canonicalCandidate = await realDirectory(candidate, false);
+      const gitdirLink = (await readRegistrationFile(join(canonicalCandidate, "gitdir"))).trim();
+      const checkoutLink = isAbsolute(gitdirLink) ? resolve(gitdirLink) : resolve(canonicalCandidate, gitdirLink);
+      if (checkoutLink === join(worktreePath, ".git")) matches.push(canonicalCandidate);
     } catch {
-      // branch already deleted
+      // Unrelated or concurrently changing Git metadata is never cleanup authority.
+    }
+  }
+  if (matches.length > 1) throw new Error("multiple per-worktree Git registrations resolve to the failed checkout");
+  return matches[0];
+}
+
+async function failedCreationSentinelProof(
+  failed: FailedWorktreeCreationIdentity,
+  marker: string,
+): Promise<Extract<WorktreeCheckoutProof, { kind: "sentinel" }> | undefined> {
+  try {
+    if (!failed.allocatedHandle) return undefined;
+    await verifySentinelCheckoutPath(failed.worktreePath, failed.allocatedIdentity, failed.allocatedHandle);
+    return (await createCheckoutSentinel(
+      failed.worktreePath,
+      failed.gitCommonRoot,
+      marker,
+      failed.allocatedIdentity,
+      failed.allocatedHandle,
+    )) as Extract<WorktreeCheckoutProof, { kind: "sentinel" }>;
+  } catch {
+    return undefined;
+  }
+}
+
+function failedCreationWorktree(
+  failed: FailedWorktreeCreationIdentity,
+  gitDir: string,
+  marker: string,
+  checkoutProof: WorktreeCheckoutProof,
+  gitDirIdentity: FileIdentity,
+  gitDirProof?: WorktreeGitDirectoryProof,
+): Worktree {
+  const cleanupMetadata: WorktreeCleanupMetadataV4 = Object.freeze({
+    version: 4,
+    registrationMarker: marker,
+    repoRoot: failed.repoRoot,
+    worktreePath: failed.worktreePath,
+    checkoutIdentity: { ...failed.allocatedIdentity },
+    checkoutProof,
+    gitDirIdentity: { ...gitDirIdentity },
+    ...(gitDirProof ? { gitDirProof } : {}),
+    branch: failed.branch,
+    branchRef: failed.branchRef,
+    baseSha: failed.baseSha,
+    gitCommonRoot: failed.gitCommonRoot,
+    gitDir,
+  });
+  return {
+    isolated: true,
+    cwd: failed.worktreePath,
+    branch: failed.branch,
+    branchRef: failed.branchRef,
+    baseSha: failed.baseSha,
+    repoRoot: failed.repoRoot,
+    cleanupMetadata,
+  };
+}
+
+async function rollbackUnregisteredWorktreeCreation(
+  failed: FailedWorktreeCreationIdentity,
+  hooks: WorktreeCleanupTestHooks,
+): Promise<WorktreeCleanupFailure[]> {
+  const identity = opaqueCleanupIdentity({
+    repoRoot: failed.repoRoot,
+    worktreePath: failed.worktreePath,
+    branchRef: failed.branchRef,
+    baseSha: failed.baseSha,
+  });
+  const marker = randomUUID();
+  const recoveryGitDir = join(failed.gitCommonRoot, `pi-workflow-unregistered-${marker}`);
+  const portableProof = await failedCreationSentinelProof(failed, marker);
+  const worktree = failedCreationWorktree(
+    failed,
+    recoveryGitDir,
+    marker,
+    portableProof ?? ({ kind: "descriptor" } as const),
+    { dev: "0", ino: "0" },
+  );
+  const expected = runtimeIdentity(worktree);
+  if (typeof expected === "string") return [identityFailure(identity, expected)];
+
+  const failures = await withRepositoryGitMetadataCleanup<WorktreeCleanupFailure[]>(failed.gitCommonRoot, async () => {
+    let claimedCheckout: ClaimedDirectory | undefined;
+    let claimedBranch: ClaimedBranch | undefined;
+    const stop = async (stage: WorktreeCleanupStage, message: string): Promise<WorktreeCleanupFailure[]> => {
+      if (claimedCheckout?.restorable === false) {
+        await claimedCheckout.handle?.close().catch(() => undefined);
+        return [
+          {
+            stage,
+            message: boundedDiagnostic(
+              `${message}; exact pending checkout claim and internal backup ref were preserved for deterministic recovery`,
+            ),
+            identity,
+          },
+        ];
+      }
+      const restoration: string[] = [];
+      if (claimedBranch) {
+        restoration.push(
+          await restoreClaimedBranch(
+            {
+              expected,
+              checkoutIdentity: failed.allocatedIdentity,
+              gitDirIdentity: { dev: "0", ino: "0" },
+              branchOid: failed.baseSha,
+              nullOid: failed.nullOid,
+            },
+            claimedBranch,
+          ),
+        );
+      }
+      if (claimedCheckout) restoration.push(await restoreClaimedDirectory(claimedCheckout, "checkout"));
+      return [
+        {
+          stage,
+          message: boundedDiagnostic(`${message}${restoration.length > 0 ? `; ${restoration.join("; ")}` : ""}`),
+          identity,
+        },
+      ];
+    };
+
+    const registrations = await readRegisteredWorktrees(failed.repoRoot);
+    if (
+      registrations.some(
+        (registration) => registration.path === failed.worktreePath || registration.branchRef === failed.branchRef,
+      )
+    ) {
+      return [
+        identityFailure(identity, "failed checkout unexpectedly remains registered; unregistered rollback stopped"),
+      ];
+    }
+
+    const checkoutStats = await lstat(failed.worktreePath, { bigint: true }).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined;
+      throw error;
+    });
+    if (
+      checkoutStats?.isDirectory() &&
+      !checkoutStats.isSymbolicLink() &&
+      hasFileIdentity(checkoutStats, failed.allocatedIdentity)
+    ) {
+      const claimParent = await secureCleanupClaimParent(expected);
+      const checkoutClaim = await claimDirectory(
+        worktree,
+        "checkout",
+        failed.worktreePath,
+        claimParent,
+        "failed-creation-checkout",
+        failed.allocatedIdentity,
+        hooks,
+      );
+      if (typeof checkoutClaim === "string") return [identityFailure(identity, checkoutClaim)];
+      claimedCheckout = checkoutClaim;
+      try {
+        await hooks.afterCheckoutClaim?.(worktree);
+      } catch (error) {
+        return stop("cleanup_dispatch", `failed-creation checkout claim hook failed: ${errorMessage(error)}`);
+      }
+    }
+
+    const verified: VerifiedCleanupIdentity = {
+      expected,
+      checkoutIdentity: claimedCheckout ? failed.allocatedIdentity : undefined,
+      gitDirIdentity: { dev: "0", ino: "0" },
+      branchOid: failed.baseSha,
+      nullOid: failed.nullOid,
+    };
+    const branchClaim = await claimBranch(worktree, verified, hooks);
+    if (typeof branchClaim === "string") return stop("branch_delete", branchClaim);
+    claimedBranch = branchClaim;
+    try {
+      await hooks.afterBranchClaim?.(worktree);
+      await hooks.beforePostClaimRegistrationCheck?.(worktree);
+      const postClaimRegistrations = await readRegisteredWorktrees(failed.repoRoot);
+      if (
+        postClaimRegistrations.some(
+          (registration) => registration.path === failed.worktreePath || registration.branchRef === failed.branchRef,
+        )
+      ) {
+        return stop("identity_verification", "a registration appeared during failed-creation rollback");
+      }
+    } catch (error) {
+      return stop("cleanup_dispatch", `failed-creation rollback verification failed: ${errorMessage(error)}`);
+    }
+
+    if (claimedCheckout) {
+      const checkoutFailure = await cleanupClaimedContents(worktree, "checkout", claimedCheckout, hooks);
+      if (checkoutFailure) return stop("worktree_remove", checkoutFailure);
+      claimedCheckout = undefined;
+    }
+    const branchFailure = await deleteClaimedBranch(worktree, expected, branchClaim, hooks);
+    if (branchFailure) {
+      return [{ stage: "branch_delete", message: boundedDiagnostic(branchFailure), identity }];
+    }
+    return [];
+  });
+  if (failures.length === 0 && portableProof) {
+    try {
+      await removeSentinelExclude(failed.gitCommonRoot, marker, portableProof, hooks);
+    } catch (error) {
+      return [
+        {
+          stage: "worktree_remove",
+          message: boundedDiagnostic(`portable sentinel restoration failed: ${errorMessage(error)}`),
+          identity,
+        },
+      ];
+    }
+  }
+  return failures;
+}
+
+async function verifyFailedCreationBranchAtBase(failed: FailedWorktreeCreationIdentity): Promise<void> {
+  const { stdout } = await exec("git", [
+    "-C",
+    failed.repoRoot,
+    "for-each-ref",
+    "--format=%(objectname)%00%(symref)",
+    failed.branchRef,
+  ]);
+  const record = stdout.trimEnd();
+  if (!record) throw new Error("temporary branch disappeared before failed-creation rollback");
+  const [oid, symref = ""] = record.split("\0");
+  if (symref.length > 0) throw new Error("temporary branch became symbolic before failed-creation rollback");
+  if (oid !== failed.baseSha) throw new Error("temporary branch advanced from its expected start OID");
+}
+
+async function recoverFailedWorktreeCreation(
+  failed: FailedWorktreeCreationIdentity,
+  hooks: WorktreeCleanupTestHooks,
+): Promise<WorktreeCleanupFailure[]> {
+  const identity = opaqueCleanupIdentity({
+    repoRoot: failed.repoRoot,
+    worktreePath: failed.worktreePath,
+    branchRef: failed.branchRef,
+    baseSha: failed.baseSha,
+  });
+  try {
+    if (!isExactRuntimeWorktreeChild(failed.gitCommonRoot, failed.worktreePath)) {
+      return [identityFailure(identity, "failed checkout is not an exact runtime direct child of the Git common root")];
+    }
+    const commonRoot = await realDirectory(failed.gitCommonRoot, false);
+    if (commonRoot !== failed.gitCommonRoot) {
+      return [identityFailure(identity, "failed checkout Git common root is no longer canonical")];
+    }
+    const registrations = await registeredWorktrees(failed.repoRoot, failed.gitCommonRoot);
+    const exactRegistrations = registrations.filter((registration) => registration.path === failed.worktreePath);
+    if (exactRegistrations.length > 1) {
+      return [identityFailure(identity, "multiple registrations name the failed checkout path")];
+    }
+    if (
+      registrations.some(
+        (registration) => registration.path !== failed.worktreePath && registration.branchRef === failed.branchRef,
+      )
+    ) {
+      return [identityFailure(identity, "temporary branch is checked out by another registered worktree")];
+    }
+
+    const registration = exactRegistrations[0];
+    if (!registration) return rollbackUnregisteredWorktreeCreation(failed, hooks);
+    if (registration.branchRef !== failed.branchRef) {
+      return [identityFailure(identity, "failed checkout registration has an unexpected branch")];
+    }
+
+    const checkoutStats = await lstat(failed.worktreePath, { bigint: true }).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined;
+      throw error;
+    });
+    if (
+      checkoutStats &&
+      (checkoutStats.isSymbolicLink() ||
+        !checkoutStats.isDirectory() ||
+        !hasFileIdentity(checkoutStats, failed.allocatedIdentity))
+    ) {
+      return [identityFailure(identity, "registered failed checkout no longer names its atomically allocated inode")];
+    }
+
+    const gitDir = await findExactPartialRegistrationGitDir(failed.gitCommonRoot, failed.worktreePath);
+    if (!gitDir) {
+      return [identityFailure(identity, "exact failed checkout registration has no matching per-worktree gitdir")];
+    }
+    await verifyFailedCreationBranchAtBase(failed);
+    const marker = randomUUID();
+    const portableProof = await failedCreationSentinelProof(failed, marker);
+    if (!portableProof) {
+      return [
+        identityFailure(
+          identity,
+          "registered failed checkout cannot initialize portable ownership without its allocated descriptor",
+        ),
+      ];
+    }
+    const gitDirectoryOwnership = await createGitDirectoryOwnershipProof(gitDir);
+    if (gitDirectoryOwnership.handle) gitDirectoryHandles.set(marker, gitDirectoryOwnership.handle);
+    const worktree = failedCreationWorktree(
+      failed,
+      gitDir,
+      marker,
+      portableProof,
+      gitDirectoryOwnership.identity,
+      gitDirectoryOwnership.proof,
+    );
+    try {
+      await writeRegistrationRecord(gitDir, worktree.cleanupMetadata as WorktreeCleanupMetadataV4);
+    } catch (error) {
+      await closeRuntimeIdentityHandles(marker);
+      throw error;
+    }
+    const callerIdentityHook = hooks.afterIdentityVerification;
+    return removeWorktreeWithDiagnostics(worktree, {
+      ...hooks,
+      async afterIdentityVerification(value) {
+        await verifyFailedCreationBranchAtBase(failed);
+        await callerIdentityHook?.(value);
+      },
+    });
+  } catch (error) {
+    return [
+      {
+        stage: "cleanup_dispatch",
+        message: boundedDiagnostic(`failed worktree creation recovery could not complete: ${errorMessage(error)}`),
+        identity,
+      },
+    ];
+  }
+}
+
+function cleanupIdentity(worktree: Worktree): WorktreeIdentity {
+  return opaqueCleanupIdentity({
+    repoRoot: worktree.repoRoot ?? "",
+    worktreePath: worktree.cwd,
+    branchRef: worktree.branchRef ?? (worktree.branch ? `refs/heads/${worktree.branch}` : ""),
+    baseSha: worktree.baseSha ?? "",
+  });
+}
+
+interface RegisteredWorktree {
+  path: string;
+  branchRef?: string;
+}
+
+function parseRegisteredWorktrees(output: string): RegisteredWorktree[] {
+  return output
+    .split("\0\0")
+    .map((record) => record.split("\0"))
+    .map((fields) => ({
+      path: fields.find((field) => field.startsWith("worktree "))?.slice("worktree ".length) ?? "",
+      branchRef: fields.find((field) => field.startsWith("branch "))?.slice("branch ".length),
+    }))
+    .filter((registration) => registration.path.length > 0);
+}
+
+interface FileIdentity extends WorktreeFilesystemIdentity {}
+
+interface VerifiedCleanupIdentity {
+  expected: RuntimeWorktreeIdentity;
+  checkoutIdentity?: FileIdentity;
+  checkoutPath?: string;
+  gitDirIdentity: FileIdentity;
+  branchOid: string;
+  nullOid: string;
+}
+
+type DirectoryClaimKind = "checkout" | "registration";
+
+interface WorktreeCleanupTestHooks {
+  afterIdentityVerification?: (worktree: Worktree) => void | Promise<void>;
+  beforeDirectoryClaim?: (worktree: Worktree, kind: DirectoryClaimKind, sourcePath: string) => void | Promise<void>;
+  afterDirectoryRename?: (worktree: Worktree, kind: DirectoryClaimKind, sourcePath: string) => void | Promise<void>;
+  afterCheckoutClaim?: (worktree: Worktree) => void | Promise<void>;
+  afterWorktreeClaim?: (worktree: Worktree) => void | Promise<void>;
+  afterBranchRefRead?: (worktree: Worktree) => void | Promise<void>;
+  afterBranchClaim?: (worktree: Worktree) => void | Promise<void>;
+  afterRegistrationClaim?: (worktree: Worktree) => void | Promise<void>;
+  beforeClaimedContentsCleanup?: (worktree: Worktree, kind: DirectoryClaimKind) => void | Promise<void>;
+  afterClaimedEntryRemoval?: (
+    worktree: Worktree,
+    kind: DirectoryClaimKind,
+    removedEntries: number,
+  ) => void | Promise<void>;
+  beforePostClaimRegistrationCheck?: (worktree: Worktree) => void | Promise<void>;
+  /** Legacy test seam retained for compatibility; legacy directory locks now fail closed. */
+  beforeEmptyRepositoryOperationLockRemoval?: (lockPath: string) => void | Promise<void>;
+  /** Runs before final inode/token verification and unlink of a fixed hard-link lock claim. */
+  beforeRepositoryOperationLockUnlink?: (lockPath: string, token: string) => void | Promise<void>;
+  /** Test-only deadline override; production permits legitimate long cleanup waits. */
+  repositoryOperationLockAcquisitionDeadlineMs?: number;
+  /** Test-only retry interval override for deterministic bounded-wait assertions. */
+  repositoryOperationLockRetryMs?: number;
+  beforeClaimedBranchDelete?: (worktree: Worktree) => void | Promise<void>;
+  /** Internal creation-only authority: delete the temporary branch only at this exact OID. */
+  creationRollbackExpectedOid?: string;
+  /** Runs after the first descriptor read and before a fresh read plus in-place sentinel-rule neutralization. */
+  beforeSentinelExcludeNeutralize?: () => void | Promise<void>;
+  /** Override for proving that Linux descriptor paths are an optional optimization. */
+  procDescriptorRoot?: string;
+  /** Simulate an inode-only verifier accepting a replacement with a reused numeric identity. */
+  simulateReusedCheckoutIdentity?: boolean;
+  /** Simulate pathname-only acceptance of a reused Git registration identity. */
+  simulateReusedGitDirIdentity?: boolean;
+  /** Simulate pathname-only acceptance of a reused Git exclude identity. */
+  simulateReusedExcludeIdentity?: boolean;
+  /** Force portable Git-registration proof creation while upgrading a legacy identity. */
+  gitDirectoryDescriptorErrorCode?: "EISDIR" | "ENOTSUP";
+}
+
+function fileIdentity(value: { dev: number | bigint; ino: number | bigint }): FileIdentity {
+  return { dev: value.dev.toString(10), ino: value.ino.toString(10) };
+}
+
+async function openBoundDirectory(path: string): Promise<{ handle: FileHandle; identity: FileIdentity }> {
+  const pathStats = await lstat(path, { bigint: true });
+  if (pathStats.isSymbolicLink() || !pathStats.isDirectory())
+    throw new Error("directory proof path is not a real directory");
+  const handle = await open(path, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+  try {
+    const handleStats = await handle.stat({ bigint: true });
+    const identity = fileIdentity(pathStats);
+    if (!handleStats.isDirectory() || !hasFileIdentity(handleStats, identity)) {
+      throw new Error("directory proof changed while its descriptor was opened");
+    }
+    return { handle, identity };
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+type DescriptorRelativeWriteKind = "checkout" | "registration" | "gitDir";
+
+interface DescriptorRelativeWriteOptions {
+  aliasMode?: "supported" | "unsupported";
+  beforeWrite?: (kind: DescriptorRelativeWriteKind, directoryPath: string) => void | Promise<void>;
+}
+
+async function verifiedDescriptorAlias(
+  directoryHandle: FileHandle,
+  expectedIdentity: FileIdentity,
+  aliasMode?: "supported" | "unsupported",
+): Promise<string> {
+  if (aliasMode === "unsupported") throw new Error("safe descriptor-relative directory aliases are unavailable");
+  for (const root of ["/proc/self/fd", "/dev/fd"]) {
+    const candidate = join(root, String(directoryHandle.fd));
+    try {
+      const aliasStats = await stat(candidate, { bigint: true });
+      if (aliasStats.isDirectory() && hasFileIdentity(aliasStats, expectedIdentity)) return candidate;
+    } catch {
+      // Try the next platform alias.
+    }
+  }
+  throw new Error("safe descriptor-relative directory aliases are unavailable");
+}
+
+async function writeExclusiveDescriptorRelative(
+  directoryPath: string,
+  directoryHandle: FileHandle,
+  expectedIdentity: FileIdentity,
+  fileName: string,
+  contents: string,
+  kind: DescriptorRelativeWriteKind,
+  options: DescriptorRelativeWriteOptions = {},
+): Promise<FileIdentity> {
+  if (basename(fileName) !== fileName || fileName === "." || fileName === "..") {
+    throw new Error("descriptor-relative proof file name is invalid");
+  }
+  const handleStats = await directoryHandle.stat({ bigint: true });
+  if (!handleStats.isDirectory() || !hasFileIdentity(handleStats, expectedIdentity)) {
+    throw new Error("descriptor-relative proof directory identity changed");
+  }
+  const aliasPath = await verifiedDescriptorAlias(directoryHandle, expectedIdentity, options.aliasMode);
+  await options.beforeWrite?.(kind, directoryPath);
+  const aliasStats = await stat(aliasPath, { bigint: true });
+  const freshHandleStats = await directoryHandle.stat({ bigint: true });
+  if (
+    !aliasStats.isDirectory() ||
+    !freshHandleStats.isDirectory() ||
+    !hasFileIdentity(aliasStats, expectedIdentity) ||
+    !hasFileIdentity(freshHandleStats, expectedIdentity)
+  ) {
+    throw new Error("descriptor-relative directory alias identity changed before proof write");
+  }
+
+  const relativePath = join(aliasPath, fileName);
+  const fileHandle = await open(
+    relativePath,
+    constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    const fileStats = await fileHandle.stat({ bigint: true });
+    if (!fileStats.isFile()) throw new Error("descriptor-relative proof is not a regular file");
+    await fileHandle.writeFile(contents, { encoding: "utf8" });
+    return fileIdentity(fileStats);
+  } catch (error) {
+    await fileHandle.close().catch(() => undefined);
+    await rm(relativePath, { force: true }).catch(() => undefined);
+    throw error;
+  } finally {
+    await fileHandle.close().catch(() => undefined);
+  }
+}
+
+function forcedDirectoryDescriptorError(code: "EISDIR" | "ENOTSUP"): NodeJS.ErrnoException {
+  const error = new Error(`forced unsupported directory descriptor: ${code}`) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+function isCurrentGitDirectorySentinelFileName(fileName: string): boolean {
+  return new RegExp(`^${GIT_DIRECTORY_SENTINEL_PREFIX.replaceAll(".", "\\.")}[0-9a-f]{64}$`).test(fileName);
+}
+
+async function createGitDirectorySentinel(
+  gitDir: string,
+  directoryHandle: FileHandle,
+  expectedIdentity: FileIdentity,
+  writeOptions: DescriptorRelativeWriteOptions = {},
+): Promise<Extract<WorktreeGitDirectoryProof, { kind: "sentinel" }>> {
+  const token = randomUUID().replaceAll("-", "") + randomUUID().replaceAll("-", "");
+  const fileName = `${GIT_DIRECTORY_SENTINEL_PREFIX}${randomUUID().replaceAll("-", "")}${randomUUID().replaceAll("-", "")}`;
+  const identity = await writeExclusiveDescriptorRelative(
+    gitDir,
+    directoryHandle,
+    expectedIdentity,
+    fileName,
+    `${token}\n`,
+    "gitDir",
+    writeOptions,
+  );
+  return { kind: "sentinel", fileName, token, identity };
+}
+
+async function createGitDirectoryOwnershipProof(
+  gitDir: string,
+  forcedErrorCode?: "EISDIR" | "ENOTSUP",
+  writeOptions: DescriptorRelativeWriteOptions = {},
+): Promise<{ identity: FileIdentity; proof: WorktreeGitDirectoryProof; handle: FileHandle }> {
+  const descriptor = await openBoundDirectory(gitDir);
+  try {
+    if (!forcedErrorCode) {
+      return { identity: descriptor.identity, proof: { kind: "descriptor" }, handle: descriptor.handle };
+    }
+    const proof = await createGitDirectorySentinel(gitDir, descriptor.handle, descriptor.identity, writeOptions);
+    return { identity: descriptor.identity, proof, handle: descriptor.handle };
+  } catch (error) {
+    await descriptor.handle.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+async function closeRuntimeIdentityHandles(marker: string): Promise<void> {
+  const handles = [
+    checkoutDirectoryHandles.get(marker),
+    gitDirectoryHandles.get(marker),
+    sentinelExcludeHandles.get(marker),
+  ];
+  checkoutDirectoryHandles.delete(marker);
+  gitDirectoryHandles.delete(marker);
+  sentinelExcludeHandles.delete(marker);
+  await Promise.all(handles.map((handle) => handle?.close().catch(() => undefined)));
+}
+
+function hasFileIdentity(
+  actual: { dev: number | bigint | string; ino: number | bigint | string },
+  expected: FileIdentity,
+): boolean {
+  return actual.dev.toString(10) === expected.dev && actual.ino.toString(10) === expected.ino;
+}
+
+function identityFailure(identity: WorktreeIdentity, message: string): WorktreeCleanupFailure {
+  return sanitizeWorktreeCleanupFailure({ stage: "identity_verification", message, identity });
+}
+
+async function readRegisteredWorktrees(repoRoot: string): Promise<RegisteredWorktree[]> {
+  const { stdout } = await exec("git", ["-C", repoRoot, "worktree", "list", "--porcelain", "-z"]);
+  return parseRegisteredWorktrees(stdout).map((registration) => ({
+    ...registration,
+    // Git for Windows may print slash-separated absolute paths while Node uses
+    // platform separators. Syntactic normalization also works after checkout loss.
+    path: resolve(registration.path),
+  }));
+}
+
+async function registeredWorktrees(
+  repoRoot: string,
+  gitCommonRoot: string,
+  hooks: WorktreeCleanupTestHooks = {},
+): Promise<RegisteredWorktree[]> {
+  return withRepositoryGitMetadataCleanup(gitCommonRoot, () => readRegisteredWorktrees(repoRoot), hooks);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function cleanupIdentityDigest(expected: RuntimeWorktreeIdentity): string {
+  return createHash("sha256")
+    .update(JSON.stringify(metadataFromRuntimeIdentity(expected)))
+    .digest("hex");
+}
+
+type CleanupClaimLayout = "direct" | "legacy";
+
+function deterministicQuarantinePaths(
+  root: string,
+  kind: DirectoryClaimKind,
+  expected: RuntimeWorktreeIdentity,
+  layout: CleanupClaimLayout = "direct",
+): { directory: string; record: string } {
+  const digest = cleanupIdentityDigest(expected);
+  const stem = layout === "direct" ? `${DIRECT_CLEANUP_CLAIM_PREFIX}-${kind}-cleanup-${digest}` : `.${kind}-${digest}`;
+  return { directory: join(root, stem), record: join(root, `${stem}.json`) };
+}
+
+async function establishQuarantineRoot(root: string): Promise<string> {
+  // A concurrent cleanup can remove a shared empty root after this transaction's
+  // initial establishment. Re-establish it through its canonical real parent;
+  // never use recursive mkdir, which would follow a replacement symlink.
+  const canonicalRoot = await secureChildDirectory(dirname(root), basename(root), true);
+  if (canonicalRoot !== root) throw new Error("cleanup quarantine root identity changed");
+  return canonicalRoot;
+}
+
+function redactQuarantinePath(message: string, quarantinePath: string): string {
+  return message.replaceAll(quarantinePath, "<cleanup-quarantine>");
+}
+
+function isLegacyCleanupShape(worktree: Worktree): boolean {
+  return (
+    worktree.isolated &&
+    typeof worktree.cwd === "string" &&
+    typeof worktree.branch === "string" &&
+    worktree.branchRef === undefined &&
+    worktree.baseSha === undefined &&
+    worktree.cleanupMetadata === undefined
+  );
+}
+
+function validRegistrationMarker(marker: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(marker);
+}
+
+function metadataFromRuntimeIdentity(
+  identity: RuntimeWorktreeIdentity,
+): WorktreeCleanupMetadataV3 | WorktreeCleanupMetadataV4 {
+  const common = {
+    registrationMarker: identity.marker,
+    repoRoot: identity.repoRoot,
+    worktreePath: identity.worktreePath,
+    checkoutIdentity: { ...identity.checkoutIdentity },
+    branch: identity.branch,
+    branchRef: identity.branchRef,
+    baseSha: identity.baseSha,
+    gitCommonRoot: identity.gitCommonRoot,
+    gitDir: identity.gitDir,
+  };
+  return identity.version === 4 && identity.checkoutProof && identity.gitDirIdentity
+    ? {
+        version: 4,
+        ...common,
+        checkoutProof: identity.checkoutProof,
+        gitDirIdentity: { ...identity.gitDirIdentity },
+        ...(identity.gitDirProof ? { gitDirProof: identity.gitDirProof } : {}),
+      }
+    : { version: 3, ...common };
+}
+
+function parseAnyRegistrationRecord(
+  contents: string,
+): WorktreeCleanupMetadataV2 | WorktreeCleanupMetadataV3 | WorktreeCleanupMetadataV4 {
+  let value: unknown;
+  try {
+    value = JSON.parse(contents);
+  } catch {
+    throw new Error("registration record is not valid JSON");
+  }
+  if (!value || typeof value !== "object") throw new Error("registration record is not an object");
+  const record = value as Partial<Omit<WorktreeCleanupMetadataV4, "version">> & { version?: 2 | 3 | 4 };
+  if (
+    (record.version !== 2 && record.version !== 3 && record.version !== 4) ||
+    typeof record.registrationMarker !== "string" ||
+    !validRegistrationMarker(record.registrationMarker) ||
+    typeof record.repoRoot !== "string" ||
+    typeof record.worktreePath !== "string" ||
+    typeof record.branch !== "string" ||
+    typeof record.branchRef !== "string" ||
+    typeof record.baseSha !== "string" ||
+    typeof record.gitCommonRoot !== "string" ||
+    typeof record.gitDir !== "string" ||
+    ((record.version === 3 || record.version === 4) &&
+      (!record.checkoutIdentity ||
+        !/^\d+$/.test(record.checkoutIdentity.dev) ||
+        !/^\d+$/.test(record.checkoutIdentity.ino))) ||
+    (record.version === 4 &&
+      (!record.gitDirIdentity ||
+        !/^\d+$/.test(record.gitDirIdentity.dev) ||
+        !/^\d+$/.test(record.gitDirIdentity.ino) ||
+        !record.checkoutProof ||
+        (record.checkoutProof.kind !== "descriptor" && record.checkoutProof.kind !== "sentinel") ||
+        (record.checkoutProof.kind === "sentinel" &&
+          ((record.checkoutProof.fileName !== LEGACY_CHECKOUT_SENTINEL_FILE &&
+            !isCurrentSentinelFileName(record.checkoutProof.fileName)) ||
+            !/^[0-9a-f]{64}$/i.test(record.checkoutProof.token) ||
+            typeof record.checkoutProof.excludeLeadingNewline !== "boolean" ||
+            !record.checkoutProof.excludeIdentity ||
+            !/^\d+$/.test(record.checkoutProof.excludeIdentity.dev) ||
+            !/^\d+$/.test(record.checkoutProof.excludeIdentity.ino))) ||
+        (record.gitDirProof !== undefined &&
+          record.gitDirProof.kind !== "descriptor" &&
+          (record.gitDirProof.kind !== "sentinel" ||
+            !isCurrentGitDirectorySentinelFileName(record.gitDirProof.fileName) ||
+            !/^[0-9a-f]{64}$/i.test(record.gitDirProof.token) ||
+            !record.gitDirProof.identity ||
+            !/^\d+$/.test(record.gitDirProof.identity.dev) ||
+            !/^\d+$/.test(record.gitDirProof.identity.ino)))))
+  ) {
+    throw new Error("registration record is incomplete or has an unsupported version");
+  }
+  const common = {
+    registrationMarker: record.registrationMarker,
+    repoRoot: record.repoRoot,
+    worktreePath: record.worktreePath,
+    branch: record.branch,
+    branchRef: record.branchRef,
+    baseSha: record.baseSha,
+    gitCommonRoot: record.gitCommonRoot,
+    gitDir: record.gitDir,
+  };
+  if (record.version === 4) {
+    return {
+      version: 4,
+      ...common,
+      checkoutIdentity: { ...record.checkoutIdentity } as FileIdentity,
+      checkoutProof: record.checkoutProof as WorktreeCheckoutProof,
+      gitDirIdentity: { ...record.gitDirIdentity } as FileIdentity,
+      ...(record.gitDirProof ? { gitDirProof: record.gitDirProof as WorktreeGitDirectoryProof } : {}),
+    };
+  }
+  return record.version === 3
+    ? { version: 3, ...common, checkoutIdentity: { ...record.checkoutIdentity } as FileIdentity }
+    : { version: 2, ...common };
+}
+
+function parseRegistrationRecord(contents: string): WorktreeCleanupMetadataV3 | WorktreeCleanupMetadataV4 {
+  const record = parseAnyRegistrationRecord(contents);
+  if (record.version !== 3 && record.version !== 4) {
+    throw new Error("registration record uses a legacy cleanup identity version");
+  }
+  return record;
+}
+
+async function readRegistrationFile(markerPath: string): Promise<string> {
+  const pathStats = await lstat(markerPath, { bigint: true });
+  if (pathStats.isSymbolicLink() || !pathStats.isFile()) {
+    throw new Error("registration record is not a regular file");
+  }
+  const handle = await open(markerPath, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const handleStats = await handle.stat({ bigint: true });
+    if (!handleStats.isFile() || !hasFileIdentity(handleStats, fileIdentity(pathStats))) {
+      throw new Error("registration record changed while its identity was verified");
+    }
+    if (handleStats.size > 16_384n) throw new Error("registration record is unexpectedly large");
+    return (await handle.readFile({ encoding: "utf8" })).trim();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readRegistrationRecord(gitDir: string): Promise<WorktreeCleanupMetadataV3 | WorktreeCleanupMetadataV4> {
+  return parseRegistrationRecord(await readRegistrationFile(join(gitDir, REGISTRATION_MARKER_FILE)));
+}
+
+async function writeRegistrationRecord(
+  gitDir: string,
+  record: WorktreeCleanupMetadataV3 | WorktreeCleanupMetadataV4,
+  boundDirectory?: { handle: FileHandle; identity: FileIdentity },
+  writeOptions: DescriptorRelativeWriteOptions = {},
+): Promise<void> {
+  const opened = boundDirectory ?? (await openBoundDirectory(gitDir));
+  try {
+    await writeExclusiveDescriptorRelative(
+      gitDir,
+      opened.handle,
+      opened.identity,
+      REGISTRATION_MARKER_FILE,
+      `${JSON.stringify(record)}\n`,
+      "registration",
+      writeOptions,
+    );
+  } finally {
+    if (!boundDirectory) await opened.handle.close().catch(() => undefined);
+  }
+}
+
+async function replaceLegacyRegistrationMarker(
+  gitDir: string,
+  record: WorktreeCleanupMetadataV3 | WorktreeCleanupMetadataV4,
+): Promise<void> {
+  const directory = await openBoundDirectory(gitDir);
+  const replacementName = `.${REGISTRATION_MARKER_FILE}-${randomUUID()}`;
+  try {
+    const aliasPath = await verifiedDescriptorAlias(directory.handle, directory.identity);
+    const markerPath = join(aliasPath, REGISTRATION_MARKER_FILE);
+    const replacementPath = join(aliasPath, replacementName);
+    try {
+      await writeExclusiveDescriptorRelative(
+        gitDir,
+        directory.handle,
+        directory.identity,
+        replacementName,
+        `${JSON.stringify(record)}\n`,
+        "registration",
+      );
+      const currentMarker = await readRegistrationFile(markerPath);
+      if (!validRegistrationMarker(currentMarker) || currentMarker !== record.registrationMarker) {
+        throw new Error("legacy registration marker changed before upgrade");
+      }
+      await rename(replacementPath, markerPath);
+    } finally {
+      await rm(replacementPath, { force: true }).catch(() => undefined);
+    }
+  } finally {
+    await directory.handle.close().catch(() => undefined);
+  }
+}
+
+async function replaceRegistrationRecord(
+  gitDir: string,
+  expectedContents: string,
+  record: WorktreeCleanupMetadataV3 | WorktreeCleanupMetadataV4,
+): Promise<void> {
+  const directory = await openBoundDirectory(gitDir);
+  const replacementName = `.${REGISTRATION_MARKER_FILE}-${randomUUID()}`;
+  try {
+    const aliasPath = await verifiedDescriptorAlias(directory.handle, directory.identity);
+    const markerPath = join(aliasPath, REGISTRATION_MARKER_FILE);
+    const replacementPath = join(aliasPath, replacementName);
+    try {
+      await writeExclusiveDescriptorRelative(
+        gitDir,
+        directory.handle,
+        directory.identity,
+        replacementName,
+        `${JSON.stringify(record)}\n`,
+        "registration",
+      );
+      if ((await readRegistrationFile(markerPath)) !== expectedContents) {
+        throw new Error("legacy registration record changed before identity upgrade");
+      }
+      await rename(replacementPath, markerPath);
+    } finally {
+      await rm(replacementPath, { force: true }).catch(() => undefined);
+    }
+  } finally {
+    await directory.handle.close().catch(() => undefined);
+  }
+}
+
+async function installUpgradedCleanupMetadata(
+  common: Omit<WorktreeCleanupMetadataV4, "version" | "checkoutProof" | "gitDirIdentity" | "gitDirProof">,
+  install: (metadata: WorktreeCleanupMetadataV4) => Promise<void>,
+  repositoryLockHeld = false,
+  gitDirectoryDescriptorErrorCode?: "EISDIR" | "ENOTSUP",
+): Promise<WorktreeCleanupMetadataV4> {
+  let handle: FileHandle | undefined;
+  let gitDirHandle: FileHandle | undefined;
+  let gitDirIdentity: FileIdentity | undefined;
+  let gitDirSentinel: Extract<WorktreeGitDirectoryProof, { kind: "sentinel" }> | undefined;
+  let proof: WorktreeCheckoutProof | undefined;
+  try {
+    try {
+      handle = await open(common.worktreePath, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+      const handleStats = await handle.stat({ bigint: true });
+      if (!handleStats.isDirectory() || !hasFileIdentity(handleStats, common.checkoutIdentity)) {
+        throw new Error("legacy upgrade descriptor does not match the checkout identity");
+      }
+      proof = { kind: "descriptor" };
+    } catch (error) {
+      await handle?.close().catch(() => undefined);
+      handle = undefined;
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code && !["EINVAL", "ENOTSUP", "EOPNOTSUPP", "EISDIR", "EPERM"].includes(code)) throw error;
+      throw new Error("safe checkout-directory descriptor is unavailable for portable identity upgrade");
+    }
+    if (!proof) throw new Error("durable checkout proof is unavailable");
+    const gitDirectoryOwnership = await createGitDirectoryOwnershipProof(
+      common.gitDir,
+      gitDirectoryDescriptorErrorCode,
+    );
+    gitDirHandle = gitDirectoryOwnership.handle;
+    gitDirIdentity = gitDirectoryOwnership.identity;
+    if (gitDirectoryOwnership.proof.kind === "sentinel") gitDirSentinel = gitDirectoryOwnership.proof;
+    const metadata: WorktreeCleanupMetadataV4 = {
+      version: 4,
+      ...common,
+      checkoutProof: proof,
+      gitDirIdentity: gitDirectoryOwnership.identity,
+      gitDirProof: gitDirectoryOwnership.proof,
+    };
+    await install(metadata);
+    if (handle) {
+      const previous = checkoutDirectoryHandles.get(metadata.registrationMarker);
+      checkoutDirectoryHandles.set(metadata.registrationMarker, handle);
+      if (previous && previous !== handle) await previous.close().catch(() => undefined);
+      handle = undefined;
+    }
+    if (gitDirHandle && gitDirectoryOwnership.proof.kind === "descriptor") {
+      const previousGitDir = gitDirectoryHandles.get(metadata.registrationMarker);
+      gitDirectoryHandles.set(metadata.registrationMarker, gitDirHandle);
+      if (previousGitDir && previousGitDir !== gitDirHandle) await previousGitDir.close().catch(() => undefined);
+      gitDirHandle = undefined;
+    } else {
+      await gitDirHandle?.close().catch(() => undefined);
+      gitDirHandle = undefined;
+    }
+    gitDirSentinel = undefined;
+    return metadata;
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await gitDirHandle?.close().catch(() => undefined);
+    if (gitDirSentinel) {
+      const currentGitDir = await lstat(common.gitDir, { bigint: true }).catch(() => undefined);
+      if (currentGitDir?.isDirectory() && gitDirIdentity && hasFileIdentity(currentGitDir, gitDirIdentity)) {
+        await rm(join(common.gitDir, gitDirSentinel.fileName), { force: true }).catch(() => undefined);
+      }
+    }
+    if (proof?.kind === "sentinel") {
+      await rm(join(common.worktreePath, proof.fileName), { force: true }).catch(() => undefined);
+      await removeSentinelExclude(common.gitCommonRoot, common.registrationMarker, proof, {}, repositoryLockHeld).catch(
+        () => undefined,
+      );
+    }
+    await closeRuntimeIdentityHandles(common.registrationMarker);
+    throw error;
+  }
+}
+
+interface LegacyAdoptionOptions {
+  repositoryLockHeld?: boolean;
+  expectedVersionTwo?: WorktreeCleanupMetadataV2;
+  expectedVersionThree?: WorktreeCleanupMetadataV3;
+  gitDirectoryDescriptorErrorCode?: "EISDIR" | "ENOTSUP";
+}
+
+async function adoptLegacyWorktree(
+  worktree: Worktree,
+  options: LegacyAdoptionOptions = {},
+): Promise<Worktree | string> {
+  if (!isLegacyCleanupShape(worktree)) return "cloneable worktree cleanup identity is unavailable or incomplete";
+  if (!worktree.branch?.startsWith("pi/wf/")) return "legacy branch is outside the runtime worktree namespace";
+
+  try {
+    if (!isAbsolute(worktree.cwd) || resolve(worktree.cwd) !== worktree.cwd) {
+      return "legacy worktree path is not canonical and absolute";
+    }
+    const checkoutStats = await lstat(worktree.cwd, { bigint: true });
+    if (checkoutStats.isSymbolicLink() || !checkoutStats.isDirectory()) {
+      return "legacy worktree path is not a real directory";
+    }
+    const checkoutIdentity = fileIdentity(checkoutStats);
+    const worktreePath = await realpath(worktree.cwd);
+    if (worktreePath !== worktree.cwd) return "legacy worktree path is not canonical";
+
+    const preliminaryGitDir = await resolveGitDirectory(worktreePath, "--git-dir");
+    let recordedMetadata: WorktreeCleanupMetadataV2 | WorktreeCleanupMetadataV3 | WorktreeCleanupMetadataV4 | undefined;
+    try {
+      recordedMetadata = parseAnyRegistrationRecord(
+        await readRegistrationFile(join(preliminaryGitDir, REGISTRATION_MARKER_FILE)),
+      );
+    } catch {
+      // Pre-v2 legacy registrations may contain only a UUID marker or no marker.
+    }
+
+    const directParent = dirname(worktreePath);
+    let derivedRepoRoot: string;
+    if (isExactPrefixedChild(directParent, worktreePath, RUNTIME_WORKTREE_PREFIX)) {
+      if (!recordedMetadata || recordedMetadata.worktreePath !== worktreePath) {
+        return "Git-common-dir runtime child has no matching immutable registration record";
+      }
+      derivedRepoRoot = recordedMetadata.repoRoot;
+    } else {
+      derivedRepoRoot = isExactLegacyDirectWorktreeChild(directParent, worktreePath)
+        ? directParent
+        : resolve(worktreePath, "..", "..", "..");
+    }
+    const repoRoot = await realpath(derivedRepoRoot);
+    if (repoRoot !== derivedRepoRoot) return "legacy repository root is not canonical";
+    if (worktree.repoRoot !== undefined) {
+      if (!isAbsolute(worktree.repoRoot) || resolve(worktree.repoRoot) !== worktree.repoRoot) {
+        return "stored legacy repository root is not canonical and absolute";
+      }
+      const storedRepoRoot = await realpath(worktree.repoRoot);
+      if (storedRepoRoot !== repoRoot || storedRepoRoot !== worktree.repoRoot) {
+        return "stored legacy repository root does not match the path-derived repository root";
+      }
+    }
+
+    const [{ stdout: topLevelOutput }, gitCommonRoot, checkoutCommonRoot] = await Promise.all([
+      executeGit(["-C", repoRoot, "rev-parse", "--show-toplevel"]),
+      resolveGitDirectory(repoRoot, "--git-common-dir"),
+      resolveGitDirectory(worktreePath, "--git-common-dir"),
+    ]);
+    const gitDir = preliminaryGitDir;
+    try {
+      await verifyRuntimeWorktreeContainment(repoRoot, gitCommonRoot, worktreePath);
+    } catch {
+      return "legacy worktree path is not an exact runtime direct child or legacy worktree-root child";
+    }
+    const canonicalTopLevel = await realpath(topLevelOutput.trim());
+    if (canonicalTopLevel !== repoRoot) return "legacy repository root is not the exact Git top-level";
+    if (checkoutCommonRoot !== gitCommonRoot) return "legacy checkout belongs to a different Git common root";
+    const gitDirStats = await lstat(gitDir, { bigint: true });
+    if (gitDirStats.isSymbolicLink() || !gitDirStats.isDirectory()) {
+      return "legacy per-worktree gitdir is not a real directory";
+    }
+    const registeredCheckoutLink = resolve((await readFile(join(gitDir, "gitdir"), "utf8")).trim());
+    if (registeredCheckoutLink !== join(worktreePath, ".git")) {
+      return "legacy per-worktree gitdir points at a different checkout";
+    }
+
+    const branchRef = `refs/heads/${worktree.branch}`;
+    const registrations = options.repositoryLockHeld
+      ? await readRegisteredWorktrees(repoRoot)
+      : await registeredWorktrees(repoRoot, gitCommonRoot);
+    const registration = registrations.find((candidate) => candidate.path === worktreePath);
+    if (!registration || registration.branchRef !== branchRef) {
+      return "legacy worktree path and runtime branch are not exactly registered together";
+    }
+    if (registrations.some((candidate) => candidate.path !== worktreePath && candidate.branchRef === branchRef)) {
+      return "legacy temporary branch is checked out by another registered worktree";
+    }
+
+    const [{ stdout: refOutput }, { stdout: objectFormatOutput }] = await Promise.all([
+      exec("git", ["-C", repoRoot, "for-each-ref", "--format=%(objectname)%00%(symref)", branchRef]),
+      exec("git", ["-C", repoRoot, "rev-parse", "--show-object-format"]),
+    ]);
+    const record = refOutput.trimEnd();
+    if (!record) return "legacy temporary branch ref does not exist";
+    const [branchOid, symref = ""] = record.split("\0");
+    if (symref.length > 0) return "legacy temporary branch ref is symbolic";
+    const objectFormat = objectFormatOutput.trim();
+    const oidWidth = objectFormat === "sha1" ? 40 : objectFormat === "sha256" ? 64 : undefined;
+    if (oidWidth === undefined || branchOid?.length !== oidWidth) {
+      return "legacy temporary branch object ID does not match the repository object format";
+    }
+
+    const currentCheckoutStats = await lstat(worktreePath, { bigint: true });
+    if (
+      currentCheckoutStats.isSymbolicLink() ||
+      !currentCheckoutStats.isDirectory() ||
+      !hasFileIdentity(currentCheckoutStats, checkoutIdentity)
+    ) {
+      return "legacy checkout identity changed before its durable identity upgrade";
+    }
+
+    let cleanupMetadata: WorktreeCleanupMetadataV4;
+    const install = (registrationMarker: string, writer: (metadata: WorktreeCleanupMetadataV4) => Promise<void>) =>
+      installUpgradedCleanupMetadata(
+        {
+          registrationMarker,
+          repoRoot,
+          worktreePath,
+          checkoutIdentity,
+          branch: worktree.branch as string,
+          branchRef,
+          baseSha: branchOid,
+          gitCommonRoot,
+          gitDir,
+        },
+        writer,
+        options.repositoryLockHeld,
+        options.gitDirectoryDescriptorErrorCode,
+      );
+    try {
+      const contents = await readRegistrationFile(join(gitDir, REGISTRATION_MARKER_FILE));
+      if (validRegistrationMarker(contents)) {
+        cleanupMetadata = await install(contents, (metadata) => replaceLegacyRegistrationMarker(gitDir, metadata));
+      } else {
+        const existing = parseAnyRegistrationRecord(contents);
+        if (
+          existing.repoRoot !== repoRoot ||
+          existing.worktreePath !== worktreePath ||
+          existing.branch !== worktree.branch ||
+          existing.branchRef !== branchRef ||
+          existing.gitCommonRoot !== gitCommonRoot ||
+          existing.gitDir !== gitDir
+        ) {
+          return "legacy worktree does not match its immutable registration record";
+        }
+        if (existing.version === 3) {
+          const expectedV3 = options.expectedVersionThree;
+          if (
+            !expectedV3 ||
+            existing.registrationMarker !== expectedV3.registrationMarker ||
+            existing.repoRoot !== expectedV3.repoRoot ||
+            existing.worktreePath !== expectedV3.worktreePath ||
+            existing.branch !== expectedV3.branch ||
+            existing.branchRef !== expectedV3.branchRef ||
+            existing.baseSha !== expectedV3.baseSha ||
+            existing.gitCommonRoot !== expectedV3.gitCommonRoot ||
+            existing.gitDir !== expectedV3.gitDir ||
+            !hasFileIdentity(existing.checkoutIdentity, expectedV3.checkoutIdentity) ||
+            !hasFileIdentity(currentCheckoutStats, expectedV3.checkoutIdentity)
+          ) {
+            return "version-three registration cannot be freshly adopted as a legacy worktree";
+          }
+          const versionThreeIdentity: RuntimeWorktreeIdentity = {
+            version: 3,
+            repoRoot: expectedV3.repoRoot,
+            worktreePath: expectedV3.worktreePath,
+            checkoutIdentity: { ...expectedV3.checkoutIdentity },
+            branch: expectedV3.branch,
+            branchRef: expectedV3.branchRef,
+            baseSha: expectedV3.baseSha,
+            gitCommonRoot: expectedV3.gitCommonRoot,
+            gitDir: expectedV3.gitDir,
+            marker: expectedV3.registrationMarker,
+          };
+          const checkoutProofFailure = await verifyCheckoutOwnershipProof(versionThreeIdentity, currentCheckoutStats);
+          if (checkoutProofFailure) {
+            return `version-three checkout ownership proof is unavailable: ${checkoutProofFailure}`;
+          }
+          cleanupMetadata = await install(existing.registrationMarker, (metadata) =>
+            replaceRegistrationRecord(gitDir, contents, metadata),
+          );
+        } else if (existing.version === 4) {
+          const expectedV2 = options.expectedVersionTwo;
+          const expectedV3 = options.expectedVersionThree;
+          const expectedLegacy = expectedV3 ?? expectedV2;
+          if (
+            !expectedLegacy ||
+            existing.registrationMarker !== expectedLegacy.registrationMarker ||
+            existing.repoRoot !== expectedLegacy.repoRoot ||
+            existing.worktreePath !== expectedLegacy.worktreePath ||
+            existing.branch !== expectedLegacy.branch ||
+            existing.branchRef !== expectedLegacy.branchRef ||
+            existing.gitCommonRoot !== expectedLegacy.gitCommonRoot ||
+            existing.gitDir !== expectedLegacy.gitDir ||
+            existing.baseSha !== branchOid ||
+            (expectedV3 !== undefined && !hasFileIdentity(existing.checkoutIdentity, expectedV3.checkoutIdentity)) ||
+            !hasFileIdentity(currentCheckoutStats, existing.checkoutIdentity) ||
+            !hasFileIdentity(gitDirStats, existing.gitDirIdentity)
+          ) {
+            return "current-version registration cannot be freshly adopted as a legacy worktree";
+          }
+          const upgradedIdentity: RuntimeWorktreeIdentity = {
+            version: 4,
+            repoRoot: existing.repoRoot,
+            worktreePath: existing.worktreePath,
+            checkoutIdentity: { ...existing.checkoutIdentity },
+            checkoutProof: existing.checkoutProof,
+            gitDirIdentity: { ...existing.gitDirIdentity },
+            ...(existing.gitDirProof ? { gitDirProof: existing.gitDirProof } : {}),
+            branch: existing.branch,
+            branchRef: existing.branchRef,
+            baseSha: existing.baseSha,
+            gitCommonRoot: existing.gitCommonRoot,
+            gitDir: existing.gitDir,
+            marker: existing.registrationMarker,
+          };
+          const [checkoutProofFailure, gitDirProofFailure] = await Promise.all([
+            verifyCheckoutOwnershipProof(upgradedIdentity, currentCheckoutStats),
+            verifyGitDirectoryOwnershipProof(upgradedIdentity, gitDirStats),
+          ]);
+          if (checkoutProofFailure || gitDirProofFailure) {
+            return "upgraded legacy registration no longer has its exact runtime ownership proofs";
+          }
+          cleanupMetadata = existing;
+        } else {
+          cleanupMetadata = await install(existing.registrationMarker, (metadata) =>
+            replaceRegistrationRecord(gitDir, contents, metadata),
+          );
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      cleanupMetadata = await install(randomUUID(), (metadata) => writeRegistrationRecord(gitDir, metadata));
+    }
+    return {
+      ...worktree,
+      cwd: worktreePath,
+      branchRef,
+      baseSha: cleanupMetadata.baseSha,
+      repoRoot,
+      cleanupMetadata,
+    };
+  } catch (error) {
+    return `legacy worktree adoption failed: ${errorMessage(error)}`;
+  }
+}
+
+async function upgradeVersionOneWorktree(worktree: Worktree): Promise<Worktree | string> {
+  const metadata = worktree.cleanupMetadata;
+  if (
+    metadata?.version !== 1 ||
+    !worktree.repoRoot ||
+    !worktree.branch ||
+    !worktree.branchRef ||
+    !worktree.baseSha ||
+    worktree.branchRef !== `refs/heads/${worktree.branch}`
+  ) {
+    return "legacy cloneable worktree cleanup identity is unavailable or incomplete";
+  }
+  const adopted = await adoptLegacyWorktree({
+    isolated: true,
+    cwd: worktree.cwd,
+    branch: worktree.branch,
+    repoRoot: worktree.repoRoot,
+  });
+  if (typeof adopted === "string") return adopted;
+  const adoptedMetadata = adopted.cleanupMetadata;
+  if (
+    adoptedMetadata?.version !== 4 ||
+    adoptedMetadata.registrationMarker !== metadata.registrationMarker ||
+    adoptedMetadata.gitCommonRoot !== metadata.gitCommonRoot ||
+    adoptedMetadata.gitDir !== metadata.gitDir
+  ) {
+    return "legacy cloneable metadata does not match its registered worktree identity";
+  }
+  return adopted;
+}
+
+async function upgradeVersionTwoWorktree(worktree: Worktree): Promise<Worktree | string> {
+  const metadata = worktree.cleanupMetadata;
+  if (
+    metadata?.version !== 2 ||
+    !worktree.repoRoot ||
+    !worktree.branch ||
+    !worktree.branchRef ||
+    !worktree.baseSha ||
+    worktree.branchRef !== `refs/heads/${worktree.branch}`
+  ) {
+    return "legacy version-two worktree cleanup identity is unavailable or incomplete";
+  }
+  if (
+    worktree.cwd !== metadata.worktreePath ||
+    worktree.repoRoot !== metadata.repoRoot ||
+    worktree.branch !== metadata.branch ||
+    worktree.branchRef !== metadata.branchRef ||
+    worktree.baseSha !== metadata.baseSha
+  ) {
+    return "legacy version-two worktree fields do not match their serialized cleanup identity";
+  }
+  let actualGitCommonRoot: string;
+  try {
+    actualGitCommonRoot = await resolveGitDirectory(worktree.cwd, "--git-common-dir");
+    if (
+      actualGitCommonRoot !== metadata.gitCommonRoot ||
+      (await realDirectory(actualGitCommonRoot, false)) !== actualGitCommonRoot
+    ) {
+      return "legacy version-two Git common root does not match its registered repository";
+    }
+  } catch (error) {
+    return `legacy version-two repository validation failed: ${errorMessage(error)}`;
+  }
+  return withRepositoryGitMetadataCleanup(actualGitCommonRoot, async () => {
+    const adopted = await adoptLegacyWorktree(
+      {
+        isolated: true,
+        cwd: worktree.cwd,
+        branch: worktree.branch,
+        repoRoot: worktree.repoRoot,
+      },
+      { repositoryLockHeld: true, expectedVersionTwo: metadata },
+    );
+    if (typeof adopted === "string") return adopted;
+    const adoptedMetadata = adopted.cleanupMetadata;
+    if (
+      adoptedMetadata?.version !== 4 ||
+      adoptedMetadata.registrationMarker !== metadata.registrationMarker ||
+      adoptedMetadata.repoRoot !== metadata.repoRoot ||
+      adoptedMetadata.worktreePath !== metadata.worktreePath ||
+      adoptedMetadata.branchRef !== metadata.branchRef ||
+      adoptedMetadata.gitCommonRoot !== metadata.gitCommonRoot ||
+      adoptedMetadata.gitDir !== metadata.gitDir
+    ) {
+      return "legacy version-two metadata does not match its registered worktree identity";
+    }
+    return adopted;
+  });
+}
+
+async function upgradeVersionThreeWorktree(
+  worktree: Worktree,
+  hooks: WorktreeCleanupTestHooks,
+): Promise<Worktree | string> {
+  const metadata = worktree.cleanupMetadata;
+  if (
+    metadata?.version !== 3 ||
+    !worktree.repoRoot ||
+    !worktree.branch ||
+    !worktree.branchRef ||
+    !worktree.baseSha ||
+    worktree.branchRef !== `refs/heads/${worktree.branch}`
+  ) {
+    return "legacy version-three worktree cleanup identity is unavailable or incomplete";
+  }
+  if (
+    worktree.cwd !== metadata.worktreePath ||
+    worktree.repoRoot !== metadata.repoRoot ||
+    worktree.branch !== metadata.branch ||
+    worktree.branchRef !== metadata.branchRef ||
+    worktree.baseSha !== metadata.baseSha
+  ) {
+    return "legacy version-three worktree fields do not match their serialized cleanup identity";
+  }
+
+  let actualGitCommonRoot: string;
+  try {
+    actualGitCommonRoot = await resolveGitDirectory(worktree.cwd, "--git-common-dir");
+    if (
+      actualGitCommonRoot !== metadata.gitCommonRoot ||
+      (await realDirectory(actualGitCommonRoot, false)) !== actualGitCommonRoot
+    ) {
+      return "legacy version-three Git common root does not match its registered repository";
+    }
+  } catch (error) {
+    return `legacy version-three repository validation failed: ${errorMessage(error)}`;
+  }
+
+  return withRepositoryGitMetadataCleanup(actualGitCommonRoot, async () => {
+    const adopted = await adoptLegacyWorktree(
+      {
+        isolated: true,
+        cwd: worktree.cwd,
+        branch: worktree.branch,
+        repoRoot: worktree.repoRoot,
+      },
+      {
+        repositoryLockHeld: true,
+        expectedVersionThree: metadata,
+        gitDirectoryDescriptorErrorCode: hooks.gitDirectoryDescriptorErrorCode,
+      },
+    );
+    if (typeof adopted === "string") return adopted;
+    const adoptedMetadata = adopted.cleanupMetadata;
+    if (
+      adoptedMetadata?.version !== 4 ||
+      adoptedMetadata.registrationMarker !== metadata.registrationMarker ||
+      adoptedMetadata.repoRoot !== metadata.repoRoot ||
+      adoptedMetadata.worktreePath !== metadata.worktreePath ||
+      !hasFileIdentity(adoptedMetadata.checkoutIdentity, metadata.checkoutIdentity) ||
+      adoptedMetadata.branch !== metadata.branch ||
+      adoptedMetadata.branchRef !== metadata.branchRef ||
+      adoptedMetadata.gitCommonRoot !== metadata.gitCommonRoot ||
+      adoptedMetadata.gitDir !== metadata.gitDir
+    ) {
+      return "legacy version-three metadata does not match its registered worktree identity";
+    }
+    return adopted;
+  });
+}
+
+function runtimeIdentity(worktree: Worktree): RuntimeWorktreeIdentity | string {
+  const metadata = worktree.cleanupMetadata;
+  if (
+    (metadata?.version !== 3 && metadata?.version !== 4) ||
+    !metadata.repoRoot ||
+    !metadata.worktreePath ||
+    !metadata.branch ||
+    !metadata.branchRef ||
+    !metadata.baseSha ||
+    !metadata.gitCommonRoot ||
+    !metadata.gitDir ||
+    !metadata.registrationMarker ||
+    (metadata.version === 4 && !metadata.gitDirIdentity)
+  ) {
+    return "cloneable worktree cleanup identity is unavailable or incomplete";
+  }
+  return {
+    version: metadata.version,
+    repoRoot: metadata.repoRoot,
+    worktreePath: metadata.worktreePath,
+    checkoutIdentity: { ...metadata.checkoutIdentity },
+    ...(metadata.version === 4
+      ? {
+          checkoutProof: metadata.checkoutProof,
+          gitDirIdentity: { ...metadata.gitDirIdentity },
+          ...(metadata.gitDirProof ? { gitDirProof: metadata.gitDirProof } : {}),
+        }
+      : {}),
+    branch: metadata.branch,
+    branchRef: metadata.branchRef,
+    baseSha: metadata.baseSha,
+    gitCommonRoot: metadata.gitCommonRoot,
+    gitDir: metadata.gitDir,
+    marker: metadata.registrationMarker,
+  };
+}
+
+function callerMatchesRuntimeIdentity(worktree: Worktree, expected: RuntimeWorktreeIdentity): boolean {
+  return (
+    worktree.repoRoot === expected.repoRoot &&
+    worktree.cwd === expected.worktreePath &&
+    worktree.branch === expected.branch &&
+    worktree.branchRef === expected.branchRef &&
+    worktree.baseSha === expected.baseSha
+  );
+}
+
+function runtimeIdentityKey(worktree: Worktree): string | undefined {
+  const identity = runtimeIdentity(worktree);
+  if (typeof identity === "string") return undefined;
+  return createHash("sha256").update(JSON.stringify(identity)).digest("hex");
+}
+
+async function verifyCheckoutOwnershipProof(
+  expected: RuntimeWorktreeIdentity,
+  checkoutStats: { isDirectory(): boolean; dev: number | bigint; ino: number | bigint },
+  checkoutPath = expected.worktreePath,
+): Promise<string | undefined> {
+  const handle = checkoutDirectoryHandles.get(expected.marker);
+  if (handle) {
+    try {
+      const handleStats = await handle.stat({ bigint: true });
+      if (
+        !handleStats.isDirectory() ||
+        !hasFileIdentity(handleStats, expected.checkoutIdentity) ||
+        !hasFileIdentity(checkoutStats, fileIdentity(handleStats))
+      ) {
+        return "process-local checkout descriptor no longer matches the registered pathname identity";
+      }
+      return undefined;
+    } catch {
+      return "process-local checkout descriptor could not be verified";
+    }
+  }
+
+  if (expected.version !== 4 || expected.checkoutProof?.kind !== "sentinel") {
+    return "process-local checkout descriptor is unavailable for current-version cleanup";
+  }
+  try {
+    const sentinel = await readRegistrationFile(join(checkoutPath, expected.checkoutProof.fileName));
+    if (sentinel !== expected.checkoutProof.token) return "checkout-local ownership sentinel does not match";
+    return undefined;
+  } catch {
+    return "checkout-local ownership sentinel is unavailable or invalid";
+  }
+}
+
+async function verifyGitDirectoryOwnershipProof(
+  expected: RuntimeWorktreeIdentity,
+  gitDirStats: { isDirectory(): boolean; dev: number | bigint; ino: number | bigint },
+  simulateReusedIdentity = false,
+): Promise<string | undefined> {
+  const handle = gitDirectoryHandles.get(expected.marker);
+  if (expected.version !== 4 || !expected.gitDirIdentity) {
+    return "Git registration ownership proof is unavailable for current-version cleanup";
+  }
+  if (handle) {
+    try {
+      const handleStats = await handle.stat({ bigint: true });
+      if (
+        !gitDirStats.isDirectory() ||
+        !handleStats.isDirectory() ||
+        (!simulateReusedIdentity && !hasFileIdentity(gitDirStats, expected.gitDirIdentity)) ||
+        !hasFileIdentity(handleStats, expected.gitDirIdentity) ||
+        !hasFileIdentity(gitDirStats, fileIdentity(handleStats))
+      ) {
+        return "process-local Git registration descriptor no longer matches the original pathname identity";
+      }
+      return undefined;
+    } catch {
+      return "process-local Git registration descriptor could not be verified";
+    }
+  }
+
+  const proof = expected.gitDirProof;
+  if (proof?.kind !== "sentinel") {
+    return "process-local Git registration descriptor is unavailable for current-version cleanup";
+  }
+  try {
+    if (
+      !gitDirStats.isDirectory() ||
+      (!simulateReusedIdentity && !hasFileIdentity(gitDirStats, expected.gitDirIdentity))
+    ) {
+      return "portable Git registration path no longer matches its original identity";
+    }
+    const sentinelPath = join(expected.gitDir, proof.fileName);
+    const sentinelStats = await lstat(sentinelPath, { bigint: true });
+    if (
+      sentinelStats.isSymbolicLink() ||
+      !sentinelStats.isFile() ||
+      !hasFileIdentity(sentinelStats, proof.identity) ||
+      (await readRegistrationFile(sentinelPath)) !== proof.token
+    ) {
+      return "portable Git registration sentinel does not match its persisted identity";
+    }
+    return undefined;
+  } catch {
+    return "portable Git registration sentinel is unavailable or invalid";
+  }
+}
+
+async function locateDescriptorProvenRenamedCheckout(expected: RuntimeWorktreeIdentity): Promise<string | undefined> {
+  const handle = checkoutDirectoryHandles.get(expected.marker);
+  if (!handle) return undefined;
+  const handleStats = await handle.stat({ bigint: true });
+  if (!handleStats.isDirectory() || !hasFileIdentity(handleStats, expected.checkoutIdentity)) {
+    throw new Error("process-local checkout descriptor no longer matches the registered identity");
+  }
+  if (handleStats.nlink === 0n) return undefined;
+
+  const canonicalParent = await realDirectory(expected.gitCommonRoot, false);
+  if (canonicalParent !== expected.gitCommonRoot) throw new Error("Git common parent is not canonical");
+  const matches: string[] = [];
+  for (const entry of await readdir(canonicalParent, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    const candidate = join(canonicalParent, entry.name);
+    try {
+      const candidateStats = await lstat(candidate, { bigint: true });
+      if (
+        candidateStats.isDirectory() &&
+        !candidateStats.isSymbolicLink() &&
+        hasFileIdentity(candidateStats, expected.checkoutIdentity) &&
+        (await realpath(candidate)) === candidate
+      ) {
+        matches.push(candidate);
+      }
+    } catch {
+      // Concurrently changing unrelated direct children are not cleanup authority.
+    }
+  }
+  if (matches.length === 1) return matches[0];
+  throw new Error(
+    matches.length === 0
+      ? "descriptor-proven checkout remains linked outside the safe Git-common parent or is unlocatable"
+      : "descriptor-proven checkout has multiple safe-parent directory links",
+  );
+}
+
+async function locateCreationRecoveryCheckout(expected: RuntimeWorktreeIdentity): Promise<string | undefined> {
+  const canonicalParent = await realDirectory(expected.gitCommonRoot, false);
+  if (canonicalParent !== expected.gitCommonRoot) throw new Error("Git common parent is not canonical");
+  const matches: string[] = [];
+  for (const entry of await readdir(canonicalParent, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    const candidate = join(canonicalParent, entry.name);
+    try {
+      const stats = await lstat(candidate, { bigint: true });
+      if (
+        stats.isDirectory() &&
+        hasFileIdentity(stats, expected.checkoutIdentity) &&
+        (await realpath(candidate)) === candidate &&
+        (await verifyCheckoutOwnershipProof(expected, stats, candidate)) === undefined
+      ) {
+        matches.push(candidate);
+      }
+    } catch {
+      // Unrelated or concurrently changing direct children are not recovery authority.
+    }
+  }
+  if (matches.length === 1) return matches[0];
+  if (matches.length > 1) throw new Error("multiple checkout paths match the held creation identity");
+  return undefined;
+}
+
+async function verifyCleanupIdentity(
+  worktree: Worktree,
+  hooks: WorktreeCleanupTestHooks = {},
+  creationAuthority?: CreationRegistrationAuthority,
+): Promise<VerifiedCleanupIdentity | string> {
+  const expected = runtimeIdentity(worktree);
+  if (typeof expected === "string") return expected;
+  if (!expected.branch.startsWith("pi/wf/") || expected.branchRef !== `refs/heads/${expected.branch}`) {
+    return "expected branch is outside the runtime worktree namespace";
+  }
+  if (!callerMatchesRuntimeIdentity(worktree, expected)) {
+    return "stored worktree identity no longer matches its cleanup metadata";
+  }
+
+  try {
+    const canonicalRepoRoot = await realpath(expected.repoRoot);
+    if (canonicalRepoRoot !== expected.repoRoot) return "stored repository root is not canonical";
+    try {
+      await verifyRuntimeWorktreeContainment(canonicalRepoRoot, expected.gitCommonRoot, expected.worktreePath);
+    } catch {
+      return "runtime worktree path is outside the trusted runtime locations";
+    }
+
+    const registrations = await registeredWorktrees(canonicalRepoRoot, expected.gitCommonRoot, hooks);
+    const registration = registrations.find((candidate) => candidate.path === expected.worktreePath);
+    if (!registration) return "exact canonical worktree path is no longer registered";
+    if (
+      registrations.some(
+        (candidate) => candidate.path !== expected.worktreePath && candidate.branchRef === expected.branchRef,
+      )
+    ) {
+      return "temporary branch is checked out by another registered worktree";
+    }
+
+    const actualCommonRoot = await resolveGitDirectory(canonicalRepoRoot, "--git-common-dir");
+    if (actualCommonRoot !== expected.gitCommonRoot) {
+      return "registered worktree belongs to a different repository common root";
+    }
+
+    const gitDirStats = await lstat(expected.gitDir, { bigint: true });
+    if (gitDirStats.isSymbolicLink() || !gitDirStats.isDirectory()) {
+      return "per-worktree gitdir is not the original real directory";
+    }
+    const gitDirProofFailure = await verifyGitDirectoryOwnershipProof(
+      expected,
+      gitDirStats,
+      hooks.simulateReusedGitDirIdentity,
+    );
+    if (gitDirProofFailure) return gitDirProofFailure;
+    const actualGitDir = await realpath(expected.gitDir);
+    if (actualGitDir !== expected.gitDir) return "per-worktree gitdir identity no longer matches cleanup identity";
+    if (expected.checkoutProof?.kind === "sentinel") {
+      try {
+        await verifiedSentinelExcludeHandle(
+          expected.gitCommonRoot,
+          expected.marker,
+          expected.checkoutProof,
+          hooks.simulateReusedExcludeIdentity,
+        );
+      } catch (error) {
+        return `portable sentinel exclude identity no longer matches cleanup identity: ${errorMessage(error)}`;
+      }
+    }
+    if (creationAuthority !== "in-memory") {
+      const registrationRecord = await readRegistrationRecord(actualGitDir);
+      const recordedIdentity: RuntimeWorktreeIdentity = {
+        version: registrationRecord.version,
+        repoRoot: registrationRecord.repoRoot,
+        worktreePath: registrationRecord.worktreePath,
+        checkoutIdentity: { ...registrationRecord.checkoutIdentity },
+        ...(registrationRecord.version === 4
+          ? {
+              checkoutProof: registrationRecord.checkoutProof,
+              gitDirIdentity: { ...registrationRecord.gitDirIdentity },
+              ...(registrationRecord.gitDirProof ? { gitDirProof: registrationRecord.gitDirProof } : {}),
+            }
+          : {}),
+        branch: registrationRecord.branch,
+        branchRef: registrationRecord.branchRef,
+        baseSha: registrationRecord.baseSha,
+        gitCommonRoot: registrationRecord.gitCommonRoot,
+        gitDir: registrationRecord.gitDir,
+        marker: registrationRecord.registrationMarker,
+      };
+      if (!sameRuntimeIdentity(recordedIdentity, expected)) {
+        return "per-worktree registration record does not match cleanup metadata";
+      }
+    }
+    const registeredCheckoutLink = resolve((await readFile(join(actualGitDir, "gitdir"), "utf8")).trim());
+    if (registeredCheckoutLink !== join(expected.worktreePath, ".git")) {
+      return "per-worktree gitdir points at a different checkout";
+    }
+    const [{ stdout: branchOutput }, { stdout: objectFormatOutput }] = await Promise.all([
+      exec("git", ["-C", canonicalRepoRoot, "rev-parse", "--verify", expected.branchRef]),
+      exec("git", ["-C", canonicalRepoRoot, "rev-parse", "--show-object-format"]),
+    ]);
+    const objectFormat = objectFormatOutput.trim();
+    const oidWidth = objectFormat === "sha1" ? 40 : objectFormat === "sha256" ? 64 : undefined;
+    if (oidWidth === undefined) return `unsupported Git object format: ${objectFormat}`;
+    const branchOid = branchOutput.trim();
+    if (branchOid.length !== oidWidth) return "branch object ID width does not match the repository object format";
+
+    let checkoutIdentity: FileIdentity | undefined;
+    let checkoutPath: string | undefined;
+    try {
+      const checkoutStats = await lstat(expected.worktreePath, { bigint: true });
+      const exactCheckout =
+        !checkoutStats.isSymbolicLink() &&
+        checkoutStats.isDirectory() &&
+        (hooks.simulateReusedCheckoutIdentity || hasFileIdentity(checkoutStats, expected.checkoutIdentity)) &&
+        (await verifyCheckoutOwnershipProof(expected, checkoutStats)) === undefined;
+      if (exactCheckout) {
+        const canonicalRegisteredPath = await realpath(registration.path);
+        if (canonicalRegisteredPath !== expected.worktreePath) {
+          return "registered worktree path is no longer canonical-equivalent";
+        }
+        checkoutIdentity = { ...expected.checkoutIdentity };
+        checkoutPath = expected.worktreePath;
+        const [checkoutCommonRoot, checkoutGitDir] = await Promise.all([
+          resolveGitDirectory(canonicalRegisteredPath, "--git-common-dir"),
+          resolveGitDirectory(canonicalRegisteredPath, "--git-dir"),
+        ]);
+        if (checkoutCommonRoot !== expected.gitCommonRoot) {
+          return "registered checkout belongs to a different repository common root";
+        }
+        if (checkoutGitDir !== expected.gitDir) return "registered checkout uses a different per-worktree gitdir";
+      } else if (creationAuthority) {
+        const relocated = await locateCreationRecoveryCheckout(expected);
+        if (!relocated) return "held creation checkout identity is no longer available for rollback";
+        checkoutIdentity = { ...expected.checkoutIdentity };
+        checkoutPath = relocated;
+      } else {
+        return "registered checkout no longer has the runtime-created filesystem identity and proof";
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const renamedPath = creationAuthority
+        ? await locateCreationRecoveryCheckout(expected)
+        : await locateDescriptorProvenRenamedCheckout(expected);
+      if (renamedPath) {
+        const renamedStats = await lstat(renamedPath, { bigint: true });
+        const proofFailure = await verifyCheckoutOwnershipProof(expected, renamedStats, renamedPath);
+        if (proofFailure) return proofFailure;
+        checkoutIdentity = { ...expected.checkoutIdentity };
+        checkoutPath = renamedPath;
+      }
+    }
+
+    return {
+      expected,
+      checkoutIdentity,
+      checkoutPath,
+      gitDirIdentity: fileIdentity(gitDirStats),
+      branchOid,
+      nullOid: "0".repeat(oidWidth),
+    };
+  } catch (error) {
+    return `worktree identity verification failed: ${errorMessage(error)}`;
+  }
+}
+
+interface ClaimedDirectory {
+  path: string;
+  quarantineRoot: string;
+  sourcePath: string;
+  pendingRecordPath?: string;
+  handle?: FileHandle;
+  identity: FileIdentity;
+  restorable: boolean;
+  /** Legacy shared roots are removed when empty; the trusted Git-common parent never is. */
+  removeParentWhenEmpty?: boolean;
+}
+
+interface PendingCleanupRecordV1 {
+  version: typeof PENDING_CLEANUP_RECORD_VERSION;
+  kind: DirectoryClaimKind;
+  state: "claimed" | "destructive";
+  identity: FileIdentity;
+  metadata: WorktreeCleanupMetadataV3 | WorktreeCleanupMetadataV4;
+}
+
+function parsePendingCleanupRecord(contents: string): PendingCleanupRecordV1 {
+  let value: unknown;
+  try {
+    value = JSON.parse(contents);
+  } catch {
+    throw new Error("pending cleanup record is not valid JSON");
+  }
+  if (!value || typeof value !== "object") throw new Error("pending cleanup record is not an object");
+  const record = value as Partial<PendingCleanupRecordV1>;
+  if (
+    record.version !== PENDING_CLEANUP_RECORD_VERSION ||
+    (record.kind !== "checkout" && record.kind !== "registration") ||
+    (record.state !== "claimed" && record.state !== "destructive") ||
+    !record.identity ||
+    typeof record.identity.dev !== "string" ||
+    !/^\d+$/.test(record.identity.dev) ||
+    typeof record.identity.ino !== "string" ||
+    !/^\d+$/.test(record.identity.ino) ||
+    !record.metadata
+  ) {
+    throw new Error("pending cleanup record is incomplete or has an unsupported version");
+  }
+  const metadata = parseRegistrationRecord(JSON.stringify(record.metadata));
+  return {
+    version: PENDING_CLEANUP_RECORD_VERSION,
+    kind: record.kind,
+    state: record.state,
+    identity: record.identity,
+    metadata,
+  };
+}
+
+async function writePendingCleanupRecord(
+  path: string,
+  kind: DirectoryClaimKind,
+  identity: FileIdentity,
+  expected: RuntimeWorktreeIdentity,
+): Promise<void> {
+  const record: PendingCleanupRecordV1 = {
+    version: PENDING_CLEANUP_RECORD_VERSION,
+    kind,
+    state: "claimed",
+    identity,
+    metadata: metadataFromRuntimeIdentity(expected),
+  };
+  await writeFile(path, `${JSON.stringify(record)}\n`, { encoding: "utf8", flag: "wx", mode: 0o600 });
+}
+
+async function markPendingCleanupDestructive(claimed: ClaimedDirectory): Promise<void> {
+  if (!claimed.pendingRecordPath) return;
+  const current = parsePendingCleanupRecord(await readRegistrationFile(claimed.pendingRecordPath));
+  if (current.state === "destructive") return;
+  const replacement = join(claimed.quarantineRoot, `.pending-state-${randomUUID()}`);
+  await writeFile(replacement, `${JSON.stringify({ ...current, state: "destructive" })}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode: 0o600,
+  });
+  try {
+    const unchanged = parsePendingCleanupRecord(await readRegistrationFile(claimed.pendingRecordPath));
+    if (
+      unchanged.state !== "claimed" ||
+      unchanged.kind !== current.kind ||
+      unchanged.identity.dev !== current.identity.dev ||
+      unchanged.identity.ino !== current.identity.ino
+    ) {
+      throw new Error("pending cleanup identity changed before destructive transition");
+    }
+    await rename(replacement, claimed.pendingRecordPath);
+  } finally {
+    await rm(replacement, { force: true }).catch(() => undefined);
+  }
+}
+
+async function removeEmptyQuarantineRoot(root: string): Promise<void> {
+  await rmdir(root).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== "ENOENT" && error.code !== "ENOTEMPTY" && error.code !== "EEXIST") throw error;
+  });
+}
+
+async function restoreClaimedDirectory(claimed: ClaimedDirectory, label: string): Promise<string> {
+  await claimed.handle?.close().catch(() => undefined);
+  claimed.handle = undefined;
+  if (!claimed.restorable) {
+    return `${label} claim was preserved in private quarantine because destructive cleanup had already started`;
+  }
+  try {
+    const claimedStats = await lstat(claimed.path, { bigint: true });
+    if (!claimedStats.isDirectory() || !hasFileIdentity(claimedStats, claimed.identity)) {
+      return `${label} claim was preserved because its quarantine path no longer names the claimed identity`;
+    }
+    if (await pathExists(claimed.sourcePath)) {
+      return `${label} claim and the occupied original path were both preserved`;
+    }
+    await rename(claimed.path, claimed.sourcePath);
+    const restoredStats = await lstat(claimed.sourcePath, { bigint: true });
+    if (!restoredStats.isDirectory() || !hasFileIdentity(restoredStats, claimed.identity)) {
+      return `${label} restoration could not be identity-verified; cleanup stopped`;
+    }
+    if (claimed.pendingRecordPath) await rm(claimed.pendingRecordPath, { force: true });
+    if (claimed.removeParentWhenEmpty) await removeEmptyQuarantineRoot(claimed.quarantineRoot);
+    return `${label} claim was restored to its original path`;
+  } catch (error) {
+    const redacted = redactQuarantinePath(
+      redactQuarantinePath(errorMessage(error), claimed.path),
+      claimed.quarantineRoot,
+    );
+    return `${label} claim was preserved in private quarantine because restoration failed: ${redacted}`;
+  }
+}
+
+async function restoreUnexpectedClaim(
+  sourcePath: string,
+  quarantinePath: string,
+  capturedIdentity: FileIdentity,
+): Promise<string> {
+  if (await pathExists(sourcePath)) {
+    return "cleanup claim captured a replacement inode; the occupied original path and captured replacement were preserved";
+  }
+  try {
+    await rename(quarantinePath, sourcePath);
+    const restoredStats = await lstat(sourcePath, { bigint: true });
+    if (!restoredStats.isDirectory() || !hasFileIdentity(restoredStats, capturedIdentity)) {
+      return "cleanup claim captured a replacement inode; restoration could not be verified and cleanup stopped";
+    }
+    return "cleanup claim captured a replacement inode; the replacement was restored to the original path";
+  } catch (error) {
+    return `cleanup claim captured a replacement inode; it was preserved in private quarantine because restoration failed: ${redactQuarantinePath(errorMessage(error), quarantinePath)}`;
+  }
+}
+
+async function claimDirectory(
+  worktree: Worktree,
+  kind: DirectoryClaimKind,
+  sourcePath: string,
+  quarantineRoot: string,
+  _prefix: string,
+  expectedIdentity: FileIdentity,
+  hooks: WorktreeCleanupTestHooks,
+  layout: CleanupClaimLayout = "direct",
+): Promise<ClaimedDirectory | string> {
+  const expected = runtimeIdentity(worktree);
+  if (typeof expected === "string") return expected;
+  const canonicalRoot =
+    layout === "direct" ? await realDirectory(quarantineRoot, false) : await establishQuarantineRoot(quarantineRoot);
+  if (layout === "direct" && canonicalRoot !== expected.gitCommonRoot) {
+    return "current cleanup claim parent is not the exact trusted Git common directory";
+  }
+  const pendingPaths = deterministicQuarantinePaths(canonicalRoot, kind, expected, layout);
+  const quarantinePath = pendingPaths.directory;
+  const requiredPrefix = `${DIRECT_CLEANUP_CLAIM_PREFIX}-${kind}-cleanup-`;
+  if (layout === "direct" && !isExactPrefixedChild(canonicalRoot, quarantinePath, requiredPrefix)) {
+    return "current cleanup claim is not a strict direct child of the Git common directory";
+  }
+  let renamed = false;
+  try {
+    if ((await pathExists(quarantinePath)) || (await pathExists(pendingPaths.record))) {
+      throw new Error("a deterministic pending cleanup claim already exists and must be resumed first");
+    }
+    await hooks.beforeDirectoryClaim?.(worktree, kind, sourcePath);
+    if ((await pathExists(quarantinePath)) || (await pathExists(pendingPaths.record))) {
+      throw new Error("a deterministic cleanup claim collision appeared before rename");
+    }
+    await rename(sourcePath, quarantinePath);
+    renamed = true;
+    await hooks.afterDirectoryRename?.(worktree, kind, sourcePath);
+  } catch (error) {
+    let restoration = "";
+    if (renamed) {
+      restoration = `; ${await restoreClaimedDirectory(
+        {
+          path: quarantinePath,
+          quarantineRoot,
+          sourcePath,
+          identity: expectedIdentity,
+          restorable: true,
+          removeParentWhenEmpty: layout === "legacy",
+        },
+        kind,
+      )}`;
+    }
+    return `cleanup claim failed: ${redactQuarantinePath(errorMessage(error), quarantinePath || quarantineRoot)}${restoration}`;
+  }
+
+  let claimedStats: Awaited<ReturnType<typeof lstat>>;
+  try {
+    claimedStats = await lstat(quarantinePath, { bigint: true });
+  } catch (error) {
+    const restoration = await restoreClaimedDirectory(
+      {
+        path: quarantinePath,
+        quarantineRoot,
+        sourcePath,
+        identity: expectedIdentity,
+        restorable: true,
+        removeParentWhenEmpty: layout === "legacy",
+      },
+      kind,
+    );
+    return `cleanup claim verification failed: ${redactQuarantinePath(errorMessage(error), quarantinePath)}; ${restoration}`;
+  }
+  if (!claimedStats.isDirectory() || !hasFileIdentity(claimedStats, expectedIdentity)) {
+    return restoreUnexpectedClaim(sourcePath, quarantinePath, fileIdentity(claimedStats));
+  }
+
+  let handle: FileHandle | undefined;
+  try {
+    handle = await open(quarantinePath, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW);
+    const handleStats = await handle.stat({ bigint: true });
+    if (!handleStats.isDirectory() || !hasFileIdentity(handleStats, expectedIdentity)) {
+      await handle.close();
+      return restoreUnexpectedClaim(sourcePath, quarantinePath, fileIdentity(handleStats));
+    }
+  } catch {
+    // Directory descriptors are only a Linux race-hardening optimization. The
+    // portable path below rechecks the claimed inode before every destructive step.
+    await handle?.close().catch(() => undefined);
+    handle = undefined;
+  }
+  const claimed: ClaimedDirectory = {
+    path: quarantinePath,
+    quarantineRoot,
+    sourcePath,
+    pendingRecordPath: pendingPaths.record,
+    handle,
+    identity: expectedIdentity,
+    restorable: true,
+    removeParentWhenEmpty: layout === "legacy",
+  };
+  try {
+    await writePendingCleanupRecord(pendingPaths.record, kind, expectedIdentity, expected);
+  } catch (error) {
+    const restoration = await restoreClaimedDirectory(claimed, kind);
+    return `cleanup pending identity creation failed: ${redactQuarantinePath(errorMessage(error), pendingPaths.record)}; ${restoration}`;
+  }
+  return claimed;
+}
+
+async function verifiedClaimPath(
+  claimed: ClaimedDirectory,
+  hooks: WorktreeCleanupTestHooks,
+): Promise<{ accessPath: string; removalPath: string }> {
+  if (claimed.handle) {
+    try {
+      const descriptorPath = join(hooks.procDescriptorRoot ?? "/proc/self/fd", String(claimed.handle.fd));
+      const [handleStats, descriptorStats, removalPath] = await Promise.all([
+        claimed.handle.stat({ bigint: true }),
+        stat(descriptorPath, { bigint: true }),
+        realpath(descriptorPath),
+      ]);
+      if (
+        handleStats.isDirectory() &&
+        hasFileIdentity(handleStats, claimed.identity) &&
+        hasFileIdentity(descriptorStats, claimed.identity)
+      ) {
+        return { accessPath: descriptorPath, removalPath };
+      }
+    } catch {
+      // Fall through to portable path identity checks when /proc is absent.
+    }
+  }
+  const claimedStats = await lstat(claimed.path, { bigint: true });
+  if (!claimedStats.isDirectory() || !hasFileIdentity(claimedStats, claimed.identity)) {
+    throw new Error("claimed directory path now names a replacement inode; contents were preserved");
+  }
+  return { accessPath: claimed.path, removalPath: claimed.path };
+}
+
+async function verifyClaimStillOwned(claimed: ClaimedDirectory, accessPath: string): Promise<void> {
+  const [pathStats, handleStats] = await Promise.all([
+    stat(accessPath),
+    claimed.handle?.stat({ bigint: true }) ?? Promise.resolve(undefined),
+  ]);
+  if (
+    !pathStats.isDirectory() ||
+    !hasFileIdentity(pathStats, claimed.identity) ||
+    (handleStats !== undefined && (!handleStats.isDirectory() || !hasFileIdentity(handleStats, claimed.identity)))
+  ) {
+    throw new Error("claimed directory identity changed; contents were preserved");
+  }
+}
+
+async function readClaimedFile(
+  claimed: ClaimedDirectory,
+  fileName: string,
+  hooks: WorktreeCleanupTestHooks,
+): Promise<string> {
+  const { accessPath } = await verifiedClaimPath(claimed, hooks);
+  await verifyClaimStillOwned(claimed, accessPath);
+  return readFile(join(accessPath, fileName), "utf8");
+}
+
+async function cleanupClaimedContents(
+  worktree: Worktree,
+  kind: DirectoryClaimKind,
+  claimed: ClaimedDirectory,
+  hooks: WorktreeCleanupTestHooks,
+  beforeDestructive?: () => Promise<void>,
+): Promise<string | undefined> {
+  let removalPath = claimed.path;
+  try {
+    await hooks.beforeClaimedContentsCleanup?.(worktree, kind);
+    const verifiedPath = await verifiedClaimPath(claimed, hooks);
+    removalPath = verifiedPath.removalPath;
+    const entries = await readdir(verifiedPath.accessPath);
+    await verifyClaimStillOwned(claimed, verifiedPath.accessPath);
+    await beforeDestructive?.();
+    await markPendingCleanupDestructive(claimed);
+    claimed.restorable = false;
+    let removedEntries = 0;
+    for (const entry of entries) {
+      await verifyClaimStillOwned(claimed, verifiedPath.accessPath);
+      await rm(join(verifiedPath.accessPath, entry), { recursive: true, force: true });
+      removedEntries++;
+      await hooks.afterClaimedEntryRemoval?.(worktree, kind, removedEntries);
+    }
+    await verifyClaimStillOwned(claimed, verifiedPath.accessPath);
+  } catch (error) {
+    return `exact-identity content cleanup failed; claimed inode was preserved in private quarantine: ${redactQuarantinePath(errorMessage(error), claimed.path)}`;
+  } finally {
+    await claimed.handle?.close().catch(() => undefined);
+  }
+
+  try {
+    const rootStats = await lstat(removalPath, { bigint: true });
+    if (!rootStats.isDirectory() || !hasFileIdentity(rootStats, claimed.identity)) {
+      return "cleaned claimed contents, but the quarantine path now names a replacement and was preserved";
+    }
+    await rmdir(removalPath);
+    if (claimed.pendingRecordPath) await rm(claimed.pendingRecordPath, { force: true });
+    if (claimed.removeParentWhenEmpty) await removeEmptyQuarantineRoot(claimed.quarantineRoot);
+    return undefined;
+  } catch (error) {
+    return `claimed contents were removed, but exact-identity quarantine root removal failed and was preserved: ${redactQuarantinePath(errorMessage(error), claimed.path)}`;
+  }
+}
+
+function sameRuntimeIdentity(left: RuntimeWorktreeIdentity, right: RuntimeWorktreeIdentity): boolean {
+  return (
+    left.version === right.version &&
+    JSON.stringify(left.checkoutProof) === JSON.stringify(right.checkoutProof) &&
+    JSON.stringify(left.gitDirProof) === JSON.stringify(right.gitDirProof) &&
+    left.repoRoot === right.repoRoot &&
+    left.worktreePath === right.worktreePath &&
+    hasFileIdentity(left.checkoutIdentity, right.checkoutIdentity) &&
+    (left.gitDirIdentity === undefined
+      ? right.gitDirIdentity === undefined
+      : right.gitDirIdentity !== undefined && hasFileIdentity(left.gitDirIdentity, right.gitDirIdentity)) &&
+    left.branch === right.branch &&
+    left.branchRef === right.branchRef &&
+    left.baseSha === right.baseSha &&
+    left.gitCommonRoot === right.gitCommonRoot &&
+    left.gitDir === right.gitDir &&
+    left.marker === right.marker
+  );
+}
+
+function sameVerifiedIdentity(left: VerifiedCleanupIdentity, right: VerifiedCleanupIdentity): boolean {
+  return (
+    sameRuntimeIdentity(left.expected, right.expected) &&
+    left.branchOid === right.branchOid &&
+    left.nullOid === right.nullOid &&
+    left.checkoutPath === right.checkoutPath &&
+    hasFileIdentity(right.gitDirIdentity, left.gitDirIdentity) &&
+    (left.checkoutIdentity === undefined
+      ? right.checkoutIdentity === undefined
+      : right.checkoutIdentity !== undefined && hasFileIdentity(right.checkoutIdentity, left.checkoutIdentity))
+  );
+}
+
+function deterministicBackupRef(identity: RuntimeWorktreeIdentity): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify(metadataFromRuntimeIdentity(identity)))
+    .digest("hex");
+  return `refs/pi-dynamic-workflows/cleanup/${digest}`;
+}
+
+interface ClaimedBranch {
+  backupRef: string;
+  oid: string;
+}
+
+async function verifyDirectBranchRef(verified: VerifiedCleanupIdentity): Promise<string | undefined> {
+  const { stdout } = await exec("git", [
+    "-C",
+    verified.expected.repoRoot,
+    "for-each-ref",
+    "--format=%(objectname)%00%(symref)",
+    verified.expected.branchRef,
+  ]);
+  const record = stdout.trimEnd();
+  if (!record) return "temporary branch ref disappeared before cleanup claim";
+  const [oid, symref = ""] = record.split("\0");
+  if (symref.length > 0) return "temporary branch ref became symbolic before cleanup claim";
+  if (oid !== verified.branchOid) return "temporary branch ref changed before cleanup claim";
+  return undefined;
+}
+
+async function claimBranch(
+  worktree: Worktree,
+  verified: VerifiedCleanupIdentity,
+  hooks: WorktreeCleanupTestHooks,
+): Promise<ClaimedBranch | string> {
+  let backupRef = "";
+  try {
+    await hooks.afterBranchRefRead?.(worktree);
+    const directRefFailure = await verifyDirectBranchRef(verified);
+    if (directRefFailure) throw new Error(directRefFailure);
+    backupRef = deterministicBackupRef(verified.expected);
+    await exec("git", [
+      "-C",
+      verified.expected.repoRoot,
+      "update-ref",
+      "--no-deref",
+      backupRef,
+      verified.branchOid,
+      verified.nullOid,
+    ]);
+    try {
+      await exec("git", [
+        "-C",
+        verified.expected.repoRoot,
+        "update-ref",
+        "--no-deref",
+        "-d",
+        verified.expected.branchRef,
+        verified.branchOid,
+      ]);
+    } catch (error) {
+      await exec("git", [
+        "-C",
+        verified.expected.repoRoot,
+        "update-ref",
+        "--no-deref",
+        "-d",
+        backupRef,
+        verified.branchOid,
+      ]).catch(() => undefined);
+      throw error;
+    }
+    return { backupRef, oid: verified.branchOid };
+  } catch (error) {
+    const message = backupRef ? errorMessage(error).replaceAll(backupRef, "<cleanup-ref>") : errorMessage(error);
+    return `branch ref changed before compare-and-delete cleanup claim: ${message}`;
+  }
+}
+
+async function restoreClaimedBranch(verified: VerifiedCleanupIdentity, claimedBranch: ClaimedBranch): Promise<string> {
+  try {
+    await exec("git", [
+      "-C",
+      verified.expected.repoRoot,
+      "update-ref",
+      "--no-deref",
+      verified.expected.branchRef,
+      claimedBranch.oid,
+      verified.nullOid,
+    ]);
+    await exec("git", [
+      "-C",
+      verified.expected.repoRoot,
+      "update-ref",
+      "--no-deref",
+      "-d",
+      claimedBranch.backupRef,
+      claimedBranch.oid,
+    ]);
+    return "the temporary branch was restored after cleanup stopped";
+  } catch (error) {
+    return `the claimed commit was preserved under an internal recovery ref: ${errorMessage(error).replaceAll(claimedBranch.backupRef, "<cleanup-ref>")}`;
+  }
+}
+
+async function deleteClaimedBranch(
+  worktree: Worktree,
+  expected: RuntimeWorktreeIdentity,
+  claimedBranch: ClaimedBranch,
+  hooks: WorktreeCleanupTestHooks,
+): Promise<string | undefined> {
+  try {
+    await hooks.beforeClaimedBranchDelete?.(worktree);
+    await exec("git", [
+      "-C",
+      expected.repoRoot,
+      "update-ref",
+      "--no-deref",
+      "-d",
+      claimedBranch.backupRef,
+      claimedBranch.oid,
+    ]);
+    return undefined;
+  } catch (error) {
+    return `internal cleanup ref deletion failed; the claimed commit remains preserved under an internal recovery ref and cleanup can be retried: ${errorMessage(error).replaceAll(claimedBranch.backupRef, "<cleanup-ref>")}`;
+  }
+}
+
+async function claimAndCleanup(
+  worktree: Worktree,
+  verified: VerifiedCleanupIdentity,
+  identity: WorktreeIdentity,
+  hooks: WorktreeCleanupTestHooks,
+  creationAuthority?: CreationRegistrationAuthority,
+  preserveBranch = false,
+): Promise<WorktreeCleanupFailure[]> {
+  return withRepositoryGitMetadataCleanup(
+    verified.expected.gitCommonRoot,
+    () => claimAndCleanupLocked(worktree, verified, identity, hooks, creationAuthority, preserveBranch),
+    hooks,
+  );
+}
+
+/** Both source-to-claim renames execute while the cross-process repository lock is held. */
+async function claimAndCleanupLocked(
+  worktree: Worktree,
+  verified: VerifiedCleanupIdentity,
+  identity: WorktreeIdentity,
+  hooks: WorktreeCleanupTestHooks,
+  creationAuthority?: CreationRegistrationAuthority,
+  preserveBranch = false,
+): Promise<WorktreeCleanupFailure[]> {
+  let claimedCheckout: ClaimedDirectory | undefined;
+  let claimedRegistration: ClaimedDirectory | undefined;
+  let claimedBranch: ClaimedBranch | undefined;
+
+  const stopCleanup = async (stage: WorktreeCleanupStage, message: string): Promise<WorktreeCleanupFailure[]> => {
+    const destructiveCleanupStarted =
+      claimedRegistration?.restorable === false || claimedCheckout?.restorable === false;
+    if (destructiveCleanupStarted) {
+      await claimedRegistration?.handle?.close().catch(() => undefined);
+      await claimedCheckout?.handle?.close().catch(() => undefined);
+      const recovery = claimedBranch
+        ? "; exact pending claims and the internal backup ref were preserved for deterministic retry"
+        : "; exact pending claims were preserved for deterministic retry";
+      return [{ stage, message: boundedDiagnostic(`${message}${recovery}`), identity }];
+    }
+
+    const restoration: string[] = [];
+    if (claimedBranch) restoration.push(await restoreClaimedBranch(verified, claimedBranch));
+    if (claimedRegistration) restoration.push(await restoreClaimedDirectory(claimedRegistration, "registration"));
+    if (claimedCheckout) restoration.push(await restoreClaimedDirectory(claimedCheckout, "checkout"));
+    const recovery = restoration.length > 0 ? `; ${restoration.join("; ")}` : "";
+    return [{ stage, message: boundedDiagnostic(`${message}${recovery}`), identity }];
+  };
+
+  let claimParent: string;
+  try {
+    claimParent = await secureCleanupClaimParent(verified.expected);
+  } catch (error) {
+    return [identityFailure(identity, `unsafe cleanup claim parent: ${errorMessage(error)}`)];
+  }
+
+  if (verified.checkoutIdentity) {
+    const checkoutClaim = await claimDirectory(
+      worktree,
+      "checkout",
+      verified.checkoutPath ?? verified.expected.worktreePath,
+      claimParent,
+      "cleanup-worktree",
+      verified.checkoutIdentity,
+      hooks,
+    );
+    if (typeof checkoutClaim === "string") return [identityFailure(identity, checkoutClaim)];
+    claimedCheckout = checkoutClaim;
+    try {
+      await hooks.afterCheckoutClaim?.(worktree);
+    } catch (error) {
+      return stopCleanup("cleanup_dispatch", `checkout claim verification failed: ${errorMessage(error)}`);
+    }
+  }
+
+  if (!preserveBranch) {
+    const branchClaim = await claimBranch(worktree, verified, hooks);
+    if (typeof branchClaim === "string") return stopCleanup("identity_verification", branchClaim);
+    claimedBranch = branchClaim;
+    try {
+      await hooks.afterBranchClaim?.(worktree);
+    } catch (error) {
+      return stopCleanup("cleanup_dispatch", `branch claim verification failed: ${errorMessage(error)}`);
+    }
+  }
+
+  const metadataCleanupFailure = await (async (): Promise<WorktreeCleanupFailure[] | undefined> => {
+    try {
+      await hooks.beforePostClaimRegistrationCheck?.(worktree);
+      const registrations = await readRegisteredWorktrees(verified.expected.repoRoot);
+      if (
+        registrations.some(
+          (registration) =>
+            registration.path !== verified.expected.worktreePath &&
+            registration.branchRef === verified.expected.branchRef,
+        )
+      ) {
+        return stopCleanup(
+          "identity_verification",
+          "temporary branch was claimed while checked out by another registered worktree",
+        );
+      }
+    } catch (error) {
+      return stopCleanup("cleanup_dispatch", `post-claim registered worktree check failed: ${errorMessage(error)}`);
+    }
+
+    const registrationClaim = await claimDirectory(
+      worktree,
+      "registration",
+      verified.expected.gitDir,
+      claimParent,
+      "registration",
+      verified.gitDirIdentity,
+      hooks,
+    );
+    if (typeof registrationClaim === "string") {
+      return stopCleanup("identity_verification", registrationClaim);
+    }
+    claimedRegistration = registrationClaim;
+
+    try {
+      if (creationAuthority !== "in-memory") {
+        const registrationRecord = parseRegistrationRecord(
+          (await readClaimedFile(registrationClaim, REGISTRATION_MARKER_FILE, hooks)).trim(),
+        );
+        const recordedIdentity: RuntimeWorktreeIdentity = {
+          version: registrationRecord.version,
+          repoRoot: registrationRecord.repoRoot,
+          worktreePath: registrationRecord.worktreePath,
+          checkoutIdentity: { ...registrationRecord.checkoutIdentity },
+          ...(registrationRecord.version === 4
+            ? {
+                checkoutProof: registrationRecord.checkoutProof,
+                gitDirIdentity: { ...registrationRecord.gitDirIdentity },
+                ...(registrationRecord.gitDirProof ? { gitDirProof: registrationRecord.gitDirProof } : {}),
+              }
+            : {}),
+          branch: registrationRecord.branch,
+          branchRef: registrationRecord.branchRef,
+          baseSha: registrationRecord.baseSha,
+          gitCommonRoot: registrationRecord.gitCommonRoot,
+          gitDir: registrationRecord.gitDir,
+          marker: registrationRecord.registrationMarker,
+        };
+        if (!sameRuntimeIdentity(recordedIdentity, verified.expected)) {
+          return stopCleanup("identity_verification", "claimed registration record changed");
+        }
+      }
+      if (claimedCheckout) await hooks.afterWorktreeClaim?.(worktree);
+      await hooks.afterRegistrationClaim?.(worktree);
+
+      if (!verified.checkoutIdentity) {
+        const registrations = await readRegisteredWorktrees(verified.expected.repoRoot);
+        if (
+          registrations.some((registration) => registration.path === verified.expected.worktreePath) ||
+          (await pathExists(verified.expected.worktreePath))
+        ) {
+          return stopCleanup(
+            "identity_verification",
+            "a replacement appeared at the original path after registration claim",
+          );
+        }
+      }
+    } catch (error) {
+      return stopCleanup(
+        "identity_verification",
+        `registration claim verification failed; claimed inodes were preserved: ${errorMessage(error)}`,
+      );
+    }
+
+    // Registration state must be finalized while the complete checkout remains
+    // recoverable in quarantine. Checkout contents are the transaction's final
+    // destructive data stage, after every registration/branch claim can no
+    // longer fail.
+    const registrationFailure = await cleanupClaimedContents(
+      worktree,
+      "registration",
+      registrationClaim,
+      hooks,
+      async () => {
+        if (!claimedCheckout) return;
+        await markPendingCleanupDestructive(claimedCheckout);
+        claimedCheckout.restorable = false;
+      },
+    );
+    if (registrationFailure) return stopCleanup("worktree_remove", registrationFailure);
+    claimedRegistration = undefined;
+
+    if (claimedCheckout) {
+      const checkoutFailure = await cleanupClaimedContents(worktree, "checkout", claimedCheckout, hooks);
+      if (checkoutFailure) return stopCleanup("worktree_remove", checkoutFailure);
+      claimedCheckout = undefined;
+    }
+    return undefined;
+  })();
+  if (metadataCleanupFailure) return metadataCleanupFailure;
+
+  if (verified.expected.checkoutProof?.kind === "sentinel") {
+    try {
+      await removeSentinelExclude(
+        verified.expected.gitCommonRoot,
+        verified.expected.marker,
+        verified.expected.checkoutProof,
+        hooks,
+        true,
+      );
+    } catch (error) {
+      return [
+        {
+          stage: "worktree_remove",
+          message: boundedDiagnostic(`portable sentinel restoration failed: ${errorMessage(error)}`),
+          identity,
+        },
+      ];
+    }
+  }
+
+  // The private backup remains the only ref guaranteed to preserve the claimed
+  // commit until every checkout, registration, and portable sentinel cleanup
+  // failure point is past.
+  if (!claimedBranch) return [];
+  const branchFailure = await deleteClaimedBranch(worktree, verified.expected, claimedBranch, hooks);
+  if (branchFailure) {
+    let restoration = "";
+    if (verified.expected.checkoutProof?.kind === "sentinel") {
+      try {
+        await restoreSentinelExclude(
+          verified.expected.gitCommonRoot,
+          verified.expected.marker,
+          verified.expected.checkoutProof,
+          true,
+        );
+      } catch (error) {
+        restoration = `; portable sentinel restoration rollback failed: ${errorMessage(error)}`;
+      }
+    }
+    return [{ stage: "branch_delete", message: boundedDiagnostic(`${branchFailure}${restoration}`), identity }];
+  }
+  claimedBranch = undefined;
+  return [];
+}
+
+interface PendingClaimResumeResult {
+  found: boolean;
+  failure?: string;
+}
+
+async function resumePendingClaim(
+  worktree: Worktree,
+  expected: RuntimeWorktreeIdentity,
+  kind: DirectoryClaimKind,
+  quarantineRoot: string,
+  hooks: WorktreeCleanupTestHooks,
+  layout: CleanupClaimLayout,
+): Promise<PendingClaimResumeResult> {
+  if (layout === "legacy") {
+    const legacyStats = await lstat(quarantineRoot, { bigint: true }).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined;
+      throw error;
+    });
+    if (!legacyStats || legacyStats.isSymbolicLink() || !legacyStats.isDirectory()) return { found: false };
+  }
+  const canonicalRoot = await realDirectory(quarantineRoot, false);
+  if (layout === "direct" && canonicalRoot !== expected.gitCommonRoot) {
+    return { found: true, failure: `${kind} direct pending claim parent is not the trusted Git common directory` };
+  }
+  const pendingPaths = deterministicQuarantinePaths(canonicalRoot, kind, expected, layout);
+  const [directoryExists, recordExists] = await Promise.all([
+    pathExists(pendingPaths.directory),
+    pathExists(pendingPaths.record),
+  ]);
+  if (!directoryExists && !recordExists) return { found: false };
+  if (!recordExists) {
+    return { found: true, failure: `${kind} quarantine exists without its exact pending identity record` };
+  }
+
+  let record: PendingCleanupRecordV1;
+  try {
+    record = parsePendingCleanupRecord(await readRegistrationFile(pendingPaths.record));
+  } catch (error) {
+    return { found: true, failure: `${kind} pending identity record verification failed: ${errorMessage(error)}` };
+  }
+  const recordedIdentity: RuntimeWorktreeIdentity = {
+    version: record.metadata.version,
+    repoRoot: record.metadata.repoRoot,
+    worktreePath: record.metadata.worktreePath,
+    checkoutIdentity: { ...record.metadata.checkoutIdentity },
+    ...(record.metadata.version === 4
+      ? {
+          checkoutProof: record.metadata.checkoutProof,
+          gitDirIdentity: { ...record.metadata.gitDirIdentity },
+          ...(record.metadata.gitDirProof ? { gitDirProof: record.metadata.gitDirProof } : {}),
+        }
+      : {}),
+    branch: record.metadata.branch,
+    branchRef: record.metadata.branchRef,
+    baseSha: record.metadata.baseSha,
+    gitCommonRoot: record.metadata.gitCommonRoot,
+    gitDir: record.metadata.gitDir,
+    marker: record.metadata.registrationMarker,
+  };
+  if (record.kind !== kind || !sameRuntimeIdentity(recordedIdentity, expected)) {
+    return { found: true, failure: `${kind} pending identity record does not match cleanup metadata` };
+  }
+  if (record.state !== "destructive") {
+    return { found: true, failure: `${kind} claim never entered destructive cleanup and was preserved` };
+  }
+
+  if (!directoryExists) {
+    try {
+      await rm(pendingPaths.record);
+      if (layout === "legacy") await removeEmptyQuarantineRoot(canonicalRoot);
+      return { found: true };
+    } catch (error) {
+      return {
+        found: true,
+        failure: `${kind} completed pending identity record removal failed: ${errorMessage(error)}`,
+      };
+    }
+  }
+
+  let pendingStats: Awaited<ReturnType<typeof lstat>>;
+  try {
+    pendingStats = await lstat(pendingPaths.directory, { bigint: true });
+  } catch (error) {
+    return { found: true, failure: `${kind} pending quarantine verification failed: ${errorMessage(error)}` };
+  }
+  if (!pendingStats.isDirectory() || !hasFileIdentity(pendingStats, record.identity)) {
+    return { found: true, failure: `${kind} pending quarantine no longer names its recorded exact inode` };
+  }
+  const claimed: ClaimedDirectory = {
+    path: pendingPaths.directory,
+    quarantineRoot: canonicalRoot,
+    sourcePath: kind === "checkout" ? expected.worktreePath : expected.gitDir,
+    pendingRecordPath: pendingPaths.record,
+    identity: record.identity,
+    restorable: false,
+    removeParentWhenEmpty: layout === "legacy",
+  };
+  const failure = await cleanupClaimedContents(worktree, kind, claimed, hooks);
+  return { found: true, ...(failure ? { failure } : {}) };
+}
+
+async function resumePendingClaims(
+  worktree: Worktree,
+  expected: RuntimeWorktreeIdentity,
+  identity: WorktreeIdentity,
+  hooks: WorktreeCleanupTestHooks,
+): Promise<WorktreeCleanupFailure[] | undefined> {
+  let claimParent: string;
+  try {
+    claimParent = await secureCleanupClaimParent(expected);
+  } catch (error) {
+    return [identityFailure(identity, `unsafe pending cleanup claim parent: ${errorMessage(error)}`)];
+  }
+
+  let found = false;
+  const locations = [
+    ["registration", claimParent, "direct"],
+    ["checkout", claimParent, "direct"],
+    ["registration", legacyQuarantineRoot(expected, "registration"), "legacy"],
+    ["checkout", legacyQuarantineRoot(expected, "checkout"), "legacy"],
+  ] as const;
+  for (const [kind, root, layout] of locations) {
+    const resumed = await resumePendingClaim(worktree, expected, kind, root, hooks, layout);
+    found ||= resumed.found;
+    if (resumed.failure) {
+      return [
+        {
+          stage: "worktree_remove",
+          message: boundedDiagnostic(`pending exact-identity cleanup failed: ${resumed.failure}`),
+          identity,
+        },
+      ];
+    }
+  }
+  return found ? [] : undefined;
+}
+
+async function finalizePendingBackup(
+  worktree: Worktree,
+  expected: RuntimeWorktreeIdentity,
+  identity: WorktreeIdentity,
+  hooks: WorktreeCleanupTestHooks,
+): Promise<WorktreeCleanupFailure[] | undefined> {
+  const backupRef = deterministicBackupRef(expected);
+  try {
+    const { stdout } = await exec("git", [
+      "-C",
+      expected.repoRoot,
+      "for-each-ref",
+      "--format=%(objectname)%00%(symref)",
+      backupRef,
+    ]);
+    const record = stdout.trimEnd();
+    if (!record) return undefined;
+    const [oid, symref = ""] = record.split("\0");
+    if (symref.length > 0) return [identityFailure(identity, "pending internal cleanup ref became symbolic")];
+
+    if (!callerMatchesRuntimeIdentity(worktree, expected)) {
+      return [identityFailure(identity, "stored worktree identity no longer matches its cleanup metadata")];
+    }
+    const canonicalRepoRoot = await realpath(expected.repoRoot);
+    if (canonicalRepoRoot !== expected.repoRoot) {
+      return [identityFailure(identity, "stored repository root is not canonical")];
+    }
+    try {
+      await verifyRuntimeWorktreeContainment(canonicalRepoRoot, expected.gitCommonRoot, expected.worktreePath);
+    } catch {
+      return [identityFailure(identity, "runtime worktree path is not an exact trusted runtime child")];
+    }
+    if ((await resolveGitDirectory(canonicalRepoRoot, "--git-common-dir")) !== expected.gitCommonRoot) {
+      return [identityFailure(identity, "pending cleanup belongs to a different repository common root")];
+    }
+    if ((await pathExists(expected.worktreePath)) || (await pathExists(expected.gitDir))) return undefined;
+    const registrations = await registeredWorktrees(canonicalRepoRoot, expected.gitCommonRoot);
+    if (registrations.some((registration) => registration.path === expected.worktreePath)) {
+      return [identityFailure(identity, "pending cleanup path is still registered after registration cleanup")];
+    }
+
+    const { stdout: objectFormatOutput } = await exec("git", [
+      "-C",
+      canonicalRepoRoot,
+      "rev-parse",
+      "--show-object-format",
+    ]);
+    const objectFormat = objectFormatOutput.trim();
+    const oidWidth = objectFormat === "sha1" ? 40 : objectFormat === "sha256" ? 64 : undefined;
+    if (oidWidth === undefined || oid.length !== oidWidth) {
+      return [identityFailure(identity, "pending internal cleanup ref has an invalid object ID")];
+    }
+
+    if (expected.checkoutProof?.kind === "sentinel") {
+      try {
+        await removeSentinelExclude(expected.gitCommonRoot, expected.marker, expected.checkoutProof, hooks);
+      } catch (error) {
+        return [
+          {
+            stage: "worktree_remove",
+            message: boundedDiagnostic(`portable sentinel restoration failed: ${errorMessage(error)}`),
+            identity,
+          },
+        ];
+      }
+    }
+    const failure = await deleteClaimedBranch(worktree, expected, { backupRef, oid }, hooks);
+    if (!failure) return [];
+    let restoration = "";
+    if (expected.checkoutProof?.kind === "sentinel") {
+      try {
+        await restoreSentinelExclude(expected.gitCommonRoot, expected.marker, expected.checkoutProof);
+      } catch (error) {
+        restoration = `; portable sentinel restoration rollback failed: ${errorMessage(error)}`;
+      }
+    }
+    return [{ stage: "branch_delete", message: boundedDiagnostic(`${failure}${restoration}`), identity }];
+  } catch (error) {
+    return [identityFailure(identity, `pending cleanup ref verification failed: ${errorMessage(error)}`)];
+  }
+}
+
+async function closeCheckoutDirectoryHandle(expected: RuntimeWorktreeIdentity): Promise<void> {
+  await closeRuntimeIdentityHandles(expected.marker);
+}
+
+/** Internal removal with diagnostics for retained-worktree recovery metadata. */
+async function removeWorktreeWithDiagnostics(
+  worktree: Worktree,
+  hooks: WorktreeCleanupTestHooks = {},
+): Promise<WorktreeCleanupFailure[]> {
+  if (!worktree.isolated) return [];
+
+  let cleanupWorktree = worktree;
+  if (cleanupWorktree.cleanupMetadata?.version === 1) {
+    const upgraded = await upgradeVersionOneWorktree(cleanupWorktree);
+    if (typeof upgraded === "string") return [identityFailure(cleanupIdentity(cleanupWorktree), upgraded)];
+    cleanupWorktree = upgraded;
+  } else if (cleanupWorktree.cleanupMetadata?.version === 2) {
+    const upgraded = await upgradeVersionTwoWorktree(cleanupWorktree);
+    if (typeof upgraded === "string") return [identityFailure(cleanupIdentity(cleanupWorktree), upgraded)];
+    cleanupWorktree = upgraded;
+  } else if (cleanupWorktree.cleanupMetadata?.version === 3) {
+    const upgraded = await upgradeVersionThreeWorktree(cleanupWorktree, hooks);
+    if (typeof upgraded === "string") return [identityFailure(cleanupIdentity(cleanupWorktree), upgraded)];
+    cleanupWorktree = upgraded;
+  } else if (typeof runtimeIdentity(cleanupWorktree) === "string" && isLegacyCleanupShape(cleanupWorktree)) {
+    const adopted = await adoptLegacyWorktree(cleanupWorktree);
+    if (typeof adopted === "string") return [identityFailure(cleanupIdentity(cleanupWorktree), adopted)];
+    cleanupWorktree = adopted;
+  }
+
+  const identityKey = runtimeIdentityKey(cleanupWorktree);
+  if (identityKey !== undefined && cleanedRuntimeWorktrees.has(identityKey)) return [];
+  const identity = cleanupIdentity(cleanupWorktree);
+  const expected = runtimeIdentity(cleanupWorktree);
+  if (typeof expected === "string") return [identityFailure(identity, expected)];
+  if (!callerMatchesRuntimeIdentity(cleanupWorktree, expected)) {
+    return [identityFailure(identity, "stored worktree identity no longer matches its cleanup metadata")];
+  }
+
+  const pendingClaims = await resumePendingClaims(cleanupWorktree, expected, identity, hooks);
+  if (pendingClaims !== undefined) {
+    if (pendingClaims.length > 0) return pendingClaims;
+    const pendingFinalization = await finalizePendingBackup(cleanupWorktree, expected, identity, hooks);
+    if (pendingFinalization === undefined) {
+      return [identityFailure(identity, "pending directory cleanup completed without its deterministic backup ref")];
+    }
+    if (pendingFinalization.length === 0) {
+      creationRecoveryAuthorities.delete(cleanupWorktree);
+      await closeCheckoutDirectoryHandle(expected);
+      if (identityKey !== undefined) rememberCleanedRuntimeWorktree(identityKey);
+    }
+    return pendingFinalization;
+  }
+
+  const creationAuthority = creationRecoveryAuthorities.get(cleanupWorktree);
+  const verification = await verifyCleanupIdentity(cleanupWorktree, hooks, creationAuthority);
+  if (typeof verification === "string") {
+    const pendingFinalization = await finalizePendingBackup(cleanupWorktree, expected, identity, hooks);
+    if (pendingFinalization === undefined) return [identityFailure(identity, verification)];
+    if (pendingFinalization.length === 0) {
+      creationRecoveryAuthorities.delete(cleanupWorktree);
+      await closeCheckoutDirectoryHandle(expected);
+      if (identityKey !== undefined) rememberCleanedRuntimeWorktree(identityKey);
+    }
+    return pendingFinalization;
+  }
+
+  try {
+    await hooks.afterIdentityVerification?.(cleanupWorktree);
+  } catch (error) {
+    return [identityFailure(identity, `cleanup verification hook failed: ${errorMessage(error)}`)];
+  }
+
+  const preclaimVerification = await verifyCleanupIdentity(cleanupWorktree, hooks, creationAuthority);
+  if (typeof preclaimVerification === "string" || !sameVerifiedIdentity(verification, preclaimVerification)) {
+    return [
+      identityFailure(
+        identity,
+        typeof preclaimVerification === "string"
+          ? `worktree identity changed before atomic cleanup claim: ${preclaimVerification}`
+          : "worktree identity changed before atomic cleanup claim",
+      ),
+    ];
+  }
+
+  try {
+    const creationExpectedOid = hooks.creationRollbackExpectedOid ?? cleanupWorktree.creationRollbackExpectedOid;
+    const preserveAdvancedBranch =
+      creationExpectedOid !== undefined && preclaimVerification.branchOid !== creationExpectedOid;
+    const failures = await claimAndCleanup(
+      cleanupWorktree,
+      preclaimVerification,
+      identity,
+      hooks,
+      creationAuthority,
+      preserveAdvancedBranch,
+    );
+    if (failures.length === 0) {
+      creationRecoveryAuthorities.delete(cleanupWorktree);
+      await closeCheckoutDirectoryHandle(expected);
+      if (identityKey !== undefined) rememberCleanedRuntimeWorktree(identityKey);
+      if (preserveAdvancedBranch) {
+        return [
+          {
+            stage: "branch_delete",
+            message: `${CREATION_ADVANCED_BRANCH_PRESERVED}; exact runtime checkout, registration, and proofs were removed`,
+            identity,
+          },
+        ];
+      }
+    }
+    return failures;
+  } catch (error) {
+    return [
+      {
+        stage: "cleanup_dispatch",
+        message: boundedDiagnostic(`unexpected worktree cleanup failure: ${errorMessage(error)}`),
+        identity,
+      },
+    ];
+  }
+}
+
+/** Remove a worktree and branch best-effort, preserving the existing no-value API. */
+export async function removeWorktree(worktree: Worktree): Promise<undefined> {
+  await removeWorktreeWithDiagnostics(worktree);
+  return undefined;
+}
+
+/** Explicit terminal proof disposal. Call only after all automatic and consumer-owned retries are impossible. */
+export async function disposeWorktreeProofs(worktree: Worktree): Promise<void> {
+  const marker = worktree.cleanupMetadata?.registrationMarker;
+  if (marker && validRegistrationMarker(marker)) await closeRuntimeIdentityHandles(marker);
+}
+
+export const DEFAULT_WORKTREE_OPERATIONS: WorktreeOperations = Object.freeze({
+  createWorktree,
+  removeWorktree: removeWorktreeWithDiagnostics,
+  disposeWorktreeProofs,
+});
+
+/** @internal Descriptor lifecycle count; deliberately exposes neither handles nor paths. */
+export function activeCheckoutProofsForTesting(): {
+  descriptorCount: number;
+  allocationDescriptorCount: number;
+  gitDirDescriptorCount: number;
+  excludeDescriptorCount: number;
+} {
+  return {
+    descriptorCount: checkoutDirectoryHandles.size,
+    allocationDescriptorCount,
+    gitDirDescriptorCount: gitDirectoryHandles.size,
+    excludeDescriptorCount: sentinelExcludeHandles.size,
+  };
+}
+
+/** @internal Narrow deterministic seam for proving the process cache remains bounded. */
+export function populateCleanedWorktreeCacheForTesting(identityKeys: readonly string[]): {
+  size: number;
+  capacity: number;
+} {
+  for (const identityKey of identityKeys) rememberCleanedRuntimeWorktree(identityKey);
+  return { size: cleanedRuntimeWorktrees.size, capacity: MAX_CLEANED_RUNTIME_WORKTREES };
+}
+
+/** @internal Narrow deterministic seam for cleanup race regression tests. */
+export function createWorktreeOperationsForTesting(hooks: WorktreeCleanupTestHooks): WorktreeOperations {
+  return Object.freeze({
+    createWorktree,
+    removeWorktree: (worktree: Worktree) => removeWorktreeWithDiagnostics(worktree, hooks),
+    disposeWorktreeProofs,
+  });
+}
+
+/**
+ * Per-root-run retained worktree registry. Consumers admitted before release are
+ * FIFO-serialized. A release request closes admission immediately, waits for all
+ * already-admitted consumers, then removes the registered runtime-created tree.
+ */
+export class RetainedWorktreeRegistry {
+  private readonly owner = Symbol("retained-worktree-owner");
+  private readonly entries = new Map<WorktreeHandle, RetainedEntry>();
+  private admissionClosed = false;
+
+  constructor(
+    private readonly operations: WorktreeOperations = DEFAULT_WORKTREE_OPERATIONS,
+    private readonly onCleanupFailure?: (failure: WorktreeCleanupFailure) => unknown,
+    private readonly validAdmissionToken?: (token: unknown) => boolean,
+  ) {}
+
+  closeAdmission(): void {
+    this.admissionClosed = true;
+  }
+
+  register(worktree: Worktree, admissionToken?: unknown): WorktreeHandle {
+    this.assertAdmission(admissionToken);
+    if (!worktree.isolated || !worktree.repoRoot || !worktree.branch || !worktree.branchRef || !worktree.baseSha) {
+      throw new Error("Cannot retain a worktree without complete runtime-created identity metadata");
+    }
+    const handle = Object.freeze(Object.create(null)) as WorktreeHandle;
+    issuedHandleOwners.set(handle, this.owner);
+    this.entries.set(handle, {
+      handle,
+      canonicalIdentity: createHash("sha256")
+        .update(JSON.stringify(["retained-worktree-handle-v1", worktree.branchRef]))
+        .digest("hex"),
+      worktree,
+      tail: Promise.resolve(),
+      releaseRequested: false,
+      released: false,
+    });
+    return handle;
+  }
+
+  /** Internal opaque identity for canonical nested-call hashing. */
+  canonicalIdentity(handle: unknown): string | undefined {
+    if ((typeof handle !== "object" && typeof handle !== "function") || handle === null) return undefined;
+    const owner = issuedHandleOwners.get(handle);
+    if (owner === undefined) return undefined;
+    if (owner !== this.owner) throw new Error("Cross-run retained worktree handles are invalid");
+    const entry = this.entries.get(handle as WorktreeHandle);
+    if (!entry) throw new Error("Unknown retained worktree handle");
+    return entry.canonicalIdentity;
+  }
+
+  acquire(handle: unknown, admissionToken?: unknown): Promise<RetainedWorktreeLease> {
+    this.assertAdmission(admissionToken);
+    const entry = this.entryFor(handle);
+    if (entry.released) throw new Error("Retained worktree handle has been released");
+    if (entry.releaseRequested)
+      throw new Error("Retained worktree release is already in progress; new consumers are rejected");
+
+    const previous = entry.tail;
+    let finish!: () => void;
+    const occupied = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    entry.tail = previous.then(() => occupied);
+    return previous.then(() => {
+      let active = true;
+      return {
+        worktree: entry.worktree,
+        release: () => {
+          if (!active) return;
+          active = false;
+          finish();
+        },
+      };
+    });
+  }
+
+  release(handle: unknown, admissionToken?: unknown): Promise<void> {
+    this.assertAdmission(admissionToken);
+    const entry = this.entryFor(handle);
+    return this.releaseEntry(entry);
+  }
+
+  async cleanupAll(): Promise<void> {
+    this.closeAdmission();
+    const entries = [...this.entries.values()];
+    const releases = entries.map((entry) => this.releaseEntry(entry));
+    await Promise.allSettled(releases);
+    await Promise.allSettled(
+      entries
+        .filter((entry) => !entry.released)
+        .map((entry) =>
+          Promise.resolve()
+            .then(() => (this.operations.disposeWorktreeProofs ?? disposeWorktreeProofs)(entry.worktree))
+            .catch((error) => {
+              this.reportCleanupFailure({
+                stage: "cleanup_dispatch",
+                message: boundedDiagnostic(error instanceof Error ? error.message : String(error)),
+                identity: cleanupIdentity(entry.worktree),
+              });
+            }),
+        ),
+    );
+  }
+
+  private assertAdmission(token: unknown): void {
+    if (this.validAdmissionToken?.(token)) return;
+    if (!this.validAdmissionToken && !this.admissionClosed) return;
+    throw new Error("Retained worktree admission is closed; a live pre-close operation token is required");
+  }
+
+  private entryFor(handle: unknown): RetainedEntry {
+    if ((typeof handle !== "object" && typeof handle !== "function") || handle === null) {
+      throw new Error("Malformed or unknown retained worktree handle");
+    }
+    const owner = issuedHandleOwners.get(handle);
+    if (owner === undefined) throw new Error("Malformed or unknown retained worktree handle");
+    if (owner !== this.owner) throw new Error("Cross-run retained worktree handles are invalid");
+    const entry = this.entries.get(handle as WorktreeHandle);
+    if (!entry) throw new Error("Unknown retained worktree handle");
+    return entry;
+  }
+
+  private releaseEntry(entry: RetainedEntry): Promise<void> {
+    if (entry.released) return Promise.resolve();
+    if (entry.releasePromise) return entry.releasePromise;
+    entry.releaseRequested = true;
+    const attempt = entry.tail.then(async () => {
+      try {
+        const failures = (await this.operations.removeWorktree(entry.worktree)) ?? [];
+        for (const failure of failures) this.reportCleanupFailure(failure);
+        if (failures.length === 0) entry.released = true;
+      } catch (error) {
+        this.reportCleanupFailure({
+          stage: "cleanup_dispatch",
+          message: boundedDiagnostic(error instanceof Error ? error.message : String(error)),
+          identity: cleanupIdentity(entry.worktree),
+        });
+      }
+    });
+    entry.releasePromise = attempt.finally(() => {
+      if (!entry.released) entry.releasePromise = undefined;
+    });
+    return entry.releasePromise;
+  }
+
+  private reportCleanupFailure(failure: WorktreeCleanupFailure): void {
+    try {
+      const callbackResult = this.onCleanupFailure?.(sanitizeWorktreeCleanupFailure(failure));
+      if (callbackResult !== undefined) void Promise.resolve(callbackResult).catch(() => undefined);
+    } catch {
+      // Cleanup diagnostics must never replace the workflow's result or error.
     }
   }
 }

--- a/tests/fixtures/worktree-cleanup-worker.ts
+++ b/tests/fixtures/worktree-cleanup-worker.ts
@@ -1,0 +1,75 @@
+import { appendFileSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { createWorktree, createWorktreeOperationsForTesting } from "../../src/worktree.js";
+
+const [repo, name, probeRoot, mode] = process.argv.slice(2);
+if (!repo || !name || !probeRoot || (mode !== "same-repo" && mode !== "different-repo" && mode !== "stale-race")) {
+  throw new Error("expected repository, worktree name, probe root, and worker mode");
+}
+
+const worktree = await createWorktree(repo, name);
+if (!worktree.isolated) throw new Error(`worker worktree creation failed: ${worktree.reason}`);
+const ready = join(probeRoot, `ready-${process.pid}`);
+writeFileSync(ready, "ready\n", { flag: "wx" });
+for (let attempt = 0; attempt < 500; attempt++) {
+  if (readdirSync(probeRoot).filter((entry) => entry.startsWith("ready-")).length >= 2) break;
+  await delay(10);
+  if (attempt === 499) throw new Error("cleanup workers did not become ready together");
+}
+
+const active = join(probeRoot, "active");
+const holderEntered = join(probeRoot, "holder-entered");
+const entered = join(probeRoot, `entered-${process.pid}`);
+const events = join(probeRoot, "events.log");
+let ownsActive = false;
+
+const operations = createWorktreeOperationsForTesting({
+  async beforePostClaimRegistrationCheck() {
+    appendFileSync(events, `enter ${process.pid}\n`);
+    if (mode !== "different-repo") {
+      mkdirSync(active);
+      ownsActive = true;
+      if (name.endsWith("one")) {
+        writeFileSync(holderEntered, "entered\n", { flag: "wx" });
+        await delay(1_200);
+      }
+      return;
+    }
+
+    writeFileSync(entered, "entered\n", { flag: "wx" });
+    for (let attempt = 0; attempt < 100; attempt++) {
+      if (readdirSync(probeRoot).filter((entry) => entry.startsWith("entered-")).length >= 2) return;
+      await delay(10);
+    }
+    throw new Error("unrelated repository cleanup did not overlap");
+  },
+  afterRegistrationClaim() {
+    appendFileSync(events, `exit ${process.pid}\n`);
+    if (ownsActive && existsSync(active)) rmSync(active, { recursive: true });
+  },
+});
+
+try {
+  if (mode === "stale-race") {
+    for (let attempt = 0; attempt < 500; attempt++) {
+      if (existsSync(join(probeRoot, "go"))) break;
+      await delay(10);
+      if (attempt === 499) throw new Error("stale-reclaim workers were not released");
+    }
+  }
+  if (mode !== "different-repo" && name.endsWith("two")) {
+    for (let attempt = 0; attempt < 500; attempt++) {
+      if (existsSync(holderEntered)) break;
+      await delay(10);
+      if (attempt === 499) throw new Error("the first cleanup never acquired the repository lock");
+    }
+  }
+  const failures = await operations.removeWorktree(worktree);
+  if (ownsActive && existsSync(active)) rmSync(active, { recursive: true });
+  process.stdout.write(`${JSON.stringify(failures)}\n`);
+  process.exitCode = failures.length === 0 ? 0 : 2;
+} catch (error) {
+  if (ownsActive && existsSync(active)) rmSync(active, { recursive: true });
+  throw error;
+}

--- a/tests/retained-worktree.test.ts
+++ b/tests/retained-worktree.test.ts
@@ -1,0 +1,3624 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import test from "node:test";
+import type { AgentRunOptions } from "../src/agent.js";
+import type { AgentRegistry } from "../src/agent-registry.js";
+import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
+import { type JournalEntry, runWorkflow, type SharedRuntime } from "../src/workflow.js";
+import { WorkflowManager } from "../src/workflow-manager.js";
+import {
+  activeCheckoutProofsForTesting,
+  createWorktree as createWorktreeLive,
+  createWorktreeOperationsForTesting,
+  DEFAULT_WORKTREE_OPERATIONS,
+  RetainedWorktreeRegistry,
+  type Worktree,
+  type WorktreeCleanupFailure,
+  type WorktreeOperations,
+} from "../src/worktree.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+function createGitRepo(prefix = "pi-retained-wt-"): { repo: string; cleanup: () => void } {
+  const repo = mkdtempSync(join(tmpdir(), prefix));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  git("init", "-q");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  writeFileSync(join(repo, "base.txt"), "base\n");
+  git("add", ".");
+  git("commit", "-q", "-m", "initial");
+  return { repo, cleanup: () => rmSync(repo, { recursive: true, force: true }) };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  while (!predicate()) await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function assertNoWorktreeLeaks(repo: string): void {
+  const worktrees = execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"], { encoding: "utf8" });
+  assert.equal(
+    worktrees.split("\n").filter((line) => line.startsWith("worktree ")).length,
+    1,
+    "only the base worktree remains registered",
+  );
+  const branches = execFileSync("git", ["-C", repo, "branch", "--list", "pi/wf/*"], { encoding: "utf8" });
+  assert.equal(branches.trim(), "", "temporary branches are deleted");
+}
+
+const RETAIN_AND_CONSUME = `export const meta = { name: 'retain_consume', description: 'retained worktree handoff' }
+const produced = await agent('produce', { label: 'producer', isolation: 'worktree', retainWorktree: true, schema: { type: 'object', properties: { schemaValidated: { type: 'boolean' } }, required: ['schemaValidated'] } })
+const consumed = await agent('consume', { label: 'consumer', worktree: produced.worktree })
+await releaseWorktree(produced.worktree)
+return { produced: produced.result, consumed }`;
+
+test("root terminal cleanup retries marker-write rollback for ordinary and retained creation", async () => {
+  for (const retainWorktree of [false, true]) {
+    const { repo, cleanup } = createGitRepo(`pi-marker-terminal-${retainWorktree ? "retained" : "ordinary"}-`);
+    const baseline = activeCheckoutProofsForTesting();
+    let agentRuns = 0;
+    const operations: WorktreeOperations = {
+      createWorktree: (cwd, name) =>
+        createWorktreeLive(cwd, name, {
+          beforeRegistrationRecordWrite() {
+            throw new Error("injected marker write failure");
+          },
+          creationCleanupHooks: {
+            afterIdentityVerification() {
+              throw new Error("injected immediate rollback failure");
+            },
+          },
+        } as never),
+      removeWorktree: DEFAULT_WORKTREE_OPERATIONS.removeWorktree,
+      disposeWorktreeProofs: DEFAULT_WORKTREE_OPERATIONS.disposeWorktreeProofs,
+    };
+    try {
+      await assert.rejects(
+        runWorkflow(
+          `export const meta = { name: 'marker_terminal_retry', description: 'marker failure recovery' }
+return agent('never runs', { isolation: 'worktree', retainWorktree: ${retainWorktree} })`,
+          {
+            cwd: repo,
+            persistLogs: false,
+            worktreeOperations: operations,
+            agent: {
+              async run() {
+                agentRuns += 1;
+                return "unexpected";
+              },
+            },
+          },
+        ),
+        /Worktree creation recovery failed/,
+      );
+      assert.equal(agentRuns, 0, "an unfinalized checkout is never handed to an agent");
+      assertNoWorktreeLeaks(repo);
+      assert.deepEqual(activeCheckoutProofsForTesting(), baseline);
+    } finally {
+      cleanup();
+    }
+  }
+});
+
+test("retained producer returns an envelope and a consumer sees the same cwd and uncommitted files", async () => {
+  const { repo, cleanup } = createGitRepo();
+  const seenCwds: string[] = [];
+  try {
+    const result = await runWorkflow(RETAIN_AND_CONSUME, {
+      cwd: repo,
+      persistLogs: false,
+      agent: {
+        async run(prompt: string, options: AgentRunOptions) {
+          assert.ok(options.cwd, "retained producer and consumer receive an isolated cwd");
+          seenCwds.push(options.cwd);
+          if (prompt === "produce") {
+            writeFileSync(join(options.cwd, "uncommitted.txt"), "visible to consumer\n");
+            return { schemaValidated: true };
+          }
+          return readFileSync(join(options.cwd, "uncommitted.txt"), "utf8");
+        },
+      },
+    });
+
+    assert.deepEqual(JSON.parse(JSON.stringify(result.result)), {
+      produced: { schemaValidated: true },
+      consumed: "visible to consumer\n",
+    });
+    assert.equal(seenCwds.length, 2);
+    assert.equal(seenCwds[0], seenCwds[1]);
+    assert.notEqual(seenCwds[0], repo);
+    assert.equal(existsSync(seenCwds[0]), false, "explicit release removes the worktree");
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("consumer accepts option-spread retainWorktree false and runs in the retained cwd", async () => {
+  const { repo, cleanup } = createGitRepo("pi-retained-false-default-");
+  const seenCwds: string[] = [];
+  try {
+    const result = await runWorkflow(
+      `export const meta = { name: 'retain_false_default', description: 'consumer option defaults' }
+const defaults = { retainWorktree: false }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+const consumed = await agent('consume', { ...defaults, worktree: produced.worktree })
+return consumed`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        agent: {
+          async run(prompt: string, options: AgentRunOptions) {
+            assert.ok(options.cwd);
+            seenCwds.push(options.cwd);
+            if (prompt === "produce") {
+              writeFileSync(join(options.cwd, "spread-default.txt"), "visible with false default\n");
+              return "ready";
+            }
+            return readFileSync(join(options.cwd, "spread-default.txt"), "utf8");
+          },
+        },
+      },
+    );
+
+    assert.equal(result.result, "visible with false default\n");
+    assert.equal(seenCwds.length, 2);
+    assert.equal(seenCwds[0], seenCwds[1]);
+    assert.notEqual(seenCwds[0], repo);
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("retained producer snapshots lifecycle options before caller mutation", async () => {
+  const { repo, cleanup } = createGitRepo("pi-retained-producer-options-snapshot-");
+  let retainedCwd = "";
+  try {
+    const result = await runWorkflow(
+      `export const meta = { name: 'retained_producer_snapshot', description: 'snapshot producer lifecycle options' }
+const lifecycle = { isolation: 'worktree', retainWorktree: true }
+const pending = agent('produce', lifecycle)
+delete lifecycle.isolation
+delete lifecycle.retainWorktree
+const produced = await pending
+const consumed = await agent('consume', { worktree: produced.worktree })
+await releaseWorktree(produced.worktree)
+return { produced: produced.result, consumed, hasHandle: produced.worktree !== undefined }`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        agent: {
+          async run(prompt: string, options: AgentRunOptions) {
+            assert.ok(options.cwd);
+            if (prompt === "produce") {
+              retainedCwd = options.cwd;
+              writeFileSync(join(options.cwd, "snapshot.txt"), "retained after mutation\n");
+              return "ready";
+            }
+            assert.equal(options.cwd, retainedCwd);
+            assert.equal(existsSync(retainedCwd), true, "the retained checkout survives until explicit release");
+            return readFileSync(join(options.cwd, "snapshot.txt"), "utf8");
+          },
+        },
+      },
+    );
+
+    assert.deepEqual(JSON.parse(JSON.stringify(result.result)), {
+      produced: "ready",
+      consumed: "retained after mutation\n",
+      hasHandle: true,
+    });
+    assert.equal(existsSync(retainedCwd), false, "explicit release removes the snapshotted producer checkout");
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("agent options reject malformed values before budget, runner, manager, or worktree side effects", async () => {
+  const malformed = [
+    { name: "null", expression: "null" },
+    { name: "array", expression: "[]" },
+    { name: "number", expression: "42" },
+    { name: "string", expression: "'invalid'" },
+    { name: "boolean", expression: "true" },
+    { name: "function", expression: "function invalid() {}" },
+    { name: "numeric label", expression: "{ label: 1 }" },
+    { name: "invalid isolation", expression: "{ isolation: 'shared' }" },
+    { name: "string retainWorktree", expression: "{ retainWorktree: 'yes' }" },
+    { name: "primitive worktree", expression: "{ worktree: 'forged' }" },
+    { name: "string timeout", expression: "{ timeoutMs: 'soon' }" },
+    { name: "string retries", expression: "{ retries: 'many' }" },
+    { name: "array schema", expression: "{ schema: [] }" },
+  ];
+
+  for (const invalid of malformed) {
+    const sharedRuntime: SharedRuntime = {
+      limiter: async (fn) => fn(),
+      agentCount: 0,
+      spent: 0,
+      tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
+      depth: 0,
+    };
+    let runnerCalls = 0;
+    let worktreeCalls = 0;
+    let starts = 0;
+    let journals = 0;
+
+    await assert.rejects(
+      runWorkflow(
+        `export const meta = { name: 'invalid_agent_options', description: 'reject malformed agent options' }
+return await agent('invalid', ${invalid.expression})`,
+        {
+          sharedRuntime,
+          persistLogs: false,
+          agent: {
+            async run() {
+              runnerCalls += 1;
+              return "unexpected";
+            },
+          },
+          worktreeOperations: {
+            async createWorktree(cwd) {
+              worktreeCalls += 1;
+              return { isolated: false, cwd, reason: "unexpected" };
+            },
+            async removeWorktree() {
+              return [];
+            },
+          },
+          onAgentStart: () => {
+            starts += 1;
+          },
+          onAgentJournal: () => {
+            journals += 1;
+          },
+        },
+      ),
+      (error: unknown) => {
+        assert.ok(error instanceof WorkflowError, invalid.name);
+        assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, invalid.name);
+        assert.match(error.message, /agent.*options/i, invalid.name);
+        return true;
+      },
+    );
+    assert.equal(sharedRuntime.agentCount, 0, `${invalid.name} does not consume agent budget`);
+    assert.equal(runnerCalls, 0, `${invalid.name} does not run an agent`);
+    assert.equal(worktreeCalls, 0, `${invalid.name} does not create a worktree`);
+    assert.equal(starts, 0, `${invalid.name} does not emit manager start state`);
+    assert.equal(journals, 0, `${invalid.name} does not journal`);
+  }
+});
+
+test("agent options preserve inherited lifecycle fields for retained producers and consumers", async () => {
+  const { repo, cleanup } = createGitRepo("pi-inherited-agent-options-");
+  const seenCwds: string[] = [];
+  try {
+    const result = await runWorkflow(
+      `export const meta = { name: 'inherited_agent_options', description: 'preserve inherited options' }
+const producerOptions = Object.create({ isolation: 'worktree', retainWorktree: true })
+const produced = await agent('produce', producerOptions)
+const consumerOptions = Object.create({ worktree: produced.worktree, retainWorktree: false })
+const consumed = await agent('consume', consumerOptions)
+await releaseWorktree(produced.worktree)
+return { produced: produced.result, consumed }`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        agent: {
+          async run(prompt, options) {
+            assert.ok(options.cwd);
+            seenCwds.push(options.cwd);
+            return prompt;
+          },
+        },
+      },
+    );
+
+    assert.deepEqual(JSON.parse(JSON.stringify(result.result)), { produced: "produce", consumed: "consume" });
+    assert.equal(seenCwds.length, 2);
+    assert.equal(seenCwds[0], seenCwds[1]);
+    assert.notEqual(seenCwds[0], repo);
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("agent options snapshot every recognized non-enumerable field before caller mutation", async () => {
+  const { repo, cleanup } = createGitRepo("pi-non-enumerable-agent-options-");
+  const starts: Array<{ label: string; phase?: string }> = [];
+  const seenOptions: AgentRunOptions[] = [];
+  let attempts = 0;
+  try {
+    const result = await runWorkflow(
+      `export const meta = { name: 'non_enumerable_agent_options', description: 'snapshot recognized fields' }
+const schema = { type: 'object', properties: { ok: { type: 'boolean' } }, required: ['ok'] }
+const options = {}
+for (const [key, value] of Object.entries({
+  label: 'hidden label', phase: 'Hidden phase', schema, model: 'provider/hidden', tier: 'small',
+  isolation: 'worktree', retainWorktree: false, agentType: 'hidden-role', timeoutMs: 5000, retries: 1,
+})) Object.defineProperty(options, key, { value, configurable: true })
+const pending = agent('hidden', options)
+for (const key of ['label', 'phase', 'schema', 'model', 'tier', 'isolation', 'retainWorktree', 'agentType', 'timeoutMs', 'retries']) delete options[key]
+return await pending`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        onAgentStart: ({ label, phase }) => starts.push({ label, phase }),
+        agent: {
+          async run(_prompt, options) {
+            attempts += 1;
+            seenOptions.push(options);
+            if (attempts === 1)
+              throw new WorkflowError("retry", WorkflowErrorCode.AGENT_TIMEOUT, { recoverable: true });
+            return { ok: true };
+          },
+        },
+      },
+    );
+
+    assert.deepEqual(JSON.parse(JSON.stringify(result.result)), { ok: true });
+    assert.equal(attempts, 2, "the non-enumerable retry count is preserved");
+    const captured = seenOptions[0];
+    assert.ok(captured?.cwd);
+    assert.equal(captured.label, "hidden label");
+    assert.equal(captured.model, "provider/hidden");
+    assert.equal(captured.tier, "small");
+    assert.deepEqual(JSON.parse(JSON.stringify(captured.schema)), {
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+      required: ["ok"],
+    });
+    assert.match(captured.instructions ?? "", /hidden-role/);
+    assert.deepEqual(starts, [{ label: "hidden label", phase: "Hidden phase" }]);
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("throwing own and inherited agent option getters become side-effect-free script validation", async () => {
+  for (const inherited of [false, true]) {
+    const sharedRuntime: SharedRuntime = {
+      limiter: async (fn) => fn(),
+      agentCount: 0,
+      spent: 0,
+      tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
+      depth: 0,
+    };
+    let runnerCalls = 0;
+    let starts = 0;
+    let worktreeCalls = 0;
+    const setup = inherited
+      ? `const prototype = {}
+Object.defineProperty(prototype, 'isolation', { get() { throw new Error('GETTER_EXECUTED') } })
+const options = Object.create(prototype)`
+      : `const options = {}
+Object.defineProperty(options, 'isolation', { enumerable: true, get() { throw new Error('GETTER_EXECUTED') } })`;
+
+    await assert.rejects(
+      runWorkflow(
+        `export const meta = { name: 'throwing_agent_getter', description: 'getter validation' }
+${setup}
+return await agent('invalid getter', options)`,
+        {
+          sharedRuntime,
+          persistLogs: false,
+          agent: {
+            async run() {
+              runnerCalls += 1;
+              return "unexpected";
+            },
+          },
+          worktreeOperations: {
+            async createWorktree(cwd) {
+              worktreeCalls += 1;
+              return { isolated: false, cwd };
+            },
+            async removeWorktree() {
+              return [];
+            },
+          },
+          onAgentStart: () => {
+            starts += 1;
+          },
+        },
+      ),
+      (error: unknown) => {
+        assert.ok(error instanceof WorkflowError);
+        assert.equal(error.code, WorkflowErrorCode.SCRIPT_VALIDATION_ERROR);
+        assert.match(error.message, /agent.*options.*isolation/i);
+        assert.doesNotMatch(error.message, /GETTER_EXECUTED/);
+        return true;
+      },
+    );
+    assert.equal(sharedRuntime.agentCount, 0);
+    assert.equal(runnerCalls, 0);
+    assert.equal(worktreeCalls, 0);
+    assert.equal(starts, 0);
+  }
+});
+
+test("retained consumer snapshots its handle before caller deletion", async () => {
+  const { repo, cleanup } = createGitRepo("pi-retained-consumer-options-snapshot-");
+  let retainedCwd = "";
+  try {
+    const result = await runWorkflow(
+      `export const meta = { name: 'retained_consumer_snapshot', description: 'snapshot consumer lifecycle options' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+const lifecycle = { worktree: produced.worktree }
+const pending = agent('consume-first', lifecycle)
+delete lifecycle.worktree
+const first = await pending
+const second = await agent('consume-second', { worktree: produced.worktree })
+await releaseWorktree(produced.worktree)
+return { first, second }`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        agent: {
+          async run(prompt: string, options: AgentRunOptions) {
+            assert.ok(options.cwd);
+            if (prompt === "produce") {
+              retainedCwd = options.cwd;
+              writeFileSync(join(options.cwd, "consumer-snapshot.txt"), "producer\n");
+              return "ready";
+            }
+            assert.equal(options.cwd, retainedCwd, "every consumer uses the registered checkout");
+            assert.equal(existsSync(options.cwd), true, "consumer mutation must not ordinary-clean the checkout");
+            if (prompt === "consume-first") {
+              writeFileSync(join(options.cwd, "consumer-snapshot.txt"), "first consumer\n");
+              return "first";
+            }
+            return readFileSync(join(options.cwd, "consumer-snapshot.txt"), "utf8");
+          },
+        },
+      },
+    );
+
+    assert.deepEqual(JSON.parse(JSON.stringify(result.result)), {
+      first: "first",
+      second: "first consumer\n",
+    });
+    assert.equal(existsSync(retainedCwd), false, "release remains valid after the mutated consumer call");
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("retainWorktree false cannot be mutated into a retained producer after invocation", async () => {
+  const { repo, cleanup } = createGitRepo("pi-ordinary-options-snapshot-");
+  let isolatedCwd = "";
+  try {
+    const result = await runWorkflow(
+      `export const meta = { name: 'ordinary_snapshot', description: 'snapshot ordinary lifecycle options' }
+const lifecycle = { isolation: 'worktree', retainWorktree: false }
+const pending = agent('ordinary', lifecycle)
+lifecycle.retainWorktree = true
+const ordinary = await pending
+return { ordinary, hasEnvelope: ordinary !== null && typeof ordinary === 'object' && 'worktree' in ordinary }`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        agent: {
+          async run(_prompt: string, options: AgentRunOptions) {
+            isolatedCwd = options.cwd ?? "";
+            return "plain-result";
+          },
+        },
+      },
+    );
+
+    assert.deepEqual(JSON.parse(JSON.stringify(result.result)), {
+      ordinary: "plain-result",
+      hasEnvelope: false,
+    });
+    assert.equal(existsSync(isolatedCwd), false, "ordinary cleanup follows the invocation-time lifecycle options");
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("ordinary isolation keeps its result shape and removes the worktree immediately", async () => {
+  const { repo, cleanup } = createGitRepo("pi-default-wt-");
+  let isolatedCwd = "";
+  try {
+    const result = await runWorkflow(
+      `export const meta = { name: 'default_isolation', description: 'compatibility' }
+const ordinary = await agent('ordinary', { isolation: 'worktree' })
+await agent('after')
+return ordinary`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        agent: {
+          async run(prompt: string, options: AgentRunOptions) {
+            if (prompt === "ordinary") {
+              isolatedCwd = options.cwd ?? "";
+              return "plain-result";
+            }
+            assert.equal(options.cwd, undefined);
+            assert.equal(existsSync(isolatedCwd), false, "ordinary isolation is removed before the next step");
+            return "after";
+          },
+        },
+      },
+    );
+    assert.equal(result.result, "plain-result");
+    assert.equal(existsSync(isolatedCwd), false);
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("ordinary isolation bypasses an external symlink at the obsolete shared root", async () => {
+  const { repo, cleanup } = createGitRepo("pi-ordinary-symlink-root-");
+  const external = mkdtempSync(join(tmpdir(), "pi-ordinary-external-root-"));
+  const prompts: string[] = [];
+  try {
+    mkdirSync(join(repo, ".pi"));
+    symlinkSync(external, join(repo, ".pi", "worktrees"), "dir");
+
+    const result = await runWorkflow(
+      `export const meta = { name: 'ordinary_symlink_root', description: 'fail closed isolation root' }
+return await agent('ordinary', { isolation: 'worktree' })`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        agent: {
+          async run(prompt, options) {
+            prompts.push(prompt);
+            assert.ok(options.cwd, "ordinary isolation still receives a worktree cwd");
+            const commonRoot = execFileSync(
+              "git",
+              ["-C", repo, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+              { encoding: "utf8" },
+            ).trim();
+            assert.equal(join(options.cwd, ".."), commonRoot, "the checkout is a direct Git-common-dir child");
+            assert.match(options.cwd, /pi-workflow-checkout-/);
+            return "safe isolated result";
+          },
+        },
+      },
+    );
+
+    assert.equal(result.result, "safe isolated result");
+    assert.deepEqual(prompts, ["ordinary"]);
+    assert.deepEqual(readdirSync(external), []);
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+    rmSync(external, { recursive: true, force: true });
+  }
+});
+
+test("ordinary and retained workflow cleanup fall back when proc descriptors are unavailable", async () => {
+  const { repo, cleanup } = createGitRepo("pi-portable-workflow-cleanup-");
+  const isolatedCwds: string[] = [];
+  try {
+    const result = await runWorkflow(
+      `export const meta = { name: 'portable_cleanup', description: 'portable cleanup fallback' }
+await agent('ordinary', { isolation: 'worktree' })
+const retained = await agent('retained', { isolation: 'worktree', retainWorktree: true })
+await releaseWorktree(retained.worktree)
+return retained.result`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        worktreeOperations: createWorktreeOperationsForTesting({
+          procDescriptorRoot: join(repo, "unavailable-proc"),
+        }),
+        agent: {
+          async run(prompt, options) {
+            assert.ok(options.cwd);
+            isolatedCwds.push(options.cwd);
+            return prompt;
+          },
+        },
+      },
+    );
+
+    assert.equal(result.result, "retained");
+    assert.equal(isolatedCwds.length, 2);
+    assert.equal(
+      isolatedCwds.every((cwd) => !existsSync(cwd)),
+      true,
+      "both cleanup lifecycles remove their checkout",
+    );
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("throwing onAgentStart cleans an ordinary isolated worktree without emitting a terminal event", async () => {
+  const { repo, cleanup } = createGitRepo("pi-start-failure-ordinary-");
+  let created: Worktree | undefined;
+  const ended: string[] = [];
+  try {
+    await assert.rejects(
+      runWorkflow(
+        `export const meta = { name: 'ordinary_start_failure', description: 'start callback cleanup' }
+return await agent('ordinary', { label: 'ordinary', isolation: 'worktree' })`,
+        {
+          cwd: repo,
+          persistLogs: false,
+          agent: {
+            async run() {
+              assert.fail("agent runner must not start when onAgentStart fails");
+            },
+          },
+          worktreeOperations: {
+            async createWorktree(baseCwd, name) {
+              created = await DEFAULT_WORKTREE_OPERATIONS.createWorktree(baseCwd, name);
+              return created;
+            },
+            removeWorktree: DEFAULT_WORKTREE_OPERATIONS.removeWorktree,
+          },
+          onAgentStart() {
+            throw new Error("injected start failure");
+          },
+          onAgentEnd(event) {
+            ended.push(event.label);
+          },
+        },
+      ),
+      /injected start failure/,
+    );
+
+    assert.equal(created?.isolated, true);
+    assert.equal(existsSync(created?.cwd ?? ""), false, "ordinary checkout path is removed");
+    assert.deepEqual(ended, [], "no terminal event is emitted when start did not complete");
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("throwing onAgentStart releases a retained consumer lease and root cleanup settles", async () => {
+  const { repo, cleanup } = createGitRepo("pi-start-failure-retained-");
+  let retainedCwd = "";
+  const ended: string[] = [];
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    const run = runWorkflow(
+      `export const meta = { name: 'retained_start_failure', description: 'retained lease cleanup' }
+const produced = await agent('produce', { label: 'producer', isolation: 'worktree', retainWorktree: true })
+return await agent('consume', { label: 'consumer', worktree: produced.worktree })`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        agent: {
+          async run(prompt, options) {
+            if (prompt === "produce") retainedCwd = options.cwd ?? "";
+            return "ready";
+          },
+        },
+        onAgentStart(event) {
+          if (event.label === "consumer") throw new Error("injected consumer start failure");
+        },
+        onAgentEnd(event) {
+          ended.push(event.label);
+        },
+      },
+    );
+    const outcome = await Promise.race([
+      run.then(
+        () => ({ status: "resolved" as const, error: undefined }),
+        (error: unknown) => ({ status: "rejected" as const, error }),
+      ),
+      new Promise<{ status: "timeout"; error: undefined }>((resolve) => {
+        timeout = setTimeout(() => resolve({ status: "timeout", error: undefined }), 5_000);
+      }),
+    ]);
+
+    assert.notEqual(outcome.status, "timeout", "root cleanup must not hang on an unreleased consumer lease");
+    assert.equal(outcome.status, "rejected");
+    assert.match(
+      outcome.error instanceof Error ? outcome.error.message : String(outcome.error),
+      /consumer start failure/,
+    );
+    assert.deepEqual(ended, ["producer"], "the consumer has no terminal event because its start did not complete");
+    assert.equal(existsSync(retainedCwd), false, "retained checkout path is removed at root terminal cleanup");
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    cleanup();
+  }
+});
+
+test("release cleans a retained Git registration after the agent deletes its checkout", async () => {
+  const { repo, cleanup } = createGitRepo("pi-retained-missing-checkout-");
+  let retainedCwd = "";
+  try {
+    const result = await runWorkflow(
+      `export const meta = { name: 'retained_missing_checkout', description: 'stale registration cleanup' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+await releaseWorktree(produced.worktree)
+return produced.result`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        agent: {
+          async run(_prompt, options) {
+            retainedCwd = options.cwd ?? "";
+            rmSync(retainedCwd, { recursive: true, force: true });
+            return "finished";
+          },
+        },
+      },
+    );
+
+    assert.equal(result.result, "finished");
+    assert.equal(existsSync(retainedCwd), false);
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("release is idempotent while malformed, cross-run, and released bindings reject", async () => {
+  const { repo, cleanup } = createGitRepo("pi-release-wt-");
+  try {
+    const released = await runWorkflow(
+      `export const meta = { name: 'release_rules', description: 'release validation' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+let combinationError = ''
+try { await agent('invalid-combination', { worktree: produced.worktree, isolation: 'worktree' }) } catch (error) { combinationError = error.message }
+await releaseWorktree(produced.worktree)
+await releaseWorktree(produced.worktree)
+let bindError = ''
+try { await agent('late', { worktree: produced.worktree }) } catch (error) { bindError = error.message }
+return { handle: produced.worktree, bindError, combinationError }`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        agent: {
+          async run() {
+            return "ok";
+          },
+        },
+      },
+    );
+    assert.match((released.result as { bindError: string }).bindError, /released/i);
+    assert.match((released.result as { combinationError: string }).combinationError, /cannot be combined/i);
+    const opaqueHandle = (released.result as { handle: object }).handle;
+    assert.deepEqual(Object.keys(opaqueHandle), [], "the handle exposes no path or identity fields");
+    assert.equal(JSON.stringify(opaqueHandle), "{}");
+
+    await assert.rejects(
+      runWorkflow(
+        `export const meta = { name: 'invalid_release', description: 'invalid handle' }
+await releaseWorktree({ cwd: args.arbitraryPath })`,
+        {
+          cwd: repo,
+          args: { arbitraryPath: repo },
+          persistLogs: false,
+          agent: {
+            async run() {
+              return "unused";
+            },
+          },
+        },
+      ),
+      /malformed|unknown/i,
+    );
+    assert.equal(existsSync(repo), true, "a path-shaped forged handle cannot remove caller-selected paths");
+
+    await assert.rejects(
+      runWorkflow(
+        `export const meta = { name: 'retain_requires_isolation', description: 'invalid producer options' }
+await agent('invalid-producer', { retainWorktree: true })`,
+        {
+          cwd: repo,
+          persistLogs: false,
+          agent: {
+            async run() {
+              return "unused";
+            },
+          },
+        },
+      ),
+      /requires isolation/i,
+    );
+
+    await assert.rejects(
+      runWorkflow(
+        `export const meta = { name: 'cross_run', description: 'cross run handle' }
+await releaseWorktree(args.handle)`,
+        {
+          cwd: repo,
+          args: { handle: (released.result as { handle: object }).handle },
+          persistLogs: false,
+          agent: {
+            async run() {
+              return "unused";
+            },
+          },
+        },
+      ),
+      /cross-run/i,
+    );
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("ordinary terminal cleanup failures dispose proofs without growing global handle maps", async () => {
+  const baseline = activeCheckoutProofsForTesting();
+  for (let round = 0; round < 3; round++) {
+    const { repo, cleanup } = createGitRepo(`pi-ordinary-terminal-proof-${round}-`);
+    try {
+      const result = await runWorkflow(
+        `export const meta = { name: 'ordinary_terminal_proof', description: 'terminal proof disposal' }
+return await agent('ordinary', { isolation: 'worktree' })`,
+        {
+          cwd: repo,
+          persistLogs: false,
+          agent: {
+            async run() {
+              return "ok";
+            },
+          },
+          worktreeOperations: createWorktreeOperationsForTesting({
+            afterIdentityVerification() {
+              throw new Error("permanent ordinary cleanup failure");
+            },
+          }),
+        },
+      );
+      assert.equal(result.worktreeCleanupFailures?.length, 1);
+      assert.deepEqual(
+        activeCheckoutProofsForTesting(),
+        baseline,
+        `terminal round ${round} disposes process-global proof handles`,
+      );
+    } finally {
+      cleanup();
+    }
+  }
+});
+
+test("failed explicit release keeps admission closed and a later release retries cleanup", async () => {
+  const cleanupFailures: WorktreeCleanupFailure[] = [];
+  let attempts = 0;
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: "/runtime-created/retry-explicit",
+    repoRoot: "/runtime-created",
+    branch: "pi/wf/retry-explicit",
+    branchRef: "refs/heads/pi/wf/retry-explicit",
+    baseSha: "a".repeat(40),
+  };
+  const result = await runWorkflow(
+    `export const meta = { name: 'retry_release', description: 'retry failed cleanup' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+await releaseWorktree(produced.worktree)
+let consumerError = ''
+try { await agent('closed-consumer', { worktree: produced.worktree }) } catch (error) { consumerError = error.message }
+await releaseWorktree(produced.worktree)
+await releaseWorktree(produced.worktree)
+return consumerError`,
+    {
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "ok";
+        },
+      },
+      worktreeOperations: {
+        async createWorktree() {
+          return worktree;
+        },
+        async removeWorktree(candidate) {
+          attempts++;
+          if (attempts === 1) {
+            return [
+              {
+                stage: "worktree_remove",
+                message: "transient cleanup failure",
+                identity: {
+                  repoRoot: candidate.repoRoot ?? "",
+                  worktreePath: candidate.cwd,
+                  branchRef: candidate.branchRef ?? "",
+                  baseSha: candidate.baseSha ?? "",
+                },
+              },
+            ];
+          }
+          return [];
+        },
+      },
+      onWorktreeCleanupFailure: (failure) => cleanupFailures.push(failure),
+    },
+  );
+
+  assert.match(String(result.result), /release.*progress|released/i);
+  assert.equal(attempts, 2, "one failed attempt is retried once and success becomes idempotent");
+  assert.equal(cleanupFailures.length, 1);
+});
+
+test("root terminal cleanup retries an earlier failed explicit release", async () => {
+  let attempts = 0;
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: "/runtime-created/retry-at-root",
+    repoRoot: "/runtime-created",
+    branch: "pi/wf/retry-at-root",
+    branchRef: "refs/heads/pi/wf/retry-at-root",
+    baseSha: "b".repeat(40),
+  };
+  await runWorkflow(
+    `export const meta = { name: 'root_retry_release', description: 'terminal retry' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+await releaseWorktree(produced.worktree)
+return 'done'`,
+    {
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "ok";
+        },
+      },
+      worktreeOperations: {
+        async createWorktree() {
+          return worktree;
+        },
+        async removeWorktree(candidate) {
+          attempts++;
+          return attempts === 1
+            ? [
+                {
+                  stage: "cleanup_dispatch",
+                  message: "transient root cleanup failure",
+                  identity: {
+                    repoRoot: candidate.repoRoot ?? "",
+                    worktreePath: candidate.cwd,
+                    branchRef: candidate.branchRef ?? "",
+                    baseSha: candidate.baseSha ?? "",
+                  },
+                },
+              ]
+            : [];
+        },
+      },
+    },
+  );
+
+  assert.equal(attempts, 2, "root cleanup retries the failed, unreleased entry exactly once");
+});
+
+test("concurrent duplicate releases share one attempt and permanent failure does not spin", async () => {
+  let attempts = 0;
+  const failures: WorktreeCleanupFailure[] = [];
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: "/runtime-created/permanent-release-failure",
+    repoRoot: "/runtime-created",
+    branch: "pi/wf/permanent-release-failure",
+    branchRef: "refs/heads/pi/wf/permanent-release-failure",
+    baseSha: "c".repeat(40),
+  };
+  await runWorkflow(
+    `export const meta = { name: 'bounded_release_failure', description: 'bounded retries' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+await Promise.all([releaseWorktree(produced.worktree), releaseWorktree(produced.worktree)])
+return 'done'`,
+    {
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "ok";
+        },
+      },
+      worktreeOperations: {
+        async createWorktree() {
+          return worktree;
+        },
+        async removeWorktree(candidate) {
+          attempts++;
+          return [
+            {
+              stage: "worktree_remove",
+              message: "permanent cleanup failure",
+              identity: {
+                repoRoot: candidate.repoRoot ?? "",
+                worktreePath: candidate.cwd,
+                branchRef: candidate.branchRef ?? "",
+                baseSha: candidate.baseSha ?? "",
+              },
+            },
+          ];
+        },
+      },
+      onWorktreeCleanupFailure: (failure) => failures.push(failure),
+    },
+  );
+
+  assert.equal(attempts, 2, "duplicates share the explicit attempt and terminal cleanup performs one bounded retry");
+  assert.equal(failures.length, 1, "the terminal retry duplicate is not dispatched twice");
+  assert.ok(failures.every((failure) => failure.message.length <= 1024));
+});
+
+test("consumers serialize FIFO; release closes admission and waits for admitted consumers", async () => {
+  const { repo, cleanup } = createGitRepo("pi-exclusive-wt-");
+  const firstGate = deferred<void>();
+  const secondGate = deferred<void>();
+  let active = 0;
+  let maxActive = 0;
+  const consumerEvents: string[] = [];
+  let consumerCwd = "";
+  try {
+    const run = runWorkflow(
+      `export const meta = { name: 'exclusive', description: 'exclusive retained consumers' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+const first = agent('consumer-1', { worktree: produced.worktree })
+const second = agent('consumer-2', { worktree: produced.worktree })
+const release = releaseWorktree(produced.worktree)
+let lateError = ''
+try { await agent('consumer-late', { worktree: produced.worktree }) } catch (error) { lateError = error.message }
+const values = await Promise.all([first, second])
+await release
+return { values, lateError }`,
+      {
+        cwd: repo,
+        concurrency: 1,
+        persistLogs: false,
+        agent: {
+          async run(prompt: string, options: AgentRunOptions) {
+            if (prompt === "produce") return "ready";
+            consumerEvents.push(`start:${prompt}`);
+            active++;
+            maxActive = Math.max(maxActive, active);
+            consumerCwd = options.cwd ?? "";
+            await (prompt === "consumer-1" ? firstGate.promise : secondGate.promise);
+            active--;
+            consumerEvents.push(`end:${prompt}`);
+            return prompt;
+          },
+        },
+      },
+    );
+
+    await waitFor(() => consumerEvents.includes("start:consumer-1"));
+    assert.equal(existsSync(consumerCwd), true, "release waits while the first admitted consumer is running");
+    firstGate.resolve();
+    await waitFor(() => consumerEvents.includes("start:consumer-2"));
+    assert.equal(existsSync(consumerCwd), true, "release also waits for the globally queued admitted consumer");
+    secondGate.resolve();
+    const result = await run;
+    assert.equal(maxActive, 1);
+    assert.deepEqual(consumerEvents, ["start:consumer-1", "end:consumer-1", "start:consumer-2", "end:consumer-2"]);
+    assert.deepEqual(Array.from((result.result as { values: string[] }).values), ["consumer-1", "consumer-2"]);
+    assert.match((result.result as { lateError: string }).lateError, /release|released/i);
+    assert.equal(existsSync(consumerCwd), false);
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    firstGate.resolve();
+    secondGate.resolve();
+    cleanup();
+  }
+});
+
+test("root terminal cleanup removes unreleased worktrees on success and thrown script errors", async () => {
+  for (const shouldThrow of [false, true]) {
+    const { repo, cleanup } = createGitRepo(`pi-terminal-${shouldThrow ? "throw" : "success"}-`);
+    let worktreeCwd = "";
+    try {
+      const run = runWorkflow(
+        `export const meta = { name: 'terminal_cleanup', description: 'root cleanup' }
+await agent('produce', { isolation: 'worktree', retainWorktree: true })
+${shouldThrow ? "throw new Error('script failed')" : "return 'done'"}`,
+        {
+          cwd: repo,
+          persistLogs: false,
+          agent: {
+            async run(_prompt: string, options: AgentRunOptions) {
+              worktreeCwd = options.cwd ?? "";
+              return "ok";
+            },
+          },
+        },
+      );
+      if (shouldThrow) await assert.rejects(run, /script failed/);
+      else assert.equal((await run).result, "done");
+      assert.equal(existsSync(worktreeCwd), false);
+      assertNoWorktreeLeaks(repo);
+    } finally {
+      cleanup();
+    }
+  }
+});
+
+test("a top-level legacy SharedRuntime depth does not suppress root retained cleanup", async () => {
+  const removals: string[] = [];
+  const sharedRuntime: SharedRuntime = {
+    limiter: async (fn) => fn(),
+    agentCount: 0,
+    spent: 0,
+    tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
+    depth: 7,
+  };
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: "/runtime-created/legacy-depth-root",
+    repoRoot: "/runtime-created",
+    branch: "pi/wf/legacy-depth-root",
+    branchRef: "refs/heads/pi/wf/legacy-depth-root",
+    baseSha: "d".repeat(40),
+  };
+
+  const result = await runWorkflow(
+    `export const meta = { name: 'legacy_depth_root', description: 'root context ownership' }
+await agent('producer', { isolation: 'worktree', retainWorktree: true })
+return 'done'`,
+    {
+      sharedRuntime,
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "ok";
+        },
+      },
+      worktreeOperations: {
+        async createWorktree() {
+          return worktree;
+        },
+        async removeWorktree(candidate) {
+          removals.push(candidate.cwd);
+          return [];
+        },
+      },
+    },
+  );
+
+  assert.equal(result.result, "done");
+  assert.deepEqual(removals, [worktree.cwd]);
+});
+
+test("manager-created root execution context owns terminal retained cleanup", async () => {
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-manager-root-owner-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "pi-manager-root-owner-cwd-"));
+  const removals: string[] = [];
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: join(cwd, ".retained"),
+    repoRoot: cwd,
+    branch: "pi/wf/manager-root-owner",
+    branchRef: "refs/heads/pi/wf/manager-root-owner",
+    baseSha: "e".repeat(40),
+  };
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const manager = new WorkflowManager({
+        cwd,
+        agent: {
+          async run() {
+            return "ok";
+          },
+        },
+        worktreeOperations: {
+          async createWorktree() {
+            return worktree;
+          },
+          async removeWorktree(candidate) {
+            removals.push(candidate.cwd);
+            return [];
+          },
+        },
+      });
+      const result = await manager.runSync(
+        `export const meta = { name: 'manager_root_owner', description: 'manager root cleanup owner' }
+await agent('producer', { isolation: 'worktree', retainWorktree: true })
+return 'done'`,
+      );
+      assert.equal(result.result, "done");
+      assert.deepEqual(removals, [worktree.cwd]);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("root abort cleanup waits for the active retained consumer to settle", async () => {
+  const { repo, cleanup } = createGitRepo("pi-abort-wt-");
+  const controller = new AbortController();
+  const gate = deferred<string>();
+  let consumerStarted = false;
+  let worktreeCwd = "";
+  try {
+    const run = runWorkflow(
+      `export const meta = { name: 'abort_cleanup', description: 'abort cleanup' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+return await agent('consumer', { worktree: produced.worktree })`,
+      {
+        cwd: repo,
+        signal: controller.signal,
+        persistLogs: false,
+        agent: {
+          async run(prompt: string, options: AgentRunOptions) {
+            worktreeCwd = options.cwd ?? "";
+            if (prompt === "produce") return "ready";
+            consumerStarted = true;
+            return gate.promise;
+          },
+        },
+      },
+    );
+    await waitFor(() => consumerStarted);
+    controller.abort();
+    assert.equal(existsSync(worktreeCwd), true);
+    gate.resolve("settled");
+    await assert.rejects(run, (error: unknown) => {
+      assert.ok(error instanceof WorkflowError);
+      return error.code === WorkflowErrorCode.WORKFLOW_ABORTED;
+    });
+    assert.equal(existsSync(worktreeCwd), false);
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    gate.resolve("settled");
+    cleanup();
+  }
+});
+
+test("terminal admission rejects late producers, consumers, and nested wrappers before side effects", async (t) => {
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  t.after(() => process.off("unhandledRejection", onUnhandled));
+  const gate = deferred<void>();
+  const records: Array<{ kind: string; message: string }> = [];
+  const prompts: string[] = [];
+  const starts: string[] = [];
+  const removals: string[] = [];
+  let created = 0;
+  const child = `export const meta = { name: 'late_child', description: 'must not enter after root settlement' }
+return await agent('late-nested-agent')`;
+  const operations: WorktreeOperations = {
+    async createWorktree(_baseCwd, name) {
+      created++;
+      return {
+        isolated: true,
+        cwd: `/runtime/terminal-admission-${created}`,
+        repoRoot: "/runtime",
+        branch: `pi/wf/${name}`,
+        branchRef: `refs/heads/pi/wf/${name}`,
+        baseSha: String(created).padStart(40, "0"),
+      };
+    },
+    async removeWorktree(worktree) {
+      removals.push(worktree.cwd);
+      return [];
+    },
+  };
+  const sharedRuntime: SharedRuntime = {
+    limiter: async (fn) => fn(),
+    agentCount: 0,
+    spent: 0,
+    tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
+    depth: 0,
+  };
+  const result = await runWorkflow(
+    `export const meta = { name: 'terminal_admission', description: 'reject detached worktree operations' }
+const produced = await agent('producer', { label: 'producer', isolation: 'worktree', retainWorktree: true })
+args.gate.then(() => agent('late-producer', { isolation: 'worktree', retainWorktree: true }).then(
+  () => args.record('producer', 'unexpected success'),
+  (error) => args.record('producer', error.message),
+))
+args.gate.then(() => agent('late-consumer', { worktree: produced.worktree }).then(
+  () => args.record('consumer', 'unexpected success'),
+  (error) => args.record('consumer', error.message),
+))
+args.gate.then(() => workflow(${JSON.stringify(child)}).then(
+  () => args.record('workflow', 'unexpected success'),
+  (error) => args.record('workflow', error.message),
+))
+args.gate.then(() => releaseWorktree(produced.worktree).then(
+  () => args.record('release', 'unexpected success'),
+  (error) => args.record('release', error.message),
+))
+return 'root result'`,
+    {
+      args: {
+        gate: gate.promise,
+        record(kind: string, message: string) {
+          records.push({ kind, message });
+        },
+      },
+      sharedRuntime,
+      worktreeOperations: operations,
+      persistLogs: false,
+      agent: {
+        async run(prompt: string) {
+          prompts.push(prompt);
+          return prompt;
+        },
+      },
+      onAgentStart: (event) => starts.push(event.label),
+    },
+  );
+
+  assert.equal(result.result, "root result");
+  assert.equal(created, 1);
+  assert.deepEqual(removals, ["/runtime/terminal-admission-1"]);
+  gate.resolve();
+  for (let turn = 0; turn < 20 && records.length < 4; turn++) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  assert.equal(records.length, 4, "every detached rejection settles safely");
+  assert.deepEqual(records.map((record) => record.kind).sort(), ["consumer", "producer", "release", "workflow"]);
+  for (const record of records) assert.match(record.message, /admission|settled|closed/i);
+  assert.deepEqual(prompts, ["producer"]);
+  assert.deepEqual(starts, ["producer"]);
+  assert.equal(sharedRuntime.agentCount, 1, "late calls do not consume agent budget");
+  assert.equal(created, 1, "late calls do not create another worktree");
+  assert.deepEqual(removals, ["/runtime/terminal-admission-1"], "terminal cleanup snapshots every admitted tree");
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.deepEqual(unhandled, []);
+});
+
+test("pre-close releases settle while late releases and concurrent roots stay isolated", async () => {
+  const lateGate = deferred<void>();
+  const activeGate = deferred<void>();
+  const lateRecords: string[] = [];
+  const removals: string[] = [];
+  let created = 0;
+  const operations: WorktreeOperations = {
+    async createWorktree(_baseCwd, name) {
+      created++;
+      return {
+        isolated: true,
+        cwd: `/runtime/release-root-${created}`,
+        repoRoot: "/runtime",
+        branch: `pi/wf/${name}`,
+        branchRef: `refs/heads/pi/wf/${name}`,
+        baseSha: String(created).padStart(40, "0"),
+      };
+    },
+    async removeWorktree(worktree) {
+      removals.push(worktree.cwd);
+      return [];
+    },
+  };
+  const common = {
+    worktreeOperations: operations,
+    persistLogs: false,
+    agent: {
+      async run(prompt: string) {
+        return prompt;
+      },
+    },
+  } as const;
+
+  const lateRun = runWorkflow(
+    `export const meta = { name: 'late_release_root', description: 'late release admission' }
+const produced = await agent('late-root', { isolation: 'worktree', retainWorktree: true })
+args.gate.then(() => releaseWorktree(produced.worktree).then(
+  () => args.record('unexpected success'),
+  (error) => args.record(error.message),
+))
+return 'late-root-done'`,
+    { ...common, args: { gate: lateGate.promise, record: (message: string) => lateRecords.push(message) } },
+  );
+  const activeRun = runWorkflow(
+    `export const meta = { name: 'active_release_root', description: 'pre-close release admission' }
+const produced = await agent('active-root', { isolation: 'worktree', retainWorktree: true })
+await args.gate
+await releaseWorktree(produced.worktree)
+return 'active-root-done'`,
+    { ...common, args: { gate: activeGate.promise } },
+  );
+
+  assert.equal((await lateRun).result, "late-root-done");
+  assert.deepEqual(removals, ["/runtime/release-root-1"]);
+  activeGate.resolve();
+  assert.equal((await activeRun).result, "active-root-done");
+  assert.deepEqual(removals.sort(), ["/runtime/release-root-1", "/runtime/release-root-2"]);
+  lateGate.resolve();
+  for (let turn = 0; turn < 20 && lateRecords.length === 0; turn++) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  assert.equal(lateRecords.length, 1);
+  assert.match(lateRecords[0] ?? "", /admission|settled|closed/i);
+  assert.equal(removals.length, 2, "the late root cannot retry cleanup owned by either root");
+});
+
+test("a late detached checkpoint rejects before manager, confirm, or journal side effects", async (t) => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-late-checkpoint-cwd-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-late-checkpoint-home-"));
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  t.after(() => process.off("unhandledRejection", onUnhandled));
+  const gate = deferred<void>();
+  const records: Array<{ outcome: string; message?: string }> = [];
+  let confirmCalls = 0;
+  let progressCalls = 0;
+
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const manager = new WorkflowManager({ cwd });
+      const result = await manager.runSync(
+        `export const meta = { name: 'late_checkpoint', description: 'reject detached checkpoint' }
+args.gate.then(() => checkpoint('late prompt?', { default: true }).then(
+  () => args.record('resolved'),
+  (error) => args.record('rejected', error.message),
+))
+return 'root result'`,
+        {
+          gate: gate.promise,
+          record(outcome: string, message?: string) {
+            records.push({ outcome, message });
+          },
+        },
+        {
+          confirm: async () => {
+            confirmCalls++;
+            return true;
+          },
+          onProgress: () => {
+            progressCalls++;
+          },
+        },
+      );
+
+      assert.equal(result.result, "root result");
+      assert.equal(result.agentCount, 0);
+      assert.equal(manager.getRun(result.runId ?? "")?.status, "completed");
+      assert.equal(manager.getRun(result.runId ?? "")?.journal.length, 0);
+      const settledProgressCalls = progressCalls;
+
+      gate.resolve();
+      await waitFor(() => records.length === 1);
+      assert.deepEqual(
+        records.map((record) => record.outcome),
+        ["rejected"],
+      );
+      assert.match(records[0]?.message ?? "", /admission|settled|closed/i);
+      assert.equal(confirmCalls, 0, "late admission fails before opening confirm UI");
+      assert.equal(manager.getRun(result.runId ?? "")?.journal.length, 0, "late rejection cannot journal");
+      assert.equal(manager.getRun(result.runId ?? "")?.snapshot.agentCount, 0, "late rejection cannot change counters");
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(progressCalls, settledProgressCalls, "no manager callbacks run after terminal settlement");
+      assert.deepEqual(unhandled, []);
+    });
+  } finally {
+    gate.resolve();
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("a detached pre-close checkpoint is tracked until confirmation and journals before manager settlement", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-inflight-checkpoint-cwd-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-inflight-checkpoint-home-"));
+  const confirmStarted = deferred<void>();
+  const confirmGate = deferred<string>();
+  let confirmCalls = 0;
+  let progressCalls = 0;
+
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const manager = new WorkflowManager({ cwd });
+      let settled = false;
+      const run = manager
+        .runSync(
+          `export const meta = { name: 'inflight_checkpoint', description: 'track detached checkpoint' }
+checkpoint('approve before settlement?')
+return 'script result'`,
+          undefined,
+          {
+            confirm: async () => {
+              confirmCalls++;
+              confirmStarted.resolve();
+              return confirmGate.promise;
+            },
+            onProgress: () => {
+              progressCalls++;
+            },
+          },
+        )
+        .then((result) => {
+          settled = true;
+          return result;
+        });
+
+      await confirmStarted.promise;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const liveRun = manager.listRuns().find((candidate) => candidate.workflowName === "inflight_checkpoint");
+      assert.equal(settled, false, "the manager waits for the admitted checkpoint");
+      assert.equal(liveRun?.status, "running");
+      assert.equal(confirmCalls, 1);
+
+      confirmGate.resolve("approved");
+      const result = await run;
+      assert.equal(result.result, "script result");
+      assert.equal(result.agentCount, 1, "the admitted checkpoint consumes one bounded slot");
+      assert.equal(manager.getRun(result.runId ?? "")?.status, "completed");
+      assert.equal(manager.getRun(result.runId ?? "")?.journal.length, 1, "the checkpoint journals before completion");
+      const settledProgressCalls = progressCalls;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(confirmCalls, 1);
+      assert.equal(manager.getRun(result.runId ?? "")?.journal.length, 1);
+      assert.equal(progressCalls, settledProgressCalls, "no manager callbacks run after settlement");
+    });
+  } finally {
+    confirmGate.resolve("approved");
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("retained registry closure rejects tokenless register and acquire before snapshot cleanup", async () => {
+  const removals: string[] = [];
+  const first: Worktree = {
+    isolated: true,
+    cwd: "/runtime/registry-close-first",
+    repoRoot: "/runtime",
+    branch: "pi/wf/registry-close-first",
+    branchRef: "refs/heads/pi/wf/registry-close-first",
+    baseSha: "1".repeat(40),
+  };
+  const second: Worktree = {
+    ...first,
+    cwd: "/runtime/registry-close-second",
+    branch: "pi/wf/registry-close-second",
+    branchRef: "refs/heads/pi/wf/registry-close-second",
+    baseSha: "2".repeat(40),
+  };
+  const registry = new RetainedWorktreeRegistry({
+    async createWorktree() {
+      return first;
+    },
+    async removeWorktree(worktree) {
+      removals.push(worktree.cwd);
+      return [];
+    },
+  });
+  const handle = registry.register(first);
+  registry.closeAdmission();
+
+  assert.throws(() => registry.acquire(handle), /admission is closed/i);
+  assert.throws(() => registry.register(second), /admission is closed/i);
+  await registry.cleanupAll();
+  assert.deepEqual(removals, [first.cwd]);
+});
+
+test("a pre-close in-flight producer retains admission through root settlement", async () => {
+  const creationGate = deferred<void>();
+  const creationStarted = deferred<void>();
+  const removals: string[] = [];
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: "/runtime/pre-close-producer",
+    repoRoot: "/runtime",
+    branch: "pi/wf/pre-close-producer",
+    branchRef: "refs/heads/pi/wf/pre-close-producer",
+    baseSha: "a".repeat(40),
+  };
+  let settled = false;
+  const run = runWorkflow(
+    `export const meta = { name: 'pre_close_producer', description: 'drain admitted producer' }
+agent('producer', { isolation: 'worktree', retainWorktree: true })
+return 'script settled'`,
+    {
+      persistLogs: false,
+      worktreeOperations: {
+        async createWorktree() {
+          creationStarted.resolve();
+          await creationGate.promise;
+          return worktree;
+        },
+        async removeWorktree(candidate) {
+          removals.push(candidate.cwd);
+          return [];
+        },
+      },
+      agent: {
+        async run() {
+          return "produced";
+        },
+      },
+    },
+  ).then((result) => {
+    settled = true;
+    return result;
+  });
+
+  await creationStarted.promise;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(settled, false, "root waits for the synchronously admitted producer");
+  creationGate.resolve();
+  const result = await run;
+  assert.equal(result.result, "script settled");
+  assert.deepEqual(removals, [worktree.cwd]);
+});
+
+test("terminal admission closure is isolated between concurrent roots", async () => {
+  const lateGate = deferred<void>();
+  const secondGate = deferred<void>();
+  const lateErrors: string[] = [];
+  const prompts: string[] = [];
+  const operations: WorktreeOperations = {
+    async createWorktree(_baseCwd, name) {
+      return {
+        isolated: true,
+        cwd: `/runtime/concurrent-admission-${name}`,
+        repoRoot: "/runtime",
+        branch: `pi/wf/${name}`,
+        branchRef: `refs/heads/pi/wf/${name}`,
+        baseSha: "b".repeat(40),
+      };
+    },
+    async removeWorktree() {
+      return [];
+    },
+  };
+  const sharedRuntime: SharedRuntime = {
+    limiter: async (fn) => fn(),
+    agentCount: 0,
+    spent: 0,
+    tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
+    depth: 0,
+  };
+  const first = await runWorkflow(
+    `export const meta = { name: 'closed_first_root', description: 'close only this root' }
+args.gate.then(() => agent('late-first', { isolation: 'worktree', retainWorktree: true }).catch((error) => args.record(error.message)))
+return 'first done'`,
+    {
+      args: { gate: lateGate.promise, record: (message: string) => lateErrors.push(message) },
+      sharedRuntime,
+      worktreeOperations: operations,
+      persistLogs: false,
+      agent: {
+        async run(prompt: string) {
+          prompts.push(prompt);
+          return prompt;
+        },
+      },
+    },
+  );
+  const secondRun = runWorkflow(
+    `export const meta = { name: 'open_second_root', description: 'remain independently open' }
+await args.gate
+return await agent('second-producer', { isolation: 'worktree', retainWorktree: true })`,
+    {
+      args: { gate: secondGate.promise },
+      sharedRuntime,
+      worktreeOperations: operations,
+      persistLogs: false,
+      agent: {
+        async run(prompt: string) {
+          prompts.push(prompt);
+          return prompt;
+        },
+      },
+    },
+  );
+
+  assert.equal(first.result, "first done");
+  lateGate.resolve();
+  secondGate.resolve();
+  const second = await secondRun;
+  for (let turn = 0; turn < 20 && lateErrors.length < 1; turn++) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  assert.equal(lateErrors.length, 1);
+  assert.match(lateErrors[0] ?? "", /admission|settled|closed/i);
+  assert.equal((second.result as { result: string }).result, "second-producer");
+  assert.deepEqual(prompts, ["second-producer"]);
+  assert.equal(sharedRuntime.agentCount, 1);
+});
+
+test("nested workflow settlement does not clean a shared retained handle owned by the root", async () => {
+  const { repo, cleanup } = createGitRepo("pi-nested-wt-");
+  const child = `export const meta = { name: 'child', description: 'consume retained worktree' }
+return await agent('child-consumer', { worktree: args.handle })`;
+  const parent = `export const meta = { name: 'parent', description: 'retain across child' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+const childResult = await workflow(${JSON.stringify(child)}, { handle: produced.worktree })
+const parentResult = await agent('parent-consumer', { worktree: produced.worktree })
+return { childResult, parentResult }`;
+  const seen: string[] = [];
+  try {
+    const result = await runWorkflow(parent, {
+      cwd: repo,
+      persistLogs: false,
+      agent: {
+        async run(prompt: string, options: AgentRunOptions) {
+          assert.ok(options.cwd);
+          seen.push(options.cwd);
+          if (prompt === "produce") writeFileSync(join(options.cwd, "nested.txt"), "still here");
+          return prompt === "produce" ? "ready" : readFileSync(join(options.cwd, "nested.txt"), "utf8");
+        },
+      },
+    });
+    assert.deepEqual(JSON.parse(JSON.stringify(result.result)), {
+      childResult: "still here",
+      parentResult: "still here",
+    });
+    assert.equal(new Set(seen).size, 1);
+    assert.equal(existsSync(seen[0]), false, "root terminal cleanup owns final removal");
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("identical nested workflows receive distinct implicit identities for distinct retained handles", async () => {
+  const { repo, cleanup } = createGitRepo("pi-nested-distinct-handles-");
+  const child = `export const meta = { name: 'child_handle', description: 'identify one retained handle' }
+return 'child-result'`;
+  const parent = `export const meta = { name: 'parent_handles', description: 'distinct retained identities' }
+const first = await agent('produce-first', { isolation: 'worktree', retainWorktree: true })
+const second = await agent('produce-second', { isolation: 'worktree', retainWorktree: true })
+return await Promise.all([
+  workflow(${JSON.stringify(child)}, { handle: first.worktree }),
+  workflow(${JSON.stringify(child)}, { handle: second.worktree })
+])`;
+  const producedCwds: string[] = [];
+  const journal: JournalEntry[] = [];
+  try {
+    const result = await runWorkflow(parent, {
+      cwd: repo,
+      persistLogs: false,
+      agent: {
+        async run(prompt: string, options: AgentRunOptions) {
+          assert.ok(options.cwd);
+          if (prompt.startsWith("produce-")) {
+            producedCwds.push(options.cwd);
+            writeFileSync(join(options.cwd, "owner.txt"), `${prompt}\n`);
+            return prompt;
+          }
+          return readFileSync(join(options.cwd, "owner.txt"), "utf8").trim();
+        },
+      },
+      onAgentJournal: (entry) => journal.push(entry),
+    });
+
+    assert.deepEqual(Array.from(result.result as string[]), ["child-result", "child-result"]);
+    assert.equal(new Set(producedCwds).size, 2);
+    assert.deepEqual(journal, [], "handle-bearing calls and retained producers remain noncacheable");
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("concurrent roots sharing SharedRuntime isolate handles and terminal cleanup", async () => {
+  const rootGate = deferred<void>();
+  const removals: string[] = [];
+  const handles: object[] = [];
+  let sequence = 0;
+  const operations: WorktreeOperations = {
+    async createWorktree(_baseCwd, name) {
+      sequence++;
+      return {
+        isolated: true,
+        cwd: `/runtime/root-${sequence}`,
+        repoRoot: "/runtime",
+        branch: `pi/wf/${name}`,
+        branchRef: `refs/heads/pi/wf/${name}`,
+        baseSha: String(sequence).padStart(40, "0"),
+      };
+    },
+    async removeWorktree(worktree) {
+      removals.push(worktree.cwd);
+      return [];
+    },
+  };
+  const sharedRuntime: SharedRuntime = {
+    limiter: async (fn) => fn(),
+    agentCount: 0,
+    spent: 0,
+    tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
+    depth: 0,
+  };
+  const first = runWorkflow(
+    `export const meta = { name: 'first_root', description: 'first root owner' }
+const produced = await agent('first-producer', { label: 'first-producer', isolation: 'worktree', retainWorktree: true })
+await args.gate
+return produced.worktree`,
+    {
+      args: { gate: rootGate.promise },
+      sharedRuntime,
+      worktreeOperations: operations,
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "first";
+        },
+      },
+      onAgentEnd(event) {
+        if (event.label === "first-producer") handles.push((event.result as { worktree: object }).worktree);
+      },
+    },
+  );
+
+  try {
+    await waitFor(() => handles.length === 1);
+    await assert.rejects(
+      runWorkflow(
+        `export const meta = { name: 'cross_root', description: 'reject foreign handle' }
+return await agent('foreign-consumer', { worktree: args.handle })`,
+        {
+          args: { handle: handles[0] },
+          sharedRuntime,
+          worktreeOperations: operations,
+          persistLogs: false,
+          agent: {
+            async run() {
+              return "must not run";
+            },
+          },
+        },
+      ),
+      /cross-run/i,
+    );
+
+    const second = await runWorkflow(
+      `export const meta = { name: 'second_root', description: 'second root cleanup' }
+await agent('second-producer', { isolation: 'worktree', retainWorktree: true })
+return 'second done'`,
+      {
+        sharedRuntime,
+        worktreeOperations: operations,
+        persistLogs: false,
+        agent: {
+          async run() {
+            return "second";
+          },
+        },
+      },
+    );
+    assert.equal(second.result, "second done");
+    assert.deepEqual(removals, ["/runtime/root-2"], "second root cleanup cannot remove the first root checkout");
+  } finally {
+    rootGate.resolve();
+    await first;
+  }
+  assert.deepEqual(removals, ["/runtime/root-2", "/runtime/root-1"]);
+});
+
+test("direct roots use collision-resistant default run and worktree identities with a frozen clock", async () => {
+  const { repo, cleanup } = createGitRepo("pi-frozen-direct-roots-");
+  const originalDateNow = Date.now;
+  const branches: string[] = [];
+  const checkouts: string[] = [];
+  const operations: WorktreeOperations = {
+    async createWorktree(baseCwd, name) {
+      const worktree = await createWorktreeLive(baseCwd, name);
+      if (worktree.branch) branches.push(worktree.branch);
+      if (worktree.isolated) checkouts.push(worktree.cwd);
+      return worktree;
+    },
+    removeWorktree: (worktree) => DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree),
+  };
+  Date.now = () => 1_700_000_000_000;
+  try {
+    const script = `export const meta = { name: 'frozen_direct_root', description: 'unique direct root identity' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+return produced.worktree`;
+    const [first, second] = await Promise.all(
+      [0, 1].map(() =>
+        runWorkflow(script, {
+          cwd: repo,
+          persistLogs: false,
+          worktreeOperations: operations,
+          agent: {
+            async run() {
+              return "ready";
+            },
+          },
+        }),
+      ),
+    );
+
+    assert.notEqual(first.runId, second.runId);
+    assert.equal(new Set(branches).size, 2);
+    assert.equal(new Set(checkouts).size, 2);
+    assert.notEqual(first.result, second.result, "retained capabilities remain root-unique");
+    for (const checkout of checkouts) assert.equal(existsSync(checkout), false);
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    Date.now = originalDateNow;
+    cleanup();
+  }
+});
+
+test("concurrent roots settle only their own tracked operations and clean independently", async () => {
+  const blockedConsumerStarted = deferred<void>();
+  const blockedConsumerGate = deferred<void>();
+  const removals: string[] = [];
+  let sequence = 0;
+  const operations: WorktreeOperations = {
+    async createWorktree(_baseCwd, name) {
+      sequence++;
+      return {
+        isolated: true,
+        cwd: `/runtime/settlement-root-${sequence}`,
+        repoRoot: "/runtime",
+        branch: `pi/wf/${name}`,
+        branchRef: `refs/heads/pi/wf/${name}`,
+        baseSha: String(sequence).padStart(40, "0"),
+      };
+    },
+    async removeWorktree(worktree) {
+      removals.push(worktree.cwd);
+      return [];
+    },
+  };
+  const sharedRuntime: SharedRuntime = {
+    limiter: async (fn) => fn(),
+    agentCount: 0,
+    spent: 0,
+    tokenUsage: { input: 0, output: 0, total: 0, cost: 0, cacheRead: 0, cacheWrite: 0 },
+    depth: 0,
+  };
+  const rootB = runWorkflow(
+    `export const meta = { name: 'blocked_root_b', description: 'foreign blocked consumer' }
+const produced = await agent('root-b-producer', { isolation: 'worktree', retainWorktree: true })
+return await agent('root-b-consumer', { worktree: produced.worktree })`,
+    {
+      sharedRuntime,
+      worktreeOperations: operations,
+      persistLogs: false,
+      agent: {
+        async run(prompt: string) {
+          if (prompt === "root-b-consumer") {
+            blockedConsumerStarted.resolve();
+            await blockedConsumerGate.promise;
+            throw new WorkflowError("root B consumer rejected", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
+              recoverable: false,
+            });
+          }
+          return "root B produced";
+        },
+      },
+    },
+  );
+
+  await blockedConsumerStarted.promise;
+  let rootASettled = false;
+  const rootA = runWorkflow(
+    `export const meta = { name: 'independent_root_a', description: 'independent successful root' }
+await agent('root-a-producer', { isolation: 'worktree', retainWorktree: true })
+return 'root A succeeded'`,
+    {
+      sharedRuntime,
+      worktreeOperations: operations,
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "root A produced";
+        },
+      },
+    },
+  ).then(
+    (result) => {
+      rootASettled = true;
+      return result;
+    },
+    (error) => {
+      rootASettled = true;
+      throw error;
+    },
+  );
+
+  for (let turn = 0; turn < 10 && !rootASettled; turn++) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  const rootASettledWhileRootBBlocked = rootASettled;
+  const removalsWhileRootBBlocked = [...removals];
+  blockedConsumerGate.resolve();
+  const [rootAOutcome, rootBOutcome] = await Promise.allSettled([rootA, rootB]);
+
+  assert.equal(rootASettledWhileRootBBlocked, true, "root A does not wait for root B's tracked consumer");
+  assert.deepEqual(removalsWhileRootBBlocked, ["/runtime/settlement-root-2"], "root A runs terminal cleanup");
+  assert.equal(rootAOutcome.status, "fulfilled", "root B's rejection cannot replace root A's successful outcome");
+  if (rootAOutcome.status === "fulfilled") assert.equal(rootAOutcome.value.result, "root A succeeded");
+  assert.equal(rootBOutcome.status, "rejected");
+  if (rootBOutcome.status === "rejected") assert.match(String(rootBOutcome.reason), /root B consumer rejected/);
+  assert.deepEqual(removals, ["/runtime/settlement-root-2", "/runtime/settlement-root-1"]);
+});
+
+test("nested retained producer makes the parent wrapper noncacheable on resume", async () => {
+  const { repo, cleanup } = createGitRepo("pi-nested-resume-wt-");
+  const journal: JournalEntry[] = [];
+  const prompts: string[] = [];
+  const child = `export const meta = { name: 'nested_producer', description: 'produce retained worktree' }
+return await agent('nested-produce', { label: 'nested-producer', isolation: 'worktree', retainWorktree: true })`;
+  const parent = `export const meta = { name: 'nested_resume_parent', description: 'resume nested retained producer' }
+const prefix = await agent('prefix')
+const produced = await workflow(${JSON.stringify(child)})
+const consumed = await agent('parent-consume', { worktree: produced.worktree })
+return { prefix, produced: produced.result, consumed }`;
+  const runner = {
+    async run(prompt: string, options: AgentRunOptions) {
+      prompts.push(prompt);
+      if (prompt === "nested-produce") {
+        assert.ok(options.cwd);
+        writeFileSync(join(options.cwd, "nested-resume.txt"), "fresh nested state");
+        return "produced";
+      }
+      if (prompt === "parent-consume") {
+        assert.ok(options.cwd);
+        return readFileSync(join(options.cwd, "nested-resume.txt"), "utf8");
+      }
+      return prompt;
+    },
+  };
+  try {
+    await runWorkflow(parent, {
+      cwd: repo,
+      runId: "nested-retained-resume",
+      persistLogs: false,
+      agent: runner,
+      onAgentJournal: (entry) => journal.push(entry),
+    });
+    assert.equal(journal.length, 1, "only the ordinary prefix is journaled");
+    assert.equal(journal[0]?.runId, "nested-retained-resume");
+
+    prompts.length = 0;
+    const resumed = await runWorkflow(parent, {
+      cwd: repo,
+      runId: "nested-retained-resume",
+      resumeFromRunId: "nested-retained-resume",
+      resumeJournal: new Map(
+        journal.map((entry) => [`${entry.runId ?? "nested-retained-resume"}:${entry.index}`, entry]),
+      ),
+      persistLogs: false,
+      agent: runner,
+    });
+
+    assert.deepEqual(prompts, ["nested-produce", "parent-consume"]);
+    assert.deepEqual(JSON.parse(JSON.stringify(resumed.result)), {
+      prefix: "prefix",
+      produced: "produced",
+      consumed: "fresh nested state",
+    });
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a cached nested wrapper carrying a fresh retained handle reruns its child and dependent suffix", async () => {
+  const child = `export const meta = { name: 'cached_handle_child', description: 'read current retained checkout' }
+return await agent('child-read', { worktree: args.handle })`;
+  const parent = `export const meta = { name: 'cached_handle_parent', description: 'invalidate stale wrapper replay' }
+const childValue = await workflow(${JSON.stringify(child)}, { handle: args.handle })
+const suffix = await agent('suffix')
+return { childValue, suffix }`;
+  const root = mkdtempSync(join(tmpdir(), "pi-cached-wrapper-handle-"));
+  const calls = new Map<string, number>();
+  const operations: WorktreeOperations = {
+    async createWorktree() {
+      assert.fail("the retained checkout is provided explicitly");
+    },
+    async removeWorktree() {
+      return [];
+    },
+  };
+  const runner = {
+    async run(prompt: string, options: AgentRunOptions) {
+      calls.set(prompt, (calls.get(prompt) ?? 0) + 1);
+      if (prompt === "child-read") {
+        assert.ok(options.cwd);
+        return readFileSync(join(options.cwd, "current.txt"), "utf8");
+      }
+      return `suffix-${calls.get(prompt)}`;
+    },
+  };
+  const worktree = (cwd: string): Worktree => ({
+    isolated: true,
+    cwd,
+    repoRoot: root,
+    branch: "pi/wf/stable-current-checkout",
+    branchRef: "refs/heads/pi/wf/stable-current-checkout",
+    baseSha: "a".repeat(40),
+  });
+  const context = (registry: RetainedWorktreeRegistry, scopes: Set<string>) => {
+    const admissions = new WeakSet<object>();
+    return {
+      retainedWorktrees: registry,
+      admitOperation(parent?: object) {
+        if (parent && !admissions.has(parent)) throw new Error("inactive test admission");
+        const admission = Object.freeze({ owner: Symbol("test-admission") });
+        admissions.add(admission);
+        return admission;
+      },
+      completeOperationAdmission(admission: object) {
+        admissions.delete(admission);
+      },
+      closeOperationAdmission() {},
+      retainedWorktreeUseScopes: scopes,
+      worktreeCleanupFailures: [],
+      liveOperations: new Set<Promise<unknown>>(),
+    } as NonNullable<Parameters<typeof runWorkflow>[1]["executionContext"]>;
+  };
+  class HistoricalUntrackedScopes extends Set<string> {
+    override add(_value: string): this {
+      return this;
+    }
+  }
+
+  try {
+    const staleCwd = join(root, "stale");
+    mkdirSync(staleCwd);
+    writeFileSync(join(staleCwd, "current.txt"), "stale checkout");
+    const staleRegistry = new RetainedWorktreeRegistry(operations);
+    const staleHandle = staleRegistry.register(worktree(staleCwd));
+    const historicalJournal: JournalEntry[] = [];
+    const stale = await runWorkflow(parent, {
+      args: { handle: staleHandle },
+      runId: "cached-handle-wrapper",
+      executionContext: context(staleRegistry, new HistoricalUntrackedScopes()),
+      persistLogs: false,
+      agent: runner,
+      onAgentJournal: (entry) => historicalJournal.push(entry),
+    });
+    assert.deepEqual(JSON.parse(JSON.stringify(stale.result)), {
+      childValue: "stale checkout",
+      suffix: "suffix-1",
+    });
+    assert.equal(historicalJournal.length, 1, "only the ordinary suffix is journaled by the upstream API");
+    await staleRegistry.cleanupAll();
+
+    const currentCwd = join(root, "current");
+    mkdirSync(currentCwd);
+    writeFileSync(join(currentCwd, "current.txt"), "current uncommitted checkout");
+    const currentRegistry = new RetainedWorktreeRegistry(operations);
+    const currentHandle = currentRegistry.register(worktree(currentCwd));
+    const resumed = await runWorkflow(parent, {
+      args: { handle: currentHandle },
+      runId: "cached-handle-wrapper",
+      executionContext: context(currentRegistry, new Set()),
+      resumeJournal: new Map(
+        historicalJournal.map((entry) => [`${entry.runId ?? "cached-handle-wrapper"}:${entry.index}`, entry]),
+      ),
+      resumeFromRunId: "cached-handle-wrapper",
+      persistLogs: false,
+      agent: runner,
+    });
+
+    assert.deepEqual(JSON.parse(JSON.stringify(resumed.result)), {
+      childValue: "current uncommitted checkout",
+      suffix: "suffix-2",
+    });
+    assert.deepEqual(Object.fromEntries(calls), { "child-read": 2, suffix: 2 });
+    await currentRegistry.cleanupAll();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("agentType-provided worktree isolation supports retained producers", async () => {
+  const { repo, cleanup } = createGitRepo("pi-agent-type-retained-wt-");
+  const agentRegistry: AgentRegistry = new Map([
+    [
+      "retained-editor",
+      {
+        name: "retained-editor",
+        isolation: "worktree",
+        prompt: "Edit in an isolated worktree.",
+        source: "project",
+      },
+    ],
+  ]);
+  try {
+    const result = await runWorkflow(
+      `export const meta = { name: 'agent_type_retained', description: 'resolved worktree isolation' }
+const produced = await agent('produce', { agentType: 'retained-editor', retainWorktree: true })
+let invalidCombination = ''
+try { await agent('invalid', { agentType: 'retained-editor', worktree: produced.worktree }) } catch (error) { invalidCombination = error.message }
+const consumed = await agent('consume', { worktree: produced.worktree })
+await releaseWorktree(produced.worktree)
+return { produced: produced.result, consumed, invalidCombination }`,
+      {
+        cwd: repo,
+        persistLogs: false,
+        agentRegistry,
+        agent: {
+          async run(prompt: string, options: AgentRunOptions) {
+            assert.ok(options.cwd);
+            if (prompt === "produce") {
+              writeFileSync(join(options.cwd, "agent-type.txt"), "resolved isolation");
+              return "ready";
+            }
+            return readFileSync(join(options.cwd, "agent-type.txt"), "utf8");
+          },
+        },
+      },
+    );
+
+    const value = JSON.parse(JSON.stringify(result.result)) as {
+      produced: string;
+      consumed: string;
+      invalidCombination: string;
+    };
+    assert.equal(value.produced, "ready");
+    assert.equal(value.consumed, "resolved isolation");
+    assert.match(value.invalidCombination, /including agentType isolation/i);
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("retained producer and consumer calls are noncacheable so resume reruns the dependent suffix", async () => {
+  const { repo, cleanup } = createGitRepo("pi-resume-wt-");
+  const journal: JournalEntry[] = [];
+  const prompts: string[] = [];
+  const script = `export const meta = { name: 'resume_retained', description: 'resume invalidation' }
+const prefix = await agent('prefix')
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+const consumed = await agent('consume', { worktree: produced.worktree })
+return { prefix, consumed }`;
+  const runner = {
+    async run(prompt: string, options: AgentRunOptions) {
+      prompts.push(prompt);
+      if (prompt === "produce") {
+        assert.ok(options.cwd);
+        writeFileSync(join(options.cwd, "resume.txt"), "live suffix");
+      }
+      if (prompt === "consume") {
+        assert.ok(options.cwd);
+        return readFileSync(join(options.cwd, "resume.txt"), "utf8");
+      }
+      return prompt;
+    },
+  };
+  try {
+    await runWorkflow(script, {
+      cwd: repo,
+      runId: "resume-retained",
+      persistLogs: false,
+      agent: runner,
+      onAgentJournal: (entry) => journal.push(entry),
+    });
+    assert.equal(journal.length, 1, "only the ordinary prefix is cacheable");
+    prompts.length = 0;
+    const resumed = await runWorkflow(script, {
+      cwd: repo,
+      runId: "resume-retained",
+      resumeFromRunId: "resume-retained",
+      resumeJournal: new Map(journal.map((entry) => [`${entry.runId ?? "resume-retained"}:${entry.index}`, entry])),
+      persistLogs: false,
+      agent: runner,
+    });
+    assert.deepEqual(prompts, ["produce", "consume"]);
+    assert.deepEqual(JSON.parse(JSON.stringify(resumed.result)), { prefix: "prefix", consumed: "live suffix" });
+    assertNoWorktreeLeaks(repo);
+  } finally {
+    cleanup();
+  }
+});
+
+test("a rejected retained consumer does not consume the maxAgents allowance", async () => {
+  await withFakeHomeAsync(mkdtempSync(join(tmpdir(), "pi-retained-limit-home-")), async () => {
+    const { repo, cleanup } = createGitRepo("pi-retained-limit-manager-");
+    const prompts: string[] = [];
+    try {
+      const manager = new WorkflowManager({
+        cwd: repo,
+        agent: {
+          async run(prompt) {
+            prompts.push(prompt);
+            return prompt;
+          },
+        },
+      });
+      const result = await manager.runSync(
+        `export const meta = { name: 'invalid_binding_limit', description: 'invalid consumers do not charge' }
+const produced = await agent('producer', { isolation: 'worktree', retainWorktree: true })
+await releaseWorktree(produced.worktree)
+let invalidError = ''
+try { await agent('invalid-consumer', { worktree: produced.worktree }) } catch (error) { invalidError = error.message }
+const ordinary = await agent('ordinary')
+return { invalidError, ordinary }`,
+        undefined,
+        { maxAgents: 2 },
+      );
+
+      assert.deepEqual(prompts, ["producer", "ordinary"]);
+      assert.match((result.result as { invalidError: string }).invalidError, /released/i);
+      assert.equal((result.result as { ordinary: string }).ordinary, "ordinary");
+      assert.equal(result.agentCount, 2);
+      assertNoWorktreeLeaks(repo);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+test("manager has no running agent row when a caught retained binding acquisition fails", async () => {
+  await withFakeHomeAsync(mkdtempSync(join(tmpdir(), "pi-retained-invalid-home-")), async () => {
+    const { repo, cleanup } = createGitRepo("pi-retained-invalid-manager-");
+    try {
+      const manager = new WorkflowManager({
+        cwd: repo,
+        agent: {
+          async run() {
+            return "ok";
+          },
+        },
+      });
+      const result = await manager.runSync(
+        `export const meta = { name: 'caught_invalid_binding', description: 'manager lifecycle terminal state' }
+const produced = await agent('produce', { label: 'producer', isolation: 'worktree', retainWorktree: true })
+await releaseWorktree(produced.worktree)
+let error = ''
+try { await agent('late-consumer', { label: 'late-consumer', worktree: produced.worktree }) } catch (caught) { error = caught.message }
+return error`,
+      );
+
+      assert.match(String(result.result), /released/i);
+      const run = manager.getRun(result.runId ?? "");
+      assert.equal(run?.status, "completed");
+      assert.equal(
+        run?.snapshot.agents.some((agent) => agent.status === "running"),
+        false,
+      );
+      assert.equal(run?.snapshot.runningCount, 0);
+      assertNoWorktreeLeaks(repo);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+test("ordinary cleanup failures preserve outcomes with bounded path-free diagnostics", async () => {
+  for (const agentFails of [false, true]) {
+    const failures: WorktreeCleanupFailure[] = [];
+    const posixSecret = join(
+      tmpdir(),
+      `ordinary private-fragment [repo],; 'quoted' "double"`,
+      "mixed\\separator checkout",
+    );
+    const windowsSecret = "C:\\Users\\ordinary private-fragment [repo],; 'quoted' \"double\"\\mixed/separator checkout";
+    const worktree: Worktree = {
+      isolated: true,
+      cwd: `/runtime-created/ordinary-${agentFails ? "failure" : "success"}`,
+      repoRoot: "/runtime-created/repo",
+      branch: `pi/wf/ordinary-${agentFails ? "failure" : "success"}`,
+      branchRef: `refs/heads/pi/wf/ordinary-${agentFails ? "failure" : "success"}`,
+      baseSha: "d".repeat(40),
+    };
+    const run = runWorkflow(
+      `export const meta = { name: 'ordinary_cleanup_failure', description: 'preserve ordinary outcome' }
+return await agent('ordinary', { isolation: 'worktree' })`,
+      {
+        persistLogs: false,
+        agent: {
+          async run() {
+            if (agentFails) {
+              throw new WorkflowError("original agent failure", WorkflowErrorCode.AGENT_EXECUTION_ERROR, {
+                recoverable: false,
+              });
+            }
+            return "successful result";
+          },
+        },
+        worktreeOperations: {
+          async createWorktree() {
+            return worktree;
+          },
+          async removeWorktree() {
+            throw new Error(`cleanup failed at ${posixSecret} and ${windowsSecret} ${"x".repeat(5000)}`);
+          },
+        },
+        onWorktreeCleanupFailure: (failure) => failures.push(failure),
+      },
+    );
+
+    if (agentFails) {
+      await assert.rejects(run, /original agent failure/);
+    } else {
+      const completed = await run;
+      assert.equal(completed.result, "successful result");
+      assert.equal(completed.worktreeCleanupFailures?.length, 1);
+      assert.match(completed.logs.join("\n"), /worktree cleanup failed/i);
+    }
+    assert.equal(failures.length, 1, "the callback receives each ordinary failure exactly once");
+    assert.equal(failures[0]?.stage, "cleanup_dispatch");
+    assert.ok((failures[0]?.message.length ?? Infinity) <= 1024);
+    assert.match(failures[0]?.identity.recoveryId ?? "", /^[0-9a-f]{64}$/);
+    const diagnostics = JSON.stringify(failures);
+    for (const secret of [
+      posixSecret,
+      windowsSecret,
+      "ordinary private-fragment",
+      "mixed\\separator checkout",
+      "mixed/separator checkout",
+      "Users",
+      `cleanup failed at ${posixSecret}`,
+    ]) {
+      assert.equal(diagnostics.includes(secret), false, `callback diagnostics omit raw prose/path fragment ${secret}`);
+    }
+    assert.match(failures[0]?.message ?? "", /cleanup failed.*cleanup_dispatch.*recovery ID/i);
+  }
+});
+
+test("rejecting async cleanup callbacks never mask successful or original-error outcomes", async (t) => {
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  t.after(() => process.off("unhandledRejection", onUnhandled));
+  let callbackCalls = 0;
+
+  for (const agentFails of [false, true]) {
+    const worktree: Worktree = {
+      isolated: true,
+      cwd: `/runtime-created/rejecting-cleanup-callback-${agentFails}`,
+      repoRoot: "/runtime-created",
+      branch: `pi/wf/rejecting-cleanup-callback-${agentFails}`,
+      branchRef: `refs/heads/pi/wf/rejecting-cleanup-callback-${agentFails}`,
+      baseSha: (agentFails ? "b" : "a").repeat(40),
+    };
+    const run = runWorkflow(
+      `export const meta = { name: 'rejecting_cleanup_callback', description: 'consume callback rejection' }
+return await agent('ordinary', { isolation: 'worktree' })`,
+      {
+        persistLogs: false,
+        agent: {
+          async run() {
+            if (agentFails) {
+              throw new WorkflowError("original agent error", WorkflowErrorCode.AGENT_EXECUTION_ERROR, {
+                recoverable: false,
+              });
+            }
+            return "successful result";
+          },
+        },
+        worktreeOperations: {
+          async createWorktree() {
+            return worktree;
+          },
+          async removeWorktree() {
+            throw new Error("ordinary cleanup failed");
+          },
+        },
+        onWorktreeCleanupFailure: async () => {
+          callbackCalls++;
+          throw new Error("async cleanup callback rejected");
+        },
+      },
+    );
+
+    if (agentFails) {
+      await assert.rejects(run, /original agent error/);
+    } else {
+      const result = await run;
+      assert.equal(result.result, "successful result");
+      assert.equal(result.worktreeCleanupFailures?.length, 1);
+    }
+  }
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(callbackCalls, 2);
+  assert.deepEqual(unhandled, []);
+});
+
+test("managed ordinary cleanup failures are bounded and deduplicated for successful and failed runs", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-managed-ordinary-cleanup-cwd-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-managed-ordinary-cleanup-home-"));
+  let sequence = 0;
+  const operations: WorktreeOperations = {
+    async createWorktree() {
+      sequence++;
+      return {
+        isolated: true,
+        cwd: join(cwd, `checkout-${sequence}`),
+        repoRoot: cwd,
+        branch: `pi/wf/managed-ordinary-${sequence}`,
+        branchRef: `refs/heads/pi/wf/managed-ordinary-${sequence}`,
+        baseSha: String(sequence).padStart(40, "0"),
+      };
+    },
+    async removeWorktree(worktree) {
+      return [
+        {
+          stage: "worktree_remove",
+          message: "ordinary managed cleanup failed",
+          identity: {
+            repoRoot: cwd,
+            worktreePath: worktree.cwd,
+            branchRef: worktree.branchRef ?? "",
+            baseSha: worktree.baseSha ?? "",
+          },
+        },
+      ];
+    },
+  };
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      let failAgent = false;
+      const manager = new WorkflowManager({
+        cwd,
+        worktreeOperations: operations,
+        agent: {
+          async run() {
+            if (failAgent) {
+              throw new WorkflowError("managed primary failure", WorkflowErrorCode.AGENT_EXECUTION_ERROR, {
+                recoverable: false,
+              });
+            }
+            return "ok";
+          },
+        },
+      });
+      const script = `export const meta = { name: 'managed_ordinary_cleanup', description: 'ordinary diagnostics' }
+return await agent('work', { isolation: 'worktree' })`;
+      const successful = await manager.runSync(script);
+      assert.equal(successful.worktreeCleanupFailures?.length, 1);
+      assert.equal(manager.getRun(successful.runId ?? "")?.worktreeCleanupFailures?.length, 1);
+      assert.equal(manager.getPersistence().load(successful.runId ?? "")?.worktreeCleanupFailures?.length, 1);
+
+      failAgent = true;
+      const failed = manager.startInBackground(script);
+      await assert.rejects(failed.promise, /managed primary failure/);
+      assert.equal(manager.getRun(failed.runId)?.worktreeCleanupFailures?.length, 1);
+      assert.equal(manager.getPersistence().load(failed.runId)?.worktreeCleanupFailures?.length, 1);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("cleanup warnings omit hostile caller labels from direct logs and manager persistence", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hostile-cleanup-label-cwd-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-hostile-cleanup-label-home-"));
+  const hostileLabel = `${cwd}/customer-secret\ncontrol\u0001 C:\\Users\\private\\checkout api-key=label-secret`;
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: join(cwd, "checkout"),
+    repoRoot: cwd,
+    branch: "pi/wf/hostile-label",
+    branchRef: "refs/heads/pi/wf/hostile-label",
+    baseSha: "d".repeat(40),
+  };
+  const creationNames: string[] = [];
+  const operations: WorktreeOperations = {
+    async createWorktree(_baseCwd, name) {
+      creationNames.push(name);
+      return worktree;
+    },
+    async removeWorktree() {
+      return [
+        {
+          stage: "worktree_remove",
+          message: "injected cleanup failure",
+          identity: {
+            repoRoot: cwd,
+            worktreePath: worktree.cwd,
+            branchRef: worktree.branchRef ?? "",
+            baseSha: worktree.baseSha ?? "",
+          },
+        },
+      ];
+    },
+  };
+  const script = `export const meta = { name: 'hostile_cleanup_label', description: 'label-free cleanup warning' }
+return await agent('work', { label: ${JSON.stringify(hostileLabel)}, isolation: 'worktree' })`;
+  const forbidden = [cwd, "customer-secret", "control", "Users", "private", "api-key", "label-secret"];
+  try {
+    const direct = await runWorkflow(script, {
+      cwd,
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "ok";
+        },
+      },
+      worktreeOperations: operations,
+    });
+    const directCleanupSurface = JSON.stringify({
+      logs: direct.logs,
+      failures: direct.worktreeCleanupFailures,
+    });
+    for (const fragment of forbidden) {
+      assert.equal(directCleanupSurface.includes(fragment), false, `direct cleanup diagnostics omit ${fragment}`);
+      assert.equal(creationNames[0]?.includes(fragment), false, `internal worktree call identity omits ${fragment}`);
+    }
+
+    await withFakeHomeAsync(fakeHome, async () => {
+      const manager = new WorkflowManager({
+        cwd,
+        agent: {
+          async run() {
+            return "ok";
+          },
+        },
+        worktreeOperations: operations,
+      });
+      const managed = await manager.runSync(script);
+      const persisted = manager.getPersistence().load(managed.runId ?? "");
+      const managerCleanupSurface = JSON.stringify({
+        resultLogs: managed.logs,
+        resultFailures: managed.worktreeCleanupFailures,
+        persistedLogs: persisted?.logs,
+        persistedFailures: persisted?.worktreeCleanupFailures,
+      });
+      for (const fragment of forbidden) {
+        assert.equal(managerCleanupSurface.includes(fragment), false, `manager cleanup persistence omits ${fragment}`);
+      }
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("direct retained cleanup failures are returned and logged without an explicit callback", async () => {
+  const absoluteRoot = join(tmpdir(), `pi direct-cleanup [private],; 'quoted' "double"`, "repo mixed\\checkout");
+  const windowsRoot = "D:\\workflow private-fragment [repo],; 'quoted' \"double\"\\mixed/separator checkout";
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: join(absoluteRoot, "checkout"),
+    repoRoot: absoluteRoot,
+    branch: "pi/wf/direct-cleanup",
+    branchRef: "refs/heads/pi/wf/direct-cleanup",
+    baseSha: "e".repeat(40),
+  };
+  const result = await runWorkflow(
+    `export const meta = { name: 'direct_cleanup_result', description: 'public retained cleanup diagnostics' }
+await agent('produce', { isolation: 'worktree', retainWorktree: true })
+return 'successful value'`,
+    {
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "ok";
+        },
+      },
+      worktreeOperations: {
+        async createWorktree() {
+          return worktree;
+        },
+        async removeWorktree() {
+          return [
+            {
+              stage: "worktree_remove",
+              message: `cannot remove ${absoluteRoot} or ${windowsRoot} ${"x".repeat(5000)}`,
+              identity: {
+                repoRoot: absoluteRoot,
+                worktreePath: worktree.cwd,
+                branchRef: worktree.branchRef ?? "",
+                baseSha: worktree.baseSha ?? "",
+              },
+            },
+          ];
+        },
+      },
+    },
+  );
+
+  assert.equal(result.result, "successful value");
+  assert.equal(result.worktreeCleanupFailures?.length, 1);
+  assert.ok((result.worktreeCleanupFailures?.[0]?.message.length ?? Infinity) <= 1024);
+  assert.match(result.worktreeCleanupFailures?.[0]?.identity.recoveryId ?? "", /^[0-9a-f]{64}$/);
+  const warning = result.logs.find((entry) => entry.includes("retained worktree cleanup failed"));
+  assert.ok(warning);
+  const diagnostics = JSON.stringify({ failures: result.worktreeCleanupFailures, logs: result.logs });
+  for (const secret of [
+    absoluteRoot,
+    windowsRoot,
+    "pi direct-cleanup",
+    "workflow private-fragment",
+    "repo mixed\\checkout",
+    "mixed/separator checkout",
+    "cannot remove",
+  ]) {
+    assert.equal(diagnostics.includes(secret), false, `result and logs omit raw prose/path fragment ${secret}`);
+  }
+  assert.match(result.worktreeCleanupFailures?.[0]?.message ?? "", /cleanup failed.*worktree_remove.*recovery ID/i);
+});
+
+test("hostile custom cleanup stages map to unknown on callback, log, result, and persistence surfaces", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-hostile-stage-cwd-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-hostile-stage-home-"));
+  const hostileStage = `${cwd}/private\ncontrol\u0000stage`;
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: join(cwd, "checkout"),
+    repoRoot: cwd,
+    branch: "pi/wf/hostile-stage",
+    branchRef: "refs/heads/pi/wf/hostile-stage",
+    baseSha: "a".repeat(40),
+  };
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const hostileOperations: WorktreeOperations = {
+        async createWorktree() {
+          return worktree;
+        },
+        async removeWorktree() {
+          return [
+            {
+              stage: hostileStage,
+              message: `hostile ${hostileStage}`,
+              identity: {
+                repoRoot: cwd,
+                worktreePath: worktree.cwd,
+                branchRef: worktree.branchRef ?? "",
+                baseSha: worktree.baseSha ?? "",
+              },
+            } as unknown as WorktreeCleanupFailure,
+          ];
+        },
+      };
+      const callbackFailures: WorktreeCleanupFailure[] = [];
+      await runWorkflow(
+        `export const meta = { name: 'hostile_callback_stage', description: 'callback runtime stage allowlist' }
+await agent('producer', { isolation: 'worktree', retainWorktree: true })
+return 'done'`,
+        {
+          cwd,
+          persistLogs: false,
+          agent: {
+            async run() {
+              return "ok";
+            },
+          },
+          worktreeOperations: hostileOperations,
+          onWorktreeCleanupFailure: (failure) => callbackFailures.push(failure),
+        },
+      );
+      const manager = new WorkflowManager({
+        cwd,
+        agent: {
+          async run() {
+            return "ok";
+          },
+        },
+        worktreeOperations: hostileOperations,
+      });
+      const result = await manager.runSync(
+        `export const meta = { name: 'hostile_stage', description: 'runtime stage allowlist' }
+await agent('producer', { isolation: 'worktree', retainWorktree: true })
+return 'done'`,
+      );
+      const persisted = manager.getPersistence().load(result.runId ?? "");
+      const surfaces = JSON.stringify({
+        callbackFailures,
+        result: result.worktreeCleanupFailures,
+        logs: result.logs,
+        live: manager.getRunMetadata(result.runId ?? ""),
+        persisted,
+      });
+
+      assert.deepEqual(
+        result.worktreeCleanupFailures?.map((failure) => failure.stage),
+        ["unknown"],
+      );
+      assert.deepEqual(callbackFailures, result.worktreeCleanupFailures);
+      assert.equal(persisted?.worktreeCleanupFailures?.[0]?.stage, "unknown");
+      assert.match(result.worktreeCleanupFailures?.[0]?.message ?? "", /cleanup failed at unknown/i);
+      assert.equal(surfaces.includes(hostileStage), false);
+      assert.equal(surfaces.includes("private"), false);
+      assert.equal(surfaces.includes("control"), false);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("hostile cleanup callbacks cannot mutate canonical diagnostics or any logged/result surface", async () => {
+  const hostile = "/callback/injected/private-path\ncontrol-stage";
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: "/runtime-created/callback-mutation",
+    repoRoot: "/runtime-created",
+    branch: "pi/wf/callback-mutation",
+    branchRef: "refs/heads/pi/wf/callback-mutation",
+    baseSha: "c".repeat(40),
+  };
+  let callbackValue: WorktreeCleanupFailure | undefined;
+  const result = await runWorkflow(
+    `export const meta = { name: 'hostile_cleanup_callback', description: 'detached callback diagnostics' }
+await agent('producer', { isolation: 'worktree', retainWorktree: true })
+return { status: 'original result' }`,
+    {
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "ok";
+        },
+      },
+      worktreeOperations: {
+        async createWorktree() {
+          return worktree;
+        },
+        async removeWorktree() {
+          return [
+            {
+              stage: "worktree_remove",
+              message: "canonical cleanup failure",
+              identity: {
+                repoRoot: worktree.repoRoot ?? "",
+                worktreePath: worktree.cwd,
+                branchRef: worktree.branchRef ?? "",
+                baseSha: worktree.baseSha ?? "",
+              },
+            },
+          ];
+        },
+      },
+      onWorktreeCleanupFailure(failure) {
+        callbackValue = failure;
+        (failure as { stage: string }).stage = hostile;
+        failure.message = hostile;
+        failure.identity.branchRef = hostile;
+        failure.identity.baseSha = hostile;
+        failure.identity.recoveryId = hostile;
+        (failure.identity as { nested?: { path: string } }).nested = { path: hostile };
+      },
+    },
+  );
+
+  assert.equal(callbackValue?.message, hostile, "the callback may mutate only its detached delivery value");
+  assert.deepEqual(JSON.parse(JSON.stringify(result.result)), { status: "original result" });
+  assert.equal(result.worktreeCleanupFailures?.length, 1);
+  assert.equal(result.worktreeCleanupFailures?.[0]?.stage, "worktree_remove");
+  assert.equal(result.worktreeCleanupFailures?.[0]?.identity.branchRef, worktree.branchRef);
+  assert.equal(result.worktreeCleanupFailures?.[0]?.identity.baseSha, worktree.baseSha);
+  assert.match(result.worktreeCleanupFailures?.[0]?.identity.recoveryId ?? "", /^[0-9a-f]{64}$/);
+  assert.equal(JSON.stringify({ result, logs: result.logs }).includes(hostile), false);
+  assert.equal(
+    result.logs.filter((entry) => entry.includes("retained worktree cleanup failed at worktree_remove")).length,
+    1,
+  );
+});
+
+test("cleanup callback dispatch and logs share the bounded deduplicated canonical order", async () => {
+  const callbackFailures: WorktreeCleanupFailure[] = [];
+  let created = 0;
+  const operations: WorktreeOperations = {
+    async createWorktree(_baseCwd, name) {
+      const index = created++;
+      return {
+        isolated: true,
+        cwd: `/runtime-created/bounded-callback-${index}`,
+        repoRoot: "/runtime-created",
+        branch: `pi/wf/${name}`,
+        branchRef: `refs/heads/pi/wf/bounded-callback-${index}`,
+        baseSha: index.toString(16).padStart(40, "0"),
+      };
+    },
+    async removeWorktree(worktree) {
+      const failure: WorktreeCleanupFailure = {
+        stage: "worktree_remove",
+        message: `unique cleanup failure for ${worktree.branchRef}`,
+        identity: {
+          repoRoot: worktree.repoRoot ?? "",
+          worktreePath: worktree.cwd,
+          branchRef: worktree.branchRef ?? "",
+          baseSha: worktree.baseSha ?? "",
+        },
+      };
+      return [failure, structuredClone(failure)];
+    },
+  };
+  const agents = Array.from(
+    { length: 25 },
+    (_, index) => `await agent('producer-${index}', { isolation: 'worktree', retainWorktree: true })`,
+  ).join("\n");
+  const result = await runWorkflow(
+    `export const meta = { name: 'bounded_cleanup_callbacks', description: 'bounded callback dispatch' }
+${agents}
+return 'stable result'`,
+    {
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "ok";
+        },
+      },
+      worktreeOperations: operations,
+      onWorktreeCleanupFailure(failure) {
+        callbackFailures.push(failure);
+      },
+    },
+  );
+  const expectedBranchRefs = Array.from({ length: 20 }, (_, index) => `refs/heads/pi/wf/bounded-callback-${index}`);
+
+  assert.equal(result.result, "stable result");
+  assert.equal(callbackFailures.length, 20, "duplicates and overflow do not dispatch callbacks");
+  assert.equal(result.worktreeCleanupFailures?.length, 20);
+  assert.deepEqual(
+    callbackFailures.map((failure) => failure.identity.branchRef),
+    expectedBranchRefs,
+  );
+  assert.deepEqual(
+    result.worktreeCleanupFailures?.map((failure) => failure.identity.branchRef),
+    expectedBranchRefs,
+  );
+  assert.equal(
+    result.logs.filter((entry) => entry.includes("retained worktree cleanup failed at worktree_remove")).length,
+    20,
+    "terminal logs preserve the bounded canonical collection",
+  );
+});
+
+test("successful retained cleanup leaves public diagnostics empty", async () => {
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: "/runtime-created/successful-cleanup",
+    repoRoot: "/runtime-created",
+    branch: "pi/wf/successful-cleanup",
+    branchRef: "refs/heads/pi/wf/successful-cleanup",
+    baseSha: "f".repeat(40),
+  };
+  const result = await runWorkflow(
+    `export const meta = { name: 'successful_cleanup', description: 'empty cleanup diagnostics' }
+await agent('produce', { isolation: 'worktree', retainWorktree: true })
+return 'ok'`,
+    {
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "ok";
+        },
+      },
+      worktreeOperations: {
+        async createWorktree() {
+          return worktree;
+        },
+        async removeWorktree() {
+          return [];
+        },
+      },
+    },
+  );
+
+  assert.equal(result.worktreeCleanupFailures, undefined);
+  assert.equal(
+    result.logs.some((entry) => entry.includes("retained worktree cleanup failed")),
+    false,
+  );
+});
+
+test("cleanup failure diagnostics do not mask the original workflow error", async () => {
+  const failures: WorktreeCleanupFailure[] = [];
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: "/runtime-created/worktree",
+    repoRoot: "/runtime-created/repo",
+    branch: "pi/wf/error",
+    branchRef: "refs/heads/pi/wf/error",
+    baseSha: "b".repeat(40),
+  };
+  await assert.rejects(
+    runWorkflow(
+      `export const meta = { name: 'cleanup_error', description: 'preserve original error' }
+await agent('produce', { isolation: 'worktree', retainWorktree: true })
+throw new Error('original workflow failure')`,
+      {
+        persistLogs: false,
+        agent: {
+          async run() {
+            return "ok";
+          },
+        },
+        worktreeOperations: {
+          async createWorktree() {
+            return worktree;
+          },
+          async removeWorktree() {
+            throw new Error("cleanup failed");
+          },
+        },
+        onWorktreeCleanupFailure: (failure) => failures.push(failure),
+        onLog(message) {
+          if (message.includes("retained worktree cleanup failed")) throw new Error("warning sink failed");
+        },
+      },
+    ),
+    /original workflow failure/,
+  );
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0]?.stage, "cleanup_dispatch");
+});
+
+test("sync and async proof-disposal failures are diagnostic-only for ordinary and retained cleanup", async () => {
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    for (const lifecycle of ["ordinary", "retained"] as const) {
+      for (const disposal of ["sync", "async"] as const) {
+        for (const primary of ["success", "script-failure", "agent-failure"] as const) {
+          const suffix = `${lifecycle}-${disposal}-${primary}`;
+          const worktree: Worktree = {
+            isolated: true,
+            cwd: `/runtime/disposal-${suffix}`,
+            repoRoot: "/runtime",
+            branch: `pi/wf/disposal-${suffix}`,
+            branchRef: `refs/heads/pi/wf/disposal-${suffix}`,
+            baseSha: "d".repeat(40),
+          };
+          const failures: WorktreeCleanupFailure[] = [];
+          const operations: WorktreeOperations = {
+            async createWorktree() {
+              return worktree;
+            },
+            async removeWorktree(candidate) {
+              return [
+                {
+                  stage: "worktree_remove",
+                  message: `terminal remove failure ${suffix}`,
+                  identity: {
+                    repoRoot: candidate.repoRoot ?? "",
+                    worktreePath: candidate.cwd,
+                    branchRef: candidate.branchRef ?? "",
+                    baseSha: candidate.baseSha ?? "",
+                  },
+                },
+              ];
+            },
+            disposeWorktreeProofs:
+              disposal === "sync"
+                ? () => {
+                    throw new Error(`sync proof disposal failure ${suffix} ${"x".repeat(5000)}`);
+                  }
+                : async () => {
+                    throw new Error(`async proof disposal failure ${suffix} ${"x".repeat(5000)}`);
+                  },
+          };
+          const run = runWorkflow(
+            `export const meta = { name: 'proof_disposal_failure', description: 'non-masking proof disposal' }
+${
+  primary === "script-failure"
+    ? `await agent('work', { isolation: 'worktree'${lifecycle === "retained" ? ", retainWorktree: true" : ""} })\nthrow new Error('original script failure')`
+    : `return await agent('work', { isolation: 'worktree'${lifecycle === "retained" ? ", retainWorktree: true" : ""} })`
+}`,
+            {
+              persistLogs: false,
+              worktreeOperations: operations,
+              agent: {
+                async run() {
+                  if (primary === "agent-failure") {
+                    throw new WorkflowError("original agent failure", WorkflowErrorCode.AGENT_EXECUTION_ERROR, {
+                      recoverable: false,
+                    });
+                  }
+                  return "successful result";
+                },
+              },
+              onWorktreeCleanupFailure: (failure) => failures.push(failure),
+            },
+          );
+
+          if (primary === "script-failure") {
+            await assert.rejects(run, /original script failure/);
+          } else if (primary === "agent-failure") {
+            await assert.rejects(run, /original agent failure/);
+          } else {
+            const result = await run;
+            assert.equal(
+              lifecycle === "retained" ? (result.result as { result: string }).result : result.result,
+              "successful result",
+            );
+            assert.equal(result.worktreeCleanupFailures?.length, 2);
+          }
+          assert.deepEqual(
+            failures.map((failure) => failure.stage),
+            ["worktree_remove", "cleanup_dispatch"],
+          );
+          assert.ok(failures.every((failure) => failure.message.length <= 1024));
+          assert.match(failures[1]?.message ?? "", /cleanup failed.*cleanup_dispatch.*recovery ID/i);
+        }
+      }
+    }
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(unhandled, []);
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+});
+
+test("manager stop and provider-limit pause clean retained worktrees after settlement", async () => {
+  await withFakeHomeAsync(mkdtempSync(join(tmpdir(), "pi-retained-home-")), async () => {
+    for (const mode of ["stop", "provider-limit"] as const) {
+      const { repo, cleanup } = createGitRepo(`pi-manager-${mode}-`);
+      const gate = deferred<string>();
+      let consumerStarted = false;
+      let worktreeCwd = "";
+      try {
+        const manager = new WorkflowManager({
+          cwd: repo,
+          agent: {
+            async run(prompt: string, options: AgentRunOptions) {
+              worktreeCwd = options.cwd ?? worktreeCwd;
+              if (prompt === "produce") return "ready";
+              consumerStarted = true;
+              if (mode === "provider-limit") {
+                throw new WorkflowError("quota", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, { recoverable: false });
+              }
+              return gate.promise;
+            },
+          },
+        });
+        const { runId, promise } = manager.startInBackground(
+          `export const meta = { name: 'managed_cleanup', description: 'managed terminal cleanup' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+return await agent('consumer', { worktree: produced.worktree })`,
+        );
+        await waitFor(() => consumerStarted);
+        if (mode === "stop") {
+          assert.equal(manager.stop(runId), true);
+          assert.equal(existsSync(worktreeCwd), true);
+          gate.resolve("settled");
+        }
+        await assert.rejects(promise);
+        assert.equal(manager.getRun(runId)?.status, mode === "stop" ? "aborted" : "paused");
+        assert.equal(existsSync(worktreeCwd), false);
+        assertNoWorktreeLeaks(repo);
+      } finally {
+        gate.resolve("settled");
+        cleanup();
+      }
+    }
+  });
+});
+
+test("failed retained git worktree add rollback is terminal and persists bounded recovery identity", async () => {
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-create-recovery-home-"));
+  const { repo, cleanup } = createGitRepo("pi-create-recovery-manager-");
+  let leakedPath = "";
+  let leakedBranch = "";
+  let agentStarted = false;
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const manager = new WorkflowManager({
+        cwd: repo,
+        agent: {
+          async run() {
+            agentStarted = true;
+            return "must not run";
+          },
+        },
+        worktreeOperations: {
+          async createWorktree(baseCwd, name) {
+            const windowsSecret = "C:\\Users\\creation-private-fragment\\checkout";
+            const worktree = await createWorktreeLive(baseCwd, name, {
+              async execGit(args) {
+                if (args.includes("worktree") && args.includes("add")) {
+                  execFileSync("git", args, { stdio: "pipe" });
+                  throw new Error(`injected git worktree add failure ${"f".repeat(5000)}`);
+                }
+                return { stdout: execFileSync("git", args, { encoding: "utf8" }) };
+              },
+              creationCleanupHooks: {
+                afterBranchClaim() {
+                  throw new Error(
+                    `injected retained creation cleanup failure at ${baseCwd}/creation-private-fragment and ${windowsSecret} ${"w".repeat(5000)}`,
+                  );
+                },
+              },
+            });
+            const recoveryIdentity = worktree.recoveryFailures?.[0]?.identity;
+            leakedBranch = recoveryIdentity?.branchRef.replace(/^refs\/heads\//, "") ?? "";
+            leakedPath =
+              execFileSync("git", ["-C", baseCwd, "worktree", "list", "--porcelain"], { encoding: "utf8" })
+                .split("\n")
+                .find((line) => line.startsWith("worktree ") && line.slice("worktree ".length) !== baseCwd)
+                ?.slice("worktree ".length) ?? "";
+            return worktree;
+          },
+          removeWorktree: DEFAULT_WORKTREE_OPERATIONS.removeWorktree,
+        },
+      });
+      manager.on("error", () => {});
+      const { runId, promise } = manager.startInBackground(
+        `export const meta = { name: 'creation_recovery_failure', description: 'persist leaked identity' }
+return await agent('retained', { isolation: 'worktree', retainWorktree: true })`,
+      );
+
+      await assert.rejects(promise, /rollback|recovery|worktree add/i);
+      const persisted = manager.getPersistence().load(runId);
+      assert.equal(persisted?.status, "failed");
+      assert.equal(agentStarted, false);
+      assert.deepEqual(
+        persisted?.worktreeCleanupFailures?.map((failure) => failure.stage),
+        ["cleanup_dispatch"],
+      );
+      for (const failure of persisted?.worktreeCleanupFailures ?? []) {
+        assert.match(failure.identity.recoveryId ?? "", /^[0-9a-f]{64}$/);
+        assert.equal(failure.identity.branchRef, `refs/heads/${leakedBranch}`);
+        assert.equal(
+          failure.identity.baseSha,
+          execFileSync("git", ["-C", repo, "rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+        );
+        assert.ok(failure.message.length <= 1024);
+      }
+      const publicDiagnostics = JSON.stringify({
+        failures: persisted?.worktreeCleanupFailures,
+        logs: persisted?.logs,
+        live: manager.getRun(runId)?.worktreeCleanupFailures,
+      });
+      for (const secret of [repo, leakedPath, basename(repo), "creation-private-fragment", "Users"]) {
+        assert.equal(publicDiagnostics.includes(secret), false, `creation diagnostics omit ${secret}`);
+      }
+      assert.equal(manager.getRun(runId)?.result, undefined, "no retained result or reusable handle is exposed");
+      assert.equal(publicDiagnostics.includes("worktreeHandle"), false);
+    });
+  } finally {
+    if (leakedPath && existsSync(leakedPath)) {
+      execFileSync("git", ["-C", repo, "worktree", "remove", "--force", leakedPath], { stdio: "pipe" });
+    }
+    if (leakedBranch) {
+      execFileSync("git", ["-C", repo, "branch", "-D", leakedBranch], { stdio: "ignore" });
+    }
+    cleanup();
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("identity-verification cleanup failures persist with the terminal run status", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-identity-failure-cwd-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-identity-failure-home-"));
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: join(cwd, ".fake-identity-worktree"),
+    repoRoot: cwd,
+    branch: "pi/wf/identity-failure",
+    branchRef: "refs/heads/pi/wf/identity-failure",
+    baseSha: "c".repeat(40),
+  };
+  const hostilePosixPath = `${cwd}/customer project [draft],; 'single' "double"/mixed\\separator checkout`;
+  const hostileWindowsPath = "C:\\Users\\customer project [draft],; 'single' \"double\"\\mixed/separator checkout";
+  const identityFailure: WorktreeCleanupFailure = {
+    stage: "identity_verification",
+    message: `registered marker failed at ${hostilePosixPath}; then ${hostileWindowsPath}`,
+    identity: {
+      repoRoot: cwd,
+      worktreePath: worktree.cwd,
+      branchRef: worktree.branchRef ?? "",
+      baseSha: worktree.baseSha ?? "",
+    },
+  };
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const manager = new WorkflowManager({
+        cwd,
+        agent: {
+          async run() {
+            return "ok";
+          },
+        },
+        worktreeOperations: {
+          async createWorktree() {
+            return worktree;
+          },
+          async removeWorktree() {
+            return [identityFailure];
+          },
+        },
+      });
+      const result = await manager.runSync(
+        `export const meta = { name: 'identity_failure', description: 'durable cleanup failure' }
+await agent('producer', { isolation: 'worktree', retainWorktree: true })
+return 'completed result'`,
+      );
+
+      assert.equal(result.result, "completed result");
+      const expectedPublicFailure = result.worktreeCleanupFailures?.[0];
+      assert.ok(expectedPublicFailure);
+      assert.match(expectedPublicFailure.identity.recoveryId ?? "", /^[0-9a-f]{64}$/);
+      assert.equal(JSON.stringify(expectedPublicFailure).includes(cwd), false);
+      assert.equal(expectedPublicFailure.identity.repoRoot, undefined);
+      assert.equal(expectedPublicFailure.identity.worktreePath, undefined);
+      assert.match(expectedPublicFailure.message, /cleanup failed.*identity_verification.*recovery ID/i);
+      const everyLiveSurface = JSON.stringify({
+        result: result.worktreeCleanupFailures,
+        logs: result.logs,
+        callback: manager.getRun(result.runId ?? "")?.worktreeCleanupFailures,
+      });
+      for (const fragment of [
+        hostilePosixPath,
+        hostileWindowsPath,
+        "customer project",
+        "mixed\\separator checkout",
+        "mixed/separator checkout",
+        "registered marker failed",
+      ]) {
+        assert.equal(everyLiveSurface.includes(fragment), false, `live public surfaces omit ${fragment}`);
+      }
+      assert.deepEqual(result.worktreeCleanupFailures, [expectedPublicFailure]);
+      assert.equal(
+        result.logs.some((entry) => entry.includes("retained worktree cleanup failed")),
+        true,
+      );
+      assert.doesNotMatch(result.logs.join("\n"), new RegExp(cwd));
+      assert.deepEqual(manager.getRun(result.runId ?? "")?.worktreeCleanupFailures, [expectedPublicFailure]);
+      assert.deepEqual(manager.getRun(result.runId ?? "")?.result?.worktreeCleanupFailures, [expectedPublicFailure]);
+      const persisted = manager.getPersistence().load(result.runId ?? "");
+      assert.equal(persisted?.status, "completed", "terminal status is durably saved");
+      assert.deepEqual(persisted?.worktreeCleanupFailures, [expectedPublicFailure]);
+      assert.deepEqual(manager.listRuns().find((run) => run.runId === result.runId)?.worktreeCleanupFailures, [
+        expectedPublicFailure,
+      ]);
+      assert.deepEqual(manager.getRunMetadata(result.runId ?? "")?.worktreeCleanupFailures, [expectedPublicFailure]);
+      assert.deepEqual(manager.listRunMetadata().find((run) => run.runId === result.runId)?.worktreeCleanupFailures, [
+        expectedPublicFailure,
+      ]);
+
+      const coldManager = new WorkflowManager({ cwd });
+      assert.equal(
+        coldManager.getRun(result.runId ?? ""),
+        undefined,
+        "getRun remains live/in-memory only after restart",
+      );
+      assert.deepEqual(coldManager.getRunMetadata(result.runId ?? "")?.worktreeCleanupFailures, [
+        expectedPublicFailure,
+      ]);
+      assert.deepEqual(
+        coldManager.listRunMetadata().find((run) => run.runId === result.runId)?.worktreeCleanupFailures,
+        [expectedPublicFailure],
+      );
+      assert.deepEqual(coldManager.listRuns().find((run) => run.runId === result.runId)?.worktreeCleanupFailures, [
+        expectedPublicFailure,
+      ]);
+      const everyColdSurface = JSON.stringify({
+        persisted: coldManager.listRuns(),
+        status: coldManager.getRunMetadata(result.runId ?? ""),
+      });
+      for (const fragment of [hostilePosixPath, hostileWindowsPath, "customer project", "registered marker failed"]) {
+        assert.equal(everyColdSurface.includes(fragment), false, `cold public/persisted surfaces omit ${fragment}`);
+      }
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("warm resume returns and persists the bounded stable union of prior and new cleanup failures", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-cleanup-union-warm-cwd-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-cleanup-union-warm-home-"));
+  let failAgent = true;
+  let cleanupGeneration = 0;
+  const worktree: Worktree = {
+    isolated: true,
+    cwd: join(cwd, "checkout"),
+    repoRoot: cwd,
+    branch: "pi/wf/cleanup-union-warm",
+    branchRef: "refs/heads/pi/wf/cleanup-union-warm",
+    baseSha: "a".repeat(40),
+  };
+  const failure = (stage: WorktreeCleanupFailure["stage"], marker: string): WorktreeCleanupFailure => ({
+    stage,
+    message: `raw ${marker} at ${cwd}/private project [x],; 'quoted'/checkout`,
+    identity: {
+      repoRoot: cwd,
+      worktreePath: worktree.cwd,
+      branchRef: worktree.branchRef ?? "",
+      baseSha: worktree.baseSha ?? "",
+    },
+  });
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const manager = new WorkflowManager({
+        cwd,
+        agent: {
+          async run() {
+            if (failAgent) throw new Error("first generation fails");
+            return "resumed-success";
+          },
+        },
+        worktreeOperations: {
+          async createWorktree() {
+            return worktree;
+          },
+          async removeWorktree() {
+            cleanupGeneration++;
+            if (cleanupGeneration === 1) return [failure("worktree_remove", "prior")];
+            return [failure("worktree_remove", "prior duplicate"), failure("branch_delete", "new")];
+          },
+        },
+      });
+      manager.on("error", () => {});
+      const { runId, promise } = manager.startInBackground(
+        `export const meta = { name: 'cleanup_union_warm', description: 'cleanup union' }
+const value = await agent('work', { isolation: 'worktree' })
+if (value === null) throw new Error('first generation fails')
+return value`,
+      );
+      await assert.rejects(promise, /first generation fails/);
+      assert.equal(manager.getRun(runId)?.worktreeCleanupFailures?.length, 1);
+
+      failAgent = false;
+      const completed = new Promise<void>((resolve) => manager.once("complete", () => resolve()));
+      assert.equal(await manager.resume(runId), true);
+      await completed;
+
+      const live = manager.getRun(runId);
+      assert.equal(live?.status, "completed");
+      assert.deepEqual(
+        live?.result?.worktreeCleanupFailures?.map((entry) => entry.stage),
+        ["worktree_remove", "branch_delete"],
+      );
+      assert.deepEqual(live?.worktreeCleanupFailures, live?.result?.worktreeCleanupFailures);
+      assert.deepEqual(
+        manager.getPersistence().load(runId)?.worktreeCleanupFailures,
+        live?.result?.worktreeCleanupFailures,
+      );
+      assert.deepEqual(manager.getRunMetadata(runId)?.worktreeCleanupFailures, live?.result?.worktreeCleanupFailures);
+      assert.match(live?.snapshot.logs.join("\n") ?? "", /2 retained worktree cleanup failure/i);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("cold background resume delivers prior persisted cleanup failures after a clean successful execution", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-cleanup-union-cold-cwd-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-cleanup-union-cold-home-"));
+  const runId = "cold-cleanup-union";
+  const prior: WorktreeCleanupFailure = {
+    stage: "cleanup_dispatch",
+    message: `raw prior failure at ${cwd}/private project [x],; 'quoted'/checkout`,
+    identity: {
+      repoRoot: cwd,
+      worktreePath: join(cwd, "checkout"),
+      branchRef: "refs/heads/pi/wf/cold-cleanup-union",
+      baseSha: "b".repeat(40),
+    },
+  };
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const seed = new WorkflowManager({ cwd });
+      seed.getPersistence().save({
+        runId,
+        workflowName: "cold_cleanup_union",
+        script: `export const meta = { name: 'cold_cleanup_union', description: 'cold cleanup union' }
+return await agent('work')`,
+        status: "failed",
+        phases: [],
+        agents: [],
+        logs: [],
+        journal: [],
+        startedAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        worktreeCleanupFailures: [prior],
+      });
+
+      const manager = new WorkflowManager({
+        cwd,
+        agent: {
+          async run() {
+            return "clean-success";
+          },
+        },
+      });
+      assert.equal(manager.getRun(runId), undefined);
+      let delivered: WorktreeCleanupFailure[] | undefined;
+      const completed = new Promise<void>((resolve) => {
+        manager.once("complete", ({ result }: { result: { worktreeCleanupFailures?: WorktreeCleanupFailure[] } }) => {
+          delivered = result.worktreeCleanupFailures;
+          resolve();
+        });
+      });
+      assert.equal(await manager.resume(runId), true);
+      await completed;
+
+      assert.equal(delivered?.length, 1);
+      assert.deepEqual(manager.getRun(runId)?.result?.worktreeCleanupFailures, delivered);
+      assert.deepEqual(manager.getRun(runId)?.worktreeCleanupFailures, delivered);
+      assert.deepEqual(manager.getPersistence().load(runId)?.worktreeCleanupFailures, delivered);
+      assert.deepEqual(manager.getRunMetadata(runId)?.worktreeCleanupFailures, delivered);
+      assert.match(manager.getRun(runId)?.snapshot.logs.join("\n") ?? "", /1 retained worktree cleanup failure/i);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("cleanup failures are bounded and persisted without a reusable handle", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-cleanup-failure-cwd-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-cleanup-failure-home-"));
+  let created = 0;
+  const createdBranchRefs: string[] = [];
+  const operations: WorktreeOperations = {
+    async createWorktree(_baseCwd: string, name: string): Promise<Worktree> {
+      created++;
+      const branchRef = `refs/heads/pi/wf/${name}`;
+      createdBranchRefs.push(branchRef);
+      return {
+        isolated: true,
+        cwd: join(cwd, `.fake-worktree-${created}`),
+        repoRoot: cwd,
+        branch: `pi/wf/${name}`,
+        branchRef,
+        baseSha: "a".repeat(40),
+      };
+    },
+    async removeWorktree(worktree: Worktree): Promise<WorktreeCleanupFailure[]> {
+      const failure: WorktreeCleanupFailure = {
+        stage: "worktree_remove",
+        message: `cannot remove ${"x".repeat(5000)}`,
+        identity: {
+          repoRoot: worktree.repoRoot ?? "",
+          worktreePath: worktree.cwd,
+          branchRef: worktree.branchRef ?? "",
+          baseSha: worktree.baseSha ?? "",
+        },
+      };
+      return [failure, structuredClone(failure)];
+    },
+  };
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const manager = new WorkflowManager({
+        cwd,
+        agent: {
+          async run() {
+            return "ok";
+          },
+        },
+        worktreeOperations: operations,
+      });
+      const agents = Array.from(
+        { length: 25 },
+        (_, index) => `await agent('producer-${index}', { isolation: 'worktree', retainWorktree: true })`,
+      ).join("\n");
+      const result = await manager.runSync(
+        `export const meta = { name: 'cleanup_failures', description: 'bounded cleanup metadata' }
+${agents}
+return 'original result'`,
+      );
+      assert.equal(result.result, "original result", "cleanup failure does not mask workflow success");
+      const persisted = manager.getPersistence().load(result.runId ?? "");
+      assert.equal(persisted?.worktreeCleanupFailures?.length, 20);
+      assert.equal(result.worktreeCleanupFailures?.length, 20);
+      assert.equal(manager.getRun(result.runId ?? "")?.worktreeCleanupFailures?.length, 20);
+      assert.deepEqual(persisted?.worktreeCleanupFailures, result.worktreeCleanupFailures);
+      assert.deepEqual(
+        persisted?.worktreeCleanupFailures?.map((failure) => failure.identity.branchRef),
+        createdBranchRefs.slice(0, 20),
+      );
+      assert.ok((persisted?.worktreeCleanupFailures?.[0]?.message.length ?? 0) <= 1024);
+      const serialized = JSON.stringify(persisted?.worktreeCleanupFailures);
+      assert.equal(serialized.includes("retain_consume"), false);
+      assert.equal(serialized.includes("worktreeHandle"), false);
+      assert.match(serialized, /worktree_remove/);
+      assert.match(serialized, /"recoveryId":"[0-9a-f]{64}"/);
+      assert.equal(serialized.includes(cwd), false);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});

--- a/tests/round29-findings.test.ts
+++ b/tests/round29-findings.test.ts
@@ -1,0 +1,467 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { runInNewContext } from "node:vm";
+import { deliverText } from "../src/task-panel.js";
+import { runWorkflow } from "../src/workflow.js";
+import { type ManagedRun, WorkflowManager } from "../src/workflow-manager.js";
+import {
+  createWorktree,
+  RetainedWorktreeRegistry,
+  removeWorktree,
+  type Worktree,
+  type WorktreeOperations,
+} from "../src/worktree.js";
+import { withFakeHomeAsync } from "./helpers/fake-home.js";
+
+const childScript = `export const meta = { name: 'child', description: 'child' }\nreturn args`;
+const parentScript = (body: string): string => `export const meta = { name: 'parent', description: 'parent' }\n${body}`;
+
+function createGitRepo(prefix: string): { repo: string; cleanup(): void } {
+  const repo = mkdtempSync(join(tmpdir(), prefix));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  git("init", "-q");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  writeFileSync(join(repo, "base.txt"), "base\n");
+  git("add", ".");
+  git("commit", "-q", "-m", "initial");
+  return { repo, cleanup: () => rmSync(repo, { recursive: true, force: true }) };
+}
+
+function runtimeWorktree(name: string): Worktree {
+  return {
+    isolated: true,
+    cwd: `/runtime/${name}`,
+    repoRoot: "/runtime",
+    branch: `pi/wf/${name}`,
+    branchRef: `refs/heads/pi/wf/${name}`,
+    baseSha: "a".repeat(40),
+  };
+}
+
+test("nested workflow validation returns rejected Promises and snapshots valid args synchronously", async () => {
+  const unsupported = [
+    { setup: "const value = {}; value.self = value", pattern: /cyclic/i },
+    { setup: "const value = () => true", pattern: /unsupported function/i },
+    { setup: "const value = Symbol('value')", pattern: /unsupported symbol/i },
+    { setup: "const value = 1n", pattern: /unsupported bigint/i },
+  ];
+  for (const item of unsupported) {
+    const result = await runWorkflow(
+      parentScript(`${item.setup}\nreturn workflow('child', value).catch(error => String(error.message))`),
+      { loadSavedWorkflow: () => childScript, persistLogs: false },
+    );
+    assert.match(String(result.result), item.pattern);
+  }
+
+  await assert.rejects(
+    runWorkflow(parentScript("const value = {}; value.self = value\nreturn workflow('child', value)"), {
+      loadSavedWorkflow: () => childScript,
+      persistLogs: false,
+    }),
+    /cyclic/i,
+  );
+
+  const snapshotted = await runWorkflow(
+    parentScript(`const value = { nested: { status: 'before' } }
+const pending = workflow('child', value)
+value.nested.status = 'after'
+return pending`),
+    { loadSavedWorkflow: () => childScript, persistLogs: false },
+  );
+  assert.deepEqual(snapshotted.result, { nested: { status: "before" } });
+});
+
+test("cross-root retained-handle scanning rejects through .catch without child side effects", async () => {
+  const worktree = runtimeWorktree("cross-root");
+  const first = await runWorkflow(
+    `export const meta = { name: 'producer', description: 'producer' }
+return await agent('produce', { isolation: 'worktree', retainWorktree: true })`,
+    {
+      persistLogs: false,
+      agent: {
+        async run() {
+          return "produced";
+        },
+      },
+      worktreeOperations: {
+        async createWorktree() {
+          return worktree;
+        },
+        async removeWorktree() {
+          return [];
+        },
+      },
+    },
+  );
+  const handle = (first.result as { worktree: object }).worktree;
+  let childLoads = 0;
+  const second = await runWorkflow(
+    parentScript("return workflow('child', args.handle).catch(error => String(error.message))"),
+    {
+      args: { handle },
+      loadSavedWorkflow: () => {
+        childLoads++;
+        return childScript;
+      },
+      persistLogs: false,
+    },
+  );
+  assert.match(String(second.result), /cross-run/i);
+  assert.equal(childLoads, 0);
+});
+
+test("hostile sync and async cleanup observers never mask ordinary or retained outcomes", async (t) => {
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  t.after(() => process.off("unhandledRejection", onUnhandled));
+
+  for (const lifecycle of ["ordinary", "retained"] as const) {
+    for (const loggerMode of ["sync", "async"] as const) {
+      for (const primaryFails of [false, true]) {
+        const worktree = runtimeWorktree(`${lifecycle}-${loggerMode}-${primaryFails}`);
+        const run = runWorkflow(
+          `export const meta = { name: 'hostile_cleanup_observers', description: 'non-masking cleanup observers' }
+${primaryFails ? "await" : "return await"} agent('work', { isolation: 'worktree'${lifecycle === "retained" ? ", retainWorktree: true" : ""} })
+${primaryFails ? "throw new Error('original workflow error')" : ""}`,
+          {
+            persistLogs: false,
+            agent: {
+              async run() {
+                return "successful result";
+              },
+            },
+            worktreeOperations: {
+              async createWorktree() {
+                return worktree;
+              },
+              async removeWorktree() {
+                throw new Error("cleanup remove failed");
+              },
+            },
+            onWorktreeCleanupFailure() {
+              throw new Error("cleanup observer failed");
+            },
+            onLog(message) {
+              if (!/cleanup/i.test(message)) return;
+              if (loggerMode === "sync") throw new Error("sync logger failed");
+              return Promise.reject(new Error("async logger failed"));
+            },
+          },
+        );
+        if (primaryFails) await assert.rejects(run, /original workflow error/);
+        else {
+          const result = await run;
+          const value = lifecycle === "retained" ? (result.result as { result: string }).result : result.result;
+          assert.equal(value, "successful result");
+          assert.equal(result.worktreeCleanupFailures?.length, 1);
+        }
+      }
+    }
+  }
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.deepEqual(unhandled, []);
+});
+
+test("managed and registry cleanup observers consume hostile asynchronous rejections", async (t) => {
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  t.after(() => process.off("unhandledRejection", onUnhandled));
+
+  const registryWorktree = runtimeWorktree("registry-observer");
+  const registry = new RetainedWorktreeRegistry(
+    {
+      async createWorktree() {
+        return registryWorktree;
+      },
+      async removeWorktree() {
+        throw new Error("registry cleanup failed");
+      },
+    },
+    async () => {
+      throw new Error("registry observer rejected");
+    },
+  );
+  registry.register(registryWorktree);
+  await registry.cleanupAll();
+
+  for (const lifecycle of ["ordinary", "retained"] as const) {
+    const cwd = mkdtempSync(join(tmpdir(), `pi-round29-managed-observer-${lifecycle}-`));
+    const fakeHome = mkdtempSync(join(tmpdir(), `pi-round29-managed-observer-home-${lifecycle}-`));
+    const worktree = runtimeWorktree(`managed-observer-${lifecycle}`);
+    try {
+      await withFakeHomeAsync(fakeHome, async () => {
+        const manager = new WorkflowManager({
+          cwd,
+          agent: {
+            async run() {
+              return "successful result";
+            },
+          },
+          worktreeOperations: {
+            async createWorktree() {
+              return worktree;
+            },
+            async removeWorktree() {
+              throw new Error("managed cleanup failed");
+            },
+          },
+        });
+        manager.on("log", async () => {
+          throw new Error("managed log observer rejected");
+        });
+        const result = await manager.runSync(
+          `export const meta = { name: 'managed_observer', description: 'managed observer' }
+return await agent('work', { isolation: 'worktree'${lifecycle === "retained" ? ", retainWorktree: true" : ""} })`,
+        );
+        assert.equal(
+          lifecycle === "retained" ? (result.result as { result: string }).result : result.result,
+          "successful result",
+        );
+      });
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  }
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.deepEqual(unhandled, []);
+});
+
+test("managed persistence redacts issued handles without changing the live foreground result", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-round29-persist-cwd-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-round29-persist-home-"));
+  const worktree = runtimeWorktree("managed-persistence");
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const manager = new WorkflowManager({
+        cwd,
+        agent: {
+          async run() {
+            return { ok: true };
+          },
+        },
+        worktreeOperations: {
+          async createWorktree() {
+            return worktree;
+          },
+          async removeWorktree() {
+            return [];
+          },
+        },
+      });
+      const result = await manager.runSync(
+        `export const meta = { name: 'persisted_handle', description: 'redact retained capability' }
+const produced = await agent('produce', { isolation: 'worktree', retainWorktree: true })
+return { envelope: produced, handles: [produced.worktree], mapped: new Map([['handle', produced.worktree]]) }`,
+      );
+      const live = result.result as {
+        envelope: { result: { ok: boolean }; worktree: object };
+        handles: object[];
+        mapped: Map<string, object>;
+      };
+      assert.equal(live.handles[0], live.envelope.worktree);
+      assert.equal(live.mapped.get("handle"), live.envelope.worktree);
+      assert.equal(typeof live.envelope.worktree, "object", "the foreground result retains the live capability");
+
+      const runId = result.runId ?? "";
+      const persisted = manager.getPersistence().load(runId);
+      const persistedResult = persisted?.result as {
+        envelope: { worktree: unknown };
+        handles: unknown[];
+        mapped: unknown;
+      };
+      assert.equal(typeof persistedResult.envelope.worktree, "string");
+      assert.equal(persistedResult.handles[0], persistedResult.envelope.worktree);
+      assert.notDeepEqual(persistedResult.envelope.worktree, {});
+
+      const raw = readFileSync(join(manager.getPersistence().getRunsDir(), `${runId}.json`), "utf8");
+      assert.doesNotMatch(raw, /"worktree"\s*:\s*\{\s*\}/);
+      assert.equal(raw.includes("retained-worktree-handle"), true);
+
+      const coldManager = new WorkflowManager({ cwd });
+      const cold = coldManager.listRuns().find((candidate) => candidate.runId === runId);
+      const coldResult = cold?.result as { envelope: { worktree: unknown } };
+      assert.equal(typeof coldResult.envelope.worktree, "string");
+      const registry = new RetainedWorktreeRegistry();
+      assert.throws(() => registry.acquire(coldResult.envelope.worktree), /malformed|unknown/i);
+      const liveManaged = manager.getRun(runId);
+      assert.ok(liveManaged);
+      const delivery = deliverText({
+        ...liveManaged,
+        result: { ...result, result: cold?.result },
+      } as ManagedRun);
+      assert.doesNotMatch(delivery, /"worktree"\s*:\s*\{\s*\}/);
+    });
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("persistence sanitizer is cycle-safe across results, journals, agent snapshots, maps, and cross-realm objects", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-round29-direct-persist-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-round29-direct-home-"));
+  const worktree = runtimeWorktree("direct-persistence");
+  const operations: WorktreeOperations = {
+    async createWorktree() {
+      return worktree;
+    },
+    async removeWorktree() {
+      return [];
+    },
+  };
+  const registry = new RetainedWorktreeRegistry(operations);
+  const handle = registry.register(worktree);
+  const crossRealm = runInNewContext("({ nested: null, mapped: new Map() })") as {
+    nested: unknown;
+    mapped: Map<unknown, unknown>;
+  };
+  crossRealm.nested = handle;
+  crossRealm.mapped.set("handle", handle);
+  const cyclic: { handle: unknown; self?: unknown; map: Map<unknown, unknown> } = {
+    handle,
+    map: new Map([["handle", handle]]),
+  };
+  cyclic.self = cyclic;
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const manager = new WorkflowManager({ cwd });
+      const state = {
+        version: 2 as const,
+        schemaVersion: 2 as const,
+        runId: "round29-direct",
+        cwd,
+        workflowName: "direct",
+        script: "export const meta = { name: 'direct', description: 'direct' }\nreturn null",
+        status: "completed" as const,
+        phases: [],
+        agents: [{ id: 1, label: "agent", prompt: "prompt", status: "done" as const, result: { handle } }],
+        logs: [],
+        result: { cyclic, crossRealm },
+        journal: [{ index: 0, key: "root/call:0", kind: "agent" as const, hash: "hash", result: [handle] }],
+        startedAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+        completedAt: new Date(0).toISOString(),
+      };
+      assert.doesNotThrow(() => manager.getPersistence().save(state));
+      const loaded = manager.getPersistence().load(state.runId);
+      const serialized = JSON.stringify(loaded);
+      assert.equal(serialized.includes("retained-worktree-handle"), true);
+      assert.doesNotMatch(serialized, /"handle"\s*:\s*\{\s*\}/);
+      const loadedResult = loaded?.result as {
+        cyclic: { handle: unknown; map: unknown };
+        crossRealm: { nested: unknown; mapped: unknown };
+      };
+      assert.equal(typeof loadedResult.cyclic.handle, "string");
+      assert.deepEqual(loadedResult.cyclic.map, [["handle", "[retained-worktree-handle]"]]);
+      assert.equal(typeof loadedResult.crossRealm.nested, "string");
+      assert.deepEqual(loadedResult.crossRealm.mapped, [["handle", "[retained-worktree-handle]"]]);
+      assert.equal(typeof loaded?.journal?.[0]?.result?.[0], "string");
+      assert.equal(typeof loaded?.agents[0]?.result === "object", true);
+    });
+  } finally {
+    await registry.cleanupAll();
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("cold resume receives only an inert scalar where a retained handle was persisted", async () => {
+  const cwd = mkdtempSync(join(tmpdir(), "pi-round29-cold-resume-cwd-"));
+  const fakeHome = mkdtempSync(join(tmpdir(), "pi-round29-cold-resume-home-"));
+  const worktree = runtimeWorktree("cold-resume");
+  const registry = new RetainedWorktreeRegistry({
+    async createWorktree() {
+      return worktree;
+    },
+    async removeWorktree() {
+      return [];
+    },
+  });
+  const handle = registry.register(worktree);
+  try {
+    await withFakeHomeAsync(fakeHome, async () => {
+      const seed = new WorkflowManager({ cwd });
+      seed.getPersistence().save({
+        version: 2,
+        schemaVersion: 2,
+        runId: "round29-cold-resume",
+        cwd,
+        workflowName: "cold_resume",
+        script: `export const meta = { name: 'cold_resume', description: 'cold inert handle' }
+return agent('consume', { worktree: args.handle }).catch(error => String(error.message))`,
+        args: { handle },
+        status: "paused",
+        phases: [],
+        agents: [],
+        logs: [],
+        journal: [],
+        startedAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+      });
+
+      let agentCalls = 0;
+      const cold = new WorkflowManager({
+        cwd,
+        agent: {
+          async run() {
+            agentCalls++;
+            return "unexpected";
+          },
+        },
+      });
+      assert.equal(await cold.resume("round29-cold-resume"), true);
+      const resumed = cold.getRun("round29-cold-resume");
+      assert.ok(resumed?.settlement);
+      const result = await resumed.settlement;
+      assert.match(String(result.result), /runtime-issued|malformed|unknown/i);
+      assert.equal(agentCalls, 0);
+      const persisted = cold.getPersistence().load("round29-cold-resume");
+      assert.match(String(persisted?.result), /runtime-issued|malformed|unknown/i);
+      assert.doesNotMatch(JSON.stringify(persisted), /"worktree"\s*:\s*\{\s*\}/);
+    });
+  } finally {
+    await registry.cleanupAll();
+    rmSync(cwd, { recursive: true, force: true });
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("public createWorktree/removeWorktree operations compose for ordinary and retained lifecycle", async () => {
+  const exportedOperations: WorktreeOperations = { createWorktree, removeWorktree };
+  for (const lifecycle of ["ordinary", "retained"] as const) {
+    const { repo, cleanup } = createGitRepo(`pi-round29-composable-${lifecycle}-`);
+    try {
+      const result = await runWorkflow(
+        `export const meta = { name: 'composable_operations', description: 'public operation composition' }
+const value = await agent('work', { isolation: 'worktree'${lifecycle === "retained" ? ", retainWorktree: true" : ""} })
+${lifecycle === "retained" ? "await releaseWorktree(value.worktree)\nreturn value.result" : "return value"}`,
+        {
+          cwd: repo,
+          persistLogs: false,
+          worktreeOperations: exportedOperations,
+          agent: {
+            async run() {
+              return "ok";
+            },
+          },
+        },
+      );
+      assert.equal(result.result, "ok");
+      assert.equal(result.worktreeCleanupFailures, undefined);
+      const listed = execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"], { encoding: "utf8" });
+      assert.equal(listed.split("\n").filter((line) => line.startsWith("worktree ")).length, 1);
+      assert.equal(existsSync(join(repo, ".pi", "worktrees")), false);
+    } finally {
+      cleanup();
+    }
+  }
+});

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -99,6 +99,45 @@ describe("installResultDelivery", () => {
     assert.ok(calls[0].content.includes("1.5s"), "should contain 1.5s");
   });
 
+  it("delivers cleanup warnings without retaining hostile caller labels", () => {
+    const hostileLabel =
+      "/tmp/customer-secret\ncontrol\u0001 C:\\Users\\private\\checkout api-key=delivery-label-secret";
+    const run = makeRun({
+      snapshot: {
+        ...makeRun().snapshot,
+        logs: [`worktree cleanup failed for "${hostileLabel}" at worktree_remove`],
+      },
+      worktreeCleanupFailures: [
+        {
+          stage: "worktree_remove",
+          message: `Cleanup failed at worktree_remove; recovery ID ${"a".repeat(64)}`,
+          identity: { recoveryId: "a".repeat(64), branchRef: "refs/heads/pi/wf/work", baseSha: "b".repeat(40) },
+        },
+      ],
+      result: {
+        ...makeRun().result,
+        worktreeCleanupFailures: [
+          {
+            stage: "worktree_remove",
+            message: `Cleanup failed at worktree_remove; recovery ID ${"a".repeat(64)}`,
+            identity: { recoveryId: "a".repeat(64), branchRef: "refs/heads/pi/wf/work", baseSha: "b".repeat(40) },
+          },
+        ],
+      },
+    });
+    const pi = createMockPi();
+    const manager = createMockManager(run);
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.emit("complete", { runId: "test-run-1" });
+
+    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
+    assert.match(content, /cleanup warning/i);
+    for (const fragment of ["customer-secret", "control", "Users", "private", "api-key", "delivery-label-secret"]) {
+      assert.equal(content.includes(fragment), false, `delivery omits raw cleanup label fragment ${fragment}`);
+    }
+  });
+
   it("shows the fresh/cache split and cost in the delivery line", () => {
     const pi = createMockPi();
     // A caching model: little fresh input+output, most of the tokens are cheap cache reads.
@@ -872,9 +911,48 @@ describe("installTaskPanel mode selection", () => {
 // ─── deliverText: pointer + truncation threshold ─────────────────────────────────
 
 describe("deliverText", () => {
-  function makeResult(result: unknown) {
-    return { snapshot: { name: "wf", agentCount: 1 }, result: { agentCount: 1, result } };
+  function makeResult(
+    result: unknown,
+    worktreeCleanupFailures?: Array<{
+      stage: "identity_verification" | "worktree_remove" | "branch_delete" | "cleanup_dispatch";
+      message: string;
+      identity: { recoveryId: string; branchRef: string; baseSha: string };
+    }>,
+  ) {
+    return {
+      snapshot: { name: "wf", agentCount: 1 },
+      result: { agentCount: 1, result, worktreeCleanupFailures },
+      worktreeCleanupFailures,
+    };
   }
+
+  it("warns on background and cold/resumed completion cleanup failures without changing the result", async () => {
+    const { deliverText } = await import("../src/task-panel.js");
+    const failure = {
+      stage: "worktree_remove" as const,
+      message: "bounded path-free failure",
+      identity: { recoveryId: "a".repeat(64), branchRef: "refs/heads/pi/wf/warning", baseSha: "b".repeat(40) },
+    };
+    const live = makeResult({ verdict: "COMPLETED" }, [failure]);
+    const liveText = deliverText(live as never);
+    assert.match(liveText, /COMPLETED/);
+    assert.match(liveText, /warning/i);
+    assert.match(liveText, /1.*cleanup/i);
+    assert.match(liveText, /worktree_remove/);
+    assert.equal(liveText.startsWith("✓"), false, "cleanup-warning delivery is not unconditional success");
+
+    const cold = makeResult({ verdict: "RESUMED COMPLETION" });
+    cold.result.worktreeCleanupFailures = undefined;
+    cold.worktreeCleanupFailures = [failure];
+    const coldText = deliverText(cold as never);
+    assert.match(coldText, /RESUMED COMPLETION/);
+    assert.match(coldText, /warning/i);
+    assert.match(coldText, /worktree_remove/);
+
+    const cleanText = deliverText(makeResult({ verdict: "CLEAN" }) as never);
+    assert.ok(cleanText.startsWith("✓"));
+    assert.doesNotMatch(cleanText, /cleanup warning/i);
+  });
 
   it("appends the Full result pointer to a verdict result without altering it", async () => {
     const { deliverText } = await import("../src/task-panel.js");

--- a/tests/type-tests/tsconfig.json
+++ b/tests/type-tests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["worktree-operations-composable.ts"]
+}

--- a/tests/type-tests/worktree-operations-composable.ts
+++ b/tests/type-tests/worktree-operations-composable.ts
@@ -1,0 +1,6 @@
+import { createWorktree, removeWorktree, type WorktreeOperations } from "../../src/index.js";
+
+export const exportedOperations: WorktreeOperations = {
+  createWorktree,
+  removeWorktree,
+};

--- a/tests/workflow-capability-contract.test.ts
+++ b/tests/workflow-capability-contract.test.ts
@@ -28,6 +28,7 @@ const EXPECTED_RUNTIME_GLOBALS = [
   "phase",
   "pipeline",
   "process",
+  "releaseWorktree",
   "retry",
   "verify",
   "workflow",

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -52,7 +52,9 @@ const RENDERED_PROMPT_BUDGET_BYTES = 800;
 // — an explicit, minimal, JSON-Schema-valid object type (additional
 // properties are allowed by default without needing to spell that out) —
 // increasing this compact definition from 4,267 to 4,283 bytes (+16).
-const TOOL_DEFINITION_BUDGET_BYTES = 4_283;
+// C-19457 adds the retained producer/consumer/release contract to the
+// discoverable script schema without expanding the always-on prompt.
+const TOOL_DEFINITION_BUDGET_BYTES = 4_551;
 
 test("rendered workflow prompt contribution stays within its accepted size", async () => {
   await withRenderedWorkflow(async ({ systemPrompt, promptLines }) => {

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -118,6 +118,10 @@ test("createWorkflowTool keeps script syntax in the parameter schema", () => {
   assert.match(description, /multiple phases.*phase\('Exact Title'\).*agent options/i);
   assert.match(description, /await workflow\(savedName, childArgs\).*saved workflow inline/i);
   assert.match(description, /nesting.*one level.*parent run's concurrency, agent, and token limits/i);
+  assert.match(description, /retainWorktree.*true/i);
+  assert.match(description, /opaque worktree handle/i);
+  assert.match(description, /releaseWorktree\(handle\)/i);
+  assert.match(description, /root settlement.*fallback cleanup/i);
   assert.match(
     description,
     /Optional quality helpers include verify\(\), judgePanel\(\), loopUntilDry\(\), and completenessCheck\(\)/i,

--- a/tests/worktree.test.ts
+++ b/tests/worktree.test.ts
@@ -1,10 +1,39 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  appendFileSync,
+  chmodSync,
+  cpSync,
+  existsSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import test from "node:test";
-import { createWorktree as createWorktreeLive, removeWorktree } from "../src/worktree.js";
+import {
+  activeCheckoutProofsForTesting,
+  createWorktree as createWorktreeLive,
+  createWorktreeOperationsForTesting,
+  DEFAULT_WORKTREE_OPERATIONS,
+  populateCleanedWorktreeCacheForTesting,
+  RetainedWorktreeRegistry,
+  removeWorktree,
+  type Worktree,
+} from "../src/worktree.js";
 
 // ── Existing tests (unchanged) ──
 
@@ -19,6 +48,162 @@ test("createWorktree no-ops (not isolated) outside a git repo", async () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+function gitCommonRoot(repo: string): string {
+  return execFileSync("git", ["-C", repo, "rev-parse", "--path-format=absolute", "--git-common-dir"], {
+    encoding: "utf8",
+  }).trim();
+}
+
+function checkoutQuarantineRoot(repo: string): string {
+  return join(gitCommonRoot(repo), "pi-dynamic-workflows-checkout-cleanup");
+}
+
+function directCleanupClaimPaths(repo: string, kind: "checkout" | "registration"): string[] {
+  const commonRoot = gitCommonRoot(repo);
+  const prefix = `.pi-dynamic-workflows-${kind}-cleanup-`;
+  return readdirSync(commonRoot)
+    .filter((entry) => entry.startsWith(prefix) && !entry.endsWith(".json"))
+    .map((entry) => join(commonRoot, entry));
+}
+
+function directCleanupPendingRecords(repo: string): string[] {
+  return readdirSync(gitCommonRoot(repo)).filter((entry) =>
+    /^\.pi-dynamic-workflows-(?:checkout|registration)-cleanup-.*\.json$/.test(entry),
+  );
+}
+
+function operationLockRoot(repo: string): string {
+  return join(gitCommonRoot(repo), "pi-dynamic-workflows-operation-lock");
+}
+
+function operationLockUniquePath(repo: string, token: string): string {
+  return join(gitCommonRoot(repo), `.pi-dynamic-workflows-operation-lock-owner-${token}`);
+}
+
+function installOperationLock(
+  repo: string,
+  owner: { version: 1; token: string; pid: number; createdAtMs: number },
+): string {
+  const uniquePath = operationLockUniquePath(repo, owner.token);
+  writeFileSync(uniquePath, `${JSON.stringify(owner)}\n`, { flag: "wx", mode: 0o600 });
+  linkSync(uniquePath, operationLockRoot(repo));
+  return uniquePath;
+}
+
+function excludePath(repo: string): string {
+  return join(gitCommonRoot(repo), "info", "exclude");
+}
+
+function isGitIgnored(repo: string, path: string): boolean {
+  try {
+    execFileSync("git", ["-C", repo, "check-ignore", "--quiet", "--no-index", path], { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sentinelExcludeBlock(proof: { fileName: string; token: string; excludeLeadingNewline?: boolean }): string {
+  const ownership = createHash("sha256").update(`${proof.fileName}\0${proof.token}`).digest("hex");
+  return `${proof.excludeLeadingNewline ? "\n" : ""}# pi-dynamic-workflows-owned-sentinel:${ownership}\n/${proof.fileName}\n`;
+}
+
+function runCleanupWorker(
+  repo: string,
+  name: string,
+  probeRoot: string,
+  mode: "same-repo" | "different-repo" | "stale-race",
+): Promise<void> {
+  return new Promise<void>((resolveWorker, rejectWorker) => {
+    const child = spawn(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        new URL("./fixtures/worktree-cleanup-worker.ts", import.meta.url).pathname,
+        repo,
+        name,
+        probeRoot,
+        mode,
+      ],
+      { cwd: new URL("..", import.meta.url).pathname, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", rejectWorker);
+    child.once("exit", (code) => {
+      if (code === 0) resolveWorker();
+      else rejectWorker(new Error(`cleanup worker exited ${code}: ${stdout}${stderr}`));
+    });
+  });
+}
+
+function assertCleanupQuarantinesEmpty(repo: string): void {
+  const commonRoot = gitCommonRoot(repo);
+  for (const root of [
+    join(commonRoot, "pi-dynamic-workflows-checkout-cleanup"),
+    join(commonRoot, "pi-dynamic-workflows-cleanup"),
+  ]) {
+    if (existsSync(root)) assert.deepEqual(readdirSync(root), [], `${root} has no per-cleanup leftovers`);
+  }
+  assert.deepEqual(
+    readdirSync(commonRoot).filter((entry) => /^\.pi-dynamic-workflows-(?:checkout|registration)-cleanup-/.test(entry)),
+    [],
+    "no direct-child cleanup claims or pending records remain",
+  );
+}
+
+function assertNoCreationArtifacts(repo: string): void {
+  const commonRoot = gitCommonRoot(repo);
+  assert.deepEqual(
+    readdirSync(commonRoot).filter((entry) => entry.startsWith("pi-workflow-checkout-")),
+    [],
+    "no runtime checkout direct child remains",
+  );
+  assert.equal(
+    execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"], { encoding: "utf8" })
+      .split("\n")
+      .filter((line) => line.startsWith("worktree ")).length,
+    1,
+    "no linked worktree registration remains",
+  );
+  assert.equal(
+    execFileSync("git", ["-C", repo, "branch", "--list", "pi/wf/*"], { encoding: "utf8" }).trim(),
+    "",
+    "no temporary branch remains",
+  );
+  assert.equal(
+    execFileSync("git", ["-C", repo, "for-each-ref", "--format=%(refname)", "refs/pi-dynamic-workflows/cleanup/"], {
+      encoding: "utf8",
+    }).trim(),
+    "",
+    "no internal cleanup ref remains",
+  );
+  assertCleanupQuarantinesEmpty(repo);
+}
+
+function supportsSha256Repositories(): boolean {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-sha256-capability-"));
+  try {
+    execFileSync("git", ["init", "-q", "--object-format=sha256", repo], { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+}
+
+const SHA256_REPOSITORIES_SUPPORTED = supportsSha256Repositories();
 
 test("createWorktree isolates in a git repo, then removeWorktree cleans up", async () => {
   const repo = mkdtempSync(join(tmpdir(), "pi-wt-git-"));
@@ -35,21 +220,2101 @@ test("createWorktree isolates in a git repo, then removeWorktree cleans up", asy
     assert.equal(wt.isolated, true);
     assert.ok(wt.cwd !== repo && existsSync(wt.cwd), "worktree dir exists");
     assert.ok(existsSync(join(wt.cwd, "file.txt")), "worktree has a checkout");
+    assert.equal(join(wt.cwd, ".."), gitCommonRoot(repo), "the checkout is a direct Git-common-dir child");
+    assert.match(wt.cwd, /pi-workflow-checkout-/);
+    assert.equal(wt.repoRoot, repo, "canonical repository root is retained");
+    assert.equal(wt.branchRef, `refs/heads/${wt.branch}`, "full temporary branch ref is retained");
+    assert.equal(
+      wt.baseSha,
+      execFileSync("git", ["-C", repo, "rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+      "exact base SHA is retained",
+    );
+    assert.equal(wt.cleanupMetadata?.version, 4);
+    const createdIdentity = lstatSync(wt.cwd, { bigint: true });
+    assert.deepEqual(wt.cleanupMetadata?.checkoutIdentity, {
+      dev: createdIdentity.dev.toString(10),
+      ino: createdIdentity.ino.toString(10),
+    });
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(wt.cleanupMetadata?.gitDir ?? "", "pi-dynamic-workflows-registration"), "utf8")),
+      wt.cleanupMetadata,
+      "the per-worktree Git metadata stores the complete versioned cleanup identity",
+    );
 
-    // Editing inside the worktree must not touch the base tree.
+    // Agents may commit after creation; cleanup verifies stable registration
+    // identity rather than comparing mutable HEAD with the creation SHA.
     writeFileSync(join(wt.cwd, "file.txt"), "changed in worktree\n");
+    execFileSync("git", ["-C", wt.cwd, "add", "."]);
+    execFileSync("git", ["-C", wt.cwd, "commit", "-q", "-m", "agent commit"]);
+    assert.notEqual(execFileSync("git", ["-C", wt.cwd, "rev-parse", "HEAD"], { encoding: "utf8" }).trim(), wt.baseSha);
     assert.equal(readFileSync(join(repo, "file.txt"), "utf8"), "base\n");
 
     await removeWorktree(wt);
+    assert.deepEqual(
+      await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(wt),
+      [],
+      "repeated cleanup is an idempotent no-op",
+    );
     assert.ok(!existsSync(wt.cwd), "worktree dir removed");
     const branches = execFileSync("git", ["-C", repo, "branch", "--list", wt.branch ?? ""], { encoding: "utf8" });
     assert.equal(branches.trim(), "", "branch deleted");
+    assertCleanupQuarantinesEmpty(repo);
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }
 });
 
 // ── NEW TESTS ──
+
+test("current checkout descriptors stay open across cleanup retries and close on terminal paths", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-proof-lifecycle-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  const baseline = activeCheckoutProofsForTesting().descriptorCount;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const current = await createWorktreeLive(repo, "descriptor-retry");
+    assert.equal(current.isolated, true);
+    assert.equal(activeCheckoutProofsForTesting().descriptorCount, baseline + 1);
+
+    const failed = await createWorktreeOperationsForTesting({
+      afterIdentityVerification() {
+        throw new Error("injected retryable verification failure");
+      },
+    }).removeWorktree(current);
+    assert.equal(failed.length, 1);
+    assert.equal(activeCheckoutProofsForTesting().descriptorCount, baseline + 1, "retry retains the original fd");
+
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(current), []);
+    assert.equal(activeCheckoutProofsForTesting().descriptorCount, baseline, "successful retry closes the fd");
+
+    const retained = await createWorktreeLive(repo, "retained-release");
+    assert.equal(retained.isolated, true);
+    const registry = new RetainedWorktreeRegistry();
+    const handle = registry.register(retained);
+    assert.equal(activeCheckoutProofsForTesting().descriptorCount, baseline + 1);
+    await registry.release(handle);
+    assert.equal(activeCheckoutProofsForTesting().descriptorCount, baseline, "retained release closes the fd");
+
+    const fallback = await createWorktreeLive(repo, "creation-fallback", {
+      afterBranchCreationBeforeGitAdd() {
+        throw new Error("injected creation fallback");
+      },
+    });
+    assert.equal(fallback.isolated, false);
+    assert.equal(activeCheckoutProofsForTesting().descriptorCount, baseline, "creation fallback leaks no fd");
+    assertNoCreationArtifacts(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("allocation descriptors remain live through replacement-safe allocation and branch rollback", async (t) => {
+  for (const stage of ["unsafe-allocation", "branch-create"] as const) {
+    await t.test(stage, async () => {
+      const repo = mkdtempSync(join(tmpdir(), `pi-wt-allocation-rollback-${stage}-`));
+      const baseline = activeCheckoutProofsForTesting();
+      const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+      let checkoutPath = "";
+      let displacedPath = "";
+      const replaceCheckout = () => {
+        assert.equal(
+          activeCheckoutProofsForTesting().allocationDescriptorCount,
+          baseline.allocationDescriptorCount + 1,
+          "the allocated inode remains descriptor-bound before rollback",
+        );
+        displacedPath = `${checkoutPath}-displaced`;
+        renameSync(checkoutPath, displacedPath);
+        mkdirSync(checkoutPath);
+        writeFileSync(join(checkoutPath, "replacement-sentinel.txt"), `${stage} replacement survives\n`);
+      };
+
+      try {
+        git("init", "-q");
+        git("config", "user.email", "t@t.t");
+        git("config", "user.name", "t");
+        writeFileSync(join(repo, "file.txt"), "base\n");
+        git("add", ".");
+        git("commit", "-q", "-m", "init");
+
+        const result = await createWorktreeLive(repo, `allocation-rollback-${stage}`, {
+          simulateReusedAllocationPathIdentity: true,
+          afterAtomicDirectoryCreation(_gitCommonRoot, path) {
+            checkoutPath = path;
+            if (stage === "unsafe-allocation") replaceCheckout();
+          },
+          async execGit(args) {
+            if (stage === "branch-create" && args.includes("update-ref")) {
+              replaceCheckout();
+              throw new Error("injected branch creation failure after replacement");
+            }
+            return { stdout: execFileSync("git", args, { encoding: "utf8" }) };
+          },
+        } as Parameters<typeof createWorktreeLive>[2] & {
+          simulateReusedAllocationPathIdentity: boolean;
+        });
+
+        assert.equal(result.isolated, false);
+        assert.match(result.reason ?? "", stage === "unsafe-allocation" ? /unsafe_allocation/ : /branch_create/);
+        assert.equal(result.recoveryFailures?.length, 1, "replacement rollback emits one bounded recovery record");
+        assert.equal(result.recoveryFailures?.[0]?.stage, "worktree_remove");
+        assert.ok((result.recoveryFailures?.[0]?.message.length ?? Infinity) <= 1024);
+        assert.equal(
+          readFileSync(join(checkoutPath, "replacement-sentinel.txt"), "utf8"),
+          `${stage} replacement survives\n`,
+        );
+        assert.equal(
+          existsSync(displacedPath),
+          true,
+          "descriptor-owned displaced state is never confused with replacement",
+        );
+        assert.deepEqual(
+          activeCheckoutProofsForTesting(),
+          baseline,
+          "terminal fallback closes the allocation descriptor",
+        );
+      } finally {
+        if (checkoutPath) rmSync(checkoutPath, { recursive: true, force: true });
+        if (displacedPath) rmSync(displacedPath, { recursive: true, force: true });
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("portable finalization retains the allocation descriptor until rollback completes", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-portable-finalization-fd-"));
+  const baseline = activeCheckoutProofsForTesting();
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  let observedDuringFinalization = 0;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const result = await createWorktreeLive(repo, "portable-finalization-fd", {
+      directoryDescriptorMode: "unsupported",
+      beforeRegistrationRecordWrite() {
+        observedDuringFinalization = activeCheckoutProofsForTesting().allocationDescriptorCount;
+        throw new Error("injected portable finalization failure");
+      },
+    } as never);
+
+    assert.equal(result.isolated, false);
+    assert.equal(
+      observedDuringFinalization,
+      baseline.allocationDescriptorCount + 1,
+      "portable proof creation does not close the allocation descriptor before finalization can fail",
+    );
+    assert.deepEqual(
+      activeCheckoutProofsForTesting(),
+      baseline,
+      "successful rollback closes every creation descriptor",
+    );
+    assertNoCreationArtifacts(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("current Git registration descriptors reject replacement directories and close only after successful retry", async (t) => {
+  for (const replacement of ["directory", "symlink", "inode-reuse"] as const) {
+    await t.test(replacement, async () => {
+      const repo = mkdtempSync(join(tmpdir(), `pi-wt-gitdir-proof-${replacement}-`));
+      const external = mkdtempSync(join(tmpdir(), `pi-wt-gitdir-proof-${replacement}-external-`));
+      const baseline = activeCheckoutProofsForTesting();
+      const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+      try {
+        git("init", "-q");
+        git("config", "user.email", "t@t.t");
+        git("config", "user.name", "t");
+        writeFileSync(join(repo, "file.txt"), "base\n");
+        git("add", ".");
+        git("commit", "-q", "-m", "init");
+
+        const worktree = await createWorktreeLive(repo, `gitdir-proof-${replacement}`);
+        if (worktree.cleanupMetadata?.version !== 4) throw new Error("expected current cleanup metadata");
+        const gitDir = worktree.cleanupMetadata.gitDir;
+        const originalIdentity = lstatSync(gitDir, { bigint: true });
+        assert.deepEqual(worktree.cleanupMetadata.gitDirIdentity, {
+          dev: originalIdentity.dev.toString(10),
+          ino: originalIdentity.ino.toString(10),
+        });
+        const displaced = `${gitDir}-displaced`;
+        renameSync(gitDir, displaced);
+        if (replacement === "symlink") {
+          const copied = join(external, "copied-registration");
+          cpSync(displaced, copied, { recursive: true });
+          writeFileSync(join(copied, "replacement.txt"), "symlink replacement survives\n");
+          symlinkSync(copied, gitDir, "dir");
+        } else {
+          cpSync(displaced, gitDir, { recursive: true });
+          writeFileSync(join(gitDir, "replacement.txt"), `${replacement} replacement survives\n`);
+        }
+
+        const failures = await createWorktreeOperationsForTesting({
+          simulateReusedGitDirIdentity: replacement === "inode-reuse",
+        } as never).removeWorktree(worktree);
+        assert.equal(failures.length, 1);
+        assert.equal(failures[0]?.stage, "identity_verification");
+        assert.equal(existsSync(worktree.cwd), true, "checkout remains untouched");
+        assert.match(git("branch", "--list", worktree.branch ?? ""), /gitdir-proof/);
+        assert.equal(
+          readFileSync(join(gitDir, "replacement.txt"), "utf8"),
+          `${replacement === "symlink" ? "symlink" : replacement} replacement survives\n`,
+        );
+        assert.equal(activeCheckoutProofsForTesting().gitDirDescriptorCount, baseline.gitDirDescriptorCount + 1);
+
+        rmSync(gitDir, { recursive: true, force: true });
+        renameSync(displaced, gitDir);
+        assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+        assert.deepEqual(activeCheckoutProofsForTesting(), baseline, "terminal cleanup closes every identity fd");
+      } finally {
+        rmSync(external, { recursive: true, force: true });
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("portable exclude descriptors reject deletion, replacement, symlink, and simulated inode reuse", async (t) => {
+  for (const replacement of ["deleted", "file", "symlink", "inode-reuse"] as const) {
+    await t.test(replacement, async () => {
+      const repo = mkdtempSync(join(tmpdir(), `pi-wt-exclude-proof-${replacement}-`));
+      const external = mkdtempSync(join(tmpdir(), `pi-wt-exclude-proof-${replacement}-external-`));
+      const baseline = activeCheckoutProofsForTesting();
+      const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+      try {
+        git("init", "-q");
+        git("config", "user.email", "t@t.t");
+        git("config", "user.name", "t");
+        writeFileSync(join(repo, "file.txt"), "base\n");
+        git("add", ".");
+        git("commit", "-q", "-m", "init");
+        writeFileSync(excludePath(repo), "# caller rule\n*.keep\n");
+
+        const worktree = await createWorktreeLive(repo, `exclude-proof-${replacement}`, {
+          directoryDescriptorMode: "unsupported",
+        } as never);
+        if (worktree.cleanupMetadata?.version !== 4 || worktree.cleanupMetadata.checkoutProof.kind !== "sentinel") {
+          throw new Error("expected portable sentinel proof");
+        }
+        const proof = worktree.cleanupMetadata.checkoutProof;
+        const originalStats = lstatSync(excludePath(repo), { bigint: true });
+        assert.deepEqual(proof.excludeIdentity, {
+          dev: originalStats.dev.toString(10),
+          ino: originalStats.ino.toString(10),
+        });
+        const pristine = readFileSync(excludePath(repo), "utf8");
+        const displaced = `${excludePath(repo)}-displaced`;
+        renameSync(excludePath(repo), displaced);
+        let replacementContents: string | undefined;
+        if (replacement === "symlink") {
+          const target = join(external, "exclude");
+          replacementContents = `${pristine}# symlink replacement survives\n`;
+          writeFileSync(target, replacementContents);
+          symlinkSync(target, excludePath(repo));
+        } else if (replacement !== "deleted") {
+          replacementContents = `${pristine}# ${replacement} replacement survives\n`;
+          writeFileSync(excludePath(repo), replacementContents);
+        }
+
+        const failures = await createWorktreeOperationsForTesting({
+          simulateReusedExcludeIdentity: replacement === "inode-reuse",
+        } as never).removeWorktree(worktree);
+        assert.equal(failures.length, 1);
+        assert.equal(failures[0]?.stage, "identity_verification");
+        assert.equal(existsSync(worktree.cwd), true, "exclude mismatch stops before checkout claim");
+        assert.match(git("branch", "--list", worktree.branch ?? ""), /exclude-proof/);
+        if (replacementContents === undefined) {
+          assert.equal(existsSync(excludePath(repo)), false, "cleanup never recreates a deleted exclude file");
+        } else {
+          assert.equal(readFileSync(excludePath(repo), "utf8"), replacementContents);
+        }
+        assert.equal(
+          activeCheckoutProofsForTesting().excludeDescriptorCount,
+          baseline.excludeDescriptorCount + 1,
+          "retry retains the original exclude fd",
+        );
+
+        rmSync(excludePath(repo), { force: true });
+        renameSync(displaced, excludePath(repo));
+        assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+        assert.equal(readFileSync(excludePath(repo), "utf8").includes(proof.fileName), false);
+        assert.deepEqual(activeCheckoutProofsForTesting(), baseline, "successful retry closes portable proof fds");
+      } finally {
+        rmSync(external, { recursive: true, force: true });
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("durable checkout proof rejects simulated inode reuse and preserves replacement contents", async () => {
+  for (const mode of ["descriptor", "sentinel"] as const) {
+    const repo = mkdtempSync(join(tmpdir(), `pi-wt-proof-reuse-${mode}-`));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.t");
+      git("config", "user.name", "t");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+
+      const original = await createWorktreeLive(
+        repo,
+        `proof-reuse-${mode}`,
+        (mode === "sentinel" ? { directoryDescriptorMode: "unsupported" } : {}) as never,
+      );
+      assert.equal(original.isolated, true);
+      assert.equal(
+        execFileSync("git", ["-C", original.cwd, "status", "--porcelain", "--untracked-files=all"], {
+          encoding: "utf8",
+        }).trim(),
+        "",
+      );
+      const displaced = `${original.cwd}-displaced`;
+      const gitPointer = readFileSync(join(original.cwd, ".git"), "utf8");
+      renameSync(original.cwd, displaced);
+      mkdirSync(original.cwd);
+      writeFileSync(join(original.cwd, ".git"), gitPointer);
+      writeFileSync(join(original.cwd, "replacement.txt"), `${mode} replacement survives\n`);
+
+      const failures = await createWorktreeOperationsForTesting({
+        simulateReusedCheckoutIdentity: true,
+      } as never).removeWorktree(original);
+      assert.equal(failures.length, 1);
+      assert.equal(failures[0]?.stage, "identity_verification");
+      assert.equal(readFileSync(join(original.cwd, "replacement.txt"), "utf8"), `${mode} replacement survives\n`);
+
+      rmSync(original.cwd, { recursive: true, force: true });
+      renameSync(displaced, original.cwd);
+      assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(original), []);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }
+});
+
+test("ordinary and retained checkout paths never enter the main worktree status namespace", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-status-namespace-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  const created: Worktree[] = [];
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    created.push(await createWorktreeLive(repo, "ordinary-status"));
+    created.push(await createWorktreeLive(repo, "retained-status"));
+    for (const worktree of created) {
+      assert.equal(worktree.isolated, true, worktree.reason);
+      assert.equal(join(worktree.cwd, ".."), gitCommonRoot(repo));
+      assert.match(worktree.cwd, /pi-workflow-checkout-/);
+    }
+
+    assert.equal(git("status", "--porcelain"), "", "runtime checkouts are invisible to status");
+    git("add", "-A");
+    assert.equal(git("diff", "--cached", "--name-only"), "", "git add -A cannot stage a checkout gitlink");
+
+    await Promise.all(created.map((worktree) => removeWorktree(worktree)));
+    assertNoCreationArtifacts(repo);
+  } finally {
+    await Promise.all(created.filter((worktree) => worktree.isolated).map((worktree) => removeWorktree(worktree)));
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("creation uses the canonical common directory when invoked from a linked main checkout", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-linked-main-"));
+  const linked = mkdtempSync(join(tmpdir(), "pi-wt-linked-source-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  let worktree: Worktree | undefined;
+  let linkedRegistered = false;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    rmSync(linked, { recursive: true });
+    git("worktree", "add", "-q", "-b", "linked-main", linked, "HEAD");
+    linkedRegistered = true;
+
+    worktree = await createWorktreeLive(linked, "linked-main-runtime");
+
+    assert.equal(worktree.isolated, true, worktree.reason);
+    assert.equal(worktree.repoRoot, realpathSync(linked));
+    assert.equal(join(worktree.cwd, ".."), gitCommonRoot(repo));
+    assert.equal(worktree.cleanupMetadata?.gitCommonRoot, gitCommonRoot(repo));
+    assert.equal(execFileSync("git", ["-C", linked, "status", "--porcelain"], { encoding: "utf8" }), "");
+
+    await removeWorktree(worktree);
+    worktree = undefined;
+    git("worktree", "remove", "--force", linked);
+    linkedRegistered = false;
+    git("branch", "-D", "linked-main");
+    assertNoCreationArtifacts(repo);
+  } finally {
+    if (worktree?.isolated) await removeWorktree(worktree);
+    if (linkedRegistered) {
+      try {
+        git("worktree", "remove", "--force", linked);
+        git("branch", "-D", "linked-main");
+      } catch {
+        // Best-effort fixture cleanup.
+      }
+    }
+    rmSync(linked, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("descriptor-unavailable failed git worktree add rolls back branch-only, registered, and nonempty partial states", async () => {
+  for (const partialState of ["branch-only", "registered", "nonempty"] as const) {
+    const repo = mkdtempSync(join(tmpdir(), `pi-wt-add-failure-${partialState}-`));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.t");
+      git("config", "user.name", "t");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+
+      const worktree = await createWorktreeLive(repo, `partial-${partialState}`, {
+        directoryDescriptorMode: "unsupported",
+        async execGit(args) {
+          if (args.includes("worktree") && args.includes("add")) {
+            if (partialState === "registered") {
+              execFileSync("git", [...args.slice(0, -1), "--no-checkout", args.at(-1) ?? ""], { stdio: "pipe" });
+            } else if (partialState === "nonempty") {
+              execFileSync("git", args, { stdio: "pipe" });
+              const checkoutPath = args.at(-2) ?? "";
+              writeFileSync(join(checkoutPath, "partial-untracked.txt"), "partial contents\n");
+            }
+            throw new Error(`injected git worktree add failure after ${partialState}`);
+          }
+          return { stdout: execFileSync("git", args, { encoding: "utf8" }) };
+        },
+      });
+
+      assert.equal(worktree.isolated, false);
+      assert.match(worktree.reason ?? "", /git_add/);
+      assert.deepEqual(worktree.recoveryFailures, undefined, "successful rollback preserves ordinary fallback");
+      assertNoCreationArtifacts(repo);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }
+});
+
+test("failed git worktree add preserves a temporary branch advanced from its expected start OID", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-add-failure-advanced-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  const branchRef = "refs/heads/pi/wf/partial-advanced-branch";
+  let checkoutPath = "";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const baseSha = git("rev-parse", "HEAD").trim();
+
+    const worktree = await createWorktreeLive(repo, "partial-advanced-branch", {
+      async execGit(args) {
+        if (args.includes("worktree") && args.includes("add")) {
+          execFileSync("git", args, { stdio: "pipe" });
+          checkoutPath = args.at(-2) ?? "";
+          const advancedOid = git("commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "advanced during failure").trim();
+          git("update-ref", branchRef, advancedOid, baseSha);
+          throw new Error("injected git worktree add failure after branch advance");
+        }
+        return { stdout: execFileSync("git", args, { encoding: "utf8" }) };
+      },
+    });
+
+    assert.equal(worktree.isolated, false);
+    assert.equal(worktree.recoveryFailures?.length, 1);
+    assert.match(worktree.recoveryFailures?.[0]?.message ?? "", /cleanup failed.*cleanup_dispatch.*recovery ID/i);
+    assert.match(worktree.recoveryFailures?.[0]?.identity.recoveryId ?? "", /^[0-9a-f]{64}$/);
+    assert.equal(JSON.stringify(worktree.recoveryFailures).includes(checkoutPath), false);
+    assert.equal(existsSync(checkoutPath), true, "the checkout is preserved when branch ownership changed");
+    assert.notEqual(git("rev-parse", branchRef).trim(), baseSha);
+  } finally {
+    if (checkoutPath && existsSync(checkoutPath)) {
+      try {
+        git("worktree", "remove", "--force", checkoutPath);
+      } catch {
+        // Best-effort fixture cleanup.
+      }
+    }
+    try {
+      git("update-ref", "-d", branchRef);
+    } catch {
+      // Best-effort fixture cleanup.
+    }
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("creation finalization preserves an advanced temporary branch while removing only owned runtime artifacts", async () => {
+  for (const advancement of ["post-hook", "concurrent"] as const) {
+    const repo = mkdtempSync(join(tmpdir(), `pi-wt-finalization-advanced-${advancement}-`));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+    const branchRef = `refs/heads/pi/wf/finalization-${advancement}`;
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.t");
+      git("config", "user.name", "t");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+      const baseSha = git("rev-parse", "HEAD").trim();
+      let advancedOid = "";
+
+      const worktree = await createWorktreeLive(repo, `finalization-${advancement}`, {
+        async afterRegistrationRecordWrite() {
+          advancedOid = git("commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", advancement).trim();
+          git("update-ref", branchRef, advancedOid, baseSha);
+          if (advancement === "concurrent") await new Promise<void>((resolve) => setImmediate(resolve));
+        },
+      });
+
+      assert.equal(worktree.isolated, false);
+      assert.equal(git("rev-parse", branchRef).trim(), advancedOid, "the advanced commit remains reachable");
+      assert.deepEqual(
+        readdirSync(gitCommonRoot(repo)).filter((entry) => entry.startsWith("pi-workflow-checkout-")),
+        [],
+        "only the exact runtime checkout and registration are rolled back",
+      );
+      assert.equal(
+        git("worktree", "list", "--porcelain")
+          .split("\n")
+          .filter((line) => line.startsWith("worktree ")).length,
+        1,
+      );
+      assert.equal(
+        worktree.creationRecoveryWorktree,
+        undefined,
+        "advanced refs never receive normal terminal cleanup authority",
+      );
+      assert.equal(worktree.recoveryFailures?.length, 1);
+      assert.equal(worktree.recoveryFailures?.[0]?.stage, "branch_delete");
+      assert.ok((worktree.recoveryFailures?.[0]?.message.length ?? Infinity) <= 1024);
+    } finally {
+      try {
+        git("update-ref", "-d", branchRef);
+      } catch {
+        // Best-effort fixture cleanup.
+      }
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }
+});
+
+test("creation recovery keeps exact branch authorization across a concurrent rollback advance", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-creation-recovery-advance-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  const branchRef = "refs/heads/pi/wf/creation-recovery-advance";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const baseSha = git("rev-parse", "HEAD").trim();
+    let advancedOid = "";
+    let advanced = false;
+    const result = await createWorktreeLive(repo, "creation-recovery-advance", {
+      afterRegistrationRecordWrite() {
+        throw new Error("force creation rollback");
+      },
+      creationCleanupHooks: {
+        afterIdentityVerification() {
+          if (advanced) return;
+          advanced = true;
+          advancedOid = git("commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "concurrent advance").trim();
+          git("update-ref", branchRef, advancedOid, baseSha);
+        },
+      },
+    });
+
+    assert.equal(result.isolated, false);
+    assert.ok(result.creationRecoveryWorktree, "the interrupted rollback retains exact recovery authority");
+    const retryFailures = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(result.creationRecoveryWorktree as Worktree);
+    assert.equal(retryFailures.length, 1);
+    assert.equal(retryFailures[0]?.stage, "branch_delete");
+    assert.equal(git("rev-parse", branchRef).trim(), advancedOid);
+    assert.equal(
+      git("worktree", "list", "--porcelain")
+        .split("\n")
+        .filter((line) => line.startsWith("worktree ")).length,
+      1,
+    );
+  } finally {
+    try {
+      git("update-ref", "-d", branchRef);
+    } catch {
+      // Best-effort fixture cleanup.
+    }
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("descriptor-relative proof writes never follow replaced checkout or registration parents", async () => {
+  for (const target of ["checkout", "registration"] as const) {
+    const repo = mkdtempSync(join(tmpdir(), `pi-wt-proof-parent-race-${target}-`));
+    const external = mkdtempSync(join(tmpdir(), `pi-wt-proof-parent-race-${target}-external-`));
+    let displaced = "";
+    try {
+      execFileSync("git", ["-C", repo, "init", "-q"]);
+      execFileSync("git", ["-C", repo, "config", "user.email", "t@t.t"]);
+      execFileSync("git", ["-C", repo, "config", "user.name", "t"]);
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      execFileSync("git", ["-C", repo, "add", "."]);
+      execFileSync("git", ["-C", repo, "commit", "-q", "-m", "init"]);
+
+      const result = await createWorktreeLive(repo, `proof-parent-race-${target}`, {
+        ...(target === "checkout" ? { directoryDescriptorMode: "unsupported" as const } : {}),
+        async beforeDescriptorRelativeWrite(kind, path) {
+          if (kind !== target || displaced) return;
+          displaced = `${path}-displaced`;
+          renameSync(path, displaced);
+          symlinkSync(external, path, "dir");
+        },
+      } as never);
+
+      assert.equal(result.isolated, false);
+      assert.deepEqual(readdirSync(external), [], "no marker or sentinel is created through the replacement symlink");
+    } finally {
+      for (const line of execFileSync("git", ["-C", repo, "worktree", "list", "--porcelain"], {
+        encoding: "utf8",
+      }).split("\n")) {
+        if (line.startsWith("worktree ") && line.slice(9) !== repo) {
+          try {
+            execFileSync("git", ["-C", repo, "worktree", "remove", "--force", line.slice(9)]);
+          } catch {
+            // Best-effort fixture cleanup.
+          }
+        }
+      }
+      if (displaced) rmSync(displaced, { recursive: true, force: true });
+      rmSync(external, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }
+});
+
+test("safe-proof capability failures fall back without artifacts or diagnostics", async () => {
+  for (const mode of ["descriptor-open", "descriptor-alias"] as const) {
+    const repo = mkdtempSync(join(tmpdir(), `pi-wt-safe-proof-${mode}-`));
+    try {
+      execFileSync("git", ["-C", repo, "init", "-q"]);
+      execFileSync("git", ["-C", repo, "config", "user.email", "t@t.t"]);
+      execFileSync("git", ["-C", repo, "config", "user.name", "t"]);
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      execFileSync("git", ["-C", repo, "add", "."]);
+      execFileSync("git", ["-C", repo, "commit", "-q", "-m", "init"]);
+
+      const result = await createWorktreeLive(repo, `safe-proof-${mode}`, {
+        directoryDescriptorMode: mode === "descriptor-open" ? "open-unsupported" : "unsupported",
+        descriptorAliasMode: mode === "descriptor-alias" ? "unsupported" : "supported",
+      } as never);
+      assert.equal(result.isolated, false);
+      assert.equal(result.recoveryFailures, undefined);
+      assertNoCreationArtifacts(repo);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }
+});
+
+test("failed git worktree add reports bounded deterministic recovery identity when rollback fails", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-add-failure-cleanup-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const expectedBase = git("rev-parse", "HEAD").trim();
+    const options = {
+      directoryDescriptorMode: "unsupported" as const,
+      async execGit(args: string[]) {
+        if (args.includes("worktree") && args.includes("add")) {
+          execFileSync("git", args, { stdio: "pipe" });
+          throw new Error("injected git worktree add failure after registration");
+        }
+        return { stdout: execFileSync("git", args, { encoding: "utf8" }) };
+      },
+      creationCleanupHooks: {
+        afterBranchClaim() {
+          throw new Error(`injected creation cleanup-stage failure ${"x".repeat(5000)}`);
+        },
+      },
+    } as Parameters<typeof createWorktreeLive>[2] & {
+      creationCleanupHooks: { afterBranchClaim(): void };
+    };
+
+    const worktree = await createWorktreeLive(repo, "partial-cleanup-failure", options);
+
+    assert.equal(worktree.isolated, false);
+    assert.equal(worktree.recoveryFailures?.length, 1);
+    assert.equal(worktree.recoveryFailures?.[0]?.stage, "cleanup_dispatch");
+    assert.ok((worktree.recoveryFailures?.[0]?.message.length ?? Infinity) <= 1024);
+    assert.deepEqual(worktree.recoveryFailures?.[0]?.identity, {
+      recoveryId: worktree.recoveryFailures?.[0]?.identity.recoveryId,
+      branchRef: "refs/heads/pi/wf/partial-cleanup-failure",
+      baseSha: expectedBase,
+    });
+    assert.match(worktree.recoveryFailures?.[0]?.identity.recoveryId ?? "", /^[0-9a-f]{64}$/);
+    const registeredCheckout = git("worktree", "list", "--porcelain")
+      .split("\n")
+      .find((line) => line.startsWith("worktree ") && line.slice("worktree ".length) !== repo)
+      ?.slice("worktree ".length);
+    assert.ok(registeredCheckout, "the exact registration remains available for deterministic recovery");
+    assert.equal(JSON.stringify(worktree.recoveryFailures).includes(registeredCheckout ?? "missing"), false);
+    assert.match(git("branch", "--list", "pi/wf/partial-cleanup-failure"), /partial-cleanup-failure/);
+    assertCleanupQuarantinesEmpty(repo);
+  } finally {
+    for (const line of git("worktree", "list", "--porcelain").split("\n")) {
+      if (line.startsWith("worktree ") && line.slice("worktree ".length) !== repo) {
+        try {
+          git("worktree", "remove", "--force", line.slice("worktree ".length));
+        } catch {
+          // Best-effort fixture cleanup.
+        }
+      }
+    }
+    try {
+      git("branch", "-D", "pi/wf/partial-cleanup-failure");
+    } catch {
+      // Best-effort fixture cleanup.
+    }
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("removeWorktree upgrades a genuinely legacy version-two identity and then pins its inode", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-v2-upgrade-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const current = await createWorktreeLive(repo, "legacy-v2-upgrade");
+    assert.equal(current.cleanupMetadata?.version, 4);
+    if (current.cleanupMetadata?.version !== 4) throw new Error("expected current cleanup metadata");
+    const {
+      checkoutIdentity: _checkoutIdentity,
+      checkoutProof: _checkoutProof,
+      version: _version,
+      ...legacyFields
+    } = current.cleanupMetadata;
+    const legacy = { ...current, cleanupMetadata: { version: 2 as const, ...legacyFields } };
+    writeFileSync(
+      join(current.cleanupMetadata.gitDir, "pi-dynamic-workflows-registration"),
+      `${JSON.stringify(legacy.cleanupMetadata)}\n`,
+      { mode: 0o600 },
+    );
+
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(JSON.parse(JSON.stringify(legacy))), []);
+    assert.equal(existsSync(current.cwd), false);
+    assert.equal(git("branch", "--list", current.branch ?? "").trim(), "");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("removeWorktree accepts structured clones and JSON-round-tripped worktrees", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-clone-cleanup-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const clonedSource = await createWorktreeLive(repo, "structured-clone");
+    assert.equal(clonedSource.isolated, true);
+    await removeWorktree(structuredClone(clonedSource));
+    assert.equal(existsSync(clonedSource.cwd), false);
+
+    const serializedSource = await createWorktreeLive(repo, "json-round-trip");
+    assert.equal(serializedSource.isolated, true);
+    await removeWorktree(JSON.parse(JSON.stringify(serializedSource)) as Worktree);
+    assert.equal(existsSync(serializedSource.cwd), false);
+
+    assert.equal(git("branch", "--list", "pi/wf/*").toString().trim(), "");
+    assert.equal(
+      git("worktree", "list", "--porcelain")
+        .toString()
+        .match(/^worktree /gm)?.length,
+      1,
+    );
+    assertCleanupQuarantinesEmpty(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("removeWorktree rejects a round-tripped worktree with a substituted temporary branch", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-substituted-branch-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let original: Worktree | undefined;
+  const substitutedBranch = "pi/wf/substituted-branch";
+  const substitutedRef = `refs/heads/${substitutedBranch}`;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    original = await createWorktreeLive(repo, "original-cleanup-identity");
+    assert.equal(original.isolated, true);
+    const substitutedOid = git("commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "substituted commit")
+      .toString()
+      .trim();
+    git("update-ref", substitutedRef, substitutedOid);
+    const mutated = JSON.parse(JSON.stringify(original)) as Worktree;
+    mutated.branch = substitutedBranch;
+    mutated.branchRef = substitutedRef;
+
+    const failures = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(mutated);
+
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.match(failures[0]?.message ?? "", /cleanup failed.*identity_verification.*recovery ID/i);
+    assert.equal(existsSync(original.cwd), true, "the original checkout is preserved");
+    assert.match(git("branch", "--list", original.branch ?? "").toString(), /original-cleanup-identity/);
+    assert.equal(git("rev-parse", "--verify", substitutedRef).toString().trim(), substitutedOid);
+  } finally {
+    if (original?.isolated && existsSync(original.cwd)) await removeWorktree(original);
+    try {
+      git("update-ref", "-d", substitutedRef);
+    } catch {
+      // Best-effort test cleanup.
+    }
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("current-version registrations never fresh-adopt stripped plain worktree values", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-legacy-cleanup-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const sources = await Promise.all([
+      createWorktreeLive(repo, "legacy-plain"),
+      createWorktreeLive(repo, "legacy-clone"),
+      createWorktreeLive(repo, "legacy-json"),
+      createWorktreeLive(repo, "legacy-repo-root"),
+    ]);
+    const legacy = (source: Worktree): Worktree => ({
+      isolated: true,
+      cwd: source.cwd,
+      branch: source.branch,
+    });
+    const values = [
+      legacy(sources[0] as Worktree),
+      structuredClone(legacy(sources[1] as Worktree)),
+      JSON.parse(JSON.stringify(legacy(sources[2] as Worktree))) as Worktree,
+      { ...legacy(sources[3] as Worktree), repoRoot: repo },
+    ];
+
+    const operations = createWorktreeOperationsForTesting({});
+    const cleanupResults = await Promise.all(values.map((value) => operations.removeWorktree(value)));
+
+    for (const [index, source] of sources.entries()) {
+      assert.equal(cleanupResults[index]?.length, 1);
+      assert.equal(cleanupResults[index]?.[0]?.stage, "identity_verification");
+      assert.equal(existsSync(source.cwd), true, `stripped current checkout ${index} is preserved`);
+      await removeWorktree(source);
+    }
+    assert.equal(git("branch", "--list", "pi/wf/*").toString().trim(), "");
+    assert.equal(
+      git("worktree", "list", "--porcelain")
+        .toString()
+        .match(/^worktree /gm)?.length,
+      1,
+    );
+    assertCleanupQuarantinesEmpty(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("concurrent legacy and current cleanup serializes destructive repository metadata changes", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-concurrent-cleanup-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    for (let round = 0; round < 6; round++) {
+      const sources = await Promise.all(
+        Array.from({ length: 6 }, (_, index) => createWorktreeLive(repo, `concurrent-cleanup-${round}-${index}`)),
+      );
+      for (const source of sources) assert.equal(source.isolated, true, source.reason);
+
+      const values = [
+        sources[0] as Worktree,
+        structuredClone(sources[1] as Worktree),
+        JSON.parse(JSON.stringify(sources[2])) as Worktree,
+        sources[3] as Worktree,
+        structuredClone(sources[4] as Worktree),
+        JSON.parse(JSON.stringify(sources[5])) as Worktree,
+      ];
+
+      let activeMetadataCleanups = 0;
+      let maximumActiveMetadataCleanups = 0;
+      const operations = createWorktreeOperationsForTesting({
+        async beforePostClaimRegistrationCheck() {
+          activeMetadataCleanups++;
+          maximumActiveMetadataCleanups = Math.max(maximumActiveMetadataCleanups, activeMetadataCleanups);
+          await new Promise<void>((resolveTurn) => setImmediate(resolveTurn));
+        },
+        afterRegistrationClaim() {
+          activeMetadataCleanups--;
+        },
+      });
+      const cleanupResults = await Promise.all(values.map((value) => operations.removeWorktree(value)));
+
+      for (const [index, source] of sources.entries()) {
+        assert.deepEqual(cleanupResults[index], [], `cleanup ${index} failed for ${source.cwd}`);
+        assert.equal(existsSync(source.cwd), false, `cleanup ${index} left ${source.cwd}`);
+      }
+      assert.equal(activeMetadataCleanups, 0);
+      assert.equal(maximumActiveMetadataCleanups, 1, "repository metadata cleanup must not overlap");
+      assert.equal(git("branch", "--list", "pi/wf/*").toString().trim(), "");
+      assert.equal(
+        git("for-each-ref", "--format=%(refname)", "refs/pi-dynamic-workflows/cleanup/").toString().trim(),
+        "",
+      );
+      assert.equal(
+        git("worktree", "list", "--porcelain")
+          .toString()
+          .match(/^worktree /gm)?.length,
+        1,
+      );
+      assertCleanupQuarantinesEmpty(repo);
+    }
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cross-process cleanup serializes one repository and leaves no Git metadata leaks", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-cross-process-same-"));
+  const probeRoot = mkdtempSync(join(tmpdir(), "pi-wt-cross-process-probe-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    await Promise.all([
+      runCleanupWorker(repo, "cross-process-one", probeRoot, "same-repo"),
+      runCleanupWorker(repo, "cross-process-two", probeRoot, "same-repo"),
+    ]);
+
+    assert.deepEqual(
+      readFileSync(join(probeRoot, "events.log"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => line.split(" ")[0]),
+      ["enter", "exit", "enter", "exit"],
+      "the cross-process destructive intervals do not overlap",
+    );
+    assertNoCreationArtifacts(repo);
+    assert.equal(existsSync(operationLockRoot(repo)), false, "the repository lock is released");
+  } finally {
+    rmSync(probeRoot, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("two processes racing stale reclaim and new ownership never overlap", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-cross-process-stale-reclaim-"));
+  const probeRoot = mkdtempSync(join(tmpdir(), "pi-wt-cross-process-stale-reclaim-probe-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const first = runCleanupWorker(repo, "stale-reclaim-one", probeRoot, "stale-race");
+    for (let attempt = 0; attempt < 500; attempt++) {
+      if (readdirSync(probeRoot).filter((entry) => entry.startsWith("ready-")).length === 1) break;
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      if (attempt === 499) throw new Error("the first stale-reclaim worker did not finish creation");
+    }
+    const second = runCleanupWorker(repo, "stale-reclaim-two", probeRoot, "stale-race");
+    for (let attempt = 0; attempt < 500; attempt++) {
+      if (readdirSync(probeRoot).filter((entry) => entry.startsWith("ready-")).length === 2) break;
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      if (attempt === 499) throw new Error("the second stale-reclaim worker did not finish creation");
+    }
+    installOperationLock(repo, {
+      version: 1,
+      token: "8".repeat(64),
+      pid: 2_147_483_647,
+      createdAtMs: Date.now() - 120_000,
+    });
+    writeFileSync(join(probeRoot, "go"), "go\n", { flag: "wx" });
+
+    await Promise.all([first, second]);
+
+    assert.deepEqual(
+      readFileSync(join(probeRoot, "events.log"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => line.split(" ")[0]),
+      ["enter", "exit", "enter", "exit"],
+    );
+    assertNoCreationArtifacts(repo);
+    assert.equal(existsSync(operationLockRoot(repo)), false);
+    assert.equal(existsSync(operationLockUniquePath(repo, "8".repeat(64))), false);
+  } finally {
+    rmSync(probeRoot, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cross-process cleanup remains parallel for unrelated repositories", async () => {
+  const probeRoot = mkdtempSync(join(tmpdir(), "pi-wt-cross-process-unrelated-probe-"));
+  const repos = [
+    mkdtempSync(join(tmpdir(), "pi-wt-cross-process-unrelated-a-")),
+    mkdtempSync(join(tmpdir(), "pi-wt-cross-process-unrelated-b-")),
+  ];
+  try {
+    for (const repo of repos) {
+      const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+      git("init", "-q");
+      git("config", "user.email", "t@t.t");
+      git("config", "user.name", "t");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+    }
+
+    await Promise.all(
+      repos.map((repo, index) =>
+        runCleanupWorker(repo, `cross-process-unrelated-${index}`, probeRoot, "different-repo"),
+      ),
+    );
+
+    assert.equal(readdirSync(probeRoot).filter((entry) => entry.startsWith("entered-")).length, 2);
+    for (const repo of repos) assertNoCreationArtifacts(repo);
+  } finally {
+    rmSync(probeRoot, { recursive: true, force: true });
+    for (const repo of repos) rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("repository operation locks recover only strict stale owners and fail closed for bounded malformed owners", async () => {
+  for (const lockState of ["stale", "malformed", "symlink"] as const) {
+    const repo = mkdtempSync(join(tmpdir(), `pi-wt-operation-lock-${lockState}-`));
+    const external = mkdtempSync(join(tmpdir(), `pi-wt-operation-lock-${lockState}-external-`));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+    let worktree: Worktree | undefined;
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.t");
+      git("config", "user.name", "t");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+      worktree = await createWorktreeLive(repo, `operation-lock-${lockState}`);
+      assert.equal(worktree.isolated, true);
+      const lockRoot = operationLockRoot(repo);
+      if (lockState === "symlink") {
+        writeFileSync(join(external, "sentinel.txt"), "external survives\n");
+        symlinkSync(external, lockRoot, "file");
+      } else if (lockState === "malformed") {
+        writeFileSync(lockRoot, "not-json\n");
+        writeFileSync(join(external, "sentinel.txt"), "external survives\n");
+      } else {
+        installOperationLock(repo, {
+          version: 1,
+          token: "a".repeat(64),
+          pid: 2_147_483_647,
+          createdAtMs: Date.now() - 120_000,
+        });
+      }
+
+      const failures = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree);
+      if (lockState === "stale") {
+        assert.deepEqual(failures, []);
+        assert.equal(existsSync(lockRoot), false);
+        worktree = undefined;
+      } else {
+        assert.equal(failures.length, 1, `${lockState} lock fails in bounded time`);
+        assert.equal(existsSync(worktree.cwd), true);
+        assert.match(git("branch", "--list", worktree.branch ?? ""), /operation-lock/);
+        assert.equal(
+          readFileSync(join(worktree.cleanupMetadata?.gitDir ?? "", "pi-dynamic-workflows-registration"), "utf8")
+            .length > 0,
+          true,
+        );
+        if (lockState === "malformed" || lockState === "symlink") {
+          assert.equal(readFileSync(join(external, "sentinel.txt"), "utf8"), "external survives\n");
+          assert.deepEqual(readdirSync(external), ["sentinel.txt"], "the lock path is never followed");
+        }
+        rmSync(lockRoot, { recursive: true, force: true });
+        assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+        worktree = undefined;
+      }
+    } finally {
+      if (worktree?.isolated) {
+        rmSync(operationLockRoot(repo), { recursive: true, force: true });
+        await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree);
+      }
+      rmSync(external, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }
+});
+
+test("repository operation lock live-owner waits settle within a configurable acquisition deadline", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-live-operation-lock-deadline-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  let worktree: Worktree | undefined;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    worktree = await createWorktreeLive(repo, "live-operation-lock-holder");
+    assert.equal(worktree.isolated, true);
+    const lockRoot = operationLockRoot(repo);
+    const ownerRecord = {
+      version: 1 as const,
+      token: "c".repeat(64),
+      pid: process.pid,
+      createdAtMs: Date.now(),
+    };
+    const ownerUniquePath = installOperationLock(repo, ownerRecord);
+    const release = setTimeout(() => {
+      rmSync(lockRoot, { force: true });
+      rmSync(ownerUniquePath, { force: true });
+    }, 1_200);
+    const started = Date.now();
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+    clearTimeout(release);
+    assert.ok(Date.now() - started >= 1_100, "a legitimate 1.2 second owner is allowed to finish");
+    worktree = undefined;
+
+    worktree = await createWorktreeLive(repo, "forged-live-operation-lock-holder");
+    assert.equal(worktree.isolated, true);
+    const forgedOwnerRecord = {
+      version: 1 as const,
+      token: "d".repeat(64),
+      pid: process.pid,
+      createdAtMs: Date.now() - 120_000,
+    };
+    const forgedOwner = `${JSON.stringify(forgedOwnerRecord)}\n`;
+    const forgedUniquePath = installOperationLock(repo, forgedOwnerRecord);
+    const bounded = createWorktreeOperationsForTesting({
+      repositoryOperationLockAcquisitionDeadlineMs: 100,
+      repositoryOperationLockRetryMs: 10,
+    } as never);
+    const forgedStarted = Date.now();
+    const failures = await bounded.removeWorktree(worktree);
+    const elapsed = Date.now() - forgedStarted;
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.ok((failures[0]?.message.length ?? Infinity) <= 1024);
+    assert.ok(elapsed >= 80 && elapsed < 1_000, `bounded live-owner wait took ${elapsed}ms`);
+    assert.equal(readFileSync(lockRoot, "utf8"), forgedOwner, "a live lock is never stolen or mutated");
+    assert.equal(existsSync(worktree.cwd), true);
+
+    rmSync(lockRoot, { force: true });
+    rmSync(forgedUniquePath, { force: true });
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+    worktree = undefined;
+  } finally {
+    rmSync(operationLockRoot(repo), { recursive: true, force: true });
+    if (worktree?.isolated) await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("legacy directory repository locks fail closed with bounded manual-recovery diagnostics", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-legacy-operation-lock-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  let worktree: Worktree | undefined;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    worktree = await createWorktreeLive(repo, "legacy-operation-lock");
+    assert.equal(worktree.isolated, true);
+    mkdirSync(operationLockRoot(repo), { mode: 0o700 });
+    writeFileSync(join(operationLockRoot(repo), "owner"), "legacy\n");
+
+    const failures = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree);
+    assert.equal(failures.length, 1);
+    assert.ok((failures[0]?.message.length ?? Infinity) <= 1024);
+    assert.equal(existsSync(worktree.cwd), true);
+
+    rmSync(operationLockRoot(repo), { recursive: true, force: true });
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+    worktree = undefined;
+  } finally {
+    rmSync(operationLockRoot(repo), { recursive: true, force: true });
+    if (worktree?.isolated) await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("stale lock reclaim never unlinks a concurrently installed new owner", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-operation-lock-reclaim-race-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  let worktree: Worktree | undefined;
+  let newUniquePath = "";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    worktree = await createWorktreeLive(repo, "operation-lock-reclaim-race");
+    assert.equal(worktree.isolated, true);
+    const staleToken = "e".repeat(64);
+    const staleUniquePath = installOperationLock(repo, {
+      version: 1,
+      token: staleToken,
+      pid: 2_147_483_647,
+      createdAtMs: Date.now() - 120_000,
+    });
+    const newOwner = { version: 1 as const, token: "f".repeat(64), pid: process.pid, createdAtMs: Date.now() };
+    let replaced = false;
+    const operations = createWorktreeOperationsForTesting({
+      beforeRepositoryOperationLockUnlink(path, token) {
+        if (replaced || token !== staleToken) return;
+        replaced = true;
+        unlinkSync(path);
+        unlinkSync(staleUniquePath);
+        newUniquePath = installOperationLock(repo, newOwner);
+      },
+      repositoryOperationLockAcquisitionDeadlineMs: 100,
+      repositoryOperationLockRetryMs: 10,
+    } as never);
+
+    const failures = await operations.removeWorktree(worktree);
+    assert.equal(failures.length, 1);
+    assert.equal(readFileSync(operationLockRoot(repo), "utf8"), `${JSON.stringify(newOwner)}\n`);
+    assert.equal(existsSync(worktree.cwd), true, "the competing live owner keeps exclusive admission");
+
+    unlinkSync(operationLockRoot(repo));
+    unlinkSync(newUniquePath);
+    newUniquePath = "";
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+    worktree = undefined;
+  } finally {
+    rmSync(operationLockRoot(repo), { force: true });
+    if (newUniquePath) rmSync(newUniquePath, { force: true });
+    if (worktree?.isolated) await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("an initialized hard-link lock survives owner crash and is safely reclaimed", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-operation-lock-crash-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  let worktree: Worktree | undefined;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    worktree = await createWorktreeLive(repo, "operation-lock-crash");
+    assert.equal(worktree.isolated, true);
+    const token = "9".repeat(64);
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        `const fs = require('node:fs');
+const [uniquePath, lockPath, token] = process.argv.slice(1);
+fs.writeFileSync(uniquePath, JSON.stringify({ version: 1, token, pid: process.pid, createdAtMs: Date.now() - 120000 }) + '\\n', { flag: 'wx', mode: 0o600 });
+fs.linkSync(uniquePath, lockPath);
+process.kill(process.pid, 'SIGKILL');`,
+        operationLockUniquePath(repo, token),
+        operationLockRoot(repo),
+        token,
+      ],
+      { stdio: "ignore" },
+    );
+    await new Promise<void>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", (_code, signal) => {
+        try {
+          assert.equal(signal, "SIGKILL");
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+    assert.equal(existsSync(operationLockRoot(repo)), false);
+    assert.equal(existsSync(operationLockUniquePath(repo, token)), false);
+    worktree = undefined;
+  } finally {
+    rmSync(operationLockRoot(repo), { force: true });
+    if (worktree?.isolated) await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("legacy cleanup rejects arbitrary paths and non-runtime branches", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-legacy-reject-"));
+  const outsidePath = mkdtempSync(join(tmpdir(), "pi-wt-legacy-outside-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let trustedSource: Worktree | undefined;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    git("worktree", "add", "-q", "-b", "pi/wf/outside", outsidePath, "HEAD");
+    await removeWorktree({ isolated: true, cwd: outsidePath, branch: "pi/wf/outside" });
+    assert.equal(existsSync(outsidePath), true, "a runtime-looking branch cannot authorize an arbitrary path");
+    assert.match(git("branch", "--list", "pi/wf/outside").toString(), /outside/);
+
+    trustedSource = await createWorktreeLive(repo, "legacy-wrong-branch");
+    assert.equal(trustedSource.isolated, true);
+    await removeWorktree({ isolated: true, cwd: trustedSource.cwd, branch: "customer/keep" });
+    assert.equal(existsSync(trustedSource.cwd), true, "a trusted path cannot authorize a non-runtime branch");
+    assert.match(git("branch", "--list", trustedSource.branch ?? "").toString(), /legacy-wrong-branch/);
+  } finally {
+    if (trustedSource?.isolated) await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(trustedSource);
+    try {
+      git("worktree", "remove", "--force", outsidePath);
+      git("branch", "-D", "pi/wf/outside");
+    } catch {
+      // Best-effort test cleanup.
+    }
+    rmSync(outsidePath, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup removes detached checkouts while preserving their unrelated commit object", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-detached-cleanup-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const worktree = await createWorktreeLive(repo, "detached-cleanup");
+    execFileSync("git", ["-C", worktree.cwd, "checkout", "--detach", "-q"], { stdio: "pipe" });
+    writeFileSync(join(worktree.cwd, "detached.txt"), "detached commit\n");
+    execFileSync("git", ["-C", worktree.cwd, "add", "."], { stdio: "pipe" });
+    execFileSync("git", ["-C", worktree.cwd, "commit", "-q", "-m", "detached commit"], { stdio: "pipe" });
+    const detachedOid = execFileSync("git", ["-C", worktree.cwd, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+    assert.equal(existsSync(worktree.cwd), false);
+    assert.equal(
+      git("branch", "--list", worktree.branch ?? "")
+        .toString()
+        .trim(),
+      "",
+    );
+    assert.equal(git("cat-file", "-t", detachedOid).toString().trim(), "commit");
+    assert.equal(
+      git("worktree", "list", "--porcelain")
+        .toString()
+        .match(/^worktree /gm)?.length,
+      1,
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup removes switched checkouts without deleting the agent-created branch", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-switched-cleanup-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  const unrelatedBranch = "customer/keep-agent-work";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const worktree = await createWorktreeLive(repo, "switched-cleanup");
+    execFileSync("git", ["-C", worktree.cwd, "switch", "-q", "-c", unrelatedBranch], { stdio: "pipe" });
+    writeFileSync(join(worktree.cwd, "kept.txt"), "keep this commit\n");
+    execFileSync("git", ["-C", worktree.cwd, "add", "."], { stdio: "pipe" });
+    execFileSync("git", ["-C", worktree.cwd, "commit", "-q", "-m", "keep agent work"], { stdio: "pipe" });
+    const unrelatedOid = execFileSync("git", ["-C", worktree.cwd, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+    assert.equal(existsSync(worktree.cwd), false);
+    assert.equal(
+      git("branch", "--list", worktree.branch ?? "")
+        .toString()
+        .trim(),
+      "",
+    );
+    assert.match(git("branch", "--list", unrelatedBranch).toString(), /keep-agent-work/);
+    assert.equal(git("rev-parse", unrelatedBranch).toString().trim(), unrelatedOid);
+    assert.equal(git("cat-file", "-t", unrelatedOid).toString().trim(), "commit");
+    assert.equal(
+      git("worktree", "list", "--porcelain")
+        .toString()
+        .match(/^worktree /gm)?.length,
+      1,
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("the process-wide cleaned identity cache remains bounded", () => {
+  const identities = Array.from({ length: 1100 }, (_, index) => `bounded-cleanup-identity-${index}`);
+
+  const metrics = populateCleanedWorktreeCacheForTesting(identities);
+  const repeated = populateCleanedWorktreeCacheForTesting(identities.slice(-20));
+
+  assert.equal(metrics.capacity, 1024);
+  assert.equal(metrics.size, metrics.capacity);
+  assert.deepEqual(repeated, metrics, "recent repeated identities remain idempotent without growing the cache");
+});
+
+test("portable cleanup works when proc descriptors are unavailable", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-no-proc-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const operations = createWorktreeOperationsForTesting({ procDescriptorRoot: join(repo, "unavailable-proc") });
+    for (const name of ["ordinary-no-proc", "retained-no-proc"]) {
+      const worktree = await operations.createWorktree(repo, name);
+      assert.equal(worktree.isolated, true);
+      assert.deepEqual(await operations.removeWorktree(worktree), []);
+      assert.equal(existsSync(worktree.cwd), false);
+    }
+
+    assert.equal(git("branch", "--list", "pi/wf/*").toString().trim(), "");
+    assert.equal(
+      git("worktree", "list", "--porcelain")
+        .toString()
+        .match(/^worktree /gm)?.length,
+      1,
+    );
+    assertCleanupQuarantinesEmpty(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("portable sentinel blocks neutralize in place without losing separators, metadata, hardlinks, or external appends", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-sentinel-restore-"));
+  const descriptorBaseline = activeCheckoutProofsForTesting();
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const initial = "# user excludes\n*.private";
+    writeFileSync(excludePath(repo), initial);
+    const [one, two] = await Promise.all([
+      createWorktreeLive(repo, "sentinel-concurrent-one", { directoryDescriptorMode: "unsupported" } as never),
+      createWorktreeLive(repo, "sentinel-concurrent-two", { directoryDescriptorMode: "unsupported" } as never),
+    ]);
+    assert.equal(one.cleanupMetadata?.version, 4);
+    assert.equal(two.cleanupMetadata?.version, 4);
+    assert.equal(
+      activeCheckoutProofsForTesting().excludeDescriptorCount,
+      descriptorBaseline.excludeDescriptorCount + 2,
+      "multiple worktrees retain independent handles to the shared exclude inode",
+    );
+    if (one.cleanupMetadata?.version !== 4 || two.cleanupMetadata?.version !== 4) throw new Error("expected v4");
+    if (
+      one.cleanupMetadata.checkoutProof.kind !== "sentinel" ||
+      two.cleanupMetadata.checkoutProof.kind !== "sentinel"
+    ) {
+      throw new Error("expected portable sentinel proofs");
+    }
+    const active = [one, two] as const;
+    const first = active.find(
+      (worktree) =>
+        worktree.cleanupMetadata?.version === 4 &&
+        worktree.cleanupMetadata.checkoutProof.kind === "sentinel" &&
+        worktree.cleanupMetadata.checkoutProof.excludeLeadingNewline,
+    );
+    const second = active.find((worktree) => worktree !== first);
+    if (
+      !first ||
+      !second ||
+      first.cleanupMetadata?.version !== 4 ||
+      second.cleanupMetadata?.version !== 4 ||
+      first.cleanupMetadata.checkoutProof.kind !== "sentinel" ||
+      second.cleanupMetadata.checkoutProof.kind !== "sentinel"
+    ) {
+      throw new Error("expected ordered portable sentinel proofs");
+    }
+    const firstProof = first.cleanupMetadata.checkoutProof;
+    const secondProof = second.cleanupMetadata.checkoutProof;
+    assert.notEqual(firstProof.fileName, secondProof.fileName);
+    assert.equal(firstProof.excludeLeadingNewline, true, "the first block owns the separator after a non-newline file");
+    assert.equal(secondProof.excludeLeadingNewline, false);
+    const during = readFileSync(excludePath(repo), "utf8");
+    assert.match(during, new RegExp(firstProof.fileName));
+    assert.match(during, new RegExp(secondProof.fileName));
+    assert.equal(during.includes("/.pi-dynamic-workflows-checkout-identity\n"), false, "no static global rule remains");
+    assert.equal(isGitIgnored(repo, firstProof.fileName), true);
+    assert.equal(isGitIgnored(repo, secondProof.fileName), true);
+
+    const hardlinkPath = join(gitCommonRoot(repo), "info", "exclude-hardlink");
+    chmodSync(excludePath(repo), 0o640);
+    linkSync(excludePath(repo), hardlinkPath);
+    const metadataBefore = statSync(excludePath(repo));
+    const externalAppend = "# external append during neutralization\n*.later\n";
+    const retrying = createWorktreeOperationsForTesting({
+      afterIdentityVerification() {
+        throw new Error("retry sentinel cleanup later");
+      },
+    });
+    const retryFailures = await retrying.removeWorktree(first);
+    assert.equal(retryFailures.length, 1);
+    assert.match(readFileSync(excludePath(repo), "utf8"), new RegExp(firstProof.fileName));
+
+    const beforeNeutralization = readFileSync(excludePath(repo), "utf8");
+    const firstBlock = sentinelExcludeBlock(firstProof);
+    const firstOffset = beforeNeutralization.indexOf(firstBlock);
+    assert.ok(firstOffset >= 0);
+    let appended = false;
+    const appendDuringNeutralization = createWorktreeOperationsForTesting({
+      beforeSentinelExcludeNeutralize() {
+        if (appended) return;
+        appended = true;
+        appendFileSync(excludePath(repo), externalAppend);
+      },
+    } as never);
+    assert.deepEqual(await appendDuringNeutralization.removeWorktree(first), []);
+    const afterFirst = readFileSync(excludePath(repo), "utf8");
+    assert.equal(afterFirst.slice(0, firstOffset), beforeNeutralization.slice(0, firstOffset));
+    assert.equal(
+      afterFirst.slice(firstOffset + firstBlock.length, beforeNeutralization.length),
+      beforeNeutralization.slice(firstOffset + firstBlock.length),
+      "every byte outside the owned range is preserved",
+    );
+    const neutralized = afterFirst.slice(firstOffset, firstOffset + firstBlock.length);
+    assert.equal(neutralized.length, firstBlock.length);
+    assert.deepEqual(
+      [...neutralized].map((character, index) => (character === "\n" ? index : -1)).filter((index) => index >= 0),
+      [...firstBlock].map((character, index) => (character === "\n" ? index : -1)).filter((index) => index >= 0),
+      "neutralization preserves every newline and separator",
+    );
+    assert.match(neutralized, /^\n# *\n# *\n$/);
+    assert.equal(afterFirst.includes(firstProof.fileName), false);
+    assert.equal(afterFirst.includes(secondProof.fileName), true);
+    assert.equal(afterFirst.endsWith(externalAppend), true, "an external append survives byte-for-byte");
+    assert.equal(isGitIgnored(repo, firstProof.fileName), false, "released sentinel rule is semantically inactive");
+    assert.equal(isGitIgnored(repo, secondProof.fileName), true, "overlapping active sentinel remains ignored");
+    assert.equal(isGitIgnored(repo, "probe.private"), true, "the user's preexisting rule keeps its semantics");
+    assert.equal(isGitIgnored(repo, "probe.later"), true, "the concurrent append keeps its semantics");
+    const metadataAfterFirst = statSync(excludePath(repo));
+    const hardlinkAfterFirst = statSync(hardlinkPath);
+    assert.equal(metadataAfterFirst.ino, metadataBefore.ino, "cleanup preserves the exclude inode");
+    assert.equal(hardlinkAfterFirst.ino, metadataBefore.ino, "cleanup preserves hardlink identity");
+    assert.equal(metadataAfterFirst.mode & 0o777, metadataBefore.mode & 0o777, "cleanup preserves mode bits");
+    assert.equal(readFileSync(hardlinkPath, "utf8"), afterFirst, "the hardlink observes the same in-place edit");
+
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(second), []);
+    const afterSecond = readFileSync(excludePath(repo), "utf8");
+    assert.equal(afterSecond.includes(secondProof.fileName), false);
+    assert.equal(afterSecond.endsWith(externalAppend), true);
+    assert.equal(isGitIgnored(repo, secondProof.fileName), false);
+    assert.equal(isGitIgnored(repo, "probe.private"), true);
+    assert.equal(isGitIgnored(repo, "probe.later"), true);
+    assert.equal(statSync(excludePath(repo)).ino, metadataBefore.ino);
+    assert.equal(statSync(excludePath(repo)).mode & 0o777, metadataBefore.mode & 0o777);
+    assert.deepEqual(activeCheckoutProofsForTesting(), descriptorBaseline);
+
+    const branchRetry = await createWorktreeLive(repo, "sentinel-branch-retry", {
+      directoryDescriptorMode: "unsupported",
+    } as never);
+    if (branchRetry.cleanupMetadata?.version !== 4 || branchRetry.cleanupMetadata.checkoutProof.kind !== "sentinel") {
+      throw new Error("expected retryable portable sentinel proof");
+    }
+    let failBranchDelete = true;
+    const branchRetryOperations = createWorktreeOperationsForTesting({
+      beforeClaimedBranchDelete() {
+        if (!failBranchDelete) return;
+        failBranchDelete = false;
+        throw new Error("retry portable branch cleanup later");
+      },
+    });
+    const branchFailures = await branchRetryOperations.removeWorktree(branchRetry);
+    assert.equal(branchFailures[0]?.stage, "branch_delete");
+    assert.match(
+      readFileSync(excludePath(repo), "utf8"),
+      new RegExp(branchRetry.cleanupMetadata.checkoutProof.fileName),
+      "retry rollback re-appends an exact active owned block",
+    );
+    assert.deepEqual(await branchRetryOperations.removeWorktree(branchRetry), []);
+    assert.equal(
+      readFileSync(excludePath(repo), "utf8").includes(branchRetry.cleanupMetadata.checkoutProof.fileName),
+      false,
+    );
+    assert.deepEqual(activeCheckoutProofsForTesting(), descriptorBaseline);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("portable sentinel cleanup fails bounded on an edited owned block and succeeds after repair", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-sentinel-edited-block-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const worktree = await createWorktreeLive(repo, "sentinel-edited-owned-block", {
+      directoryDescriptorMode: "unsupported",
+    } as never);
+    if (worktree.cleanupMetadata?.version !== 4 || worktree.cleanupMetadata.checkoutProof.kind !== "sentinel") {
+      throw new Error("expected portable sentinel proof");
+    }
+    const proof = worktree.cleanupMetadata.checkoutProof;
+    const exactBlock = sentinelExcludeBlock(proof);
+    let pristine = "";
+    const edited = createWorktreeOperationsForTesting({
+      beforeSentinelExcludeNeutralize() {
+        pristine = readFileSync(excludePath(repo), "utf8");
+        const offset = pristine.indexOf(exactBlock);
+        if (offset < 0) throw new Error("owned block missing from fixture");
+        writeFileSync(excludePath(repo), `${pristine.slice(0, offset)}!${pristine.slice(offset + 1)}`);
+      },
+    } as never);
+
+    const failures = await edited.removeWorktree(worktree);
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "worktree_remove");
+    assert.match(failures[0]?.message ?? "", /portable sentinel restoration failed.*incomplete or changed/i);
+    assert.ok((failures[0]?.message.length ?? Infinity) <= 1024);
+    assert.match(
+      git("for-each-ref", "--format=%(refname)", "refs/pi-dynamic-workflows/cleanup/"),
+      /refs\/pi-dynamic-workflows\/cleanup\//,
+      "the deterministic backup ref retains retry authority",
+    );
+
+    writeFileSync(excludePath(repo), pristine);
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+    assert.equal(readFileSync(excludePath(repo), "utf8").includes(proof.fileName), false);
+    assert.equal(isGitIgnored(repo, proof.fileName), false);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("portable sentinel state is semantically neutralized after fully rolled-back creation", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-sentinel-rollback-"));
+  const descriptorBaseline = activeCheckoutProofsForTesting();
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const initial = "# keep exactly\n*.keep\n";
+    writeFileSync(excludePath(repo), initial);
+
+    const result = await createWorktreeLive(repo, "sentinel-rollback", {
+      directoryDescriptorMode: "unsupported",
+      async canonicalizePath(path) {
+        if (path.includes("pi-workflow-checkout-")) throw new Error("rollback finalized portable creation");
+        return realpathSync(path);
+      },
+    });
+
+    assert.equal(result.isolated, false);
+    assert.match(result.reason ?? "", /identity_finalization/);
+    const afterRollback = readFileSync(excludePath(repo), "utf8");
+    assert.equal(afterRollback.slice(0, initial.length), initial);
+    assert.match(afterRollback.slice(initial.length), /^# *\n# *\n$/);
+    assert.equal(afterRollback.includes("pi-dynamic-workflows-owned-sentinel"), false);
+    assert.equal(afterRollback.includes(".pi-dynamic-workflows-checkout-identity"), false);
+    assert.equal(isGitIgnored(repo, "probe.keep"), true);
+    assert.deepEqual(activeCheckoutProofsForTesting(), descriptorBaseline, "full rollback closes all proof fds");
+    assertNoCreationArtifacts(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("removeWorktree supports SHA-256 repositories", {
+  skip: !SHA256_REPOSITORIES_SUPPORTED && "git does not support SHA-256 repositories",
+}, async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-sha256-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q", "--object-format=sha256");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    assert.equal(git("rev-parse", "HEAD").toString().trim().length, 64);
+
+    const worktree = await createWorktreeLive(repo, "sha256-cleanup");
+    assert.equal(worktree.isolated, true);
+    assert.equal(join(worktree.cwd, ".."), gitCommonRoot(repo));
+    assert.match(worktree.cwd, /pi-workflow-checkout-/);
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+    assert.equal(existsSync(worktree.cwd), false);
+    assert.equal(
+      git("branch", "--list", worktree.branch ?? "")
+        .toString()
+        .trim(),
+      "",
+    );
+    assertCleanupQuarantinesEmpty(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("createWorktree ignores a pre-existing symlink at the obsolete shared worktree root", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-symlink-root-"));
+  const external = mkdtempSync(join(tmpdir(), "pi-wt-external-root-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    mkdirSync(join(repo, ".pi"));
+    symlinkSync(external, join(repo, ".pi", "worktrees"), "dir");
+
+    const worktree = await createWorktreeLive(repo, "symlink-escape");
+
+    assert.equal(worktree.isolated, true, worktree.reason);
+    assert.equal(join(worktree.cwd, ".."), gitCommonRoot(repo));
+    assert.match(worktree.cwd, /pi-workflow-checkout-/);
+    assert.deepEqual(readdirSync(external), [], "the external directory receives no checkout");
+    assert.equal(
+      git("branch", "--list", worktree.branch ?? "")
+        .toString()
+        .trim().length > 0,
+      true,
+    );
+    await removeWorktree(worktree);
+    assert.equal(git("branch", "--list", "pi/wf/*").toString().trim(), "");
+    assert.equal(
+      git("worktree", "list", "--porcelain")
+        .toString()
+        .split("\n")
+        .filter((line) => line.startsWith("worktree ")).length,
+      1,
+      "cleanup removes the Git-common-dir registration without resolving the obsolete root",
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(external, { recursive: true, force: true });
+  }
+});
+
+test("swapping the obsolete shared root cannot redirect direct-child worktree creation", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-shared-root-swap-"));
+  const external = mkdtempSync(join(tmpdir(), "pi-wt-shared-root-external-"));
+  const displaced = join(repo, ".pi", "displaced-worktrees");
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let worktree: Worktree | undefined;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    mkdirSync(join(repo, ".pi", "worktrees"), { recursive: true });
+
+    worktree = await createWorktreeLive(repo, "shared-root-swap", {
+      afterAtomicDirectoryCreation() {
+        renameSync(join(repo, ".pi", "worktrees"), displaced);
+        symlinkSync(external, join(repo, ".pi", "worktrees"), "dir");
+      },
+    });
+
+    assert.equal(worktree.isolated, true, worktree.reason);
+    assert.equal(join(worktree.cwd, ".."), gitCommonRoot(repo), "the checkout is a direct Git-common-dir child");
+    assert.match(worktree.cwd, /pi-workflow-checkout-/);
+    assert.equal(readFileSync(join(worktree.cwd, "file.txt"), "utf8"), "base\n");
+    assert.deepEqual(readdirSync(external), [], "Git never resolves the attacker-controlled shared root");
+
+    await removeWorktree(worktree);
+    worktree = undefined;
+    assert.equal(git("branch", "--list", "pi/wf/*").toString().trim(), "");
+    assert.equal(
+      git("worktree", "list", "--porcelain")
+        .toString()
+        .split("\n")
+        .filter((line) => line.startsWith("worktree ")).length,
+      1,
+      "the exact Git-common-dir registration is removed",
+    );
+    assert.deepEqual(readdirSync(external), [], "cleanup never follows the swapped shared root");
+  } finally {
+    if (worktree?.isolated) await removeWorktree(worktree);
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(external, { recursive: true, force: true });
+  }
+});
+
+test("rebound allocated checkout paths fail closed before git worktree add", async () => {
+  for (const replacement of ["directory", "symlink"] as const) {
+    const repo = mkdtempSync(join(tmpdir(), `pi-wt-pre-add-${replacement}-`));
+    const external = mkdtempSync(join(tmpdir(), `pi-wt-pre-add-${replacement}-external-`));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+    let checkoutPath = "";
+    let gitAddCalled = false;
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.t");
+      git("config", "user.name", "t");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+      writeFileSync(join(external, "sentinel.txt"), "external survives\n");
+      if (replacement === "directory") {
+        mkdirSync(join(external, "replacement"));
+        writeFileSync(join(external, "replacement", "attacker.txt"), "replacement survives\n");
+      }
+      const excludeBefore = "# caller-owned exclude\n*.private\n";
+      writeFileSync(excludePath(repo), excludeBefore);
+
+      const worktree = await createWorktreeLive(repo, `pre-add-${replacement}`, {
+        directoryDescriptorMode: "unsupported",
+        async execGit(args) {
+          if (args.includes("worktree") && args.includes("add")) gitAddCalled = true;
+          return { stdout: execFileSync("git", args, { encoding: "utf8" }) };
+        },
+        afterBranchCreationBeforeGitAdd(_gitCommonRoot, allocatedPath) {
+          checkoutPath = allocatedPath;
+          rmdirSync(allocatedPath);
+          if (replacement === "directory") {
+            renameSync(join(external, "replacement"), allocatedPath);
+          } else {
+            symlinkSync(external, allocatedPath, "dir");
+          }
+        },
+      } as Parameters<typeof createWorktreeLive>[2] & {
+        afterBranchCreationBeforeGitAdd(gitCommonRoot: string, worktreePath: string): void;
+      });
+
+      assert.equal(worktree.isolated, false);
+      assert.match(worktree.reason ?? "", /pre_add_verification/);
+      assert.equal(gitAddCalled, false, "Git never receives the rebound checkout path");
+      assert.equal(git("branch", "--list", `pi/wf/pre-add-${replacement}`).trim(), "", "the owned branch is removed");
+      assert.equal(readFileSync(join(external, "sentinel.txt"), "utf8"), "external survives\n");
+      assert.equal(
+        readFileSync(excludePath(repo), "utf8"),
+        excludeBefore,
+        "identity mismatch performs zero exclude writes",
+      );
+      if (replacement === "directory") {
+        assert.deepEqual(
+          readdirSync(checkoutPath),
+          ["attacker.txt"],
+          "recovery writes nothing into the rebound directory",
+        );
+        assert.equal(readFileSync(join(checkoutPath, "attacker.txt"), "utf8"), "replacement survives\n");
+      } else {
+        assert.deepEqual(
+          readdirSync(external),
+          ["sentinel.txt"],
+          "recovery writes nothing through the rebound symlink",
+        );
+        assert.equal(realpathSync(checkoutPath), external);
+      }
+      assert.deepEqual(worktree.recoveryFailures, undefined);
+    } finally {
+      if (checkoutPath) rmSync(checkoutPath, { recursive: true, force: true });
+      rmSync(external, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }
+});
+
+test("pre-add rebound rollback failures return bounded recovery diagnostics", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-pre-add-rollback-failure-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  let checkoutPath = "";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const worktree = await createWorktreeLive(repo, "pre-add-rollback-failure", {
+      afterBranchCreationBeforeGitAdd(_gitCommonRoot, allocatedPath) {
+        checkoutPath = allocatedPath;
+        rmdirSync(allocatedPath);
+        mkdirSync(allocatedPath);
+        writeFileSync(join(allocatedPath, "attacker.txt"), "preserved\n");
+      },
+      creationCleanupHooks: {
+        afterBranchClaim() {
+          throw new Error(`injected exact rollback failure ${"x".repeat(5000)}`);
+        },
+      },
+    } as Parameters<typeof createWorktreeLive>[2] & {
+      afterBranchCreationBeforeGitAdd(gitCommonRoot: string, worktreePath: string): void;
+      creationCleanupHooks: { afterBranchClaim(): void };
+    });
+
+    assert.equal(worktree.isolated, false);
+    assert.equal(worktree.recoveryFailures?.length, 1);
+    assert.equal(worktree.recoveryFailures?.[0]?.stage, "cleanup_dispatch");
+    assert.ok((worktree.recoveryFailures?.[0]?.message.length ?? Infinity) <= 1024);
+    assert.equal(readFileSync(join(checkoutPath, "attacker.txt"), "utf8"), "preserved\n");
+  } finally {
+    if (checkoutPath) rmSync(checkoutPath, { recursive: true, force: true });
+    try {
+      git("update-ref", "-d", "refs/heads/pi/wf/pre-add-rollback-failure");
+    } catch {
+      // Best-effort fixture cleanup.
+    }
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("older Git plumbing creates and cleans ordinary and retained worktrees without path-format", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-old-git-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  const commands: string[][] = [];
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const createWithOldGit = (name: string) =>
+      createWorktreeLive(repo, name, {
+        async execGit(args) {
+          commands.push([...args]);
+          if (args.includes("--path-format=absolute")) throw new Error("unknown option: --path-format");
+          return { stdout: execFileSync("git", args, { encoding: "utf8" }) };
+        },
+      });
+
+    const ordinary = await createWithOldGit("old-git-ordinary");
+    assert.equal(ordinary.isolated, true, ordinary.reason);
+    await removeWorktree(ordinary);
+
+    const retained = await createWithOldGit("old-git-retained");
+    assert.equal(retained.isolated, true, retained.reason);
+    const registry = new RetainedWorktreeRegistry();
+    const handle = registry.register(retained);
+    await registry.release(handle);
+
+    assert.equal(
+      commands.some((args) => args.includes("--path-format=absolute")),
+      false,
+    );
+    assert.equal(
+      readFileSync(new URL("../src/worktree.ts", import.meta.url), "utf8").includes("--path-format=absolute"),
+      false,
+    );
+    assert.equal(git("branch", "--list", "pi/wf/*").toString().trim(), "");
+    assert.equal(
+      git("worktree", "list", "--porcelain")
+        .toString()
+        .split("\n")
+        .filter((line) => line.startsWith("worktree ")).length,
+      1,
+    );
+    assertCleanupQuarantinesEmpty(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
 
 test("createWorktree falls back when git fails (non-git directory)", async () => {
   const dir = mkdtempSync(join(tmpdir(), "pi-wt-noexec-"));
@@ -64,7 +2329,7 @@ test("createWorktree falls back when git fails (non-git directory)", async () =>
   }
 });
 
-test("removeWorktree does not throw when worktree directory is already missing", async () => {
+test("removeWorktree cleans the exact stale registration and branch when its checkout is missing", async () => {
   const repo = mkdtempSync(join(tmpdir(), "pi-wt-missing-"));
   const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
   try {
@@ -82,9 +2347,91 @@ test("removeWorktree does not throw when worktree directory is already missing",
     rmSync(wt.cwd, { recursive: true, force: true });
     assert.ok(!existsSync(wt.cwd), "worktree dir removed manually before removeWorktree");
 
-    // removeWorktree must not throw despite git commands failing
     await assert.doesNotReject(removeWorktree(wt));
+    const registrations = git("worktree", "list", "--porcelain").toString();
+    assert.equal(
+      registrations.split("\n").filter((line) => line.startsWith("worktree ")).length,
+      1,
+      "the stale registration is removed",
+    );
+    assert.equal(
+      git("branch", "--list", wt.branch ?? "")
+        .toString()
+        .trim(),
+      "",
+      "the temporary branch is removed",
+    );
   } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup finds a descriptor-proven checkout renamed within the Git-common parent", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-renamed-within-parent-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const worktree = await createWorktreeLive(repo, "renamed-within-parent");
+    const renamed = join(gitCommonRoot(repo), "renamed-runtime-checkout");
+    renameSync(worktree.cwd, renamed);
+    writeFileSync(join(renamed, "uncommitted.txt"), "descriptor-proven contents\n");
+
+    const failures = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree);
+
+    assert.deepEqual(failures, []);
+    assert.equal(existsSync(renamed), false, "the exact linked descriptor inode is removed at its new basename");
+    assertNoCreationArtifacts(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup fails closed when a descriptor-proven checkout is renamed outside its safe parent", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-renamed-outside-parent-"));
+  const outside = mkdtempSync(join(tmpdir(), "pi-wt-renamed-outside-target-"));
+  const moved = join(outside, "moved-checkout");
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  let worktree: Worktree | undefined;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    worktree = await createWorktreeLive(repo, "renamed-outside-parent");
+    renameSync(worktree.cwd, moved);
+    writeFileSync(join(moved, "uncommitted.txt"), "preserve outside contents\n");
+    const registrationBefore = readFileSync(
+      join(worktree.cleanupMetadata?.gitDir ?? "", "pi-dynamic-workflows-registration"),
+      "utf8",
+    );
+
+    const failures = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree);
+
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.equal(readFileSync(join(moved, "uncommitted.txt"), "utf8"), "preserve outside contents\n");
+    assert.match(git("branch", "--list", worktree.branch ?? ""), /renamed-outside-parent/);
+    assert.equal(
+      readFileSync(join(worktree.cleanupMetadata?.gitDir ?? "", "pi-dynamic-workflows-registration"), "utf8"),
+      registrationBefore,
+    );
+
+    renameSync(moved, worktree.cwd);
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+    worktree = undefined;
+  } finally {
+    if (worktree?.isolated) {
+      if (existsSync(moved) && !existsSync(worktree.cwd)) renameSync(moved, worktree.cwd);
+      await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree);
+    }
+    rmSync(outside, { recursive: true, force: true });
     rmSync(repo, { recursive: true, force: true });
   }
 });
@@ -109,7 +2456,1290 @@ test("createWorktree falls back when target branch already exists", async () => 
     const wt = await createWorktreeLive(repo, name);
     assert.equal(wt.isolated, false);
     assert.equal(wt.cwd, repo);
-    assert.ok(/already exists/i.test(wt.reason ?? ""), `Expected 'already exists' error, got: ${wt.reason}`);
+    assert.match(wt.reason ?? "", /branch_create/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("long retained producer names preserve distinct paths and refs within the length cap", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-unique-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  const created: Worktree[] = [];
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const prefix = "managed-workflow-name-that-consumes-the-entire-prefix-";
+    created.push(await createWorktreeLive(repo, `${prefix}0-producer-alpha`));
+    created.push(await createWorktreeLive(repo, `${prefix}1-producer-beta`));
+
+    assert.equal(
+      created.every((worktree) => worktree.isolated),
+      true,
+    );
+    assert.notEqual(created[0]?.cwd, created[1]?.cwd);
+    assert.notEqual(created[0]?.branchRef, created[1]?.branchRef);
+    for (const worktree of created) {
+      assert.ok((worktree.branch?.replace("pi/wf/", "").length ?? Infinity) <= 32);
+    }
+
+    await Promise.all(created.map((worktree) => removeWorktree(worktree)));
+    const registrations = git("worktree", "list", "--porcelain").toString();
+    assert.equal(registrations.split("\n").filter((line) => line.startsWith("worktree ")).length, 1);
+    assert.equal(git("branch", "--list", "pi/wf/*").toString().trim(), "");
+  } finally {
+    await Promise.all(created.filter((worktree) => worktree.isolated).map((worktree) => removeWorktree(worktree)));
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup rejects pre-claim checkout replacement inodes and preserves all unrelated state", async (t) => {
+  for (const replacement of ["directory", "symlink", "path-reuse"] as const) {
+    await t.test(replacement, async () => {
+      const repo = mkdtempSync(join(tmpdir(), `pi-wt-original-inode-${replacement}-`));
+      const external = mkdtempSync(join(tmpdir(), `pi-wt-original-inode-${replacement}-external-`));
+      const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+      try {
+        git("init", "-q");
+        git("config", "user.email", "t@t.t");
+        git("config", "user.name", "t");
+        writeFileSync(join(repo, "file.txt"), "base\n");
+        git("add", ".");
+        git("commit", "-q", "-m", "init");
+
+        const original = await createWorktreeLive(repo, `original-inode-${replacement}`);
+        assert.equal(original.isolated, true);
+        const displaced = `${original.cwd}-displaced`;
+        const gitPointer = readFileSync(join(original.cwd, ".git"), "utf8");
+        const registrationBefore = git("worktree", "list", "--porcelain");
+        const markerBefore = readFileSync(
+          join(original.cleanupMetadata?.gitDir ?? "", "pi-dynamic-workflows-registration"),
+          "utf8",
+        );
+        renameSync(original.cwd, displaced);
+
+        if (replacement === "symlink") {
+          writeFileSync(join(external, ".git"), gitPointer);
+          writeFileSync(join(external, "sentinel-private-fragment.txt"), "symlink sentinel survives\n");
+          symlinkSync(external, original.cwd, "dir");
+        } else {
+          const candidate = replacement === "path-reuse" ? join(external, "candidate") : original.cwd;
+          mkdirSync(candidate);
+          writeFileSync(join(candidate, ".git"), gitPointer);
+          writeFileSync(join(candidate, "sentinel-private-fragment.txt"), `${replacement} sentinel survives\n`);
+          if (replacement === "path-reuse") renameSync(candidate, original.cwd);
+        }
+
+        const roundTripped = JSON.parse(JSON.stringify(structuredClone(original))) as Worktree;
+        const failures = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(roundTripped);
+        const sentinelRoot = replacement === "symlink" ? external : original.cwd;
+        assert.equal(
+          readFileSync(join(sentinelRoot, "sentinel-private-fragment.txt"), "utf8"),
+          `${replacement === "symlink" ? "symlink" : replacement} sentinel survives\n`,
+        );
+        assert.equal(git("worktree", "list", "--porcelain"), registrationBefore, "registration remains untouched");
+        assert.equal(
+          readFileSync(join(original.cleanupMetadata?.gitDir ?? "", "pi-dynamic-workflows-registration"), "utf8"),
+          markerBefore,
+          "trusted registration marker remains untouched",
+        );
+        assert.match(git("branch", "--list", original.branch ?? ""), /original-inode/);
+        assert.equal(failures.length, 1);
+        assert.equal(failures[0]?.stage, "identity_verification");
+        const diagnostics = JSON.stringify(failures);
+        for (const secret of [
+          repo,
+          original.cwd,
+          external,
+          basename(repo),
+          basename(external),
+          "sentinel-private-fragment",
+        ]) {
+          assert.equal(diagnostics.includes(secret), false, `diagnostics omit path or path fragment: ${secret}`);
+        }
+        assert.ok((failures[0]?.message.length ?? Infinity) <= 1024);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+        rmSync(external, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("cleanup restores a same-path same-branch replacement raced in after identity verification", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-raced-replacement-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "raced-same-path-same-branch");
+    assert.equal(original.isolated, true);
+    const operations = createWorktreeOperationsForTesting({
+      afterIdentityVerification() {
+        git("worktree", "remove", "--force", original.cwd);
+        git("branch", "-D", original.branch ?? "");
+        git("worktree", "add", "-b", original.branch ?? "", original.cwd, "HEAD");
+        writeFileSync(join(original.cwd, "replacement.txt"), "uncommitted replacement must survive\n");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(readFileSync(join(original.cwd, "replacement.txt"), "utf8"), "uncommitted replacement must survive\n");
+    assert.match(git("branch", "--list", original.branch ?? "").toString(), /raced-same-path-same-branch/);
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.match(failures[0]?.message ?? "", /changed|claim|identity/i);
+
+    git("worktree", "remove", "--force", original.cwd);
+    git("branch", "-D", original.branch ?? "");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup restores a replacement captured by the atomic claim when the original path remains empty", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-claim-captured-restore-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let original: Worktree | undefined;
+  const displacedPath = join(repo, "displaced-original");
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    original = await createWorktreeLive(repo, "captured-replacement-restored");
+    assert.equal(original.isolated, true);
+    const operations = createWorktreeOperationsForTesting({
+      beforeDirectoryClaim(_worktree, kind, sourcePath) {
+        if (kind !== "checkout") return;
+        renameSync(sourcePath, displacedPath);
+        mkdirSync(sourcePath);
+        writeFileSync(join(sourcePath, "captured-replacement.txt"), "restore me\n");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(readFileSync(join(original.cwd, "captured-replacement.txt"), "utf8"), "restore me\n");
+    assert.equal(failures.length, 1);
+    assert.match(failures[0]?.message ?? "", /cleanup failed.*identity_verification.*recovery ID/i);
+  } finally {
+    if (original?.isolated) {
+      rmSync(original.cwd, { recursive: true, force: true });
+      if (existsSync(displacedPath)) renameSync(displacedPath, original.cwd);
+      await removeWorktree(original);
+    }
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup preserves a captured replacement in quarantine when the original path becomes occupied", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-claim-captured-occupied-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let original: Worktree | undefined;
+  const displacedPath = join(repo, "displaced-original");
+  let quarantineRoot = "";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    original = await createWorktreeLive(repo, "captured-replacement-preserved");
+    assert.equal(original.isolated, true);
+    quarantineRoot = gitCommonRoot(repo);
+    const operations = createWorktreeOperationsForTesting({
+      beforeDirectoryClaim(_worktree, kind, sourcePath) {
+        if (kind !== "checkout") return;
+        renameSync(sourcePath, displacedPath);
+        mkdirSync(sourcePath);
+        writeFileSync(join(sourcePath, "captured-replacement.txt"), "preserve me\n");
+      },
+      afterDirectoryRename(_worktree, kind, sourcePath) {
+        if (kind !== "checkout") return;
+        mkdirSync(sourcePath);
+        writeFileSync(join(sourcePath, "occupied-original.txt"), "do not replace me\n");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(readFileSync(join(original.cwd, "occupied-original.txt"), "utf8"), "do not replace me\n");
+    const quarantines = directCleanupClaimPaths(repo, "checkout");
+    assert.equal(quarantines.length, 1);
+    assert.equal(readFileSync(join(quarantines[0] ?? "", "captured-replacement.txt"), "utf8"), "preserve me\n");
+    assert.equal(failures.length, 1);
+    assert.match(failures[0]?.message ?? "", /cleanup failed.*identity_verification.*recovery ID/i);
+    assert.equal((failures[0]?.message ?? "").includes(quarantines[0] ?? ""), false, "nonce path is not diagnosed");
+    const serializedFailures = JSON.stringify(failures);
+    assert.equal(serializedFailures.includes(original.cleanupMetadata?.registrationMarker ?? "missing-marker"), false);
+    assert.equal(serializedFailures.includes("cleanupMetadata"), false);
+  } finally {
+    if (original?.isolated) {
+      rmSync(original.cwd, { recursive: true, force: true });
+      for (const claim of directCleanupClaimPaths(repo, "checkout")) rmSync(claim, { recursive: true, force: true });
+      for (const record of directCleanupPendingRecords(repo)) rmSync(join(quarantineRoot, record), { force: true });
+      if (existsSync(displacedPath)) renameSync(displacedPath, original.cwd);
+      await removeWorktree(original);
+    }
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup removes only the claimed original when a replacement appears at its former path", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-post-claim-replacement-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  const replacementBranch = "pi/wf/post-claim-replacement";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "claimed-original");
+    assert.equal(original.isolated, true);
+    writeFileSync(join(original.cwd, "original-uncommitted.txt"), "claimed original\n");
+    const operations = createWorktreeOperationsForTesting({
+      afterWorktreeClaim() {
+        git("worktree", "add", "-b", replacementBranch, original.cwd, "HEAD");
+        writeFileSync(join(original.cwd, "replacement.txt"), "uncommitted replacement must survive\n");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.deepEqual(failures, []);
+    assert.equal(readFileSync(join(original.cwd, "replacement.txt"), "utf8"), "uncommitted replacement must survive\n");
+    assert.match(git("branch", "--list", replacementBranch).toString(), /post-claim-replacement/);
+    assert.equal(
+      git("branch", "--list", original.branch ?? "")
+        .toString()
+        .trim(),
+      "",
+      "only original branch removed",
+    );
+
+    git("worktree", "remove", "--force", original.cwd);
+    git("branch", "-D", replacementBranch);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup never deletes a replacement raced into the private quarantine after claim", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-quarantine-replacement-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  const replacementBranch = "pi/wf/quarantine-replacement";
+  let replacementPath = "";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "quarantine-race-original");
+    assert.equal(original.isolated, true);
+    const operations = createWorktreeOperationsForTesting({
+      afterWorktreeClaim() {
+        const candidates = directCleanupClaimPaths(repo, "checkout");
+        assert.equal(candidates.length, 1, "the claimed inode is in one private quarantine");
+        replacementPath = candidates[0] ?? "";
+        const displaced = `${replacementPath}-displaced`;
+        renameSync(replacementPath, displaced);
+        git("worktree", "add", "-b", replacementBranch, replacementPath, "HEAD");
+        writeFileSync(join(replacementPath, "replacement.txt"), "quarantine replacement must survive\n");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(
+      readFileSync(join(replacementPath, "replacement.txt"), "utf8"),
+      "quarantine replacement must survive\n",
+    );
+    assert.match(git("branch", "--list", replacementBranch).toString(), /quarantine-replacement/);
+    assert.equal(failures.length, 0);
+
+    git("worktree", "remove", "--force", replacementPath);
+    git("branch", "-D", replacementBranch);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup ignores a symlink at the obsolete checkout quarantine root", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-checkout-quarantine-symlink-"));
+  const externalRoot = mkdtempSync(join(tmpdir(), "pi-wt-checkout-quarantine-external-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const original = await createWorktreeLive(repo, "checkout-quarantine-symlink");
+    writeFileSync(join(externalRoot, "sentinel.txt"), "external contents survive\n");
+    const quarantineRoot = checkoutQuarantineRoot(repo);
+    symlinkSync(externalRoot, quarantineRoot, "dir");
+
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(original), []);
+    assert.equal(existsSync(original.cwd), false);
+    assert.deepEqual(readdirSync(externalRoot), ["sentinel.txt"], "cleanup makes no external writes or deletions");
+    assert.equal(readFileSync(join(externalRoot, "sentinel.txt"), "utf8"), "external contents survive\n");
+    rmSync(quarantineRoot);
+    assertNoCreationArtifacts(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(externalRoot, { recursive: true, force: true });
+  }
+});
+
+test("cleanup ignores a symlink at the obsolete registration quarantine root", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-registration-quarantine-symlink-"));
+  const externalRoot = mkdtempSync(join(tmpdir(), "pi-wt-registration-quarantine-external-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const original = await createWorktreeLive(repo, "registration-quarantine-symlink");
+    writeFileSync(join(externalRoot, "sentinel.txt"), "external contents survive\n");
+    const quarantineRoot = join(original.cleanupMetadata?.gitCommonRoot ?? "", "pi-dynamic-workflows-cleanup");
+    symlinkSync(externalRoot, quarantineRoot, "dir");
+
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(original), []);
+    assert.equal(existsSync(original.cwd), false);
+    assert.deepEqual(readdirSync(externalRoot), ["sentinel.txt"], "cleanup makes no external writes or deletions");
+    assert.equal(readFileSync(join(externalRoot, "sentinel.txt"), "utf8"), "external contents survive\n");
+    rmSync(quarantineRoot);
+    assertNoCreationArtifacts(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(externalRoot, { recursive: true, force: true });
+  }
+});
+
+test("cleanup transaction restores checkout, registration, and branch after each claim stage", async () => {
+  const stages = ["checkout", "branch", "registration"] as const;
+  for (const stage of stages) {
+    const repo = mkdtempSync(join(tmpdir(), `pi-wt-rollback-${stage}-`));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.t");
+      git("config", "user.name", "t");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+
+      const original = await createWorktreeLive(repo, `rollback-${stage}`);
+      assert.equal(original.isolated, true);
+      writeFileSync(join(original.cwd, "uncommitted.txt"), `${stage} survives\n`);
+      const fail = () => {
+        throw new Error(`injected failure after ${stage} claim`);
+      };
+      const operations = createWorktreeOperationsForTesting({
+        ...(stage === "checkout" ? { afterCheckoutClaim: fail } : {}),
+        ...(stage === "branch" ? { afterBranchClaim: fail } : {}),
+        ...(stage === "registration" ? { afterRegistrationClaim: fail } : {}),
+      });
+
+      const failures = await operations.removeWorktree(original);
+
+      assert.equal(failures.length, 1);
+      assert.match(failures[0]?.message ?? "", new RegExp(`after ${stage} claim`, "i"));
+      assert.ok((failures[0]?.message.length ?? Infinity) <= 1024);
+      assert.equal(readFileSync(join(original.cwd, "uncommitted.txt"), "utf8"), `${stage} survives\n`);
+      assert.equal(realpathSync(original.cwd), original.cwd, "the checkout returns to its exact original cwd");
+      assert.equal(realpathSync(original.cleanupMetadata?.gitDir ?? ""), original.cleanupMetadata?.gitDir);
+      assert.equal(
+        git("rev-parse", "--verify", original.branchRef ?? "")
+          .toString()
+          .trim().length,
+        40,
+      );
+      assert.equal(
+        execFileSync("git", ["-C", original.cwd, "status", "--porcelain"], { encoding: "utf8" }).trim(),
+        "?? uncommitted.txt",
+      );
+      assertCleanupQuarantinesEmpty(repo);
+
+      assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(original), []);
+      assertCleanupQuarantinesEmpty(repo);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }
+});
+
+test("registration-content cleanup failure restores every uncommitted checkout file and remains retryable", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-registration-content-failure-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let failRegistrationCleanup = true;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "registration-content-failure");
+    assert.equal(original.isolated, true);
+    writeFileSync(join(original.cwd, "file.txt"), "tracked modification survives\n");
+    mkdirSync(join(original.cwd, "nested"));
+    writeFileSync(join(original.cwd, "nested", "first.txt"), "first untracked file\n");
+    writeFileSync(join(original.cwd, "nested", "second.txt"), "second untracked file\n");
+    const expectedStatus = execFileSync("git", ["-C", original.cwd, "status", "--porcelain", "--untracked-files=all"], {
+      encoding: "utf8",
+    });
+    const expectedRegistrations = git("worktree", "list", "--porcelain").toString();
+    const operations = createWorktreeOperationsForTesting({
+      beforeClaimedContentsCleanup(_worktree, kind) {
+        if (kind !== "registration" || !failRegistrationCleanup) return;
+        failRegistrationCleanup = false;
+        throw new Error("injected registration-content cleanup failure");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "worktree_remove");
+    assert.match(failures[0]?.message ?? "", /injected registration-content cleanup failure/i);
+    assert.ok((failures[0]?.message.length ?? Infinity) <= 1024);
+    assert.equal(readFileSync(join(original.cwd, "file.txt"), "utf8"), "tracked modification survives\n");
+    assert.equal(readFileSync(join(original.cwd, "nested", "first.txt"), "utf8"), "first untracked file\n");
+    assert.equal(readFileSync(join(original.cwd, "nested", "second.txt"), "utf8"), "second untracked file\n");
+    assert.equal(
+      execFileSync("git", ["-C", original.cwd, "status", "--porcelain", "--untracked-files=all"], {
+        encoding: "utf8",
+      }),
+      expectedStatus,
+    );
+    assert.equal(git("worktree", "list", "--porcelain").toString(), expectedRegistrations);
+    assert.equal(
+      git("rev-parse", "--verify", original.branchRef ?? "")
+        .toString()
+        .trim().length,
+      40,
+    );
+    assert.equal(
+      git("for-each-ref", "--format=%(refname)", "refs/pi-dynamic-workflows/cleanup").toString().trim(),
+      "",
+      "rollback removes the deterministic backup ref",
+    );
+    assertCleanupQuarantinesEmpty(repo);
+
+    assert.deepEqual(await operations.removeWorktree(original), [], "cleanup succeeds on deterministic retry");
+    assertCleanupQuarantinesEmpty(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("partial claimed-directory deletion resumes by deterministic identity", async () => {
+  for (const failingKind of ["registration", "checkout"] as const) {
+    const repo = mkdtempSync(join(tmpdir(), `pi-wt-partial-${failingKind}-`));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+    let injectFailure = true;
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.t");
+      git("config", "user.name", "t");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+
+      const original = await createWorktreeLive(repo, `partial-${failingKind}`);
+      assert.equal(original.isolated, true);
+      writeFileSync(join(original.cwd, "one.txt"), "one\n");
+      writeFileSync(join(original.cwd, "two.txt"), "two\n");
+      const operations = createWorktreeOperationsForTesting({
+        afterClaimedEntryRemoval(_worktree, kind, removedEntries) {
+          if (kind !== failingKind || removedEntries !== 1 || !injectFailure) return;
+          injectFailure = false;
+          throw new Error(`injected partial ${kind} content-deletion failure`);
+        },
+      });
+
+      const first = await operations.removeWorktree(original);
+
+      assert.equal(first.length, 1);
+      assert.equal(first[0]?.stage, "worktree_remove");
+      assert.match(first[0]?.message ?? "", new RegExp(`partial ${failingKind} content-deletion failure`, "i"));
+      assert.ok((first[0]?.message.length ?? Infinity) <= 1024);
+      assert.equal(existsSync(original.cwd), false, "the original mutable checkout pathname is not restored");
+      assert.equal(existsSync(original.cleanupMetadata?.gitDir ?? ""), false, "registration stays claimed or is gone");
+      assert.equal(
+        git("branch", "--list", original.branch ?? "")
+          .toString()
+          .trim(),
+        "",
+      );
+      assert.notEqual(
+        git("for-each-ref", "--format=%(refname)", "refs/pi-dynamic-workflows/cleanup").toString().trim(),
+        "",
+        "the backup ref preserves branch reachability while exact claims are pending",
+      );
+      assert.equal(
+        directCleanupPendingRecords(repo).length > 0,
+        true,
+        "deterministic pending identity metadata survives the partial deletion",
+      );
+
+      assert.deepEqual(await operations.removeWorktree(original), [], "the next release resumes exact pending claims");
+      assert.equal(existsSync(original.cwd), false);
+      assert.equal(existsSync(original.cleanupMetadata?.gitDir ?? ""), false);
+      assert.equal(git("branch", "--list", "pi/wf/*").toString().trim(), "");
+      assert.equal(
+        git("for-each-ref", "--format=%(refname)", "refs/pi-dynamic-workflows/cleanup").toString().trim(),
+        "",
+      );
+      assert.equal(
+        git("worktree", "list", "--porcelain")
+          .toString()
+          .split("\n")
+          .filter((line) => line.startsWith("worktree ")).length,
+        1,
+      );
+      assertCleanupQuarantinesEmpty(repo);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }
+});
+
+test("permanent partial deletion failure is one bounded attempt per release", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-partial-permanent-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let attempts = 0;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const original = await createWorktreeLive(repo, "partial-permanent");
+    const operations = createWorktreeOperationsForTesting({
+      afterClaimedEntryRemoval(_worktree, kind, removedEntries) {
+        if (kind !== "registration" || removedEntries !== 1) return;
+        attempts++;
+        throw new Error("permanent partial deletion failure");
+      },
+    });
+
+    const first = await operations.removeWorktree(original);
+    const second = await operations.removeWorktree(original);
+
+    assert.equal(attempts, 2, "each release performs one bounded resume attempt without spinning");
+    for (const failures of [first, second]) {
+      assert.equal(failures.length, 1);
+      assert.ok((failures[0]?.message.length ?? Infinity) <= 1024);
+    }
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("final backup-ref deletion failure leaves a retryable private ref after checkout cleanup", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-backup-delete-retry-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let failDeletion = true;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "backup-delete-retry");
+    writeFileSync(join(original.cwd, "agent-commit.txt"), "reachable after failed finalization\n");
+    execFileSync("git", ["-C", original.cwd, "add", "."], { stdio: "pipe" });
+    execFileSync("git", ["-C", original.cwd, "commit", "-q", "-m", "agent commit"], { stdio: "pipe" });
+    const claimedOid = execFileSync("git", ["-C", original.cwd, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+    const operations = createWorktreeOperationsForTesting({
+      beforeClaimedBranchDelete() {
+        if (!failDeletion) return;
+        failDeletion = false;
+        throw new Error("injected final backup-ref deletion failure");
+      },
+    });
+
+    const firstFailures = await operations.removeWorktree(original);
+    assert.equal(firstFailures.length, 1);
+    assert.equal(firstFailures[0]?.stage, "branch_delete");
+    assert.match(firstFailures[0]?.message ?? "", /final backup-ref deletion failure/i);
+    assert.match(firstFailures[0]?.message ?? "", /preserved.*internal recovery ref|internal recovery ref.*preserved/i);
+    assert.equal((firstFailures[0]?.message ?? "").includes("refs/pi-dynamic-workflows/cleanup"), false);
+    assert.equal(existsSync(original.cwd), false, "checkout cleanup completed before final ref deletion");
+    assert.equal(existsSync(original.cleanupMetadata?.gitDir ?? ""), false, "registration cleanup completed");
+    assert.equal(
+      git("branch", "--list", original.branch ?? "")
+        .toString()
+        .trim(),
+      "",
+    );
+    assert.equal(
+      git("worktree", "list", "--porcelain")
+        .toString()
+        .match(/^worktree /gm)?.length,
+      1,
+    );
+    const backupRefs = git("for-each-ref", "--format=%(refname) %(objectname)", "refs/pi-dynamic-workflows/cleanup")
+      .toString()
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    assert.equal(backupRefs.length, 1);
+    assert.equal(backupRefs[0]?.split(" ")[1], claimedOid, "the original commit remains reachable under the backup");
+    assert.equal(git("cat-file", "-t", claimedOid).toString().trim(), "commit");
+
+    const roundTripped = JSON.parse(JSON.stringify(original)) as Worktree;
+    assert.deepEqual(await operations.removeWorktree(roundTripped), []);
+    assert.deepEqual(await operations.removeWorktree(original), [], "successful retry is idempotent");
+    assert.equal(
+      git("for-each-ref", "--format=%(refname)", "refs/pi-dynamic-workflows/cleanup").toString().trim(),
+      "",
+      "the exact pending backup is removed without leaking refs",
+    );
+    assertCleanupQuarantinesEmpty(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("a competing branch restoration cannot strand the claimed commit without its private backup", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-competing-restore-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "competing-restore");
+    writeFileSync(join(original.cwd, "agent-commit.txt"), "original claimed commit\n");
+    execFileSync("git", ["-C", original.cwd, "add", "."], { stdio: "pipe" });
+    execFileSync("git", ["-C", original.cwd, "commit", "-q", "-m", "agent commit"], { stdio: "pipe" });
+    const claimedOid = git("rev-parse", original.branchRef ?? "")
+      .toString()
+      .trim();
+    const competingOid = git("commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "competing commit").toString().trim();
+    const operations = createWorktreeOperationsForTesting({
+      afterBranchClaim() {
+        git("update-ref", original.branchRef ?? "", competingOid);
+        throw new Error("injected failure with competing branch restoration");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(failures.length, 1);
+    assert.equal(
+      git("rev-parse", original.branchRef ?? "")
+        .toString()
+        .trim(),
+      competingOid,
+    );
+    const backupOids = git("for-each-ref", "--format=%(objectname)", "refs/pi-dynamic-workflows/cleanup")
+      .toString()
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    assert.deepEqual(backupOids, [claimedOid]);
+    assert.equal(git("cat-file", "-t", claimedOid).toString().trim(), "commit");
+    assert.match(failures[0]?.message ?? "", /preserved under an internal recovery ref/i);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup rollback preserves both claimed and occupying checkout paths with redacted diagnostics", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-rollback-occupied-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "rollback-occupied");
+    assert.equal(original.isolated, true);
+    writeFileSync(join(original.cwd, "claimed.txt"), "claimed checkout\n");
+    const operations = createWorktreeOperationsForTesting({
+      afterBranchClaim() {
+        mkdirSync(original.cwd);
+        writeFileSync(join(original.cwd, "occupant.txt"), "occupying checkout path\n");
+        throw new Error("injected occupied rollback");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(readFileSync(join(original.cwd, "occupant.txt"), "utf8"), "occupying checkout path\n");
+    const quarantines = directCleanupClaimPaths(repo, "checkout");
+    assert.equal(quarantines.length, 1);
+    assert.equal(readFileSync(join(quarantines[0] ?? "", "claimed.txt"), "utf8"), "claimed checkout\n");
+    assert.equal((failures[0]?.message ?? "").includes(quarantines[0] ?? ""), false);
+    assert.match(failures[0]?.message ?? "", /occupied.*preserved|preserved.*occupied/i);
+    assert.match(git("branch", "--list", original.branch ?? "").toString(), /rollback-occupied/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("branch cleanup fails closed when the temporary branch becomes a symbolic ref", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-symref-race-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let original: Worktree | undefined;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const mainBranch = git("branch", "--show-current").toString().trim();
+    const mainRef = `refs/heads/${mainBranch}`;
+    const mainOid = git("rev-parse", mainRef).toString().trim();
+    original = await createWorktreeLive(repo, "symref-race");
+    assert.equal(original.isolated, true);
+    const operations = createWorktreeOperationsForTesting({
+      afterBranchRefRead() {
+        git("symbolic-ref", original?.branchRef ?? "", mainRef);
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(git("rev-parse", mainRef).toString().trim(), mainOid, "the symbolic-ref target is untouched");
+    assert.equal(
+      git("symbolic-ref", original.branchRef ?? "")
+        .toString()
+        .trim(),
+      mainRef,
+    );
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.match(failures[0]?.message ?? "", /symbolic|direct|branch ref changed/i);
+    assert.equal(readFileSync(join(original.cwd, "file.txt"), "utf8"), "base\n", "checkout claim is rolled back");
+    assert.equal(realpathSync(original.cleanupMetadata?.gitDir ?? ""), original.cleanupMetadata?.gitDir);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("branch cleanup refuses a branch already checked out by another registered worktree", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-duplicate-branch-before-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  const otherPath = join(repo, "other-checkout");
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "duplicate-branch-before");
+    assert.equal(original.isolated, true);
+    git("worktree", "add", "--force", otherPath, original.branch ?? "");
+    writeFileSync(join(otherPath, "other.txt"), "reachable commit\n");
+    execFileSync("git", ["-C", otherPath, "add", "."], { stdio: "pipe" });
+    execFileSync("git", ["-C", otherPath, "commit", "-q", "-m", "other checkout commit"], { stdio: "pipe" });
+    const otherOid = execFileSync("git", ["-C", otherPath, "rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+
+    const failures = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(original);
+
+    assert.equal(
+      execFileSync("git", ["-C", otherPath, "symbolic-ref", "HEAD"], { encoding: "utf8" }).trim(),
+      original.branchRef,
+    );
+    assert.equal(
+      git("rev-parse", original.branchRef ?? "")
+        .toString()
+        .trim(),
+      otherOid,
+    );
+    assert.equal(git("cat-file", "-t", otherOid).toString().trim(), "commit");
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.match(failures[0]?.message ?? "", /cleanup failed.*identity_verification.*recovery ID/i);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("branch cleanup restores its claim when another checkout races in during the claim", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-duplicate-branch-during-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  const otherPath = join(repo, "raced-checkout");
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "duplicate-branch-during");
+    assert.equal(original.isolated, true);
+    const branchOid = git("rev-parse", original.branchRef ?? "")
+      .toString()
+      .trim();
+    const operations = createWorktreeOperationsForTesting({
+      afterBranchRefRead() {
+        git("worktree", "add", "--force", otherPath, original.branch ?? "");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(
+      execFileSync("git", ["-C", otherPath, "symbolic-ref", "HEAD"], { encoding: "utf8" }).trim(),
+      original.branchRef,
+    );
+    assert.equal(
+      git("rev-parse", original.branchRef ?? "")
+        .toString()
+        .trim(),
+      branchOid,
+    );
+    assert.equal(git("cat-file", "-t", branchOid).toString().trim(), "commit");
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.match(failures[0]?.message ?? "", /another|other|registered worktree|checked out/i);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("branch cleanup compare-and-delete preserves a ref advanced after verification", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-ref-race-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let advancedOid = "";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "compare-delete-race");
+    assert.equal(original.isolated, true);
+    const hooks = {
+      afterWorktreeClaim() {},
+      afterBranchRefRead() {
+        advancedOid = git("commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "replacement ref commit").toString().trim();
+        git("update-ref", original.branchRef ?? "", advancedOid);
+      },
+    };
+    const operations = createWorktreeOperationsForTesting(hooks);
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(
+      git("rev-parse", "--verify", original.branchRef ?? "")
+        .toString()
+        .trim(),
+      advancedOid,
+    );
+    assert.equal(git("cat-file", "-t", advancedOid).toString().trim(), "commit");
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.match(failures[0]?.message ?? "", /branch ref changed|claim/i);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("branch cleanup preserves the same ref recreated and checked out after the atomic claim", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-ref-recreated-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  const replacementPath = join(repo, "replacement-checkout");
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "recreated-ref");
+    assert.equal(original.isolated, true);
+    const operations = createWorktreeOperationsForTesting({
+      afterWorktreeClaim() {
+        git("worktree", "add", "-b", original.branch ?? "", replacementPath, "HEAD");
+        writeFileSync(join(replacementPath, "replacement.txt"), "recreated branch checkout survives\n");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.deepEqual(failures, []);
+    assert.equal(
+      readFileSync(join(replacementPath, "replacement.txt"), "utf8"),
+      "recreated branch checkout survives\n",
+    );
+    assert.match(git("branch", "--list", original.branch ?? "").toString(), /recreated-ref/);
+
+    git("worktree", "remove", "--force", replacementPath);
+    git("branch", "-D", original.branch ?? "");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("removeWorktree cleans an initialized-submodule checkout without git worktree move", async () => {
+  const childRepo = mkdtempSync(join(tmpdir(), "pi-wt-submodule-child-"));
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-submodule-parent-"));
+  const childGit = (...args: string[]) => execFileSync("git", ["-C", childRepo, ...args], { stdio: "pipe" });
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    childGit("init", "-q");
+    childGit("config", "user.email", "t@t.t");
+    childGit("config", "user.name", "t");
+    writeFileSync(join(childRepo, "child.txt"), "child\n");
+    childGit("add", ".");
+    childGit("commit", "-q", "-m", "child init");
+
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    execFileSync(
+      "git",
+      ["-c", "protocol.file.allow=always", "-C", repo, "submodule", "add", "-q", childRepo, "modules/child"],
+      { stdio: "pipe" },
+    );
+    git("commit", "-q", "-am", "add submodule");
+
+    const worktree = await createWorktreeLive(repo, "initialized-submodule");
+    assert.equal(worktree.isolated, true);
+    assert.equal(join(worktree.cwd, ".."), gitCommonRoot(repo));
+    assert.match(worktree.cwd, /pi-workflow-checkout-/);
+    execFileSync(
+      "git",
+      ["-c", "protocol.file.allow=always", "-C", worktree.cwd, "submodule", "update", "--init", "--recursive"],
+      { stdio: "pipe" },
+    );
+    assert.equal(readFileSync(join(worktree.cwd, "modules", "child", "child.txt"), "utf8"), "child\n");
+
+    const failures = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree);
+
+    assert.deepEqual(failures, []);
+    assert.equal(existsSync(worktree.cwd), false, "the original checkout path is gone");
+    assert.equal(
+      git("branch", "--list", worktree.branch ?? "")
+        .toString()
+        .trim(),
+      "",
+    );
+    assert.equal(
+      git("worktree", "list", "--porcelain")
+        .toString()
+        .split("\n")
+        .filter((line) => line.startsWith("worktree ")).length,
+      1,
+    );
+    assert.equal(
+      git("for-each-ref", "--format=%(refname)", "refs/pi-dynamic-workflows/cleanup").toString().trim(),
+      "",
+      "the private backup ref is removed",
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(childRepo, { recursive: true, force: true });
+  }
+});
+
+test("missing-checkout cleanup preserves a replacement raced in before stale-registration claim", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-missing-raced-replacement-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "missing-raced-replacement");
+    assert.equal(original.isolated, true);
+    rmSync(original.cwd, { recursive: true, force: true });
+    const operations = createWorktreeOperationsForTesting({
+      afterIdentityVerification() {
+        git("worktree", "remove", "--force", original.cwd);
+        git("branch", "-D", original.branch ?? "");
+        git("worktree", "add", "-b", original.branch ?? "", original.cwd, "HEAD");
+        writeFileSync(join(original.cwd, "replacement.txt"), "missing-path replacement must survive\n");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(
+      readFileSync(join(original.cwd, "replacement.txt"), "utf8"),
+      "missing-path replacement must survive\n",
+    );
+    assert.match(git("branch", "--list", original.branch ?? "").toString(), /missing-raced-replacement/);
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+
+    git("worktree", "remove", "--force", original.cwd);
+    git("branch", "-D", original.branch ?? "");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("missing-checkout cleanup never deletes a replacement raced into registration quarantine", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-registration-quarantine-race-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let replacementPath = "";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "registration-quarantine-race");
+    assert.equal(original.isolated, true);
+    rmSync(original.cwd, { recursive: true, force: true });
+    const operations = createWorktreeOperationsForTesting({
+      afterRegistrationClaim() {
+        const candidates = directCleanupClaimPaths(repo, "registration");
+        assert.equal(candidates.length, 1);
+        replacementPath = candidates[0] ?? "";
+        renameSync(replacementPath, `${replacementPath}-displaced`);
+        mkdirSync(replacementPath);
+        writeFileSync(join(replacementPath, "replacement.txt"), "registration replacement survives\n");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.deepEqual(failures, []);
+    assert.equal(readFileSync(join(replacementPath, "replacement.txt"), "utf8"), "registration replacement survives\n");
+    assert.equal(
+      git("branch", "--list", original.branch ?? "")
+        .toString()
+        .trim(),
+      "",
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("missing-checkout cleanup fails closed when a replacement appears after registration claim", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-missing-post-claim-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  const replacementBranch = "pi/wf/missing-post-claim-replacement";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "missing-post-claim-original");
+    assert.equal(original.isolated, true);
+    rmSync(original.cwd, { recursive: true, force: true });
+    const operations = createWorktreeOperationsForTesting({
+      afterRegistrationClaim() {
+        git("worktree", "add", "-b", replacementBranch, original.cwd, "HEAD");
+        writeFileSync(join(original.cwd, "replacement.txt"), "post-claim replacement must survive\n");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(readFileSync(join(original.cwd, "replacement.txt"), "utf8"), "post-claim replacement must survive\n");
+    assert.match(git("branch", "--list", replacementBranch).toString(), /missing-post-claim-replacement/);
+    assert.match(git("branch", "--list", original.branch ?? "").toString(), /missing-post-claim-original/);
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.match(failures[0]?.message ?? "", /replacement.*original path/i);
+
+    git("worktree", "remove", "--force", original.cwd);
+    git("branch", "-D", replacementBranch);
+    git("branch", "-D", original.branch ?? "");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup preserves a replacement worktree whose identity no longer matches", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-replaced-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "replacement-identity-original");
+    assert.equal(original.isolated, true);
+    git("worktree", "remove", "--force", original.cwd);
+    git("branch", "-D", original.branch ?? "");
+    git("worktree", "add", "-b", "pi/wf/unrelated-replacement", original.cwd, "HEAD");
+    writeFileSync(join(original.cwd, "unrelated.txt"), "must survive cleanup\n");
+
+    const failures = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(original);
+
+    assert.equal(existsSync(join(original.cwd, "unrelated.txt")), true, "replacement contents are preserved");
+    assert.match(git("branch", "--list", "pi/wf/unrelated-replacement").toString(), /unrelated-replacement/);
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.match(failures[0]?.message ?? "", /identity|branch ref/i);
+    assert.ok((failures[0]?.message.length ?? Infinity) <= 1024);
+
+    git("worktree", "remove", "--force", original.cwd);
+    git("branch", "-D", "pi/wf/unrelated-replacement");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("cleanup preserves a same-path same-branch replacement with a new Git registration", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-same-identity-replaced-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "same-path-same-branch");
+    assert.equal(original.isolated, true);
+    git("worktree", "remove", "--force", original.cwd);
+    git("branch", "-D", original.branch ?? "");
+    git("worktree", "add", "-b", original.branch ?? "", original.cwd, "HEAD");
+    writeFileSync(join(original.cwd, "replacement.txt"), "must survive cleanup\n");
+
+    const failures = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(original);
+
+    assert.equal(existsSync(join(original.cwd, "replacement.txt")), true, "replacement contents are preserved");
+    assert.match(git("branch", "--list", original.branch ?? "").toString(), /same-path-same-branch/);
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.ok((failures[0]?.message.length ?? Infinity) <= 1024);
+
+    git("worktree", "remove", "--force", original.cwd);
+    git("branch", "-D", original.branch ?? "");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("post-create canonicalization failure rolls back the directory, registration, and branch", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-finalize-"));
+  const baseline = activeCheckoutProofsForTesting().descriptorCount;
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  let created: Worktree | undefined;
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    created = await createWorktreeLive(repo, "canonicalization-failure", {
+      async canonicalizePath(path) {
+        if (path.includes("pi-workflow-checkout-")) throw new Error("injected canonicalization failure");
+        return realpathSync(path);
+      },
+    });
+
+    assert.equal(created.isolated, false);
+    assert.match(created.reason ?? "", /identity_finalization/);
+    assert.equal(activeCheckoutProofsForTesting().descriptorCount, baseline, "failed finalization leaks no fd");
+    const registrations = git("worktree", "list", "--porcelain").toString();
+    assert.equal(registrations.split("\n").filter((line) => line.startsWith("worktree ")).length, 1);
+    assert.equal(git("branch", "--list", "pi/wf/*").toString().trim(), "");
+    assert.equal(
+      readdirSync(gitCommonRoot(repo)).some((entry) => entry.startsWith("pi-workflow-checkout-")),
+      false,
+      "the exact Git-common-dir checkout is removed",
+    );
+  } finally {
+    if (created?.isolated) await removeWorktree(created);
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("low-level cleanup contains an unexpected failure after atomic claims begin", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-post-claim-failure-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { stdio: "pipe" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const original = await createWorktreeLive(repo, "post-claim-list-failure");
+    assert.equal(original.isolated, true);
+    rmSync(original.cwd, { recursive: true, force: true });
+    const operations = createWorktreeOperationsForTesting({
+      beforePostClaimRegistrationCheck() {
+        throw new Error("injected registeredWorktrees failure");
+      },
+    });
+
+    const failures = await operations.removeWorktree(original);
+
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "cleanup_dispatch");
+    assert.match(failures[0]?.message ?? "", /registeredWorktrees failure/);
+    assert.ok((failures[0]?.message.length ?? Infinity) <= 1024);
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }
@@ -141,6 +3771,704 @@ test("removeWorktree does not throw when git operations fail (corrupted metadata
 
     // Both git operations should fail silently — no throw from removeWorktree
     await assert.doesNotReject(removeWorktree(wt));
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("current cleanup claims ignore attacker-rebound legacy quarantine roots", async (t) => {
+  for (const targetKind of ["checkout", "registration"] as const) {
+    await t.test(targetKind, async () => {
+      const repo = mkdtempSync(join(tmpdir(), `pi-wt-old-root-swap-${targetKind}-`));
+      const external = mkdtempSync(join(tmpdir(), `pi-wt-old-root-swap-${targetKind}-external-`));
+      const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+      let oldRoot = "";
+      let displaced = "";
+      let observedExternalClaim = false;
+      try {
+        git("init", "-q");
+        git("config", "user.email", "t@t.t");
+        git("config", "user.name", "t");
+        writeFileSync(join(repo, "file.txt"), "base\n");
+        git("add", ".");
+        git("commit", "-q", "-m", "init");
+        writeFileSync(join(external, "probe.txt"), "external must survive\n");
+
+        const worktree = await createWorktreeLive(repo, `old-root-swap-${targetKind}`);
+        oldRoot = join(
+          gitCommonRoot(repo),
+          targetKind === "checkout" ? "pi-dynamic-workflows-checkout-cleanup" : "pi-dynamic-workflows-cleanup",
+        );
+        displaced = `${oldRoot}-trusted`;
+        const operations = createWorktreeOperationsForTesting({
+          beforeDirectoryClaim(_worktree, kind) {
+            if (kind !== targetKind) return;
+            if (!existsSync(oldRoot)) mkdirSync(oldRoot);
+            renameSync(oldRoot, displaced);
+            symlinkSync(external, oldRoot, "dir");
+          },
+          afterDirectoryRename(_worktree, kind) {
+            if (kind === targetKind)
+              observedExternalClaim = readdirSync(external).some((entry) => entry !== "probe.txt");
+          },
+        });
+        assert.deepEqual(await operations.removeWorktree(worktree), []);
+        assert.equal(observedExternalClaim, false, "cleanup never moves an owned inode through a rebound old root");
+        assert.equal(readFileSync(join(external, "probe.txt"), "utf8"), "external must survive\n");
+      } finally {
+        if (oldRoot && existsSync(oldRoot)) rmSync(oldRoot, { recursive: true, force: true });
+        if (displaced && existsSync(displaced)) renameSync(displaced, oldRoot);
+        rmSync(external, { recursive: true, force: true });
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("direct-child cleanup claim replacement collisions fail closed", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-direct-claim-collision-"));
+  const external = mkdtempSync(join(tmpdir(), "pi-wt-direct-claim-collision-external-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  let collisionPath = "";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    writeFileSync(join(external, "probe.txt"), "collision target survives\n");
+
+    const worktree = await createWorktreeLive(repo, "direct-claim-collision");
+    if (worktree.cleanupMetadata?.version !== 4) throw new Error("expected current cleanup metadata");
+    const metadata = worktree.cleanupMetadata;
+    const normalized = {
+      version: 4,
+      registrationMarker: metadata.registrationMarker,
+      repoRoot: metadata.repoRoot,
+      worktreePath: metadata.worktreePath,
+      checkoutIdentity: metadata.checkoutIdentity,
+      branch: metadata.branch,
+      branchRef: metadata.branchRef,
+      baseSha: metadata.baseSha,
+      gitCommonRoot: metadata.gitCommonRoot,
+      gitDir: metadata.gitDir,
+      checkoutProof: metadata.checkoutProof,
+      gitDirIdentity: metadata.gitDirIdentity,
+      ...(metadata.gitDirProof ? { gitDirProof: metadata.gitDirProof } : {}),
+    };
+    const digest = createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
+    collisionPath = join(gitCommonRoot(repo), `.pi-dynamic-workflows-checkout-cleanup-${digest}`);
+    const failures = await createWorktreeOperationsForTesting({
+      beforeDirectoryClaim(_candidate, kind) {
+        if (kind === "checkout") symlinkSync(external, collisionPath, "dir");
+      },
+    }).removeWorktree(worktree);
+
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0]?.stage, "identity_verification");
+    assert.equal(existsSync(worktree.cwd), true, "collision preserves the original checkout");
+    assert.equal(realpathSync(collisionPath), external, "collision is not replaced");
+    assert.equal(readFileSync(join(external, "probe.txt"), "utf8"), "collision target survives\n");
+    rmSync(collisionPath);
+    collisionPath = "";
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+  } finally {
+    if (collisionPath) rmSync(collisionPath, { force: true });
+    rmSync(external, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("unsupported Git-directory descriptors use a portable registration-local sentinel", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-portable-gitdir-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  const baseline = activeCheckoutProofsForTesting();
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    for (const code of ["EISDIR", "ENOTSUP"] as const) {
+      const worktree = await createWorktreeLive(repo, `portable-gitdir-${code}`, {
+        gitDirectoryDescriptorErrorCode: code,
+      } as never);
+      assert.equal(worktree.isolated, true, worktree.reason);
+      const metadata = worktree.cleanupMetadata as unknown as {
+        version: number;
+        gitDirProof?: { kind: string; fileName: string; token: string };
+      };
+      assert.equal(metadata.gitDirProof?.kind, "sentinel");
+      assert.match(metadata.gitDirProof?.fileName ?? "", /^\.pi-dynamic-workflows-registration-identity-/);
+      if (code === "ENOTSUP") {
+        const registry = new RetainedWorktreeRegistry();
+        const handle = registry.register(worktree);
+        await registry.release(handle);
+      } else {
+        assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+      }
+      assertNoCreationArtifacts(repo);
+    }
+    assert.deepEqual(activeCheckoutProofsForTesting(), baseline, "portable finalization and cleanup leak no handles");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("registration direct-child replacement collisions fail closed and restore the checkout claim", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-registration-claim-collision-"));
+  const external = mkdtempSync(join(tmpdir(), "pi-wt-registration-claim-collision-external-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  let collisionPath = "";
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    writeFileSync(join(external, "probe.txt"), "registration collision survives\n");
+    const worktree = await createWorktreeLive(repo, "registration-claim-collision");
+    if (worktree.cleanupMetadata?.version !== 4) throw new Error("expected current cleanup metadata");
+    const metadata = worktree.cleanupMetadata;
+    const normalized = {
+      version: 4,
+      registrationMarker: metadata.registrationMarker,
+      repoRoot: metadata.repoRoot,
+      worktreePath: metadata.worktreePath,
+      checkoutIdentity: metadata.checkoutIdentity,
+      branch: metadata.branch,
+      branchRef: metadata.branchRef,
+      baseSha: metadata.baseSha,
+      gitCommonRoot: metadata.gitCommonRoot,
+      gitDir: metadata.gitDir,
+      checkoutProof: metadata.checkoutProof,
+      gitDirIdentity: metadata.gitDirIdentity,
+      ...(metadata.gitDirProof ? { gitDirProof: metadata.gitDirProof } : {}),
+    };
+    const digest = createHash("sha256").update(JSON.stringify(normalized)).digest("hex");
+    collisionPath = join(gitCommonRoot(repo), `.pi-dynamic-workflows-registration-cleanup-${digest}`);
+    const failures = await createWorktreeOperationsForTesting({
+      beforeDirectoryClaim(_candidate, kind) {
+        if (kind === "registration") symlinkSync(external, collisionPath, "dir");
+      },
+    }).removeWorktree(worktree);
+    assert.equal(failures.length, 1);
+    assert.equal(existsSync(worktree.cwd), true, "the preclaimed checkout is restored without destructive work");
+    assert.equal(existsSync(metadata.gitDir), true, "the original registration is untouched");
+    assert.equal(realpathSync(collisionPath), external);
+    assert.equal(readFileSync(join(external, "probe.txt"), "utf8"), "registration collision survives\n");
+    rmSync(collisionPath);
+    collisionPath = "";
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+  } finally {
+    if (collisionPath) rmSync(collisionPath, { force: true });
+    rmSync(external, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("portable Git-registration sentinels reject directory and sentinel inode replacement", async (t) => {
+  for (const replacement of ["directory", "sentinel"] as const) {
+    await t.test(replacement, async () => {
+      const repo = mkdtempSync(join(tmpdir(), `pi-wt-portable-registration-${replacement}-`));
+      const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+      try {
+        git("init", "-q");
+        git("config", "user.email", "t@t.t");
+        git("config", "user.name", "t");
+        writeFileSync(join(repo, "file.txt"), "base\n");
+        git("add", ".");
+        git("commit", "-q", "-m", "init");
+        const worktree = await createWorktreeLive(repo, `portable-registration-${replacement}`, {
+          gitDirectoryDescriptorErrorCode: "EISDIR",
+        } as never);
+        if (worktree.cleanupMetadata?.version !== 4 || worktree.cleanupMetadata.gitDirProof?.kind !== "sentinel") {
+          throw new Error("expected portable Git registration proof");
+        }
+        const metadata = worktree.cleanupMetadata;
+        const displaced = `${metadata.gitDir}-displaced`;
+        if (replacement === "directory") {
+          renameSync(metadata.gitDir, displaced);
+          cpSync(displaced, metadata.gitDir, { recursive: true });
+          writeFileSync(join(metadata.gitDir, "replacement.txt"), "replacement survives\n");
+        } else {
+          const sentinelPath = join(metadata.gitDir, metadata.gitDirProof.fileName);
+          renameSync(sentinelPath, displaced);
+          cpSync(displaced, sentinelPath);
+        }
+        const failures = await createWorktreeOperationsForTesting({
+          simulateReusedGitDirIdentity: replacement === "directory",
+        }).removeWorktree(worktree);
+        assert.equal(failures.length, 1);
+        assert.equal(failures[0]?.stage, "identity_verification");
+        assert.equal(existsSync(worktree.cwd), true);
+        if (replacement === "directory") {
+          assert.equal(readFileSync(join(metadata.gitDir, "replacement.txt"), "utf8"), "replacement survives\n");
+          rmSync(metadata.gitDir, { recursive: true, force: true });
+          renameSync(displaced, metadata.gitDir);
+        } else {
+          rmSync(join(metadata.gitDir, metadata.gitDirProof.fileName));
+          renameSync(displaced, join(metadata.gitDir, metadata.gitDirProof.fileName));
+        }
+        assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(worktree), []);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("retained terminal cleanup disposes proofs after its final failed attempt", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-terminal-proof-disposal-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  const baseline = activeCheckoutProofsForTesting();
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+
+    const worktree = await createWorktreeLive(repo, "terminal-proof-disposal");
+    const registry = new RetainedWorktreeRegistry(
+      createWorktreeOperationsForTesting({
+        afterIdentityVerification() {
+          throw new Error("permanent cleanup failure");
+        },
+      }),
+    );
+    const handle = registry.register(worktree);
+    await registry.release(handle);
+    assert.notDeepEqual(activeCheckoutProofsForTesting(), baseline, "explicit failure preserves retry proofs");
+    await registry.cleanupAll();
+    assert.deepEqual(activeCheckoutProofsForTesting(), baseline, "terminal failure disposes every proof handle");
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("version-two cleanup captures an agent commit as its cleanup CAS target", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-v2-agent-commit-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const current = await createWorktreeLive(repo, "v2-agent-commit");
+    if (current.cleanupMetadata?.version !== 4) throw new Error("expected current metadata");
+    const {
+      checkoutIdentity: _a,
+      checkoutProof: _b,
+      gitDirIdentity: _c,
+      version: _d,
+      ...fields
+    } = current.cleanupMetadata;
+    const legacy = { ...current, cleanupMetadata: { version: 2 as const, ...fields } };
+    writeFileSync(
+      join(current.cleanupMetadata.gitDir, "pi-dynamic-workflows-registration"),
+      `${JSON.stringify(legacy.cleanupMetadata)}\n`,
+    );
+    writeFileSync(join(current.cwd, "agent.txt"), "committed by agent\n");
+    execFileSync("git", ["-C", current.cwd, "add", "."]);
+    execFileSync("git", ["-C", current.cwd, "commit", "-q", "-m", "agent commit"]);
+
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(JSON.parse(JSON.stringify(legacy))), []);
+    assertNoCreationArtifacts(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("version-three cleanup upgrades exact same-process identities across clone formats and proof modes", async (t) => {
+  for (const mode of ["descriptor", "portable"] as const) {
+    await t.test(mode, async () => {
+      const repo = mkdtempSync(join(tmpdir(), `pi-wt-v3-${mode}-`));
+      const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+      const baseline = activeCheckoutProofsForTesting();
+      try {
+        git("init", "-q");
+        git("config", "user.email", "t@t.t");
+        git("config", "user.name", "t");
+        writeFileSync(join(repo, "file.txt"), "base\n");
+        git("add", ".");
+        git("commit", "-q", "-m", "init");
+        const current = await createWorktreeLive(repo, `v3-${mode}`);
+        if (current.cleanupMetadata?.version !== 4) throw new Error("expected current metadata");
+        const {
+          checkoutProof: _a,
+          gitDirIdentity: _b,
+          gitDirProof: _c,
+          version: _d,
+          ...fields
+        } = current.cleanupMetadata;
+        const original = { ...current, cleanupMetadata: { version: 3 as const, ...fields } };
+        const legacy = (
+          mode === "descriptor" ? structuredClone(original) : JSON.parse(JSON.stringify(original))
+        ) as Worktree;
+        const markerPath = join(current.cleanupMetadata.gitDir, "pi-dynamic-workflows-registration");
+        writeFileSync(markerPath, `${JSON.stringify(legacy.cleanupMetadata)}\n`);
+        writeFileSync(join(current.cwd, "agent.txt"), "mutable branch commit\n");
+        execFileSync("git", ["-C", current.cwd, "add", "."]);
+        execFileSync("git", ["-C", current.cwd, "commit", "-q", "-m", "agent commit"]);
+
+        let failFirstCleanup = true;
+        const operations = createWorktreeOperationsForTesting({
+          ...(mode === "portable" ? { gitDirectoryDescriptorErrorCode: "EISDIR" as const } : {}),
+          afterIdentityVerification() {
+            if (!failFirstCleanup) return;
+            failFirstCleanup = false;
+            throw new Error("first v3 cleanup fails after upgrade");
+          },
+        } as never);
+        const first = await operations.removeWorktree(legacy);
+        assert.equal(first.length, 1);
+        const upgradedContents = readFileSync(markerPath, "utf8");
+        const upgraded = JSON.parse(upgradedContents) as {
+          version: number;
+          gitDirProof?: { kind: string };
+          baseSha: string;
+        };
+        assert.equal(upgraded.version, 4);
+        assert.equal(upgraded.gitDirProof?.kind, mode === "portable" ? "sentinel" : "descriptor");
+        assert.equal(
+          upgraded.baseSha,
+          execFileSync("git", ["-C", current.cwd, "rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+          "upgrade captures the mutable branch tip",
+        );
+
+        writeFileSync(
+          markerPath,
+          `${JSON.stringify({ ...upgraded, registrationMarker: "00000000-0000-4000-8000-000000000000" })}\n`,
+        );
+        const replacementFailure = await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(legacy);
+        assert.equal(replacementFailure.length, 1, "the original v3 value never adopts a replacement marker");
+        assert.equal(existsSync(current.cwd), true);
+
+        writeFileSync(markerPath, upgradedContents);
+        assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(legacy), []);
+        assert.deepEqual(activeCheckoutProofsForTesting(), baseline);
+        assertNoCreationArtifacts(repo);
+      } finally {
+        rmSync(repo, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test("final creation revalidation rejects same-path replacement identities before agent handoff", async () => {
+  for (const replacement of ["checkout", "gitdir", "checkout-sentinel", "gitdir-sentinel", "exclude"] as const) {
+    const repo = mkdtempSync(join(tmpdir(), `pi-wt-final-revalidation-${replacement}-`));
+    const external = mkdtempSync(join(tmpdir(), `pi-wt-final-revalidation-${replacement}-external-`));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+    const baseline = activeCheckoutProofsForTesting();
+    let displaced = "";
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.t");
+      git("config", "user.name", "t");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+      writeFileSync(join(external, "sentinel.txt"), "external survives\n");
+
+      const result = await createWorktreeLive(repo, `final-revalidation-${replacement}`, {
+        ...(replacement === "checkout-sentinel" || replacement === "exclude"
+          ? { directoryDescriptorMode: "unsupported" as const }
+          : {}),
+        ...(replacement === "gitdir-sentinel" ? { gitDirectoryDescriptorErrorCode: "EISDIR" as const } : {}),
+        afterRegistrationRecordWrite(metadata) {
+          if (replacement === "checkout") {
+            displaced = `${metadata.worktreePath}-owned`;
+            renameSync(metadata.worktreePath, displaced);
+            mkdirSync(metadata.worktreePath);
+            writeFileSync(join(metadata.worktreePath, "replacement-sentinel.txt"), "replacement survives\n");
+          } else if (replacement === "gitdir") {
+            displaced = `${metadata.gitDir}-owned`;
+            renameSync(metadata.gitDir, displaced);
+            mkdirSync(metadata.gitDir);
+            writeFileSync(join(metadata.gitDir, "replacement-sentinel.txt"), "replacement survives\n");
+          } else if (replacement === "checkout-sentinel") {
+            if (metadata.checkoutProof.kind !== "sentinel") throw new Error("expected portable checkout proof");
+            const sentinelPath = join(metadata.worktreePath, metadata.checkoutProof.fileName);
+            displaced = `${sentinelPath}-owned`;
+            renameSync(sentinelPath, displaced);
+            writeFileSync(sentinelPath, "replacement survives\n");
+          } else if (replacement === "gitdir-sentinel") {
+            if (metadata.gitDirProof?.kind !== "sentinel") throw new Error("expected portable Git-directory proof");
+            const sentinelPath = join(metadata.gitDir, metadata.gitDirProof.fileName);
+            displaced = `${sentinelPath}-owned`;
+            renameSync(sentinelPath, displaced);
+            writeFileSync(sentinelPath, "replacement survives\n");
+          } else {
+            displaced = `${excludePath(repo)}-owned`;
+            renameSync(excludePath(repo), displaced);
+            writeFileSync(excludePath(repo), "replacement survives\n");
+          }
+        },
+      } as never);
+
+      assert.equal(result.isolated, false, `${replacement} replacement is never handed to an agent`);
+      assert.match(result.reason ?? "", /identity_finalization/);
+      assert.equal(readFileSync(join(external, "sentinel.txt"), "utf8"), "external survives\n");
+      const recovery = (result as Worktree & { creationRecoveryWorktree?: Worktree }).creationRecoveryWorktree;
+      if (recovery) {
+        if (replacement === "gitdir") {
+          const metadata = recovery.cleanupMetadata;
+          if (metadata?.version !== 4) throw new Error("expected current recovery metadata");
+          assert.equal(
+            readFileSync(join(metadata.gitDir, "replacement-sentinel.txt"), "utf8"),
+            "replacement survives\n",
+          );
+          rmSync(metadata.gitDir, { recursive: true, force: true });
+          renameSync(displaced, metadata.gitDir);
+        } else if (replacement === "checkout-sentinel") {
+          const metadata = recovery.cleanupMetadata;
+          if (metadata?.version !== 4 || metadata.checkoutProof.kind !== "sentinel") {
+            throw new Error("expected portable recovery metadata");
+          }
+          const sentinelPath = join(metadata.worktreePath, metadata.checkoutProof.fileName);
+          assert.equal(readFileSync(sentinelPath, "utf8"), "replacement survives\n");
+          rmSync(sentinelPath);
+          renameSync(displaced, sentinelPath);
+        } else if (replacement === "gitdir-sentinel") {
+          const metadata = recovery.cleanupMetadata;
+          if (metadata?.version !== 4 || metadata.gitDirProof?.kind !== "sentinel") {
+            throw new Error("expected portable Git-directory recovery metadata");
+          }
+          const sentinelPath = join(metadata.gitDir, metadata.gitDirProof.fileName);
+          assert.equal(readFileSync(sentinelPath, "utf8"), "replacement survives\n");
+          rmSync(sentinelPath);
+          renameSync(displaced, sentinelPath);
+        } else if (replacement === "exclude") {
+          assert.equal(readFileSync(excludePath(repo), "utf8"), "replacement survives\n");
+          rmSync(excludePath(repo));
+          renameSync(displaced, excludePath(repo));
+        }
+        assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(recovery), []);
+      }
+      if (replacement === "checkout") {
+        const replacementPath = readdirSync(gitCommonRoot(repo))
+          .filter((entry) => entry.startsWith("pi-workflow-checkout-"))
+          .map((entry) => join(gitCommonRoot(repo), entry))
+          .find((path) => existsSync(join(path, "replacement-sentinel.txt")));
+        assert.ok(replacementPath);
+        assert.equal(readFileSync(join(replacementPath, "replacement-sentinel.txt"), "utf8"), "replacement survives\n");
+        rmSync(replacementPath, { recursive: true, force: true });
+      }
+      assert.deepEqual(activeCheckoutProofsForTesting(), baseline);
+      assertNoCreationArtifacts(repo);
+    } finally {
+      rmSync(external, { recursive: true, force: true });
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }
+});
+
+test("portable creation rolls back exact sentinel state when initial registration persistence fails", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-registration-write-rollback-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  const baseline = activeCheckoutProofsForTesting();
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const initial = "# caller-owned\n*.keep";
+    writeFileSync(excludePath(repo), initial);
+    chmodSync(excludePath(repo), 0o640);
+    const hardlinkPath = join(gitCommonRoot(repo), "info", "exclude-registration-write-hardlink");
+    linkSync(excludePath(repo), hardlinkPath);
+    const metadataBefore = statSync(excludePath(repo));
+    let writes = 0;
+
+    const result = await createWorktreeLive(repo, "registration-write-rollback", {
+      directoryDescriptorMode: "unsupported",
+      beforeRegistrationRecordWrite() {
+        writes += 1;
+        if (writes === 1) throw new Error("injected initial registration write failure");
+      },
+    } as never);
+
+    assert.equal(result.isolated, false);
+    assert.match(result.reason ?? "", /identity_finalization/);
+    assert.equal(writes, 1, "registration persistence failure rolls back from the complete in-memory identity");
+    const after = readFileSync(excludePath(repo), "utf8");
+    assert.equal(after.slice(0, initial.length), initial);
+    assert.match(after.slice(initial.length), /^\n# *\n# *\n$/);
+    assert.equal(after.includes("pi-dynamic-workflows-owned-sentinel"), false);
+    assert.equal(readFileSync(hardlinkPath, "utf8"), after);
+    assert.equal(statSync(excludePath(repo)).ino, metadataBefore.ino);
+    assert.equal(statSync(excludePath(repo)).mode & 0o777, metadataBefore.mode & 0o777);
+    assert.equal(isGitIgnored(repo, "probe.keep"), true);
+    assert.deepEqual(activeCheckoutProofsForTesting(), baseline);
+    assertNoCreationArtifacts(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("marker-write recovery retries every identity-bound rollback stage", async () => {
+  for (const stage of [
+    "afterIdentityVerification",
+    "afterCheckoutClaim",
+    "afterBranchClaim",
+    "afterRegistrationClaim",
+    "beforeClaimedContentsCleanup",
+  ] as const) {
+    const repo = mkdtempSync(join(tmpdir(), `pi-wt-marker-stage-${stage}-`));
+    const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+    const baseline = activeCheckoutProofsForTesting();
+    let failStage = true;
+    try {
+      git("init", "-q");
+      git("config", "user.email", "t@t.t");
+      git("config", "user.name", "t");
+      writeFileSync(join(repo, "file.txt"), "base\n");
+      git("add", ".");
+      git("commit", "-q", "-m", "init");
+      const hook = () => {
+        if (failStage) throw new Error(`injected ${stage} failure`);
+      };
+      const result = await createWorktreeLive(repo, `marker-stage-${stage}`, {
+        beforeRegistrationRecordWrite(metadata) {
+          if (stage === "afterIdentityVerification") {
+            writeFileSync(join(metadata.gitDir, "pi-dynamic-workflows-registration"), "{partial\n");
+          }
+          throw new Error("injected marker failure");
+        },
+        creationCleanupHooks: { [stage]: hook },
+      } as never);
+      assert.equal(result.isolated, false);
+      assert.ok((result.recoveryFailures?.length ?? 0) >= 1);
+      const recovery = (result as Worktree & { creationRecoveryWorktree?: Worktree }).creationRecoveryWorktree;
+      assert.ok(recovery, `${stage} retains exact root-owned retry authority`);
+      failStage = false;
+      assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(recovery), []);
+      assertNoCreationArtifacts(repo);
+      assert.deepEqual(activeCheckoutProofsForTesting(), baseline);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  }
+});
+
+test("repeated registration rollback failures retain bounded root-owned recovery and no terminal leaks", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-registration-write-persisted-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  const baseline = activeCheckoutProofsForTesting();
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const initial = "# retained caller rule\n*.keep\n";
+    writeFileSync(excludePath(repo), initial);
+    let writes = 0;
+    let failRollback = true;
+    const failSentinelRollback = () => {
+      if (failRollback) throw new Error(`sentinel restore failure ${"y".repeat(5000)}`);
+    };
+
+    const result = await createWorktreeLive(repo, "registration-write-persisted", {
+      directoryDescriptorMode: "unsupported",
+      beforeRegistrationRecordWrite() {
+        writes += 1;
+        throw new Error(`repeated registration failure ${"x".repeat(5000)}`);
+      },
+      creationCleanupHooks: { beforeSentinelExcludeNeutralize: failSentinelRollback },
+    } as never);
+
+    assert.equal(result.isolated, false);
+    assert.equal(writes, 1);
+    assert.ok((result.recoveryFailures?.length ?? 0) >= 1);
+    for (const failure of result.recoveryFailures ?? []) {
+      assert.ok(failure.message.length <= 1024);
+      assert.equal(JSON.stringify(failure).includes(repo), false);
+    }
+    assert.match(result.reason ?? "", /identity_finalization.*cleanup failure/i);
+    assert.match(readFileSync(excludePath(repo), "utf8"), /pi-dynamic-workflows-owned-sentinel/);
+    const registered = git("worktree", "list", "--porcelain");
+    assert.equal(registered.includes("pi-workflow-checkout-"), false, "failed destructive cleanup is retryable");
+    assert.equal(git("branch", "--list", "pi/wf/registration-write-persisted").trim(), "");
+    const recovery = (result as Worktree & { creationRecoveryWorktree?: Worktree }).creationRecoveryWorktree;
+    assert.ok(recovery, "failed immediate rollback returns root-owned retry identity");
+    const retrying = createWorktreeOperationsForTesting({
+      beforeSentinelExcludeNeutralize: failSentinelRollback,
+    } as never);
+    const repeated = await retrying.removeWorktree(recovery);
+    assert.equal(repeated.length, 1);
+    assert.ok((repeated[0]?.message.length ?? Infinity) <= 1024);
+    failRollback = false;
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(recovery), []);
+    assert.deepEqual(activeCheckoutProofsForTesting(), baseline, "successful terminal retry disposes every proof fd");
+    assertNoCreationArtifacts(repo);
+  } finally {
+    for (const line of git("worktree", "list", "--porcelain").split("\n")) {
+      if (line.startsWith("worktree ") && line.slice("worktree ".length) !== repo) {
+        try {
+          git("worktree", "remove", "--force", line.slice("worktree ".length));
+        } catch {
+          // Best-effort fixture cleanup.
+        }
+      }
+    }
+    if (git("branch", "--list", "pi/wf/registration-write-persisted").trim()) {
+      git("branch", "-D", "pi/wf/registration-write-persisted");
+    }
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("the original version-two value adopts its exact upgraded marker after a failed first cleanup", async () => {
+  const repo = mkdtempSync(join(tmpdir(), "pi-wt-v2-upgrade-retry-"));
+  const git = (...args: string[]) => execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  const baseline = activeCheckoutProofsForTesting();
+  try {
+    git("init", "-q");
+    git("config", "user.email", "t@t.t");
+    git("config", "user.name", "t");
+    writeFileSync(join(repo, "file.txt"), "base\n");
+    git("add", ".");
+    git("commit", "-q", "-m", "init");
+    const current = await createWorktreeLive(repo, "v2-upgrade-retry");
+    if (current.cleanupMetadata?.version !== 4) throw new Error("expected current metadata");
+    const {
+      checkoutIdentity: _a,
+      checkoutProof: _b,
+      gitDirIdentity: _c,
+      version: _d,
+      ...fields
+    } = current.cleanupMetadata;
+    const legacy = JSON.parse(
+      JSON.stringify({ ...current, cleanupMetadata: { version: 2 as const, ...fields } }),
+    ) as Worktree;
+    writeFileSync(
+      join(current.cleanupMetadata.gitDir, "pi-dynamic-workflows-registration"),
+      `${JSON.stringify(legacy.cleanupMetadata)}\n`,
+    );
+    const first = await createWorktreeOperationsForTesting({
+      afterIdentityVerification() {
+        throw new Error("first cleanup fails after upgrade");
+      },
+    }).removeWorktree(legacy);
+    assert.equal(first.length, 1);
+    assert.notDeepEqual(activeCheckoutProofsForTesting(), baseline, "the retry still owns its proofs");
+
+    assert.deepEqual(await DEFAULT_WORKTREE_OPERATIONS.removeWorktree(legacy), []);
+    assert.deepEqual(activeCheckoutProofsForTesting(), baseline);
+    assertNoCreationArtifacts(repo);
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What
- Add opt-in retained worktree producers and opaque same-run handles so later workflow steps can inspect uncommitted agent output while preserving existing immediate cleanup by default.
- Add serialized retained consumers, idempotent explicit release, terminal admission barriers, and root-owned cleanup across success, abort, stop, and error paths.
- Persist bounded, redacted cleanup diagnostics while preventing runtime handles from being serialized or reused after release.
- Harden Git lifecycle operations with exact identity proofs, cross-process locking, transactional rollback, legacy compatibility, documentation, and real-repository regression coverage.

## Linear
C-19457: [Pi Workflows] Retain isolated worktrees across agent steps
https://linear.app/courier/issue/C-19457

## ADRs
None

## Open Items
- The full suite currently has one real-provider schema test blocked by OpenAI `PROVIDER_USAGE_LIMIT`; the remaining 1,323 tests, focused retained-worktree suites, check, lint, and build pass.
