### PR TITLE
fix: prefer session provider for fuzzy workflow models

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -775,7 +775,9 @@ export class WorkflowAgent {
     let resolvedModel: Model<any> | undefined;
     let resolvedThinkingLevel: CreateAgentSessionOptions["thinkingLevel"] | undefined;
     if (modelSpec) {
-      const resolved = resolveModelSpecWithThinking(modelSpec, modelRegistry);
+      const resolved = resolveModelSpecWithThinking(modelSpec, modelRegistry, {
+        preferredProvider: this.mainModel?.split("/", 1)[0],
+      });
       if (resolved.warning) console.warn(`[workflow] ${resolved.warning}`);
       if (!resolved.model) {
         if (isExplicitRequest) {

--- a/src/model-spec.ts
+++ b/src/model-spec.ts
@@ -127,7 +127,11 @@ function findExactModelReferenceMatch(modelReference: string, availableModels: M
   return idMatches.length === 1 ? idMatches[0] : undefined;
 }
 
-function tryMatchModel(modelPattern: string, availableModels: Model<Api>[]): Model<Api> | undefined {
+function tryMatchModel(
+  modelPattern: string,
+  availableModels: Model<Api>[],
+  preferredProvider?: string,
+): Model<Api> | undefined {
   const exactMatch = findExactModelReferenceMatch(modelPattern, availableModels);
   if (exactMatch) return exactMatch;
 
@@ -136,15 +140,19 @@ function tryMatchModel(modelPattern: string, availableModels: Model<Api>[]): Mod
     (model) =>
       model.id.toLowerCase().includes(normalizedPattern) || model.name?.toLowerCase().includes(normalizedPattern),
   );
-  if (matches.length === 0) return undefined;
+  const preferredMatches = preferredProvider
+    ? matches.filter((model) => model.provider.toLowerCase() === preferredProvider.toLowerCase())
+    : [];
+  const rankedMatches = preferredMatches.length > 0 ? preferredMatches : matches;
+  if (rankedMatches.length === 0) return undefined;
 
-  const aliases = matches.filter((model) => isAlias(model.id));
+  const aliases = rankedMatches.filter((model) => isAlias(model.id));
   if (aliases.length > 0) {
     aliases.sort((a, b) => b.id.localeCompare(a.id));
     return aliases[0];
   }
 
-  const datedVersions = matches.filter((model) => !isAlias(model.id));
+  const datedVersions = rankedMatches.filter((model) => !isAlias(model.id));
   datedVersions.sort((a, b) => b.id.localeCompare(a.id));
   return datedVersions[0];
 }
@@ -152,9 +160,9 @@ function tryMatchModel(modelPattern: string, availableModels: Model<Api>[]): Mod
 function parseModelPattern(
   pattern: string,
   availableModels: Model<Api>[],
-  options?: ParseModelPatternOptions,
+  options?: ParseModelPatternOptions & { preferredProvider?: string },
 ): ParsedModelPattern {
-  const exactMatch = tryMatchModel(pattern, availableModels);
+  const exactMatch = tryMatchModel(pattern, availableModels, options?.preferredProvider);
   if (exactMatch) return { model: exactMatch };
 
   const lastColonIndex = pattern.lastIndexOf(":");
@@ -206,6 +214,7 @@ function buildFallbackModel(provider: string, modelId: string, availableModels: 
 export function resolveModelSpecWithThinking(
   spec: string,
   modelRegistry: Pick<ModelRegistry, "getAll"> & Partial<Pick<ModelRegistry, "hasConfiguredAuth">>,
+  options?: { preferredProvider?: string },
 ): ResolvedModelSpec {
   const requestedSpec = spec.trim();
   if (!requestedSpec) return { requestedSpec, error: "No model spec provided." };
@@ -247,6 +256,7 @@ export function resolveModelSpecWithThinking(
   const candidates = provider ? availableModels.filter((model) => model.provider === provider) : availableModels;
   const { model, thinkingLevel, warning } = parseModelPattern(pattern, candidates, {
     allowInvalidThinkingLevelFallback: false,
+    ...(provider === undefined ? { preferredProvider: options?.preferredProvider } : {}),
   });
   if (model) {
     // The provider was inferred from a slash prefix (e.g. "moonshotai/kimi-k3"),
@@ -286,6 +296,7 @@ export function resolveModelSpecWithThinking(
 
     const fallback = parseModelPattern(requestedSpec, availableModels, {
       allowInvalidThinkingLevelFallback: false,
+      preferredProvider: options?.preferredProvider,
     });
     if (fallback.model) {
       return {

--- a/tests/model-spec.test.ts
+++ b/tests/model-spec.test.ts
@@ -55,6 +55,28 @@ describe("model spec thinking suffixes", () => {
     assert.equal(resolved.resolvedSpec, "openai-codex/gpt-5.5:xhigh");
   });
 
+  it("prefers the active provider for an unqualified fuzzy workflow model", () => {
+    const gatewayLuna = model("vercel-ai-gateway", "openai/gpt-5.6-luna");
+    const openrouterLunaPro = model("openrouter", "openai/gpt-5.6-luna-pro");
+
+    const resolved = resolveModelSpecWithThinking("gpt-5.6-luna", registry([gatewayLuna, openrouterLunaPro]), {
+      preferredProvider: "vercel-ai-gateway",
+    });
+
+    assert.equal(resolved.model, gatewayLuna);
+    assert.equal(resolved.resolvedSpec, "vercel-ai-gateway/openai/gpt-5.6-luna");
+  });
+
+  it("uses global fuzzy matching when the preferred provider has no match", () => {
+    const openrouterLunaPro = model("openrouter", "openai/gpt-5.6-luna-pro");
+
+    const resolved = resolveModelSpecWithThinking("gpt-5.6-luna", registry([openrouterLunaPro]), {
+      preferredProvider: "vercel-ai-gateway",
+    });
+
+    assert.equal(resolved.model, openrouterLunaPro);
+  });
+
   it("resolves max as a Pi thinking level instead of a synthetic model id", () => {
     const gpt56 = model("openai-codex", "gpt-5.6-sol");
     const resolved = resolveModelSpecWithThinking("openai-codex/gpt-5.6-sol:max", registry([gpt56]));


### PR DESCRIPTION
## Problem

Workflow `agent()` calls accept bare model names. Before this change, an unqualified fuzzy request could search the full built-in catalog without preferring the active session provider.

For example, in a Pi session using Vercel AI Gateway, this workflow request:

```js
agent("…", { model: "gpt-5.6-luna" });
```

could resolve to `openrouter/openai/gpt-5.6-luna-pro` instead of the configured `vercel-ai-gateway/openai/gpt-5.6-luna`. On a machine without OpenRouter credentials, every affected subagent immediately failed with `No API key found for openrouter`.

## Summary

- prefer the active session provider for unqualified fuzzy workflow model requests
- retain global fuzzy fallback when the preferred provider has no matching model
- cover the Vercel AI Gateway vs OpenRouter GPT-5.6 Luna collision

## Verification

- `npm run test:unit -- --test-name-pattern="prefers the active provider|uses global fuzzy matching"`
- `npm run check:scripts`
- `npm run build`
- `npm run docs:check`
- `npm run context:check`
- `npm run release:verify`

The full unit suite also passed: 1,184 tests.