### PR TITLE
fix: make workflow token budgets opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,10 @@ The comprehension harness is manual and never runs in normal CI, `npm test`, or 
 npm run comprehension -- --model provider/model                    # quick writing scenario
 npm run comprehension -- --model provider/model --suite full       # write, edit, review, and debug
 npm run comprehension -- --model provider/model --output runs/a.json
+npm run delivery-choice -- --model provider/model                  # timing and token-budget choices
 ```
 
-By default, evidence is written under ignored `.pi/model-comprehension/`. Each JSON run records the exact prompts and versions, generated workflows, skill reads, provider token usage, deterministic runtime calls/topology/results, assertions, and failure details. Scenario failures are retained as non-blocking evidence and do not produce a failing exit status; argument, model-selection, and setup errors do.
+By default, evidence is written under ignored `.pi/model-comprehension/`. Each JSON run records the exact prompts and versions, generated workflows, skill reads, provider token usage, deterministic runtime calls/topology/results, assertions, and failure details. The delivery-choice harness also checks that ordinary requests omit `tokenBudget` and explicit user caps are preserved exactly. Scenario failures are retained as non-blocking evidence and do not produce a failing exit status; argument, model-selection, and setup errors do.
 
 Features are also verified end-to-end against real Pi subagent sessions before release. See [CONTRIBUTING.md](./CONTRIBUTING.md) to contribute.
 

--- a/docs/workflow-authoring-evidence.md
+++ b/docs/workflow-authoring-evidence.md
@@ -57,6 +57,6 @@ A separate protected check ran the six core scenarios three times on GPT-5.4 Min
 
 The optional harness is available through `npm run comprehension -- --suite coverage --model <provider/model:thinking> --output <path>`. It records the selected and resolved model, thinking level, skill-loading evidence, generated workflow, runtime evidence, assertions, and token usage.
 
-The delivery-choice harness has a deterministic scorer and optional provider CLI for default background delivery versus `background:false` inline delivery. This report includes no provider-run delivery-choice result.
+The delivery-choice harness has a deterministic scorer and optional provider CLI for background versus inline delivery and token-budget intent. It expects ordinary requests to omit `tokenBudget` and preserves an explicit user cap exactly. A final-candidate run with `openai-codex/gpt-5.6-sol:high` passed 3/3 scenarios: the model omitted `tokenBudget` for both ordinary requests and preserved the explicit `200000` cap.
 
 Raw provider evidence remains local and uncommitted because it is large and variable. The committed release gate verifies the harness, parser/runtime replay seam, package discovery, coverage manifest, generated references, context measurements, and all model-free examples without making provider calls.

--- a/docs/workflow-context-surfaces.json
+++ b/docs/workflow-context-surfaces.json
@@ -13,7 +13,7 @@
     },
     "providerVisibleWorkflowToolDefinition": {
       "serialization": "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
-      "bytes": 4283
+      "bytes": 4276
     },
     "registeredSkillsDiscovery": {
       "serialization": "sum of UTF-8 bytes of normalized Pi skill XML (name + description + location) across every root in package.json's pi.skills",
@@ -33,16 +33,16 @@
     },
     "ordinaryWorkflowOwnedAlwaysOn": {
       "serialization": "sum of permanent prompt, provider-visible tool definition, and every registered skill's discovery bytes",
-      "bytes": 5956
+      "bytes": 5949
     },
     "workflowAuthoringSkillCorpus": {
       "serialization": "sum of UTF-8 bytes for every file under skills/workflow-authoring",
       "files": 27,
-      "bytes": 67450
+      "bytes": 67915
     },
     "representativeAuthoringProfiles": {
       "serialization": "sum of UTF-8 bytes for each profile's declared package-relative files",
-      "medianBytes": 11662,
+      "medianBytes": 11728,
       "profiles": [
         {
           "name": "write",
@@ -54,7 +54,7 @@
             "skills/workflow-authoring/examples/fan-out-and-synthesize.js",
             "skills/workflow-authoring/examples/structured-output.js"
           ],
-          "bytes": 11590
+          "bytes": 11656
         },
         {
           "name": "edit",
@@ -66,7 +66,7 @@
             "skills/workflow-authoring/examples/phased-budgets.js",
             "skills/workflow-authoring/examples/saved-nested-workflows.js"
           ],
-          "bytes": 14828
+          "bytes": 15293
         },
         {
           "name": "review",
@@ -77,7 +77,7 @@
             "skills/workflow-authoring/references/quality-helpers.md",
             "skills/workflow-authoring/examples/adversarial-verification.js"
           ],
-          "bytes": 10772
+          "bytes": 10838
         },
         {
           "name": "debug",
@@ -88,7 +88,7 @@
             "skills/workflow-authoring/references/specialized-helpers.md",
             "skills/workflow-authoring/examples/validated-gate.js"
           ],
-          "bytes": 11734
+          "bytes": 11800
         },
         {
           "name": "loop",
@@ -101,7 +101,7 @@
             "skills/workflow-authoring/examples/loop-until-done.js",
             "skills/workflow-authoring/examples/structured-output.js"
           ],
-          "bytes": 15416
+          "bytes": 15829
         },
         {
           "name": "retry",
@@ -113,7 +113,7 @@
             "skills/workflow-authoring/examples/bounded-semantic-retry.js",
             "skills/workflow-authoring/examples/structured-output.js"
           ],
-          "bytes": 10568
+          "bytes": 10634
         }
       ]
     }

--- a/docs/workflow-guidance-baseline.json
+++ b/docs/workflow-guidance-baseline.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "algorithm": "sha256",
   "surfaces": {
-    "compactGuidance": "6db7b76e4e4017674cbad91c28c51132cef03121da20e1a23d3561f5652945cf",
-    "detailedProse": "7485668b8b814e50dad371df9e9da5ff5decc6c6e62e08aa783dec765091f91c"
+    "compactGuidance": "533ed767108434b9eeff79119b1f895dcba2267e42fb9ef9742ba21de52607f2",
+    "detailedProse": "aadbd03ed86ccd6572e1e64eb15abae81ceb18ef368331554e0f79ed609d8645"
   }
 }

--- a/scripts/run-workflow-delivery-choice.ts
+++ b/scripts/run-workflow-delivery-choice.ts
@@ -185,8 +185,8 @@ function parseArgs(args: string[]): CliOptions {
 function printUsage(): void {
   process.stdout.write(`Usage: npm run delivery-choice -- --model <provider/model> [--output <path>]
 
