### PR TITLE
chore(release): 3.4.1 — version bump and generated surfaces

### DIFF
--- a/docs/workflow-guidance-baseline.json
+++ b/docs/workflow-guidance-baseline.json
@@ -3,6 +3,6 @@
   "algorithm": "sha256",
   "surfaces": {
     "compactGuidance": "533ed767108434b9eeff79119b1f895dcba2267e42fb9ef9742ba21de52607f2",
-    "detailedProse": "aadbd03ed86ccd6572e1e64eb15abae81ceb18ef368331554e0f79ed609d8645"
+    "detailedProse": "93af687246a37125bcdbffd054cf9cacebba5262bf8dd3ee206c4f4651ecbefc"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quintinshaw/pi-dynamic-workflows",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@quintinshaw/pi-dynamic-workflows",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintinshaw/pi-dynamic-workflows",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Claude-Code-style dynamic workflows for Pi — fan a task out across 100s of subagents with real model routing, token/cost accounting, resume, git-worktree isolation, an interactive /workflows TUI, and a real /deep-research.",
   "type": "module",
   "main": "./dist/index.js",

--- a/skills/workflow-authoring/SKILL.md
+++ b/skills/workflow-authoring/SKILL.md
@@ -2,7 +2,7 @@
 name: workflow-authoring
 description: Guidance for writing, editing, reviewing, and debugging JavaScript workflow code for pi-dynamic-workflows. Use when authoring or changing workflow scripts; not for merely running an existing workflow.
 metadata:
-  version: "3.4.0"
+  version: "3.4.1"
 ---
 
 # Workflow authoring

--- a/skills/workflow-authoring/references/capabilities.md
+++ b/skills/workflow-authoring/references/capabilities.md
@@ -2,7 +2,7 @@
 # Workflow capability index
 
 Contract format: `1.0.0`<br>
-Contract content / skill / extension: `3.4.0`
+Contract content / skill / extension: `3.4.1`
 
 This compact generated index covers supported runtime globals and workflow-tool inputs. For constraints, compatibility behavior, internal boundaries, and dynamic-reference ownership, follow the [exhaustive generated facts](capability-details.md).
 

--- a/skills/workflow-authoring/references/capability-details.md
+++ b/skills/workflow-authoring/references/capability-details.md
@@ -2,7 +2,7 @@
 # Exhaustive workflow capability facts
 
 Contract format: `1.0.0`<br>
-Contract content / skill / extension: `3.4.0`
+Contract content / skill / extension: `3.4.1`
 
 Every exact fact below is projected from the installed extension's capability contract. Explanatory judgment belongs in the hand-written references next to this file.
 

--- a/skills/workflow-patterns/SKILL.md
+++ b/skills/workflow-patterns/SKILL.md
@@ -2,7 +2,7 @@
 name: workflow-patterns
 description: Argument shapes for the 5 built-in workflow patterns — deep-research, adversarial-review, code-review, multi-perspective, codebase-audit — runnable via the `workflow` tool's `name` input, without slash-command syntax. Use for requests like "research X", "fact-check/adversarially review this", "review this diff/PR", "analyze from multiple perspectives", or "audit the codebase for Y". Not for authoring a new workflow script — see workflow-authoring.
 metadata:
-  version: "3.4.0"
+  version: "3.4.1"
 ---
 
 # Built-in workflow patterns

--- a/src/workflow-authoring-coverage.ts
+++ b/src/workflow-authoring-coverage.ts
@@ -33,7 +33,7 @@ export const WORKFLOW_COMPREHENSION_SCENARIO_IDS = COMPREHENSION_SCENARIOS.map((
 export const WORKFLOW_AUTHORING_FROZEN_FILES = [
   {
     path: "skills/workflow-authoring/SKILL.md",
-    sha256: "ce60f85872722617e306aec4cf5cf39d5f2f922039a914c43149cd6a16225ebf",
+    sha256: "62b92fda97f86e54bbb5d399b8a796359f0c4ca3ade5579a2f9028fcd678a4ef",
   },
   {
     path: "skills/workflow-authoring/references/runtime.md",


### PR DESCRIPTION
## Summary

- Bump package version to 3.4.1 and sync both skills' frontmatter versions.
- Regenerate the tracked capability docs, context-measurement, and guidance-baseline surfaces for the new version.

## Test plan

- [x] `npm run release:verify` — 0 warnings
- [x] `npm run docs:check` / `context:check` / `guidance:check` — clean