### PR TITLE
fix: restore agreed token budget wording

### DIFF
--- a/docs/workflow-context-surfaces.json
+++ b/docs/workflow-context-surfaces.json
@@ -13,7 +13,7 @@
     },
     "providerVisibleWorkflowToolDefinition": {
       "serialization": "UTF-8 bytes of JSON.stringify({ name, description, parameters })",
-      "bytes": 4276
+      "bytes": 4392
     },
     "registeredSkillsDiscovery": {
       "serialization": "sum of UTF-8 bytes of normalized Pi skill XML (name + description + location) across every root in package.json's pi.skills",
@@ -33,7 +33,7 @@
     },
     "ordinaryWorkflowOwnedAlwaysOn": {
       "serialization": "sum of permanent prompt, provider-visible tool definition, and every registered skill's discovery bytes",
-      "bytes": 5949
+      "bytes": 6065
     },
     "workflowAuthoringSkillCorpus": {
       "serialization": "sum of UTF-8 bytes for every file under skills/workflow-authoring",

--- a/docs/workflow-guidance-baseline.json
+++ b/docs/workflow-guidance-baseline.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "algorithm": "sha256",
   "surfaces": {
-    "compactGuidance": "533ed767108434b9eeff79119b1f895dcba2267e42fb9ef9742ba21de52607f2",
+    "compactGuidance": "7c699635fe8677afdcb3b57fddc457ea68f9250ef4b4413dc6f385dc1b910d48",
     "detailedProse": "93af687246a37125bcdbffd054cf9cacebba5262bf8dd3ee206c4f4651ecbefc"
   }
 }

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -100,7 +100,7 @@ const workflowToolSchema = Type.Object({
   tokenBudget: Type.Optional(
     Type.Number({
       description:
-        "Opt-in soft spend gate, not a planning target. Never invent or infer `tokenBudget`; set it only when the user supplies or requests a cap. Omit for configured `defaultTokenBudget`; without one, unlimited. Exhaustion blocks later calls; in-flight work can overshoot.",
+        "Optional user-requested soft spend gate, not a planning target. Do not set `tokenBudget` unless the user explicitly supplies a cap or asks you to choose one; never infer or invent one from task size. If omitted, the configured `defaultTokenBudget` applies; without one, the run is unlimited. Reaching the gate blocks later `agent()` calls; concurrent in-flight work can overshoot.",
     }),
   ),
   resumeFromRunId: Type.Optional(

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -52,7 +52,12 @@ const RENDERED_PROMPT_BUDGET_BYTES = 800;
 // — an explicit, minimal, JSON-Schema-valid object type (additional
 // properties are allowed by default without needing to spell that out) —
 // increasing this compact definition from 4,267 to 4,283 bytes (+16).
-const TOOL_DEFINITION_BUDGET_BYTES = 4_283;
+//
+// #127 adopts the reviewed tokenBudget contract verbatim rather than
+// compressing its wording to preserve the previous ceiling. The exact text
+// increases the measured definition from 4,276 to 4,392 bytes (+116), so the
+// accepted ceiling moves from 4,283 to 4,392 bytes (+109).
+const TOOL_DEFINITION_BUDGET_BYTES = 4_392;
 
 test("rendered workflow prompt contribution stays within its accepted size", async () => {
   await withRenderedWorkflow(async ({ systemPrompt, promptLines }) => {

--- a/tests/workflow-prompt-budget.test.ts
+++ b/tests/workflow-prompt-budget.test.ts
@@ -53,10 +53,11 @@ const RENDERED_PROMPT_BUDGET_BYTES = 800;
 // properties are allowed by default without needing to spell that out) —
 // increasing this compact definition from 4,267 to 4,283 bytes (+16).
 //
-// #127 adopts the reviewed tokenBudget contract verbatim rather than
-// compressing its wording to preserve the previous ceiling. The exact text
-// increases the measured definition from 4,276 to 4,392 bytes (+116), so the
-// accepted ceiling moves from 4,283 to 4,392 bytes (+109).
+// #127 compressed the reviewed tokenBudget contract to stay under the
+// previous ceiling; this follow-up restores the agreed text verbatim
+// instead. The exact wording increases the measured definition from 4,276
+// to 4,392 bytes (+116), and the accepted ceiling moves with it, from
+// 4,283 to 4,392.
 const TOOL_DEFINITION_BUDGET_BYTES = 4_392;
 
 test("rendered workflow prompt contribution stays within its accepted size", async () => {

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -187,17 +187,14 @@ test("createWorkflowTool schema describes the configured or unbounded timeout", 
   assert.match(description, /only when the user asks/i);
 });
 
-test("createWorkflowTool schema makes token budgets explicit opt-in spend gates", () => {
+test("createWorkflowTool schema uses the agreed token-budget wording exactly", () => {
   const tool = createWorkflowTool();
   const description = parameterDescription(tool, "tokenBudget");
 
-  assert.match(description, /opt-in soft spend gate, not a planning target/i);
-  assert.match(description, /never invent or infer `tokenBudget`/i);
-  assert.match(description, /set it only when the user supplies or requests a cap/i);
-  assert.match(description, /configured `defaultTokenBudget`/i);
-  assert.match(description, /without one.*unlimited/i);
-  assert.match(description, /exhaustion blocks later calls/i);
-  assert.match(description, /in-flight work can overshoot/i);
+  assert.equal(
+    description,
+    "Optional user-requested soft spend gate, not a planning target. Do not set `tokenBudget` unless the user explicitly supplies a cap or asks you to choose one; never infer or invent one from task size. If omitted, the configured `defaultTokenBudget` applies; without one, the run is unlimited. Reaching the gate blocks later `agent()` calls; concurrent in-flight work can overshoot.",
+  );
 });
 
 test("createWorkflowTool schema exposes resource controls and large-fan-out authority", () => {


### PR DESCRIPTION
## Summary

Follow-up correction to #127.

#127 compressed the reviewed `tokenBudget` schema wording to remain under the existing provider-visible byte ceiling. That was the wrong tradeoff: the agreed language was the requirement, so this PR restores it verbatim and deliberately revises the ceiling instead.

> Optional user-requested soft spend gate, not a planning target. Do not set `tokenBudget` unless the user explicitly supplies a cap or asks you to choose one; never infer or invent one from task size. If omitted, the configured `defaultTokenBudget` applies; without one, the run is unlimited. Reaching the gate blocks later `agent()` calls; concurrent in-flight work can overshoot.

- Pins the full sentence with a strict equality regression test.
- Revises the accepted provider-visible definition ceiling from 4,283 to 4,392 bytes.
- Regenerates the context measurement and guidance baseline.

## Evidence

- `npx tsx --test tests/workflow-tool.test.ts tests/workflow-prompt-budget.test.ts` — 35/35
- `npm run build`
- `npm run docs:check`
- `npm run context:check`
- `npm run guidance:check`
- `npm run release:verify` — 0 warnings
- `npm run delivery-choice -- --model openai-codex/gpt-5.6-sol:high` — 3/3 scenarios passed against the exact wording