-Runs two optional delivery-choice scenarios against the real workflow tool definition.
-The evidence records whether the model kept the default background run or selected background:false for same-turn use.\n`);
+Runs three optional timing and token-budget scenarios against the real workflow tool definition.
+The evidence records background versus same-turn delivery, omitted budgets for ordinary requests, and exact user-supplied caps.\n`);
 }
 
 main().catch((error: unknown) => {

--- a/skills/workflow-authoring/SKILL.md
+++ b/skills/workflow-authoring/SKILL.md
@@ -25,6 +25,6 @@ Read only what the task needs:
 - Start with literal `export const meta = { name, description }`; declare phases as an array of used `{ title }` objects and enter each named phase.
 - Call `agent()` at least once, give every call a short unique `label`, and return plain JSON data explicitly.
 - Pair ordered results with stable work IDs before filtering. When one agent consumes another's selected result, include both its stable ID and actual data in the downstream prompt. Treat recoverable `null` as missing coverage and report it.
-- Bound fan-out, loops, retries, agents, concurrency, time, and token spend to the task.
+- Bound fan-out, loops, retries, agents, and concurrency to the task. Treat invocation-level token and time caps as opt-in user constraints, not defaults.
 - Use `log()` for new code; `console` is compatibility-only.
 - Write plain JavaScript without imports or filesystem modules. Pass nondeterminism through `args`; `Date.now()`, `Math.random()`, and no-argument `new Date()` are unavailable.

--- a/skills/workflow-authoring/examples/phased-budgets.js
+++ b/skills/workflow-authoring/examples/phased-budgets.js
@@ -4,7 +4,7 @@ export const meta = {
   phases: [{ title: "Explore" }, { title: "Deliver" }],
 };
 
-// ADAPT: validate the work, choose phase budgets, prompts, schemas, and invocation-level tokenBudget.
+// ADAPT: validate the work and choose phase budgets, prompts, and schemas; add invocation-level tokenBudget only when the user explicitly requests a cap.
 const work = args && Array.isArray(args.work) ? args.work.slice(0, 8) : [{ id: "sample" }];
 const phaseBudget =
   args && Number.isFinite(args.phaseBudget) ? Math.max(1, Math.min(args.phaseBudget, 100000)) : 2000;

--- a/skills/workflow-authoring/references/lifecycle.md
+++ b/skills/workflow-authoring/references/lifecycle.md
@@ -2,7 +2,7 @@
 
 ## Bounds and budget
 
-Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script. An omitted `agentTimeoutMs` uses the configured `defaultAgentTimeoutMs` and is otherwise unbounded. An omitted `tokenBudget` uses the configured `defaultTokenBudget` and is otherwise unlimited.
+Set finite bounds that match the work for `maxAgents`, `concurrency`, and `agentRetries`; bound loops and semantic retries inside the script. Treat invocation-level `agentTimeoutMs` and `tokenBudget` as opt-in user constraints, not precautionary defaults. Omit `tokenBudget` unless the user supplies a cap or explicitly asks you to choose one. If asked to choose, allow for every planned agent call, retry, synthesis, and verification pass, with headroom. A tight gate can terminate coverage; it does not reduce work already in flight. An omitted `agentTimeoutMs` uses the configured `defaultAgentTimeoutMs` and is otherwise unbounded. An omitted `tokenBudget` uses the configured `defaultTokenBudget` and is otherwise unlimited.
 
 Enter a phase budget with `phase("Name", { budget: N })`; phase metadata does not carry budgets. `N` is a token allowance, not a call or round count: size it for the intended agent work instead of copying a small iteration limit. Token and phase budgets are soft pre-call gates. Spend lands after agents finish, so concurrent work can overshoot. A phase budget gates later calls in that phase; it neither reserves tokens nor cancels active calls. `budget.spent()` and `budget.remaining()` include nested work.
 

--- a/src/effort-command.ts
+++ b/src/effort-command.ts
@@ -1,12 +1,13 @@
 /**
  * Standing `/effort` opt-in (pi's answer to CC's ultracode): a session toggle that
  * auto-arms a workflow for substantive interactive messages, with effort-tier
- * guidance nudging fan-out breadth and the hard caps (tokenBudget / maxAgents) the
- * model should set on the workflow tool call.
+ * guidance nudging fan-out breadth and the maxAgents ceiling the model should set
+ * on the workflow tool call.
  *
  * Honest scope: the runtime cannot enforce "reviewer N / loop K" — those live in
  * the script the model writes — so the tiers are guidance plus the model setting
- * the real hard caps (tokenBudget/maxAgents are genuine runtime ceilings). The
+ * maxAgents to match the planned fan-out. Token budgets remain opt-in spend gates
+ * governed by the workflow tool schema; an effort level does not imply one. The
  * pre-flight ceiling-confirm dialog (roadmap P1-5 #4) is a downscope point: an
  * `input` hook transforms synchronously and can't await a confirm, so it is left
  * to a follow-up; `/effort` is explicit opt-in, which is the safety valve.
@@ -25,9 +26,9 @@ export function createEffortState(): EffortState {
 }
 
 const HIGH_DIRECTIVE =
-  "Effort: HIGH. Be thorough — use a few parallel reviewers/perspectives and an adversarial verify pass (see verify()/judgePanel()); set a moderate tokenBudget and maxAgents on the workflow tool call.";
+  "Effort: HIGH. Be thorough — use a few parallel reviewers/perspectives and an adversarial verify pass (see verify()/judgePanel()); set maxAgents to match the planned fan-out.";
 const ULTRA_DIRECTIVE =
-  "Effort: ULTRA. Be exhaustive — fan out widely (more reviewers/judges, deeper loopUntilDry rounds, a completenessCheck at the end), and prefer the big tier for synthesis. This can spend a lot of tokens quickly, so set explicit caps you're comfortable paying for (a generous but bounded tokenBudget and a high maxAgents) on the workflow tool call rather than leaving them unbounded.";
+  "Effort: ULTRA. Be exhaustive — fan out widely (more reviewers/judges, deeper loopUntilDry rounds, a completenessCheck at the end), prefer the big tier for synthesis, and set a high maxAgents that matches the planned fan-out. This can spend a lot of tokens quickly; maximal effort does not imply an inferred spend ceiling.";
 
 /** The extra directive appended to the forced-workflow prompt for an effort level. */
 export function effortDirective(level: EffortLevel): string | undefined {

--- a/src/workflow-authoring-coverage.ts
+++ b/src/workflow-authoring-coverage.ts
@@ -33,7 +33,7 @@ export const WORKFLOW_COMPREHENSION_SCENARIO_IDS = COMPREHENSION_SCENARIOS.map((
 export const WORKFLOW_AUTHORING_FROZEN_FILES = [
   {
     path: "skills/workflow-authoring/SKILL.md",
-    sha256: "cfd6de08089a3e234ee5168b59d9e18d5ecf18931820df559bcf90a6d8a697bc",
+    sha256: "ce60f85872722617e306aec4cf5cf39d5f2f922039a914c43149cd6a16225ebf",
   },
   {
     path: "skills/workflow-authoring/references/runtime.md",
@@ -49,7 +49,7 @@ export const WORKFLOW_AUTHORING_FROZEN_FILES = [
   },
   {
     path: "skills/workflow-authoring/references/lifecycle.md",
-    sha256: "e2f187a7b633beef0ca257e6782f72a140fc06b37a58aac423432d36d1dc19ee",
+    sha256: "ec3b851066b55c716362553d99680ba7a00275551750586c4fa74f603342ac62",
   },
   {
     path: "skills/workflow-authoring/references/pattern-selection.md",
@@ -218,31 +218,35 @@ const FROZEN_GUIDANCE_BY_CAPABILITY: Readonly<Record<string, readonly ProtectedG
     {
       path: LIFECYCLE_PATH,
       requiredText:
-        "Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script.",
+        "Set finite bounds that match the work for `maxAgents`, `concurrency`, and `agentRetries`; bound loops and semantic retries inside the script.",
     },
   ],
   "workflow.tool-input.concurrency": [
     {
       path: LIFECYCLE_PATH,
       requiredText:
-        "Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script.",
+        "Set finite bounds that match the work for `maxAgents`, `concurrency`, and `agentRetries`; bound loops and semantic retries inside the script.",
     },
   ],
   "workflow.tool-input.agentRetries": [
     {
       path: LIFECYCLE_PATH,
       requiredText:
-        "Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script.",
+        "Set finite bounds that match the work for `maxAgents`, `concurrency`, and `agentRetries`; bound loops and semantic retries inside the script.",
     },
   ],
   "workflow.tool-input.agentTimeoutMs": [
     {
       path: LIFECYCLE_PATH,
       requiredText:
-        "Set finite bounds that match the work: `maxAgents`, `concurrency`, `agentRetries`, `agentTimeoutMs`, and `tokenBudget` at invocation time; loop and semantic-retry bounds inside the script.",
+        "Treat invocation-level `agentTimeoutMs` and `tokenBudget` as opt-in user constraints, not precautionary defaults.",
     },
   ],
   "workflow.tool-input.tokenBudget": [
+    {
+      path: LIFECYCLE_PATH,
+      requiredText: "Omit `tokenBudget` unless the user supplies a cap or explicitly asks you to choose one.",
+    },
     {
       path: LIFECYCLE_PATH,
       requiredText:

--- a/src/workflow-delivery-choice.ts
+++ b/src/workflow-delivery-choice.ts
@@ -1,30 +1,41 @@
-/** One model-facing timing decision for invoking the workflow tool. */
+/** One model-facing timing and token-budget decision for invoking the workflow tool. */
 export interface WorkflowDeliveryChoiceScenario {
   id: string;
   prompt: string;
   expectedBackground: boolean;
+  expectedTokenBudget: number | null;
 }
 
 /** Pure scoring result for one captured workflow tool invocation. */
 export interface WorkflowDeliveryChoiceEvaluation {
   passed: boolean;
   resolvedBackground: boolean | null;
+  resolvedTokenBudget: number | null;
   assertions: Array<{ name: string; passed: boolean; details: string }>;
 }
 
-/** Focused #89 scenarios for default background delivery versus same-turn use. */
+/** Focused #89 scenarios for delivery timing and opt-in token budgets. */
 export const WORKFLOW_DELIVERY_CHOICE_SCENARIOS: readonly WorkflowDeliveryChoiceScenario[] = [
   {
     id: "background-delivery",
     prompt:
       "Run a workflow to audit the repository from several independent angles. I do not need the result in this turn; let it be delivered back later so I can keep working.",
     expectedBackground: true,
+    expectedTokenBudget: null,
   },
   {
     id: "inline-result",
     prompt:
       "Run a workflow to compare the two proposed designs, then use its result in your answer in this same turn. I am waiting for the result before you respond.",
     expectedBackground: false,
+    expectedTokenBudget: null,
+  },
+  {
+    id: "explicit-token-budget",
+    prompt:
+      "Run a workflow to audit the repository from several independent angles. Cap the run at exactly 200,000 tokens and let the result be delivered back later.",
+    expectedBackground: true,
+    expectedTokenBudget: 200_000,
   },
 ];
 
@@ -35,14 +46,22 @@ export function evaluateWorkflowDeliveryChoice(
 ): WorkflowDeliveryChoiceEvaluation {
   const input = isRecord(value) ? value : null;
   const hasScript = typeof input?.script === "string" && input.script.trim().length > 0;
+  const hasName = typeof input?.name === "string" && input.name.trim().length > 0;
+  const hasWorkflow = hasScript || hasName;
   const validBackground = input !== null && (input.background === undefined || typeof input.background === "boolean");
   const resolvedBackground = validBackground ? (typeof input.background === "boolean" ? input.background : true) : null;
+  const validTokenBudget =
+    input !== null &&
+    (input.tokenBudget === undefined ||
+      (typeof input.tokenBudget === "number" && Number.isFinite(input.tokenBudget) && input.tokenBudget > 0));
+  const resolvedTokenBudget = validTokenBudget && typeof input.tokenBudget === "number" ? input.tokenBudget : null;
   const timingMatches = resolvedBackground === scenario.expectedBackground;
+  const tokenBudgetMatches = validTokenBudget && resolvedTokenBudget === scenario.expectedTokenBudget;
   const assertions = [
     {
-      name: "workflow:called-with-script",
-      passed: hasScript,
-      details: "the model must invoke the real workflow tool shape with a nonblank script",
+      name: "workflow:called-with-script-or-name",
+      passed: hasWorkflow,
+      details: "the model must invoke the workflow tool with a nonblank script or saved/built-in name",
     },
     {
       name: "background:valid-type",
@@ -56,10 +75,24 @@ export function evaluateWorkflowDeliveryChoice(
         ? "later delivery should use the default background run"
         : "same-turn use should pass background: false",
     },
+    {
+      name: "tokenBudget:valid-positive-number",
+      passed: validTokenBudget,
+      details: "tokenBudget must be omitted or supplied as a positive finite number",
+    },
+    {
+      name: "tokenBudget:matches-user-intent",
+      passed: tokenBudgetMatches,
+      details:
+        scenario.expectedTokenBudget === null
+          ? "ordinary workflow requests should omit tokenBudget"
+          : `the user-supplied cap must be preserved exactly (${scenario.expectedTokenBudget})`,
+    },
   ];
   return {
     passed: assertions.every(({ passed }) => passed),
     resolvedBackground,
+    resolvedTokenBudget,
     assertions,
   };
 }

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -100,7 +100,7 @@ const workflowToolSchema = Type.Object({
   tokenBudget: Type.Optional(
     Type.Number({
       description:
-        "Soft pre-call token gate for the whole run. Once recorded spend reaches it, further agent() calls fail; concurrent in-flight work can overshoot. Omit to use configured `defaultTokenBudget`; without one, the run is unlimited. Set it only when the user asks to bound spend.",
+        "Opt-in soft spend gate, not a planning target. Never invent or infer `tokenBudget`; set it only when the user supplies or requests a cap. Omit for configured `defaultTokenBudget`; without one, unlimited. Exhaustion blocks later calls; in-flight work can overshoot.",
     }),
   ),
   resumeFromRunId: Type.Optional(

--- a/tests/effort-command.test.ts
+++ b/tests/effort-command.test.ts
@@ -3,10 +3,17 @@ import test from "node:test";
 import { createEffortState, effortDirective, isSubstantive, registerEffortCommand } from "../src/effort-command.js";
 import { buildArmedWorkflowPrompt } from "../src/workflow-editor.js";
 
-test("effortDirective returns a tier nudge for high/ultra, nothing for off", () => {
+test("effortDirective shapes fan-out without inventing token budgets", () => {
+  const high = effortDirective("high") ?? "";
+  const ultra = effortDirective("ultra") ?? "";
+
   assert.equal(effortDirective("off"), undefined);
-  assert.match(effortDirective("high") ?? "", /HIGH/);
-  assert.match(effortDirective("ultra") ?? "", /ULTRA/);
+  assert.match(high, /HIGH/);
+  assert.match(ultra, /ULTRA/);
+  assert.match(high, /maxAgents/);
+  assert.match(ultra, /maxAgents/);
+  assert.doesNotMatch(high, /tokenBudget/);
+  assert.doesNotMatch(ultra, /tokenBudget/);
 });
 
 test("isSubstantive accepts real requests, rejects terse text and slash commands", () => {

--- a/tests/workflow-authoring-skill.test.ts
+++ b/tests/workflow-authoring-skill.test.ts
@@ -184,12 +184,18 @@ test("generated capability index and exhaustive details are fresh and absent fro
   }
 });
 
-test("lifecycle guidance explains configured timeout and token-budget defaults", () => {
+test("authoring guidance makes invocation token budgets explicit opt-in gates", () => {
+  const skill = readFileSync(join(ROOT, SKILL_ROOT, "SKILL.md"), "utf8");
   const lifecycle = readFileSync(join(ROOT, SKILL_ROOT, "references/lifecycle.md"), "utf8");
 
+  assert.match(skill, /invocation-level token and time caps as opt-in user constraints, not defaults/i);
+  assert.match(lifecycle, /omit `tokenBudget` unless the user.*explicitly/is);
+  assert.match(lifecycle, /asked to choose.*every planned agent call.*retr.*synthesis.*verification.*headroom/is);
+  assert.match(lifecycle, /tight gate can terminate coverage.*does not reduce work already in flight/is);
   assert.match(lifecycle, /omitted `agentTimeoutMs`.*configured `defaultAgentTimeoutMs`.*otherwise.*unbounded/is);
   assert.match(lifecycle, /omitted `tokenBudget`.*configured `defaultTokenBudget`.*otherwise.*unlimited/is);
   assert.match(lifecycle, /soft pre-call gates.*concurrent work can overshoot/is);
+  assert.doesNotMatch(lifecycle, /set finite bounds[^.]*`tokenBudget`/i);
 });
 
 test("generated facts cover the lifecycle constraints taught by the skill", () => {
@@ -683,6 +689,7 @@ test("loop-until-done resets its consecutive dry streak after missing coverage",
 
 test("phased-budget recipe reports soft-gate spending and bounds later calls", async () => {
   const script = readFileSync(join(ROOT, SKILL_ROOT, "examples/phased-budgets.js"), "utf8");
+  assert.match(script, /invocation-level tokenBudget only when the user explicitly requests a cap/i);
   const labels: string[] = [];
   const result = await runWorkflow<{
     phases: Array<{ title: string; startSpent: number; endSpent: number; attempted: string[]; missing: string[] }>;

--- a/tests/workflow-delivery-choice.test.ts
+++ b/tests/workflow-delivery-choice.test.ts
@@ -8,23 +8,48 @@ import { evaluateWorkflowDeliveryChoice, WORKFLOW_DELIVERY_CHOICE_SCENARIOS } fr
 const ROOT = resolve(import.meta.dirname, "..");
 const delayed = WORKFLOW_DELIVERY_CHOICE_SCENARIOS.find(({ id }) => id === "background-delivery");
 const inline = WORKFLOW_DELIVERY_CHOICE_SCENARIOS.find(({ id }) => id === "inline-result");
+const CAPPED_SCENARIO = WORKFLOW_DELIVERY_CHOICE_SCENARIOS.find(({ id }) => id === "explicit-token-budget");
 
-test("delivery-choice scenarios cover background delivery and same-turn inline use", () => {
+test("delivery-choice scenarios cover timing and token-budget intent", () => {
   assert.ok(delayed);
   assert.ok(inline);
-  assert.equal(WORKFLOW_DELIVERY_CHOICE_SCENARIOS.length, 2);
+  assert.ok(CAPPED_SCENARIO);
+  assert.equal(WORKFLOW_DELIVERY_CHOICE_SCENARIOS.length, 3);
   assert.equal(delayed.expectedBackground, true);
+  assert.equal(delayed.expectedTokenBudget, null);
   assert.match(delayed.prompt, /deliver.*later|later.*deliver/i);
   assert.equal(inline.expectedBackground, false);
+  assert.equal(inline.expectedTokenBudget, null);
   assert.match(inline.prompt, /same turn/i);
   assert.match(inline.prompt, /waiting/i);
+  assert.equal(CAPPED_SCENARIO.expectedBackground, true);
+  assert.equal(CAPPED_SCENARIO.expectedTokenBudget, 200_000);
+  assert.match(CAPPED_SCENARIO.prompt, /exactly 200,?000 tokens/i);
 });
 
-test("delivery-choice scoring accepts the default for later delivery", () => {
+test("delivery-choice scoring accepts omitted token budgets for ordinary requests", () => {
   assert.ok(delayed);
   assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "return {}" }).passed, true);
   assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "return {}", background: true }).passed, true);
   assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "return {}", background: false }).passed, false);
+  assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "return {}", tokenBudget: 20_000 }).passed, false);
+});
+
+test("delivery-choice scoring requires the exact user-supplied token budget", () => {
+  assert.ok(CAPPED_SCENARIO);
+  const matching = evaluateWorkflowDeliveryChoice(CAPPED_SCENARIO, { script: "return {}", tokenBudget: 200_000 });
+  const named = evaluateWorkflowDeliveryChoice(CAPPED_SCENARIO, {
+    name: "codebase-audit",
+    tokenBudget: 200_000,
+  });
+  assert.equal(matching.passed, true);
+  assert.equal(named.passed, true);
+  assert.equal(matching.resolvedTokenBudget, 200_000);
+  assert.equal(evaluateWorkflowDeliveryChoice(CAPPED_SCENARIO, { script: "return {}" }).passed, false);
+  assert.equal(
+    evaluateWorkflowDeliveryChoice(CAPPED_SCENARIO, { script: "return {}", tokenBudget: 20_000 }).passed,
+    false,
+  );
 });
 
 test("delivery-choice scoring requires background false for same-turn use", () => {
@@ -39,7 +64,10 @@ test("delivery-choice scoring rejects malformed workflow calls", () => {
   assert.equal(evaluateWorkflowDeliveryChoice(delayed, null).passed, false);
   assert.equal(evaluateWorkflowDeliveryChoice(delayed, { background: true }).passed, false);
   assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "", background: true }).passed, false);
+  assert.equal(evaluateWorkflowDeliveryChoice(delayed, { name: "", background: true }).passed, false);
   assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "return {}", background: "true" }).passed, false);
+  assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "return {}", tokenBudget: "200000" }).passed, false);
+  assert.equal(evaluateWorkflowDeliveryChoice(delayed, { script: "return {}", tokenBudget: -1 }).passed, false);
 });
 
 test("delivery-choice CLI is package-wired and exposes help without provider calls", () => {
@@ -60,4 +88,5 @@ test("delivery-choice CLI is package-wired and exposes help without provider cal
   );
   assert.match(help, /--model <provider\/model>/i);
   assert.match(help, /--output <path>/i);
+  assert.match(help, /three.*timing and token-budget scenarios/is);
 });

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -187,15 +187,17 @@ test("createWorkflowTool schema describes the configured or unbounded timeout", 
   assert.match(description, /only when the user asks/i);
 });
 
-test("createWorkflowTool schema describes the configured or unlimited token budget", () => {
+test("createWorkflowTool schema makes token budgets explicit opt-in spend gates", () => {
   const tool = createWorkflowTool();
   const description = parameterDescription(tool, "tokenBudget");
 
-  assert.match(description, /soft pre-call token gate/i);
-  assert.match(description, /concurrent in-flight work can overshoot/i);
-  assert.match(description, /Omit to use configured `defaultTokenBudget`/i);
+  assert.match(description, /opt-in soft spend gate, not a planning target/i);
+  assert.match(description, /never invent or infer `tokenBudget`/i);
+  assert.match(description, /set it only when the user supplies or requests a cap/i);
+  assert.match(description, /configured `defaultTokenBudget`/i);
   assert.match(description, /without one.*unlimited/i);
-  assert.match(description, /only when the user asks/i);
+  assert.match(description, /exhaustion blocks later calls/i);
+  assert.match(description, /in-flight work can overshoot/i);
 });
 
 test("createWorkflowTool schema exposes resource controls and large-fan-out authority", () => {


### PR DESCRIPTION
## Summary

- Make `tokenBudget` an opt-in soft spend gate and tell models never to infer it as a planning target.
- Align the workflow-authoring skill, lifecycle guidance, phased-budget example, and HIGH/ULTRA effort directives with that policy.
- Extend the #89 choice harness to verify omitted ordinary budgets and exact explicit caps across both `script` and named workflow invocations.
- Preserve the existing provider-visible definition ceiling: 4,276 bytes against the accepted 4,283-byte limit.

Addresses #89.

## Evidence

- `npm run build`
- `npm run docs:check`
- `npm run context:check`
- `npm run guidance:check`
- `npm run release:verify` — 0 warnings
- Focused changed-area tests — 160/160 before final review fixes; affected tests rerun after each fix
- `npm run delivery-choice -- --model openai-codex/gpt-5.6-sol:high` — 3/3 scenarios passed
- `npm test` — 1,149/1,150 locally. The only failure is the unchanged faux-provider object-schema test at `tests/agent.test.ts:335`, which also fails when run alone and is outside this diff.
