### PR TITLE
feat: safely auto-scope large bare code reviews

### DIFF
--- a/src/builtin-commands.ts
+++ b/src/builtin-commands.ts
@@ -10,8 +10,7 @@
  * whole session until the workflow finished (#104).
  */
 
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { spawn } from "node:child_process";
 import type { ExtensionAPI, ExtensionCommandContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { BuiltinWorkflowInvocation } from "./builtin-workflows.js";
 import { findBuiltinWorkflow } from "./builtin-workflows.js";
@@ -20,16 +19,68 @@ import { parseCommandArgs } from "./saved-commands.js";
 import type { WorkflowManager } from "./workflow-manager.js";
 import { createWorkflowStorage, type WorkflowStorage } from "./workflow-saved.js";
 
-const execFileAsync = promisify(execFile);
+const COMMAND_ERROR_MAX_CHARS = 32_000;
+
+export interface CapturedCommandPrefix {
+  stdout: string;
+  totalChars: number;
+}
 
 /**
- * Cap on the diff-source exec's stdout+stderr buffer. Node's default (1 MB)
- * throws on anything but a small diff — `gh pr diff` on a sizeable PR routinely
- * exceeds it. 64 MB comfortably covers any realistic diff while still bounding
- * worst-case memory; the prompt-side cap (code-review.ts's MAX_DIFF_CHARS) is
- * what actually protects the review from a huge diff, not this buffer.
+ * Stream command output while retaining only the prefix the review can use.
+ * This keeps memory bounded by MAX_DIFF_CHARS without imposing a child-process
+ * maxBuffer that rejects large diffs before the review's own truncation policy
+ * can run. stdout is decoded incrementally so split UTF-8 sequences are counted
+ * the same way as JavaScript String.length.
  */
-const DIFF_EXEC_MAX_BUFFER = 64 * 1024 * 1024;
+export function captureCommandPrefix(
+  command: string,
+  args: string[],
+  options: { cwd: string; maxChars: number },
+): Promise<CapturedCommandPrefix> {
+  if (!Number.isSafeInteger(options.maxChars) || options.maxChars < 1) {
+    return Promise.reject(new Error("captureCommandPrefix: maxChars must be a positive safe integer"));
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+
+    let stdout = "";
+    let totalChars = 0;
+    let stderr = "";
+    let stderrTruncated = false;
+
+    child.stdout.on("data", (chunk: string) => {
+      totalChars += chunk.length;
+      const remaining = options.maxChars - stdout.length;
+      if (remaining > 0) stdout += chunk.slice(0, remaining);
+    });
+    child.stderr.on("data", (chunk: string) => {
+      const remaining = COMMAND_ERROR_MAX_CHARS - stderr.length;
+      if (remaining > 0) stderr += chunk.slice(0, remaining);
+      if (chunk.length > remaining) stderrTruncated = true;
+    });
+
+    child.once("error", reject);
+    child.stdout.once("error", reject);
+    child.stderr.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve({ stdout, totalChars });
+        return;
+      }
+      const reason = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
+      const detail = stderr.trim();
+      const truncationNote = stderrTruncated ? " [stderr truncated]" : "";
+      reject(new Error(`${command} failed with ${reason}${detail ? `: ${detail}${truncationNote}` : ""}`));
+    });
+  });
+}
 
 function alreadyRegistered(pi: ExtensionAPI, name: string): boolean {
   try {
@@ -199,6 +250,7 @@ export function registerBuiltinWorkflows(
         const input = args.trim();
         let diffSource = "git diff HEAD";
         let diff = "";
+        let originalLength = 0;
 
         try {
           let cmd: string;
@@ -220,35 +272,26 @@ export function registerBuiltinWorkflows(
             cmd = "git";
             cmdArgs = ["diff", "HEAD", "--", input];
           }
-          // execFile (not exec/shell) + array args: input can't break out into a
-          // shell command. maxBuffer raised well past Node's 1MB default so a
-          // large `gh pr diff` doesn't throw ERR_CHILD_PROCESS_STDOUT_MAXBUFFER.
-          const { stdout } = await execFileAsync(cmd, cmdArgs, { cwd: getCwd(), maxBuffer: DIFF_EXEC_MAX_BUFFER });
-          diff = stdout;
+          // spawn (not a shell) + array args: input cannot break out into a shell
+          // command. Stream the complete output for an accurate size warning while
+          // retaining only the prefix the review can consume.
+          const captured = await captureCommandPrefix(cmd, cmdArgs, {
+            cwd: getCwd(),
+            maxChars: MAX_DIFF_CHARS,
+          });
+          diff = captured.stdout;
+          originalLength = captured.totalChars;
           if (!diff.trim()) {
             return ctx.ui.notify(`No diff output from: ${diffSource}`, "warning");
           }
         } catch (err) {
-          const code = (err as NodeJS.ErrnoException | undefined)?.code;
-          if (code === "ERR_CHILD_PROCESS_STDOUT_MAXBUFFER") {
-            return ctx.ui.notify(
-              `Diff from ${diffSource} exceeds the ${Math.floor(DIFF_EXEC_MAX_BUFFER / (1024 * 1024))}MB capture limit — ` +
-                `narrow the target (e.g. a specific file or path) and try again.`,
-              "error",
-            );
-          }
           return ctx.ui.notify(
             `Failed to get diff (${diffSource}): ${err instanceof Error ? err.message : err}`,
             "error",
           );
         }
 
-        // The workflow itself also caps prompt size (MAX_DIFF_CHARS), but truncating
-        // here lets us tell the user clearly rather than have it happen silently deep
-        // inside the generated script.
-        const originalLength = diff.length;
         if (originalLength > MAX_DIFF_CHARS) {
-          diff = diff.slice(0, MAX_DIFF_CHARS);
           ctx.ui.notify(
             `Diff is ${originalLength.toLocaleString()} characters — truncated to the first ` +
               `${MAX_DIFF_CHARS.toLocaleString()} for the review. Findings past the cut are not covered.`,

--- a/src/builtin-commands.ts
+++ b/src/builtin-commands.ts
@@ -20,10 +20,52 @@ import type { WorkflowManager } from "./workflow-manager.js";
 import { createWorkflowStorage, type WorkflowStorage } from "./workflow-saved.js";
 
 const COMMAND_ERROR_MAX_CHARS = 32_000;
+const AUTO_SCOPE_METADATA_MAX_CHARS = 2_000_000;
+const AUTO_SCOPE_MAX_PATHS = 4_096;
+const AUTO_SCOPE_MAX_ARG_BYTES = 256 * 1024;
+
+const AUTO_SCOPE_ROOT_RULES: ReadonlyArray<readonly [prefix: string, reason: string]> = [
+  [".playwright-mcp", "browser capture"],
+  ["graphify-out", "graph index output"],
+  ["supabase/.temp", "tool state"],
+  [".code-review-graph", "code index output"],
+  [".gitnexus", "code index output"],
+  [".codegraph", "code index output"],
+];
+
+const AUTO_SCOPE_DIRECTORY_RULES = new Map<string, string>([
+  ["node_modules", "dependency output"],
+  ["coverage", "coverage output"],
+  [".nyc_output", "coverage output"],
+  ["__pycache__", "cache output"],
+  [".pytest_cache", "cache output"],
+  [".mypy_cache", "cache output"],
+  [".ruff_cache", "cache output"],
+  [".turbo", "cache output"],
+  [".cache", "cache output"],
+  ["playwright-report", "browser report"],
+  ["test-results", "test output"],
+]);
 
 export interface CapturedCommandPrefix {
   stdout: string;
   totalChars: number;
+}
+
+export interface DiffNumstatEntry {
+  path: string;
+  addedLines: number | null;
+  deletedLines: number | null;
+  binary: boolean;
+}
+
+export interface ExcludedDiffEntry extends DiffNumstatEntry {
+  reason: string;
+}
+
+export interface CodeReviewAutoScope {
+  included: DiffNumstatEntry[];
+  excluded: ExcludedDiffEntry[];
 }
 
 /**
@@ -80,6 +122,147 @@ export function captureCommandPrefix(
       reject(new Error(`${command} failed with ${reason}${detail ? `: ${detail}${truncationNote}` : ""}`));
     });
   });
+}
+
+/** Parse `git diff --numstat -z --no-renames` without losing unusual filenames. */
+export function parseDiffNumstat(output: string): DiffNumstatEntry[] {
+  if (output.length === 0) return [];
+  if (!output.endsWith("\0")) throw new Error("git numstat output is not NUL-terminated");
+
+  return output
+    .slice(0, -1)
+    .split("\0")
+    .map((record, index) => {
+      const firstTab = record.indexOf("\t");
+      const secondTab = firstTab < 0 ? -1 : record.indexOf("\t", firstTab + 1);
+      if (firstTab < 1 || secondTab < firstTab + 2) {
+        throw new Error(`git numstat record ${index + 1} is malformed`);
+      }
+
+      const addedText = record.slice(0, firstTab);
+      const deletedText = record.slice(firstTab + 1, secondTab);
+      const path = record.slice(secondTab + 1);
+      if (!path || path.includes("\uFFFD")) {
+        throw new Error(`git numstat record ${index + 1} has an unsupported path`);
+      }
+
+      const binary = addedText === "-" && deletedText === "-";
+      if (!binary && (!/^\d+$/.test(addedText) || !/^\d+$/.test(deletedText))) {
+        throw new Error(`git numstat record ${index + 1} has invalid line counts`);
+      }
+      if (!binary && (addedText === "-" || deletedText === "-")) {
+        throw new Error(`git numstat record ${index + 1} has inconsistent binary markers`);
+      }
+
+      const addedLines = binary ? null : Number.parseInt(addedText, 10);
+      const deletedLines = binary ? null : Number.parseInt(deletedText, 10);
+      if (
+        (addedLines !== null && !Number.isSafeInteger(addedLines)) ||
+        (deletedLines !== null && !Number.isSafeInteger(deletedLines))
+      ) {
+        throw new Error(`git numstat record ${index + 1} exceeds safe integer limits`);
+      }
+
+      return { path, addedLines, deletedLines, binary };
+    });
+}
+
+/** Return a reason only for paths that are high-confidence generated artifacts. */
+export function classifyCodeReviewArtifact(path: string): string | undefined {
+  for (const [prefix, reason] of AUTO_SCOPE_ROOT_RULES) {
+    if (path.startsWith(`${prefix}/`)) return reason;
+  }
+
+  const segments = path.split("/");
+  for (const segment of segments.slice(0, -1)) {
+    const reason = AUTO_SCOPE_DIRECTORY_RULES.get(segment);
+    if (reason) return reason;
+  }
+  for (let index = 0; index < segments.length - 2; index += 1) {
+    if (segments[index] === "cypress" && ["screenshots", "videos"].includes(segments[index + 1])) {
+      return "browser capture";
+    }
+  }
+
+  const basename = segments.at(-1)?.toLowerCase() ?? "";
+  if (/\.(?:[cm]?js|css)\.map$/.test(basename)) return "source map";
+  if (/\.(?:min|bundle)\.(?:[cm]?js|css)$/.test(basename)) return "compiled bundle";
+  if (basename.endsWith(".tsbuildinfo")) return "compiler state";
+  if (basename.includes(".generated.") || basename.includes(".gen.")) return "generated file";
+  return undefined;
+}
+
+export async function discoverCodeReviewAutoScope(cwd: string): Promise<CodeReviewAutoScope> {
+  const metadata = await captureCommandPrefix(
+    "git",
+    ["diff", "HEAD", "--numstat", "-z", "--no-renames", "--no-ext-diff", "--no-textconv", "--no-color"],
+    { cwd, maxChars: AUTO_SCOPE_METADATA_MAX_CHARS },
+  );
+  if (metadata.totalChars > metadata.stdout.length) {
+    throw new Error(`tracked-change metadata exceeds ${AUTO_SCOPE_METADATA_MAX_CHARS.toLocaleString()} characters`);
+  }
+
+  const included: DiffNumstatEntry[] = [];
+  const excluded: ExcludedDiffEntry[] = [];
+  for (const entry of parseDiffNumstat(metadata.stdout)) {
+    const reason = classifyCodeReviewArtifact(entry.path);
+    if (reason) excluded.push({ ...entry, reason });
+    else included.push(entry);
+  }
+  return { included, excluded };
+}
+
+function buildAutoScopedDiffArgs(scope: CodeReviewAutoScope): string[] {
+  if (scope.included.length > AUTO_SCOPE_MAX_PATHS) {
+    throw new Error(
+      `auto-scope selected ${scope.included.length.toLocaleString()} paths (limit ${AUTO_SCOPE_MAX_PATHS})`,
+    );
+  }
+  const argBytes = scope.included.reduce((total, entry) => total + Buffer.byteLength(entry.path, "utf8") + 1, 0);
+  if (argBytes > AUTO_SCOPE_MAX_ARG_BYTES) {
+    throw new Error(
+      `auto-scope path arguments use ${argBytes.toLocaleString()} bytes (limit ${AUTO_SCOPE_MAX_ARG_BYTES.toLocaleString()})`,
+    );
+  }
+  return [
+    "--literal-pathspecs",
+    "diff",
+    "HEAD",
+    "--no-ext-diff",
+    "--no-textconv",
+    "--no-color",
+    "--no-renames",
+    "--",
+    ...scope.included.map((entry) => entry.path),
+  ];
+}
+
+function sumChangedLines(entries: DiffNumstatEntry[]): number {
+  return entries.reduce((total, entry) => total + (entry.addedLines ?? 0) + (entry.deletedLines ?? 0), 0);
+}
+
+function formatAutoScopeNotice(scope: CodeReviewAutoScope): string {
+  const reasons = new Map<string, number>();
+  for (const entry of scope.excluded) reasons.set(entry.reason, (reasons.get(entry.reason) ?? 0) + 1);
+  const reasonSummary = [...reasons.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([reason, count]) => `${reason}: ${count}`)
+    .join(", ");
+  const selectedLines = sumChangedLines(scope.included);
+  const skippedLines = sumChangedLines(scope.excluded);
+  const skippedBinaries = scope.excluded.filter((entry) => entry.binary).length;
+  const binarySummary = skippedBinaries > 0 ? `; ${skippedBinaries.toLocaleString()} binary` : "";
+  return (
+    `Auto-scope: reviewing ${scope.included.length.toLocaleString()} tracked files ` +
+    `(~${selectedLines.toLocaleString()} changed lines); skipped ${scope.excluded.length.toLocaleString()} ` +
+    `high-confidence artifacts (~${skippedLines.toLocaleString()} changed lines${binarySummary}). ` +
+    `Rules: ${reasonSummary}. Use /code-review <path> to include an artifact explicitly.`
+  );
+}
+
+function shortError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length > 500 ? `${message.slice(0, 500)}…` : message;
 }
 
 function alreadyRegistered(pi: ExtensionAPI, name: string): boolean {
@@ -248,48 +431,102 @@ export function registerBuiltinWorkflows(
       async handler(args: string, ctx: ExtensionCommandContext) {
         if (runSavedShadowIfPresent("code-review", args, ctx)) return;
         const input = args.trim();
+        const cwd = getCwd();
         let diffSource = "git diff HEAD";
-        let diff = "";
-        let originalLength = 0;
+        let cmd: string;
+        let cmdArgs: string[];
+        let autoScope: CodeReviewAutoScope | undefined;
 
-        try {
-          let cmd: string;
-          let cmdArgs: string[];
-          if (!input) {
-            diffSource = "git diff HEAD";
+        if (!input) {
+          try {
+            const discovered = await discoverCodeReviewAutoScope(cwd);
+            if (discovered.excluded.length > 0 && discovered.included.length === 0) {
+              return ctx.ui.notify(
+                `Auto-scope skipped all ${discovered.excluded.length.toLocaleString()} tracked changes as ` +
+                  `high-confidence generated/cache artifacts. Use /code-review <path> to review one explicitly.`,
+                "warning",
+              );
+            }
+            if (discovered.excluded.length > 0) {
+              cmd = "git";
+              cmdArgs = buildAutoScopedDiffArgs(discovered);
+              autoScope = discovered;
+              diffSource =
+                `git diff HEAD (auto-scope: ${discovered.included.length.toLocaleString()} included, ` +
+                `${discovered.excluded.length.toLocaleString()} artifacts skipped)`;
+            } else {
+              cmd = "git";
+              cmdArgs = ["diff", "HEAD"];
+            }
+          } catch (error) {
+            ctx.ui.notify(
+              `Auto-scope unavailable (${shortError(error)}); reviewing the full git diff HEAD without skipping files.`,
+              "warning",
+            );
             cmd = "git";
             cmdArgs = ["diff", "HEAD"];
-          } else if (/^\d+$/.test(input)) {
-            diffSource = `gh pr diff ${input}`;
-            cmd = "gh";
-            cmdArgs = ["pr", "diff", input];
-          } else if (input.includes("..")) {
-            diffSource = `git diff ${input}`;
-            cmd = "git";
-            cmdArgs = ["diff", input];
-          } else {
-            diffSource = `git diff HEAD -- ${input}`;
-            cmd = "git";
-            cmdArgs = ["diff", "HEAD", "--", input];
           }
-          // spawn (not a shell) + array args: input cannot break out into a shell
-          // command. Stream the complete output for an accurate size warning while
-          // retaining only the prefix the review can consume.
-          const captured = await captureCommandPrefix(cmd, cmdArgs, {
-            cwd: getCwd(),
+        } else if (/^\d+$/.test(input)) {
+          diffSource = `gh pr diff ${input}`;
+          cmd = "gh";
+          cmdArgs = ["pr", "diff", input];
+        } else if (input.includes("..")) {
+          diffSource = `git diff ${input}`;
+          cmd = "git";
+          cmdArgs = ["diff", input];
+        } else {
+          diffSource = `git diff HEAD -- ${input}`;
+          cmd = "git";
+          cmdArgs = ["diff", "HEAD", "--", input];
+        }
+
+        let captured: CapturedCommandPrefix;
+        try {
+          captured = await captureCommandPrefix(cmd, cmdArgs, {
+            cwd,
             maxChars: MAX_DIFF_CHARS,
           });
-          diff = captured.stdout;
-          originalLength = captured.totalChars;
-          if (!diff.trim()) {
-            return ctx.ui.notify(`No diff output from: ${diffSource}`, "warning");
+        } catch (error) {
+          if (!autoScope) {
+            return ctx.ui.notify(`Failed to get diff (${diffSource}): ${shortError(error)}`, "error");
           }
-        } catch (err) {
-          return ctx.ui.notify(
-            `Failed to get diff (${diffSource}): ${err instanceof Error ? err.message : err}`,
-            "error",
+          ctx.ui.notify(
+            `Auto-scoped diff failed (${shortError(error)}); retrying the full git diff HEAD without skipping files.`,
+            "warning",
           );
+          autoScope = undefined;
+          diffSource = "git diff HEAD";
+          try {
+            captured = await captureCommandPrefix("git", ["diff", "HEAD"], {
+              cwd,
+              maxChars: MAX_DIFF_CHARS,
+            });
+          } catch (fallbackError) {
+            return ctx.ui.notify(`Failed to get diff (${diffSource}): ${shortError(fallbackError)}`, "error");
+          }
         }
+
+        if (autoScope && !captured.stdout.trim()) {
+          ctx.ui.notify(
+            "Auto-scoped diff became empty while it was being collected; retrying the full git diff HEAD.",
+            "warning",
+          );
+          autoScope = undefined;
+          diffSource = "git diff HEAD";
+          try {
+            captured = await captureCommandPrefix("git", ["diff", "HEAD"], {
+              cwd,
+              maxChars: MAX_DIFF_CHARS,
+            });
+          } catch (fallbackError) {
+            return ctx.ui.notify(`Failed to get diff (${diffSource}): ${shortError(fallbackError)}`, "error");
+          }
+        }
+
+        const diff = captured.stdout;
+        const originalLength = captured.totalChars;
+        if (!diff.trim()) return ctx.ui.notify(`No diff output from: ${diffSource}`, "warning");
+        if (autoScope) ctx.ui.notify(formatAutoScopeNotice(autoScope), "info");
 
         if (originalLength > MAX_DIFF_CHARS) {
           ctx.ui.notify(

--- a/tests/builtin-commands.test.ts
+++ b/tests/builtin-commands.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { registerBuiltinWorkflows } from "../src/builtin-commands.js";
+import { captureCommandPrefix, registerBuiltinWorkflows } from "../src/builtin-commands.js";
+import { MAX_DIFF_CHARS } from "../src/code-review.js";
 import { parseWorkflowScript } from "../src/workflow.js";
 import type { WorkflowManager } from "../src/workflow-manager.js";
 import type { SavedWorkflow, WorkflowStorage } from "../src/workflow-saved.js";
@@ -49,6 +50,34 @@ function makeFakeManager() {
   } as unknown as WorkflowManager;
   return { manager, started };
 }
+
+test("captureCommandPrefix streams output beyond the legacy 64 MiB capture limit", async () => {
+  const chunkChars = 1024 * 1024;
+  const chunkCount = 65;
+  const childScript = `
+    const chunk = "x".repeat(${chunkChars});
+    let remaining = ${chunkCount};
+    function write() {
+      while (remaining > 0) {
+        remaining -= 1;
+        if (!process.stdout.write(chunk)) {
+          process.stdout.once("drain", write);
+          return;
+        }
+      }
+    }
+    write();
+  `;
+
+  const captured = await captureCommandPrefix(process.execPath, ["-e", childScript], {
+    cwd: process.cwd(),
+    maxChars: MAX_DIFF_CHARS,
+  });
+
+  assert.equal(captured.totalChars, chunkChars * chunkCount);
+  assert.equal(captured.stdout.length, MAX_DIFF_CHARS);
+  assert.equal(captured.stdout, "x".repeat(MAX_DIFF_CHARS));
+});
 
 test("registerBuiltinWorkflows registers all five built-in workflow commands", () => {
   const { pi, commands } = makeCommandRegistryPi();

--- a/tests/builtin-commands.test.ts
+++ b/tests/builtin-commands.test.ts
@@ -1,6 +1,15 @@
 import assert from "node:assert/strict";
-import test from "node:test";
-import { captureCommandPrefix, registerBuiltinWorkflows } from "../src/builtin-commands.js";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test, { type TestContext } from "node:test";
+import {
+  captureCommandPrefix,
+  classifyCodeReviewArtifact,
+  parseDiffNumstat,
+  registerBuiltinWorkflows,
+} from "../src/builtin-commands.js";
 import { MAX_DIFF_CHARS } from "../src/code-review.js";
 import { parseWorkflowScript } from "../src/workflow.js";
 import type { WorkflowManager } from "../src/workflow-manager.js";
@@ -51,6 +60,34 @@ function makeFakeManager() {
   return { manager, started };
 }
 
+function git(repo: string, args: string[]): string {
+  return execFileSync("git", args, { cwd: repo, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+async function writeRepoFile(repo: string, path: string, content: string | Uint8Array): Promise<void> {
+  const target = join(repo, path);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, content);
+}
+
+async function makeGitRepo(t: TestContext, files: Record<string, string | Uint8Array>): Promise<string> {
+  const repo = await mkdtemp(join(tmpdir(), "pi-code-review-auto-scope-"));
+  t.after(() => rm(repo, { recursive: true, force: true }));
+  git(repo, ["init", "-q"]);
+  for (const [path, content] of Object.entries(files)) await writeRepoFile(repo, path, content);
+  git(repo, ["add", "-A"]);
+  git(repo, [
+    "-c",
+    "user.name=Workflow Tests",
+    "-c",
+    "user.email=workflow-tests@example.invalid",
+    "commit",
+    "-qm",
+    "initial",
+  ]);
+  return repo;
+}
+
 test("captureCommandPrefix streams output beyond the legacy 64 MiB capture limit", async () => {
   const chunkChars = 1024 * 1024;
   const chunkCount = 65;
@@ -77,6 +114,114 @@ test("captureCommandPrefix streams output beyond the legacy 64 MiB capture limit
   assert.equal(captured.totalChars, chunkChars * chunkCount);
   assert.equal(captured.stdout.length, MAX_DIFF_CHARS);
   assert.equal(captured.stdout, "x".repeat(MAX_DIFF_CHARS));
+});
+
+test("parseDiffNumstat preserves NUL-delimited unusual paths and binary markers", () => {
+  assert.deepEqual(parseDiffNumstat("3\t4\tsrc/a\tname\nfile.ts\0-\t-\tpublic/image.png\0"), [
+    { path: "src/a\tname\nfile.ts", addedLines: 3, deletedLines: 4, binary: false },
+    { path: "public/image.png", addedLines: null, deletedLines: null, binary: true },
+  ]);
+  assert.throws(() => parseDiffNumstat("1\t2\tsrc/a.ts"), /NUL-terminated/);
+  assert.throws(() => parseDiffNumstat("1\tx\tsrc/a.ts\0"), /invalid line counts/);
+  assert.throws(() => parseDiffNumstat("1\t2\t\0"), /unsupported path/);
+});
+
+test("classifyCodeReviewArtifact excludes only high-confidence generated paths", () => {
+  assert.equal(classifyCodeReviewArtifact("graphify-out/cache/a.json"), "graph index output");
+  assert.equal(classifyCodeReviewArtifact("packages/app/node_modules/pkg/index.js"), "dependency output");
+  assert.equal(classifyCodeReviewArtifact("cypress/screenshots/home.png"), "browser capture");
+  assert.equal(classifyCodeReviewArtifact("dist/app.min.js"), "compiled bundle");
+  assert.equal(classifyCodeReviewArtifact("src/schema.generated.ts"), "generated file");
+  assert.equal(classifyCodeReviewArtifact("build/cache.tsbuildinfo"), "compiler state");
+
+  assert.equal(classifyCodeReviewArtifact(".claude/commands/review.md"), undefined);
+  assert.equal(classifyCodeReviewArtifact("dist/manual.js"), undefined);
+  assert.equal(classifyCodeReviewArtifact("public/data.json"), undefined);
+  assert.equal(classifyCodeReviewArtifact("fixtures/large-output.log"), undefined);
+  assert.equal(classifyCodeReviewArtifact("src/generator.ts"), undefined);
+});
+
+test("bare code-review auto-scopes artifacts and safely includes unusual source paths", {
+  skip: process.platform === "win32",
+}, async (t) => {
+  const initial: Record<string, string> = {
+    "src/real.ts": "export const value = 'before';\n",
+    "dist/manual.js": "export const manual = 'before';\n",
+    "src/space name.ts": "export const space = 'before';\n",
+    "src/:literal[1].ts": "export const colon = 'before';\n",
+    "-leading.ts": "export const leading = 'before';\n",
+    "src/line\nbreak.ts": "export const newline = 'before';\n",
+    "src/tab\tname.ts": "export const tab = 'before';\n",
+    "src/你好.ts": "export const unicode = 'before';\n",
+    "src/$(echo-pwn).ts": "export const shell = 'before';\n",
+    ".playwright-mcp/capture.yml": "capture-before\n",
+    "graphify-out/cache/a.json": '{"artifact":"before"}\n',
+    "supabase/.temp/version": "before\n",
+  };
+  const repo = await makeGitRepo(t, initial);
+  const markers: Record<string, string> = {
+    "src/real.ts": "AUTO_SCOPE_REAL",
+    "dist/manual.js": "AUTO_SCOPE_UNCERTAIN_DIST",
+    "src/space name.ts": "AUTO_SCOPE_SPACE",
+    "src/:literal[1].ts": "AUTO_SCOPE_COLON",
+    "-leading.ts": "AUTO_SCOPE_LEADING",
+    "src/line\nbreak.ts": "AUTO_SCOPE_NEWLINE",
+    "src/tab\tname.ts": "AUTO_SCOPE_TAB",
+    "src/你好.ts": "AUTO_SCOPE_UNICODE",
+    "src/$(echo-pwn).ts": "AUTO_SCOPE_SHELL",
+    ".playwright-mcp/capture.yml": "AUTO_SCOPE_PLAYWRIGHT_ARTIFACT",
+    "graphify-out/cache/a.json": "AUTO_SCOPE_GRAPH_ARTIFACT",
+    "supabase/.temp/version": "AUTO_SCOPE_SUPABASE_ARTIFACT",
+  };
+  for (const [path, marker] of Object.entries(markers)) await writeRepoFile(repo, path, `${marker}\n`);
+
+  const { pi, commands } = makeCommandRegistryPi();
+  const { manager, started } = makeFakeManager();
+  registerBuiltinWorkflows(pi, { cwd: repo, manager, storage: makeFakeStorage({}) });
+  const handler = commands.find((command) => command.name === "code-review")?.handler;
+  assert.ok(handler);
+  const { ctx, notified } = makeNotifyCtx();
+
+  await handler("   ", ctx);
+
+  assert.equal(started.length, 1);
+  const autoArgs = started[0].args as { diff: string; diffSource: string };
+  for (const marker of Object.values(markers).filter((value) => !value.endsWith("_ARTIFACT"))) {
+    assert.match(autoArgs.diff, new RegExp(marker));
+  }
+  assert.doesNotMatch(autoArgs.diff, /AUTO_SCOPE_(?:PLAYWRIGHT|GRAPH|SUPABASE)_ARTIFACT/);
+  assert.match(autoArgs.diffSource, /auto-scope: 9 included, 3 artifacts skipped/);
+  const scopeNotice = notified.find((entry) => entry.message.startsWith("Auto-scope:"));
+  assert.ok(scopeNotice);
+  assert.equal(scopeNotice.type, "info");
+  assert.match(scopeNotice.message, /reviewing 9 tracked files/);
+  assert.match(scopeNotice.message, /skipped 3 high-confidence artifacts/);
+
+  await handler("graphify-out/cache/a.json", ctx);
+  assert.equal(started.length, 2, "an explicit artifact path must bypass auto-scope");
+  const explicitArgs = started[1].args as { diff: string; diffSource: string };
+  assert.match(explicitArgs.diff, /AUTO_SCOPE_GRAPH_ARTIFACT/);
+  assert.equal(explicitArgs.diffSource, "git diff HEAD -- graphify-out/cache/a.json");
+});
+
+test("bare code-review stops cleanly when only generated artifacts changed", async (t) => {
+  const repo = await makeGitRepo(t, { "graphify-out/cache/a.json": "before\n" });
+  await writeRepoFile(repo, "graphify-out/cache/a.json", "after\n");
+
+  const { pi, commands } = makeCommandRegistryPi();
+  const { manager, started } = makeFakeManager();
+  registerBuiltinWorkflows(pi, { cwd: repo, manager, storage: makeFakeStorage({}) });
+  const handler = commands.find((command) => command.name === "code-review")?.handler;
+  assert.ok(handler);
+  const { ctx, notified } = makeNotifyCtx();
+
+  await handler("", ctx);
+
+  assert.equal(started.length, 0);
+  assert.equal(notified.length, 1);
+  assert.equal(notified[0].type, "warning");
+  assert.match(notified[0].message, /skipped all 1 tracked changes/);
+  assert.match(notified[0].message, /review one explicitly/);
 });
 
 test("registerBuiltinWorkflows registers all five built-in workflow commands", () => {


### PR DESCRIPTION
## Problem

`/code-review` captures `git diff`/`gh pr diff` with `execFile(..., { maxBuffer: 64 MiB })`. A large tracked diff therefore fails before the command's existing 200,000-character prompt bound can help. Newer Node versions can also report this as `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`, which the current special case does not catch.

For a bare `/code-review`, generated browser/index/cache output can dominate the diff and make a prefix-only review cover none of the hand-authored changes.

## Changes

- Stream diff output with `spawn()` while retaining only the first `MAX_DIFF_CHARS` characters and counting the complete output for an accurate coverage warning.
- Auto-scope **only an empty/whitespace `/code-review`** using NUL-delimited `git diff HEAD --numstat -z --no-renames` metadata.
- Skip only high-confidence generated/cache families; uncertain files remain included. Broad roots such as `dist/`, `build/`, `public/`, fixtures, JSON, and logs are deliberately not skipped.
- Rebuild the selected diff with literal argv pathspecs, bounded path count/argument bytes, and no shell interpolation.
- Report included/skipped files, line estimates, binary counts, and skip reasons.
- Fail open: metadata, parsing, argument-limit, or selected-diff failures warn and retry the exact unfiltered `git diff HEAD` path.
- Preserve explicit file/path, Git range, and numeric PR behavior unchanged. Explicit artifact paths bypass auto-scope.

If every tracked change is a high-confidence artifact, the command explains that nothing reviewable remains instead of launching an empty review.

## Validation

- `npm test`: **1,187 passed, 0 failed**; release gate passed.
- Added a 65 MiB streaming regression (past the old 64 MiB limit).
- Added NUL parser/binary tests and conservative classifier tests.
- Added Git integration coverage for generated-only changes, explicit artifact bypass, spaces, tabs, newlines, Unicode, leading dashes, pathspec metacharacters, and shell metacharacters.
- Smoke-tested a ~383 million-character tracked diff: auto-scope retained 23 uncertain/source files, skipped 825 high-confidence artifacts, and produced a complete 155,763-character selected diff.

No workflow runtime/tool API or agent execution behavior changes, so no provider-backed E2E run is needed.
