### PR TITLE
feat: stream live agent token usage

### DIFF
--- a/src/agent-usage.ts
+++ b/src/agent-usage.ts
@@ -33,10 +33,10 @@ interface AgentCallUsageUpdate {
   committedUsage?: AgentUsage;
 }
 
-/** Settled token count plus exact provider usage when the provider reported it. */
+/** Settled cumulative usage for one logical agent call, including retries. */
 interface AgentUsageCommit {
   tokens: number;
-  terminalUsage?: AgentUsage;
+  tokenUsage?: AgentUsage;
 }
 
 /**
@@ -57,16 +57,14 @@ export function createAgentCallUsageTracker(onUpdate: (update: AgentCallUsageUpd
       const emitProgress = () => {
         onUpdate({ tokenUsage: sumAgentUsage(committedCallUsage, attemptUsage) });
       };
-      const commitUsage = (usage: AgentUsage, reportedTerminalUsage?: AgentUsage): AgentUsageCommit => {
+      const commitUsage = (usage: AgentUsage): AgentUsageCommit => {
         if (!isOpen()) {
           return { tokens: 0 };
         }
         closed = true;
         committedCallUsage = sumAgentUsage(committedCallUsage, usage);
         onUpdate({ tokenUsage: committedCallUsage, committedUsage: usage });
-        return reportedTerminalUsage
-          ? { tokens: usage.total, terminalUsage: reportedTerminalUsage }
-          : { tokens: usage.total };
+        return { tokens: committedCallUsage.total, tokenUsage: committedCallUsage };
       };
 
       return {
@@ -89,7 +87,7 @@ export function createAgentCallUsageTracker(onUpdate: (update: AgentCallUsageUpd
         },
         commitWithFallback(fallbackTotal: number) {
           if (terminalUsage && (terminalUsage.total > 0 || terminalUsage.cost > 0)) {
-            return commitUsage(terminalUsage, terminalUsage);
+            return commitUsage(terminalUsage);
           }
           return commitUsage({ ...createEmptyAgentUsage(), total: Math.max(0, fallbackTotal) });
         },
@@ -98,7 +96,7 @@ export function createAgentCallUsageTracker(onUpdate: (update: AgentCallUsageUpd
             closed = true;
             return { tokens: 0 };
           }
-          return commitUsage(terminalUsage, terminalUsage);
+          return commitUsage(terminalUsage);
         },
       };
     },

--- a/src/agent-usage.ts
+++ b/src/agent-usage.ts
@@ -1,0 +1,118 @@
+/** Token and cost usage for one subagent attempt or logical agent call. */
+export interface AgentUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+  cost: number;
+}
+
+/** Create an independent zero-valued agent usage record. */
+export function createEmptyAgentUsage(): AgentUsage {
+  return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0, cost: 0 };
+}
+
+/** Add agent usage records without mutating either input. */
+export function sumAgentUsage(...records: AgentUsage[]): AgentUsage {
+  const total = createEmptyAgentUsage();
+  for (const usage of records) {
+    total.input += usage.input;
+    total.output += usage.output;
+    total.cacheRead += usage.cacheRead;
+    total.cacheWrite += usage.cacheWrite;
+    total.total += usage.total;
+    total.cost += usage.cost;
+  }
+  return total;
+}
+
+/** Cumulative display usage plus the exact attempt delta when usage becomes committed. */
+interface AgentCallUsageUpdate {
+  tokenUsage: AgentUsage;
+  committedUsage?: AgentUsage;
+}
+
+/** Settled token count plus exact provider usage when the provider reported it. */
+interface AgentUsageCommit {
+  tokens: number;
+  terminalUsage?: AgentUsage;
+}
+
+/**
+ * Track provisional and committed usage for one logical agent call across retries.
+ * Starting a new attempt closes older attempts so their late callbacks are ignored.
+ */
+export function createAgentCallUsageTracker(onUpdate: (update: AgentCallUsageUpdate) => void) {
+  let committedCallUsage = createEmptyAgentUsage();
+  let activeAttempt = 0;
+
+  return {
+    startAttempt() {
+      const attemptId = ++activeAttempt;
+      let attemptUsage = createEmptyAgentUsage();
+      let terminalUsage: AgentUsage | undefined;
+      let closed = false;
+      const isOpen = () => !closed && attemptId === activeAttempt;
+      const emitProgress = () => {
+        onUpdate({ tokenUsage: sumAgentUsage(committedCallUsage, attemptUsage) });
+      };
+      const commitUsage = (usage: AgentUsage, reportedTerminalUsage?: AgentUsage): AgentUsageCommit => {
+        if (!isOpen()) {
+          return { tokens: 0 };
+        }
+        closed = true;
+        committedCallUsage = sumAgentUsage(committedCallUsage, usage);
+        onUpdate({ tokenUsage: committedCallUsage, committedUsage: usage });
+        return reportedTerminalUsage
+          ? { tokens: usage.total, terminalUsage: reportedTerminalUsage }
+          : { tokens: usage.total };
+      };
+
+      return {
+        reportProgress(usage: AgentUsage) {
+          if (!isOpen() || agentUsageEquals(attemptUsage, usage)) {
+            return;
+          }
+          attemptUsage = usage;
+          emitProgress();
+        },
+        reportTerminal(usage: AgentUsage) {
+          if (!isOpen()) {
+            return;
+          }
+          terminalUsage = usage;
+          if (!agentUsageEquals(attemptUsage, usage)) {
+            attemptUsage = usage;
+            emitProgress();
+          }
+        },
+        commitWithFallback(fallbackTotal: number) {
+          if (terminalUsage && (terminalUsage.total > 0 || terminalUsage.cost > 0)) {
+            return commitUsage(terminalUsage, terminalUsage);
+          }
+          return commitUsage({ ...createEmptyAgentUsage(), total: Math.max(0, fallbackTotal) });
+        },
+        commitTerminalUsage() {
+          if (!terminalUsage) {
+            closed = true;
+            return { tokens: 0 };
+          }
+          return commitUsage(terminalUsage, terminalUsage);
+        },
+      };
+    },
+  };
+}
+
+/** Return whether two complete agent usage records contain the same values. */
+export function agentUsageEquals(left: AgentUsage, right: AgentUsage): boolean {
+  return (
+    left.input === right.input &&
+    left.output === right.output &&
+    left.cacheRead === right.cacheRead &&
+    left.cacheWrite === right.cacheWrite &&
+    left.total === right.total &&
+    left.cost === right.cost
+  );
+}

--- a/src/agent-usage.ts
+++ b/src/agent-usage.ts
@@ -93,7 +93,14 @@ export function createAgentCallUsageTracker(onUpdate: (update: AgentCallUsageUpd
         },
         commitTerminalUsage() {
           if (!terminalUsage) {
+            if (!isOpen()) {
+              return { tokens: 0 };
+            }
             closed = true;
+            const displayedUsage = sumAgentUsage(committedCallUsage, attemptUsage);
+            if (!agentUsageEquals(displayedUsage, committedCallUsage)) {
+              onUpdate({ tokenUsage: committedCallUsage });
+            }
             return { tokens: 0 };
           }
           return commitUsage(terminalUsage);

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -3,6 +3,7 @@ import { unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AssistantMessage, Model, TextContent } from "@earendil-works/pi-ai";
 import {
+  type AgentSessionEvent,
   type CreateAgentSessionOptions,
   createAgentSession,
   createCodingTools,
@@ -17,6 +18,10 @@ import {
 import type { Static, TSchema } from "typebox";
 import { Check, Convert } from "typebox/value";
 import { type AgentHistoryEntry, compactAgentHistory } from "./agent-history.js";
+import { type AgentUsage, agentUsageEquals, createEmptyAgentUsage, sumAgentUsage } from "./agent-usage.js";
+
+export type { AgentUsage } from "./agent-usage.js";
+
 import { applyToolPolicy } from "./agent-registry.js";
 import { classifyProviderLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import { canonicalModelSpec, resolveModelSpecWithThinking } from "./model-spec.js";
@@ -28,6 +33,8 @@ import {
   resolveTierModel,
 } from "./model-tier-config.js";
 import { createStructuredOutputTool, type StructuredOutputCapture } from "./structured-output.js";
+
+const LIVE_USAGE_EMIT_INTERVAL_MS = 250;
 
 /**
  * Find a JSON object/array in free-form text: a fenced ```json block if present,
@@ -365,16 +372,6 @@ function warnPersistSecretsOnce(sessionDir: string): void {
   );
 }
 
-/** Real token/cost usage for a single subagent run, read from the SDK session. */
-export interface AgentUsage {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-  total: number;
-  cost: number;
-}
-
 /**
  * Map session stats to an AgentUsage, or undefined when the provider reported
  * no usage at all (all-zero stats). Returning undefined — instead of a zero
@@ -397,6 +394,57 @@ export function usageFromStats(stats: {
   };
 }
 
+function estimateStreamingAssistantUsage(event: AgentSessionEvent): AgentUsage | undefined {
+  if (event.type !== "message_update" && event.type !== "message_end") {
+    return undefined;
+  }
+  if (event.message.role !== "assistant") {
+    return undefined;
+  }
+
+  const reported = event.message.usage;
+  const reportedTotal = reported.input + reported.output + reported.cacheRead + reported.cacheWrite;
+  if (reportedTotal > 0 || reported.cost.total > 0) {
+    return {
+      input: reported.input,
+      output: reported.output,
+      cacheRead: reported.cacheRead,
+      cacheWrite: reported.cacheWrite,
+      total: reportedTotal,
+      cost: reported.cost.total,
+    };
+  }
+
+  let streamedCharacters = 0;
+  for (const content of event.message.content) {
+    if (content.type === "text") {
+      streamedCharacters += content.text.length;
+    } else if (content.type === "thinking") {
+      streamedCharacters += content.thinking.length;
+    } else if (content.type === "toolCall") {
+      streamedCharacters += JSON.stringify(content.arguments).length;
+    }
+  }
+  if (streamedCharacters === 0) {
+    return undefined;
+  }
+
+  const estimatedOutput = Math.max(1, Math.ceil(streamedCharacters / 4));
+  return { input: 0, output: estimatedOutput, cacheRead: 0, cacheWrite: 0, total: estimatedOutput, cost: 0 };
+}
+
+function usageFromSessionProgress(
+  stats: Parameters<typeof usageFromStats>[0],
+  event: AgentSessionEvent,
+): AgentUsage | undefined {
+  const persisted = usageFromStats(stats);
+  const streaming = estimateStreamingAssistantUsage(event);
+  if (!streaming) {
+    return persisted;
+  }
+  return sumAgentUsage(persisted ?? createEmptyAgentUsage(), streaming);
+}
+
 export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefined> {
   label?: string;
   /**
@@ -410,13 +458,14 @@ export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefi
   tools?: ToolDefinition[];
   instructions?: string;
   signal?: AbortSignal;
-  /**
-   * Called once with this subagent's real usage, read from the session right
-   * before disposal. Fires on both the success and error paths so partial
-   * usage is never lost — but NOT when the provider reported no usage at all
-   * (all-zero stats), so consumers keep their scalar fallback.
-   */
+  /** Called once before disposal with exact cumulative provider usage, when reported. */
   onUsage?: (usage: AgentUsage) => void;
+  /**
+   * Called with cumulative progress while the subagent runs. The current
+   * streaming response uses an output-token estimate until the provider's exact
+   * terminal usage replaces it.
+   */
+  onUsageProgress?: (usage: AgentUsage) => void;
   /**
    * Model spec for this subagent: either `provider/modelId` (unambiguous) or a
    * bare `modelId`, parsed with the same grammar as Pi CLI's `--model`. When it
@@ -925,6 +974,9 @@ export class WorkflowAgent {
     let removeTurnListener: (() => void) | undefined;
     let lastHistoryEmit = 0;
     let threadTurnSucceeded = false;
+    let removeSessionListener: (() => void) | undefined;
+    let lastUsageProgressEmit = 0;
+    let lastProgressUsage: AgentUsage | undefined;
     const emitHistory = () => options.onHistory?.(compactAgentHistory(session.messages));
     const maybeEmitHistory = () => {
       if (!options.onHistory) return;
@@ -933,6 +985,34 @@ export class WorkflowAgent {
       lastHistoryEmit = now;
       emitHistory();
     };
+    const emitUsageProgress = (event: AgentSessionEvent) => {
+      if (!options.onUsageProgress) {
+        return;
+      }
+      const now = Date.now();
+      if (
+        event.type === "message_update" &&
+        lastProgressUsage &&
+        now - lastUsageProgressEmit < LIVE_USAGE_EMIT_INTERVAL_MS
+      ) {
+        return;
+      }
+      const usage = usageFromSessionProgress(session.getSessionStats(), event);
+      if (!usage || (lastProgressUsage && agentUsageEquals(lastProgressUsage, usage))) {
+        return;
+      }
+      lastUsageProgressEmit = now;
+      lastProgressUsage = usage;
+      options.onUsageProgress(usage);
+    };
+    const emitSessionProgress = (event: AgentSessionEvent) => {
+      maybeEmitHistory();
+      try {
+        emitUsageProgress(event);
+      } catch {
+        // Usage progress is best-effort; never let stats failure interrupt the agent.
+      }
+    };
     try {
       if (options.signal?.aborted) throw new Error("Subagent was aborted");
       if (options.signal) {
@@ -940,8 +1020,8 @@ export class WorkflowAgent {
         options.signal.addEventListener("abort", onAbort, { once: true });
         removeAbortListener = () => options.signal?.removeEventListener("abort", onAbort);
       }
-      if (options.onHistory) {
-        removeHistoryListener = session.subscribe(() => maybeEmitHistory());
+      if (options.onHistory || options.onUsageProgress) {
+        removeSessionListener = session.subscribe(emitSessionProgress);
       }
       removeTurnListener = session.subscribe((event) => {
         if (event.type === "message_end") turnMessages.push(event.message);
@@ -984,6 +1064,7 @@ export class WorkflowAgent {
       removeAbortListener?.();
       removeHistoryListener?.();
       removeTurnListener?.();
+      removeSessionListener?.();
       try {
         emitHistory();
       } catch {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -433,10 +433,31 @@ function estimateStreamingAssistantUsage(event: AgentSessionEvent): AgentUsage |
   return { input: 0, output: estimatedOutput, cacheRead: 0, cacheWrite: 0, total: estimatedOutput, cost: 0 };
 }
 
-function usageFromSessionProgress(
-  stats: Parameters<typeof usageFromStats>[0],
-  event: AgentSessionEvent,
-): AgentUsage | undefined {
+type SessionUsageStats = Parameters<typeof usageFromStats>[0];
+
+function subtractSessionUsageStats(stats: SessionUsageStats, baseline?: SessionUsageStats): SessionUsageStats {
+  if (!baseline) {
+    return stats;
+  }
+  return {
+    tokens: {
+      input: Math.max(0, stats.tokens.input - baseline.tokens.input),
+      output: Math.max(0, stats.tokens.output - baseline.tokens.output),
+      cacheRead: Math.max(0, stats.tokens.cacheRead - baseline.tokens.cacheRead),
+      cacheWrite: Math.max(0, stats.tokens.cacheWrite - baseline.tokens.cacheWrite),
+      total: Math.max(0, stats.tokens.total - baseline.tokens.total),
+    },
+    cost: Math.max(0, stats.cost - baseline.cost),
+  };
+}
+
+/**
+ * Combine usage from completed messages with the current streaming message.
+ * AgentSession notifies subscribers before it appends a message_end event to
+ * SessionManager, so the event's assistant usage is absent from stats and must
+ * be added exactly once. The real-session regression test pins this ordering.
+ */
+function usageFromSessionProgress(stats: SessionUsageStats, event: AgentSessionEvent): AgentUsage | undefined {
   const persisted = usageFromStats(stats);
   const streaming = estimateStreamingAssistantUsage(event);
   if (!streaming) {
@@ -997,7 +1018,10 @@ export class WorkflowAgent {
       ) {
         return;
       }
-      const usage = usageFromSessionProgress(session.getSessionStats(), event);
+      const usage = usageFromSessionProgress(
+        subtractSessionUsageStats(session.getSessionStats(), usageBeforeTurn),
+        event,
+      );
       if (!usage || (lastProgressUsage && agentUsageEquals(lastProgressUsage, usage))) {
         return;
       }
@@ -1077,20 +1101,7 @@ export class WorkflowAgent {
       if (options.onUsage) {
         try {
           const stats = session.getSessionStats();
-          const usage = usageFromStats(
-            usageBeforeTurn
-              ? {
-                  tokens: {
-                    input: Math.max(0, stats.tokens.input - usageBeforeTurn.tokens.input),
-                    output: Math.max(0, stats.tokens.output - usageBeforeTurn.tokens.output),
-                    cacheRead: Math.max(0, stats.tokens.cacheRead - usageBeforeTurn.tokens.cacheRead),
-                    cacheWrite: Math.max(0, stats.tokens.cacheWrite - usageBeforeTurn.tokens.cacheWrite),
-                    total: Math.max(0, stats.tokens.total - usageBeforeTurn.tokens.total),
-                  },
-                  cost: Math.max(0, stats.cost - usageBeforeTurn.cost),
-                }
-              : stats,
-          );
+          const usage = usageFromStats(subtractSessionUsageStats(stats, usageBeforeTurn));
           if (usage) options.onUsage(usage);
         } catch {
           // Usage is best-effort; never let stats failure mask the real result/error.

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -44,6 +44,15 @@ export interface PersistedAgentState {
   model?: string;
 }
 
+/** Serialized journal entry; runId is absent on legacy numeric-only journals. */
+export interface PersistedJournalEntry {
+  index: number;
+  runId?: string;
+  hash: string;
+  result: unknown;
+  storeDelta?: Record<string, unknown>;
+}
+
 export interface PersistedRunState {
   runId: string;
   workflowName: string;
@@ -78,17 +87,11 @@ export interface PersistedRunState {
    * Cached agent/checkpoint results for resume, keyed by deterministic call
    * index. `runId` namespaces `index` (a nested workflow() call restarts its
    * own callSeq at 0) — absent on journals persisted before that namespacing
-   * existed; see JournalEntry.runId in workflow.ts for the resume-time
-   * legacy-degradation behavior. `storeDelta` is this call's SharedStore
-   * write delta, replayed additively on resume.
+   * existed; see PersistedJournalEntry.runId in workflow.ts / the manager's
+   * resume() for the resume-time legacy-degradation behavior. `storeDelta` is
+   * this call's SharedStore write delta, replayed additively on resume.
    */
-  journal?: Array<{
-    index: number;
-    runId?: string;
-    hash: string;
-    result: unknown;
-    storeDelta?: Record<string, unknown>;
-  }>;
+  journal?: PersistedJournalEntry[];
   /**
    * Opt-out of auto-resume for this run (default true, i.e. eligible unless
    * explicitly set to false via ExecOptions.autoResume). Set once at run start

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -973,14 +973,10 @@ export function renderPanelDetailed(
     const done = agents.filter((a) => a.status === "done").length;
     const icon = r.status === "paused" ? "⏸" : "◆";
     const usage = snap?.tokenUsage ?? r.tokenUsage;
-    // The run-level tokenUsage aggregate is only finalized when the run ends, so
-    // it reads 0 for the whole live run; per-agent figures update on each agent
-    // completion, so aggregate those instead. The rate samples the same
-    // fresh+cacheRead sum the header displays, so tok/s tracks the visible
-    // figures. Tokens land at agent-completion granularity, so the rate reflects
-    // completion throughput — it decays to 0 during a single long-running agent
-    // or a stall (which is the intended signal). Paused runs don't accrue
-    // tokens, so their rate is suppressed (a stalled rate would mislead).
+    // Per-agent figures stream while agents run, so aggregate them for the same
+    // fresh+cacheRead sum the header displays. A flat rate now indicates a real
+    // lull rather than merely waiting for a long-running agent to return. Paused
+    // runs do not accrue tokens, so their rate is suppressed.
     const runUsage = aggregateAgentUsage(agents);
     sampleTokens(r.runId, runUsage.fresh + runUsage.cacheRead, now);
     const rate = r.status === "running" ? tokensPerSecond(r.runId) : 0;

--- a/src/workflow-commands.ts
+++ b/src/workflow-commands.ts
@@ -73,7 +73,7 @@ function watchRun(manager: WorkflowManager, pi: ExtensionAPI, ctx: ExtensionComm
     if (!e || e.runId === id) update();
   };
   let settled = false;
-  const progressEvents = ["agentStart", "agentEnd", "phase", "log"];
+  const progressEvents = ["agentStart", "agentEnd", "phase", "log", "tokenUsage"];
   const finalEvents = ["complete", "error", "stopped", "paused"];
   const finish = (e: { runId?: string }) => {
     if (e && e.runId !== id) return;

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -5,6 +5,7 @@
 import { EventEmitter } from "node:events";
 import type { ModelRegistry, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { WorkflowAgent } from "./agent.js";
+import { type AgentUsage, createEmptyAgentUsage, sumAgentUsage } from "./agent-usage.js";
 import { MAX_AGENTS_PER_RUN } from "./config.js";
 import { preview, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
 import { isProviderUsageLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
@@ -28,6 +29,25 @@ interface LifecycleControl {
 /** Per-execution identity for an abort received from the host/tool signal. */
 interface ExternalAbort {
   abortReason: object;
+}
+
+const PAUSED_EXECUTION_SETTLE_TIMEOUT_MS = 1_000;
+
+async function waitForPausedExecutionSettlement(execution: Promise<unknown>): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const settled = execution.then(
+    () => true,
+    () => true,
+  );
+  const timeout = new Promise<boolean>((resolve) => {
+    timer = setTimeout(() => resolve(false), PAUSED_EXECUTION_SETTLE_TIMEOUT_MS);
+    timer.unref?.();
+  });
+  const didSettle = await Promise.race([settled, timeout]);
+  if (timer) {
+    clearTimeout(timer);
+  }
+  return didSettle;
 }
 
 export interface ManagedRun {
@@ -170,6 +190,7 @@ export interface ExecOptions {
    * WorkflowRunOptions.resumeJournal in workflow.ts.
    */
   resumeJournal?: Map<string, JournalEntry>;
+
   /** Cap on total agents for this run. */
   maxAgents?: number;
   /** Per-agent timeout in milliseconds. null/omitted means no hard timeout. */
@@ -213,14 +234,7 @@ export interface ExecOptions {
    * execution's fresh SharedRuntime starts counting from the already-spent
    * total instead of zero (see A2 in workflow-manager's resume()).
    */
-  initialTokenUsage?: {
-    input: number;
-    output: number;
-    total: number;
-    cost: number;
-    cacheRead: number;
-    cacheWrite: number;
-  };
+  initialTokenUsage?: AgentUsage;
 }
 
 export interface WorkflowManagerOptions {
@@ -365,6 +379,9 @@ export class WorkflowManager extends EventEmitter {
    */
   private terminalRunQueue: string[] = [];
   private maxTerminalRunsInMemory: number;
+
+  /** Executions by managed run, so pause/resume can wait for settlement before overlapping. */
+  private readonly executions = new WeakMap<ManagedRun, Promise<WorkflowRunResult>>();
   private persistence: RunPersistence;
   private cwd: string;
   private concurrency: number;
@@ -625,6 +642,7 @@ export class WorkflowManager extends EventEmitter {
     // already records status/event/persist, but the promise still rejects.
     // The original promise is returned so callers can await it in try/catch.
     const promise = this.executeRun(managed, script, args, exec);
+    this.executions.set(managed, promise);
     promise.catch(() => {});
 
     return { runId, promise };
@@ -653,7 +671,9 @@ export class WorkflowManager extends EventEmitter {
     // Persist the initial state immediately so listRuns()/the task panel can see
     // the run the moment it starts, not only after the first agent journals.
     this.persistRun(managed);
-    return this.executeRun(managed, script, args, exec);
+    const execution = this.executeRun(managed, script, args, exec);
+    this.executions.set(managed, execution);
+    return execution;
   }
 
   /** Build a fresh managed run with an empty snapshot. */
@@ -746,6 +766,8 @@ export class WorkflowManager extends EventEmitter {
     const progress = () => {
       if (this.isCurrent(managed)) onProgress?.(managed.snapshot);
     };
+    // Live per-call display updates are keyed by the same unique `id` upstream
+    // events carry (see managed.agentsById) — the manager keeps no separate map.
     // Let a host abort (e.g. Esc during a blocking tool call) cancel this run.
     // Own this listener for exactly this executeRun() invocation: a reused host
     // signal must not retain a settled manager/run closure or abort it later.
@@ -797,14 +819,6 @@ export class WorkflowManager extends EventEmitter {
         // runWorkflow only applies this on the fresh-SharedRuntime branch, never
         // overriding an inherited options.sharedRuntime from a nested workflow()).
         initialTokenUsage,
-        // Retried-attempt spend (see WorkflowRunOptions.onRetrySpend and A2):
-        // recordTokens() in workflow.ts already folded this into
-        // shared.spent/tokenUsage, but onAgentEnd never sees a retried
-        // (non-final) attempt — fold it into the same persisted aggregate here
-        // so a run paused after a retry doesn't under-count against the budget.
-        onRetrySpend: (tokens) => {
-          this.accumulateTokenUsage(managed, tokens);
-        },
         onAgentJournal: (entry) => {
           // Append (crash-safe-ish): keep the latest entry per (runId, index)
           // pair, then persist. Matching on index ALONE would let a nested
@@ -845,13 +859,31 @@ export class WorkflowManager extends EventEmitter {
           };
           managed.snapshot.agents.push(agentSnapshot);
           // Index by the call's unique id (never label — see agentsById's doc
-          // comment) so onAgentEnd/onAgentHistory can resolve back to exactly
-          // THIS entry even when a concurrent sibling shares its label.
+          // comment) so onAgentEnd/onAgentHistory/onAgentUsage can resolve back
+          // to exactly THIS entry even when a concurrent sibling shares its
+          // label.
           managed.agentsById.set(event.id, agentSnapshot);
           // Real per-agent start time, captured the moment the agent actually
           // starts (not the run's startedAt) — see agentTimestamps.
           managed.agentTimestamps.set(id, { startedAt: new Date().toISOString() });
           this.emitLive(managed, "agentStart", { runId: managed.runId, ...event });
+          progress();
+        },
+        onAgentUsage: (event) => {
+          const agent = managed.agentsById.get(event.id);
+          if (!agent) {
+            return;
+          }
+
+          agent.tokens = event.tokenUsage.total;
+          agent.tokenUsage = event.tokenUsage;
+          if (event.committedUsage) {
+            this.commitFinalizedAgentUsage(managed, event.committedUsage);
+          }
+          this.emitLive(managed, "agentUsage", { runId: managed.runId, ...event });
+          // Detailed displays aggregate live per-agent usage; this event triggers
+          // their refresh without committing estimates into persisted run totals.
+          this.emitLive(managed, "tokenUsage", { runId: managed.runId, usage: managed.snapshot.tokenUsage });
           progress();
         },
         onAgentEnd: (event) => {
@@ -865,28 +897,17 @@ export class WorkflowManager extends EventEmitter {
             agent.error = event.error;
             agent.errorCode = event.errorCode;
             agent.recoverable = event.recoverable;
-            agent.tokens = event.tokens;
-            if (event.tokenUsage) agent.tokenUsage = event.tokenUsage;
+            agent.tokens = Math.max(agent.tokens ?? 0, event.tokens ?? 0);
+            if (!agent.tokenUsage && event.tokenUsage) {
+              agent.tokenUsage = event.tokenUsage;
+            }
             if (event.model) agent.model = event.model;
             // Real per-agent end time — only terminal agents get one; a still-
             // running agent's entry keeps endedAt undefined.
             const ts = managed.agentTimestamps.get(agent.id);
             if (ts) ts.endedAt = new Date().toISOString();
+            managed.agentsById.delete(event.id);
           }
-          // Progressive run-wide token aggregate (A2): workflow.ts's onTokenUsage
-          // callback below fires exactly once, only when the whole script finishes
-          // successfully (a deliberate, tested contract — see
-          // "agent() accumulates usage across multiple agents" in agent.test.ts,
-          // which asserts one final event, not one per agent). A run that
-          // pauses/aborts/fails mid-flight never reaches it, so without tracking
-          // it here too, a paused run's persisted tokenUsage would stay whatever
-          // it was (usually unset) — starving resume()'s spend-seeding of the
-          // very data it needs. Accumulate additively from every onAgentEnd
-          // instead: a cache-hit replay reports tokens: 0 (see agent()'s replay
-          // branch in workflow.ts), so replaying the unchanged prefix on resume
-          // is a no-op add here, matching the "already historically spent, don't
-          // double-count" semantics of journal replay.
-          this.accumulateTokenUsage(managed, event.tokens ?? 0, event.tokenUsage);
           this.emitLive(managed, "agentEnd", { runId: managed.runId, ...event });
           progress();
         },
@@ -1107,38 +1128,20 @@ export class WorkflowManager extends EventEmitter {
     }
   }
 
-  /**
-   * Additively fold one agent-call's token cost into the run-wide persisted
-   * aggregate (managed.snapshot.tokenUsage), seeded (on resume) from the
-   * persisted total-at-pause — see A2. Shared by onAgentEnd (a completed or
-   * finally-failed agent call) and onRetrySpend (a failed attempt that WILL
-   * be retried, whose cost recordTokens() already folded into
-   * shared.spent/tokenUsage in workflow.ts, but which onAgentEnd never sees —
-   * see WorkflowRunOptions.onRetrySpend for why that needs its own channel).
-   */
-  private accumulateTokenUsage(
-    managed: ManagedRun,
-    tokens: number,
-    tokenUsage?: { input: number; output: number; cost: number; cacheRead: number; cacheWrite: number },
-  ): void {
+  /** Add one settled logical agent's exact usage to the persisted run aggregate. */
+  private commitFinalizedAgentUsage(managed: ManagedRun, usage: AgentUsage): void {
     const prior = managed.snapshot.tokenUsage;
-    const usage = {
-      input: prior?.input ?? 0,
-      output: prior?.output ?? 0,
-      total: prior?.total ?? 0,
-      cost: prior?.cost ?? 0,
-      cacheRead: prior?.cacheRead ?? 0,
-      cacheWrite: prior?.cacheWrite ?? 0,
-    };
-    usage.total += tokens;
-    if (tokenUsage) {
-      usage.input += tokenUsage.input;
-      usage.output += tokenUsage.output;
-      usage.cost += tokenUsage.cost;
-      usage.cacheRead += tokenUsage.cacheRead;
-      usage.cacheWrite += tokenUsage.cacheWrite;
-    }
-    managed.snapshot.tokenUsage = usage;
+    const priorUsage: AgentUsage = prior
+      ? {
+          input: prior.input,
+          output: prior.output,
+          total: prior.total,
+          cost: prior.cost ?? 0,
+          cacheRead: prior.cacheRead ?? 0,
+          cacheWrite: prior.cacheWrite ?? 0,
+        }
+      : createEmptyAgentUsage();
+    managed.snapshot.tokenUsage = sumAgentUsage(priorUsage, usage);
   }
 
   /** Abort this execution for a host/tool signal, retaining provenance so a
@@ -1336,8 +1339,9 @@ export class WorkflowManager extends EventEmitter {
     managed.status = "paused";
     this.abortForLifecycleControl(managed, "pause");
     this.emit("paused", { runId });
+    // Persist the requested lifecycle state immediately, but retain the lease
+    // until executeRun settles and writes exact abort-teardown usage.
     this.persistRun(managed);
-    this.releaseRunLease(managed);
     return true;
   }
 
@@ -1347,9 +1351,10 @@ export class WorkflowManager extends EventEmitter {
    *
    * `opts.script` lets the orchestrating model resume with an EDITED script
    * (cached-prefix reuse / iteration): unchanged agent() calls whose content
-   * hash still matches the journal entry at their positional callIndex replay
-   * from cache, while the first changed or newly inserted call — and everything
-   * after it — re-runs live. When `opts.script` is omitted, resume behaves
+   * hash still matches the journal entry at their run-qualified call identity
+   * replay from cache, while the first changed or newly inserted call — including
+   * downstream nested workflows — and everything after it re-runs live. When
+   * `opts.script` is omitted, resume behaves
    * exactly as before and uses the persisted script (auto-resume, TUI resume);
    * this keeps the existing single-arg `resume(runId)` callers (e.g. the
    * UsageLimitScheduler) unchanged. `opts.args` overrides the persisted args
@@ -1361,6 +1366,17 @@ export class WorkflowManager extends EventEmitter {
     const active = this.runs.get(runId);
     if (active?.status === "running") return false;
     if (active?.status === "aborted") return false;
+
+    const settlingExecution = active ? this.executions.get(active) : undefined;
+    if (settlingExecution) {
+      if (!(await waitForPausedExecutionSettlement(settlingExecution))) {
+        return false;
+      }
+      const current = this.runs.get(runId);
+      if (current !== active || current?.status === "aborted") {
+        return false;
+      }
+    }
 
     const persisted = this.persistence.load(runId);
     if (!persisted?.script || persisted.status === "completed" || persisted.status === "aborted") return false;
@@ -1418,8 +1434,8 @@ export class WorkflowManager extends EventEmitter {
         errorCount: 0,
         // Seed the live snapshot's aggregate from the persisted total-at-pause
         // (see A2) so a pause that lands before this resume's first agent
-        // completes doesn't lose the prior spend — onAgentEnd accumulates on
-        // top of this rather than starting from scratch.
+        // completes doesn't lose the prior spend — committed onAgentUsage
+        // deltas accumulate on top of this rather than starting from scratch.
         tokenUsage: priorTokenUsage,
       },
       controller,
@@ -1482,7 +1498,6 @@ export class WorkflowManager extends EventEmitter {
     // Persist before notifying renderers: listRuns() is their source of truth for
     // lifecycle status, while getRun() supplies the live in-memory snapshot.
     this.persistRun(managed);
-
     // Namespace by (runId, index) exactly like the live onAgentJournal dedup
     // above and like SharedStore's deltaKey — see JournalEntry.runId. A
     // legacy entry persisted before namespacing existed has no `runId`; it is
@@ -1497,7 +1512,7 @@ export class WorkflowManager extends EventEmitter {
     // (A2) from the persisted total-at-pause, so the tokenBudget cap holds
     // cumulatively instead of resetting to zero. Note: shared.agentCount is
     // deliberately NOT seeded the same way — it doesn't need to be. Unlike
-    // token spend (whose cache-hit replay branch skips recordTokens() to avoid
+    // token spend (whose cache-hit replay branch skips committing usage to avoid
     // double-counting already-spent tokens), agent()'s shared.agentCount++
     // fires unconditionally for EVERY call, cache-hit or live, before the
     // replay check runs (see workflow.ts). Because resume() always replays the
@@ -1505,7 +1520,12 @@ export class WorkflowManager extends EventEmitter {
     // correct cumulative count inside this fresh SharedRuntime by the time any
     // new live agent runs — so maxAgents (via A1) is already a genuine
     // cumulative cap across resume with no extra seeding required.
-    void this.executeRun(managed, script, args, { resumeJournal, initialTokenUsage: priorTokenUsage }).catch(() => {});
+    const execution = this.executeRun(managed, script, args, {
+      resumeJournal,
+      initialTokenUsage: priorTokenUsage,
+    });
+    this.executions.set(managed, execution);
+    void execution.catch(() => {});
     return true;
   }
 

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -897,9 +897,11 @@ export class WorkflowManager extends EventEmitter {
             agent.error = event.error;
             agent.errorCode = event.errorCode;
             agent.recoverable = event.recoverable;
-            agent.tokens = Math.max(agent.tokens ?? 0, event.tokens ?? 0);
-            if (!agent.tokenUsage && event.tokenUsage) {
+            if (event.tokenUsage) {
               agent.tokenUsage = event.tokenUsage;
+              agent.tokens = event.tokenUsage.total;
+            } else if (event.tokens !== undefined) {
+              agent.tokens = event.tokens;
             }
             if (event.model) agent.model = event.model;
             // Real per-agent end time — only terminal agents get one; a still-

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -1944,7 +1944,18 @@ export function openWorkflowNavigator(
       const rerender = () => tui.requestRender();
       const markdownTheme = getMarkdownTheme();
       const renderCache = new NavigatorTextRenderCache();
-      const events = ["agentStart", "agentEnd", "phase", "log", "complete", "error", "stopped", "paused", "resumed"];
+      const events = [
+        "agentStart",
+        "agentEnd",
+        "phase",
+        "log",
+        "tokenUsage",
+        "complete",
+        "error",
+        "stopped",
+        "paused",
+        "resumed",
+      ];
       const onEvent = () => {
         if (state.kind === "runs") state.noteManagerEvent(model.visible(state.filter));
         rerender();

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -892,7 +892,7 @@ export async function runWorkflow<T = unknown>(
               phase: assignedPhase,
               result,
               tokens: usageCommit.tokens,
-              tokenUsage: usageCommit.terminalUsage,
+              tokenUsage: usageCommit.tokenUsage,
               worktree: runCwd,
               model: displayModel,
             });
@@ -943,7 +943,7 @@ export async function runWorkflow<T = unknown>(
               phase: assignedPhase,
               result: null,
               tokens: usageCommit.tokens,
-              tokenUsage: usageCommit.terminalUsage,
+              tokenUsage: usageCommit.tokenUsage,
               worktree: runCwd,
               model: displayModel,
               error: workflowError.message,

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -4,7 +4,6 @@ import vm from "node:vm";
 import type { Node } from "acorn";
 import { parse } from "acorn";
 import type { TSchema } from "typebox";
-import type { AgentUsage } from "./agent.js";
 import { type AgentRunOptions, WorkflowAgent, type WorkflowAgentOptions } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
 import {
@@ -14,6 +13,7 @@ import {
   loadAgentRegistry,
   resolveAgentType,
 } from "./agent-registry.js";
+import { type AgentUsage, createAgentCallUsageTracker, sumAgentUsage } from "./agent-usage.js";
 import { DEFAULT_AGENT_TIMEOUT_MS, MAX_AGENT_RETRIES, MAX_AGENTS_PER_RUN, MAX_CONCURRENCY } from "./config.js";
 import { WorkflowError, WorkflowErrorCode, wrapError } from "./errors.js";
 import { createWorkflowLogger } from "./logger.js";
@@ -42,6 +42,7 @@ import { createWorktree, removeWorktree, type Worktree } from "./worktree.js";
  * the breaching fan-out's own queue is short-circuited.
  */
 const fanoutScope = new AsyncLocalStorage<{ cancelled: boolean }>();
+const workflowNestingScope = new AsyncLocalStorage<number>();
 
 export interface WorkflowMetaPhase {
   title: string;
@@ -57,7 +58,7 @@ export interface WorkflowMeta {
   model?: string;
 }
 
-/** One cached agent() result, keyed by its deterministic call index. */
+/** One cached agent/checkpoint result, keyed by its deterministic workflow call identity. */
 export interface JournalEntry {
   index: number;
   /**
@@ -94,7 +95,8 @@ export interface SharedRuntime {
   limiter: <T>(fn: () => Promise<T>) => Promise<T>;
   agentCount: number;
   spent: number;
-  tokenUsage: { input: number; output: number; total: number; cost: number; cacheRead: number; cacheWrite: number };
+  tokenUsage: AgentUsage;
+  /** @deprecated Nesting depth is async-context scoped; retained for injected runtime compatibility. */
   depth: number;
   /**
    * Monotonic count of every workflow() call anywhere in this run tree,
@@ -197,17 +199,9 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
   /** Called after each live agent completes so the caller can persist the journal. */
   onAgentJournal?: (entry: JournalEntry) => void;
   /**
-   * Called once per FAILED-AND-RETRIED attempt (not the final attempt of an
-   * agent() call, which reports its own tokens via onAgentEnd as before),
-   * with that attempt's token cost. recordTokens() already folds a retried
-   * attempt's spend into shared.spent/shared.tokenUsage (so the run-wide
-   * budget was never leaky) — but onAgentEnd only ever reports the FINAL
-   * attempt's tokens, so a caller accumulating a persisted total purely from
-   * onAgentEnd (see WorkflowManager) would under-count by exactly the
-   * wasted retried attempts' spend. This is a separate, silent channel
-   * specifically so retried-attempt spend can be accounted for without
-   * changing onAgentEnd's one-call-per-agent-call cadence (a contract other
-   * code depends on).
+   * Called once per failed-and-retried attempt with that attempt's finalized token cost.
+   * @deprecated Use `onAgentUsage` for per-agent display and `onTokenUsage` for
+   * finalized run accounting. Do not combine those cumulative callbacks with this delta.
    */
   onRetrySpend?: (tokens: number) => void;
   /** Internal: shared runtime inherited by a nested workflow() call. */
@@ -222,14 +216,7 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
    * enforce the ceiling against only what THIS execution spends, ignoring
    * whatever was already spent before the pause.
    */
-  initialTokenUsage?: {
-    input: number;
-    output: number;
-    total: number;
-    cost: number;
-    cacheRead: number;
-    cacheWrite: number;
-  };
+  initialTokenUsage?: AgentUsage;
   /**
    * Shared store for this run. One instance is created per top-level run and
    * propagated into nested workflow() calls. Pass an existing instance to share
@@ -269,6 +256,14 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
     error?: string;
     errorCode?: WorkflowErrorCode;
     recoverable?: boolean;
+  }) => void;
+  /** Called with cumulative display usage and an exact delta whenever usage becomes committed. */
+  onAgentUsage?: (event: {
+    id: string;
+    label: string;
+    phase?: string;
+    tokenUsage: AgentUsage;
+    committedUsage?: AgentUsage;
   }) => void;
   onAgentHistory?: (event: { id: string; label: string; phase?: string; history: AgentHistoryEntry[] }) => void;
   onTokenUsage?: (usage: {
@@ -474,7 +469,7 @@ export async function runWorkflow<T = unknown>(
   // SharedRuntime by the time any new live agent executes, so maxAgents stays
   // a genuine cumulative cap across resume with no extra seeding. Token spend
   // needs seeding precisely because its cache-hit branch deliberately does NOT
-  // re-run recordTokens() (to avoid double-counting already-spent tokens) —
+  // recommit usage (to avoid double-counting already-spent tokens) —
   // there is no replay-based reconstruction for it the way there is for count.
   const shared: SharedRuntime = options.sharedRuntime ?? {
     limiter: createLimiter(concurrency),
@@ -729,7 +724,6 @@ export async function runWorkflow<T = unknown>(
     // push slightly past total, then further agent() calls throw.)
     shared.agentCount++;
     const label = requestedLabel || defaultAgentLabel(assignedPhase, shared.agentCount);
-
     // Longest-unchanged-prefix resume: replay a cached result only while the
     // prefix is still intact — this call's index is before the first changed/new
     // call. Once any call misses, it AND everything after it run live (matching
@@ -761,7 +755,9 @@ export async function runWorkflow<T = unknown>(
     }
     // A genuine miss (no journal entry, or the hash changed) marks where the
     // unchanged prefix ends; this call and every later one then run live.
-    if (!hashMatches || cachedEmptyOutput) state.firstMiss = Math.min(state.firstMiss, callIndex);
+    if (!hashMatches || cachedEmptyOutput) {
+      state.firstMiss = Math.min(state.firstMiss, callIndex);
+    }
 
     return limiter(async () => {
       const timeout = agentOptions.timeoutMs !== undefined ? agentOptions.timeoutMs : agentTimeoutMs;
@@ -783,31 +779,23 @@ export async function runWorkflow<T = unknown>(
       }
       const runCwd = worktree?.isolated ? worktree.cwd : undefined;
 
-      // Captured from the subagent's real session usage; falls back to an
-      // estimate when the provider reports no usage (total === 0). Usage is reset
-      // per retry attempt so a failed attempt does not double-count the next one.
-      let usage: AgentUsage | undefined;
-      const recordTokens = (result: unknown): number => {
-        const tokens = usage && usage.total > 0 ? usage.total : estimateTokens(result) + estimateTokens(prompt);
-        if (usage) {
-          shared.tokenUsage.input += usage.input;
-          shared.tokenUsage.output += usage.output;
-          shared.tokenUsage.cost += usage.cost;
-          shared.tokenUsage.cacheRead += usage.cacheRead;
-          shared.tokenUsage.cacheWrite += usage.cacheWrite;
+      // The tracker keeps provisional estimates separate from committed usage,
+      // accumulates retries, and rejects callbacks from attempts that already settled.
+      const usageTracker = createAgentCallUsageTracker((update) => {
+        if (update.committedUsage) {
+          shared.tokenUsage = sumAgentUsage(shared.tokenUsage, update.committedUsage);
+          shared.spent += update.committedUsage.total;
         }
-        shared.tokenUsage.total += tokens;
-        shared.spent += tokens;
-        return tokens;
-      };
+        options.onAgentUsage?.({ id: deltaKey, label, phase: assignedPhase, ...update });
+      });
 
       try {
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-          usage = undefined;
+          const attemptUsage = usageTracker.startAttempt();
           const externalSignal = options.signal;
           let onExternalAbort: (() => void) | undefined;
           let onRunFatal: (() => void) | undefined;
-          let attemptRunPromise: Promise<unknown> | undefined;
+          let runPromise: Promise<unknown> | undefined;
           try {
             throwIfAborted();
             // This agent's own fan-out already breached maxAgents while this
@@ -836,7 +824,7 @@ export async function runWorkflow<T = unknown>(
               onRunFatal = () => agentController.abort();
               shared.runFatalController.signal.addEventListener("abort", onRunFatal, { once: true });
             }
-            const runPromise = agentRunner.run(prompt, {
+            runPromise = agentRunner.run(prompt, {
               label,
               // Identifiable name for persisted sessions (persistAgentSessions).
               sessionName: agentOptions.thread
@@ -851,7 +839,7 @@ export async function runWorkflow<T = unknown>(
               toolNames: agentDef?.tools,
               disallowedToolNames: agentDef?.disallowedTools,
               // Per-agent store tools track this agent's writes by the
-              // run-unique deltaKey so the delta can be journaled and replayed
+              // run-unique agentId so the delta can be journaled and replayed
               // correctly on resume, even when a nested workflow() run shares
               // this store concurrently with the parent run.
               systemTools: createAgentStoreTools(store, deltaKey),
@@ -866,19 +854,16 @@ export async function runWorkflow<T = unknown>(
                 // throws MODEL_NOT_FOUND and never reaches this callback.
                 log(`default "${tier}" tier model "${requestedSpec}" unavailable — using the session default`);
               },
-              onUsage: (u: AgentUsage) => {
-                usage = u;
-              },
+              onUsageProgress: attemptUsage.reportProgress,
+              onUsage: attemptUsage.reportTerminal,
               onHistory: (history: AgentHistoryEntry[]) => {
                 options.onAgentHistory?.({ id: deltaKey, label, phase: assignedPhase, history });
               },
               thread: agentOptions.thread,
             });
-            attemptRunPromise = runPromise;
-            // After a timeout the run() promise still settles later, rejecting with
-            // "aborted" once agentController fires; the race has already resolved,
-            // so swallow that to avoid an unhandled rejection.
-            runPromise.catch(() => {});
+            // Attach a rejection handler immediately: a timed-out run can reject
+            // before the timeout catch awaits its teardown for usage reconciliation.
+            void runPromise.catch(() => undefined);
             const result = await withTimeout(runPromise, timeout, label, () => agentController.abort());
 
             throwIfAborted();
@@ -889,7 +874,7 @@ export async function runWorkflow<T = unknown>(
               });
             }
 
-            const tokens = recordTokens(result);
+            const usageCommit = attemptUsage.commitWithFallback(estimateTokens(result) + estimateTokens(prompt));
             if (!agentOptions.thread) {
               options.onAgentJournal?.({
                 index: callIndex,
@@ -906,8 +891,8 @@ export async function runWorkflow<T = unknown>(
               label,
               phase: assignedPhase,
               result,
-              tokens,
-              tokenUsage: usage,
+              tokens: usageCommit.tokens,
+              tokenUsage: usageCommit.terminalUsage,
               worktree: runCwd,
               model: displayModel,
             });
@@ -916,12 +901,18 @@ export async function runWorkflow<T = unknown>(
             // A named thread cannot start its next turn while an aborted wrapper
             // is still unwinding against the shared SessionManager. Wait for the
             // wrapper to restore its prior leaf before retrying or returning.
-            if (agentOptions.thread && attemptRunPromise) await attemptRunPromise.catch(() => {});
-            if (isAborted()) throw error;
+            if (agentOptions.thread && runPromise) await runPromise.catch(() => {});
+            if (isAborted()) {
+              attemptUsage.commitTerminalUsage();
+              throw error;
+            }
 
             const workflowError = wrapError(error, { agentLabel: label });
+            if (workflowError.code === WorkflowErrorCode.AGENT_TIMEOUT && runPromise) {
+              await runPromise.catch(() => undefined);
+            }
             logger.error(`agent ${label} attempt ${attempt}/${maxAttempts} failed: ${workflowError.message}`);
-            const tokens = recordTokens(null);
+            const usageCommit = attemptUsage.commitWithFallback(estimateTokens(prompt));
             // This attempt's store writes must not survive it — a failed
             // attempt shares this call's deltaKey with every other attempt
             // (retried or not), so without rolling back here its writes would
@@ -939,10 +930,10 @@ export async function runWorkflow<T = unknown>(
                 `agent "${label}" attempt ${attempt}/${maxAttempts} failed: ${workflowError.code} ${workflowError.message}; retrying`,
               );
               // This attempt's spend already accrued into shared.spent/tokenUsage
-              // above (recordTokens) — but it will never reach onAgentEnd (only
+              // above — but it will never reach onAgentEnd (only
               // the final attempt does), so report it on the dedicated channel
               // instead (see WorkflowRunOptions.onRetrySpend).
-              options.onRetrySpend?.(tokens);
+              options.onRetrySpend?.(usageCommit.tokens);
               continue;
             }
 
@@ -951,8 +942,8 @@ export async function runWorkflow<T = unknown>(
               label,
               phase: assignedPhase,
               result: null,
-              tokens,
-              tokenUsage: usage,
+              tokens: usageCommit.tokens,
+              tokenUsage: usageCommit.terminalUsage,
               worktree: runCwd,
               model: displayModel,
               error: workflowError.message,
@@ -1063,7 +1054,12 @@ export async function runWorkflow<T = unknown>(
   // run's limiter/counters/budget so the global caps hold. One level deep only.
   const workflowFn = async (nameOrScript: string, childArgs?: unknown) => {
     throwIfAborted();
-    if (shared.depth >= 1) {
+    // Nesting depth is async-context scoped (see SharedRuntime.depth's
+    // deprecated note), so parallel sibling branches can each nest one level
+    // without a shared counter tripping the second one. A parent-to-child
+    // chain still increments per nesting level, so second-level throws keep.
+    const nestingDepth = workflowNestingScope.getStore() ?? 0;
+    if (nestingDepth >= 1) {
       throw new WorkflowError("workflow() can nest only one level deep", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
         recoverable: false,
       });
@@ -1072,7 +1068,6 @@ export async function runWorkflow<T = unknown>(
     const childScript = resolved ?? String(nameOrScript);
     const workflowName = String(nameOrScript);
     options.onRuntimeEvent?.({ type: "workflow", stage: "start", name: workflowName, args: childArgs });
-    shared.depth++;
     try {
       // Propagate the resumeJournal into the child frame ONLY while the
       // parent's own longest-unchanged-prefix is still intact at the moment
@@ -1092,27 +1087,28 @@ export async function runWorkflow<T = unknown>(
       // no exception; once anything upstream in the parent has missed, cut
       // the child off from the journal entirely so it runs fully live.
       const prefixIntact = state.firstMiss === Number.POSITIVE_INFINITY;
-      const child = await runWorkflow(childScript, {
-        ...options,
-        args: childArgs,
-        sharedRuntime: shared,
-        // Propagate the parent's store so nested agents share the same key-value space.
-        sharedStore: store,
-        resumeJournal: prefixIntact ? options.resumeJournal : undefined,
-        resumeFromRunId: undefined,
-        // Reuse the same runner so named threads span parent/child frames but
-        // still die with this one top-level runWorkflow invocation.
-        agent: agentRunner,
-        // shared.nestedCallSeq, not shared.depth — see its doc comment: depth
-        // returns to 0 between sequential sibling calls, which would otherwise
-        // mint the same child runId (and hence colliding deltaKeys/event ids)
-        // for two different children.
-        runId: `${runId}-nested${++shared.nestedCallSeq}`,
-        persistLogs: false,
-      });
+      const child = await workflowNestingScope.run(nestingDepth + 1, () =>
+        runWorkflow(childScript, {
+          ...options,
+          args: childArgs,
+          sharedRuntime: shared,
+          // Propagate the parent's store so nested agents share the same key-value space.
+          sharedStore: store,
+          resumeJournal: prefixIntact ? options.resumeJournal : undefined,
+          resumeFromRunId: undefined,
+          // Reuse the same runner so named threads span parent/child frames but
+          // still die with this one top-level runWorkflow invocation.
+          agent: agentRunner,
+          // shared.nestedCallSeq, not shared.depth — see its doc comment: depth
+          // returns to 0 between sequential sibling calls, which would otherwise
+          // mint the same child runId (and hence colliding deltaKeys/event ids)
+          // for two different children.
+          runId: `${runId}-nested${++shared.nestedCallSeq}`,
+          persistLogs: false,
+        }),
+      );
       return child.result;
     } finally {
-      shared.depth--;
       options.onRuntimeEvent?.({ type: "workflow", stage: "end", name: workflowName, args: childArgs });
     }
   };
@@ -1298,7 +1294,7 @@ export async function runWorkflow<T = unknown>(
 
   // Deterministic, journaled, replayable human checkpoint. Spends no tokens, so it
   // is gated on the agent counter + abort (not budget). On resume the human's reply
-  // replays by callIndex exactly like a cached agent() — the genuine edge over CC,
+  // replays by run-qualified call identity like a cached agent() — the genuine edge over CC,
   // whose steering is in-session only. Headless (no UI threaded in): takes the
   // declared default and journals THAT, so a detached/background run never hangs.
   const checkpoint = async (promptText: string, checkpointOptions: CheckpointOptions = {}) => {
@@ -1314,7 +1310,9 @@ export async function runWorkflow<T = unknown>(
       shared.agentCount++;
       return cached.result; // replay the journaled human reply
     }
-    if (cached == null || cached.hash !== callHash) state.firstMiss = Math.min(state.firstMiss, callIndex);
+    if (cached == null || cached.hash !== callHash) {
+      state.firstMiss = Math.min(state.firstMiss, callIndex);
+    }
     shared.agentCount++;
 
     let reply: unknown;
@@ -1709,7 +1707,8 @@ function normalizeAgentRetries(value: unknown): number {
  * race — the caller uses it to abort the underlying work (e.g. the subagent
  * session) so it can release its resources instead of streaming on in the
  * background with the whole session graph (messages, etc.) retained (#109). The
- * losing promise still settles later; the caller must swallow its rejection.
+ * losing promise still settles later; the caller must await its teardown before
+ * committing usage or starting a retry.
  */
 async function withTimeout<T>(
   promise: Promise<T>,

--- a/tests/agent-usage.test.ts
+++ b/tests/agent-usage.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  type AgentUsage,
+  agentUsageEquals,
+  createAgentCallUsageTracker,
+  createEmptyAgentUsage,
+  sumAgentUsage,
+} from "../src/agent-usage.js";
+
+const FIRST_USAGE = { input: 10, output: 5, cacheRead: 2, cacheWrite: 1, total: 18, cost: 0.1 };
+const SECOND_USAGE = { input: 4, output: 3, cacheRead: 1, cacheWrite: 0, total: 8, cost: 0.04 };
+
+test("agent usage arithmetic sums complete records without mutating inputs", () => {
+  assert.deepEqual(sumAgentUsage(FIRST_USAGE, SECOND_USAGE), {
+    input: 14,
+    output: 8,
+    cacheRead: 3,
+    cacheWrite: 1,
+    total: 26,
+    cost: 0.14,
+  });
+  assert.deepEqual(FIRST_USAGE, { input: 10, output: 5, cacheRead: 2, cacheWrite: 1, total: 18, cost: 0.1 });
+});
+
+test("agent call usage tracker reconciles provisional estimates to exact terminal usage", () => {
+  const updates: Array<{ tokenUsage: AgentUsage; committedUsage?: AgentUsage }> = [];
+  const tracker = createAgentCallUsageTracker((update) => updates.push(update));
+  const attempt = tracker.startAttempt();
+
+  attempt.reportProgress({ ...createEmptyAgentUsage(), output: 10, total: 10 });
+  const exactUsage = { ...createEmptyAgentUsage(), input: 4, output: 3, total: 7, cost: 0.2 };
+  attempt.reportTerminal(exactUsage);
+  assert.deepEqual(attempt.commitWithFallback(99), { tokens: 7, terminalUsage: exactUsage });
+  attempt.reportProgress({ ...createEmptyAgentUsage(), output: 100, total: 100 });
+
+  assert.deepEqual(updates, [
+    { tokenUsage: { ...createEmptyAgentUsage(), output: 10, total: 10 } },
+    { tokenUsage: { ...createEmptyAgentUsage(), input: 4, output: 3, total: 7, cost: 0.2 } },
+    {
+      tokenUsage: { ...createEmptyAgentUsage(), input: 4, output: 3, total: 7, cost: 0.2 },
+      committedUsage: { ...createEmptyAgentUsage(), input: 4, output: 3, total: 7, cost: 0.2 },
+    },
+  ]);
+});
+
+test("agent call usage tracker accumulates retries and exposes each committed delta", () => {
+  const updates: Array<{ tokenUsage: AgentUsage; committedUsage?: AgentUsage }> = [];
+  const tracker = createAgentCallUsageTracker((update) => updates.push(update));
+
+  const firstAttempt = tracker.startAttempt();
+  firstAttempt.reportTerminal({ ...createEmptyAgentUsage(), output: 40, total: 40 });
+  firstAttempt.commitWithFallback(1);
+
+  const secondAttempt = tracker.startAttempt();
+  secondAttempt.reportProgress({ ...createEmptyAgentUsage(), output: 30, total: 30 });
+  secondAttempt.reportTerminal({ ...createEmptyAgentUsage(), output: 25, total: 25 });
+  secondAttempt.commitWithFallback(1);
+
+  assert.deepEqual(
+    updates.filter((update) => update.committedUsage).map((update) => update.committedUsage?.total),
+    [40, 25],
+  );
+  assert.equal(updates.at(-1)?.tokenUsage.total, 65);
+});
+
+test("agent call usage tracker aborts estimates but commits cost-only terminal usage", () => {
+  const updates: Array<{ tokenUsage: AgentUsage; committedUsage?: AgentUsage }> = [];
+  const tracker = createAgentCallUsageTracker((update) => updates.push(update));
+
+  const estimatedAttempt = tracker.startAttempt();
+  estimatedAttempt.reportProgress({ ...createEmptyAgentUsage(), output: 10, total: 10 });
+  assert.deepEqual(estimatedAttempt.commitTerminalUsage(), { tokens: 0 });
+  estimatedAttempt.reportTerminal({ ...createEmptyAgentUsage(), output: 20, total: 20 });
+
+  const costOnlyAttempt = tracker.startAttempt();
+  costOnlyAttempt.reportTerminal({ ...createEmptyAgentUsage(), cost: 0.5 });
+  assert.deepEqual(costOnlyAttempt.commitTerminalUsage(), {
+    tokens: 0,
+    terminalUsage: { ...createEmptyAgentUsage(), cost: 0.5 },
+  });
+
+  assert.deepEqual(
+    updates.filter((update) => update.committedUsage).map((update) => update.committedUsage),
+    [{ ...createEmptyAgentUsage(), cost: 0.5 }],
+  );
+  assert.deepEqual(updates.at(-1)?.tokenUsage, { ...createEmptyAgentUsage(), cost: 0.5 });
+});
+
+test("agent usage equality compares every accounting field", () => {
+  assert.equal(agentUsageEquals(FIRST_USAGE, { ...FIRST_USAGE }), true);
+  assert.equal(agentUsageEquals(FIRST_USAGE, { ...FIRST_USAGE, cacheRead: 3 }), false);
+});

--- a/tests/agent-usage.test.ts
+++ b/tests/agent-usage.test.ts
@@ -31,7 +31,7 @@ test("agent call usage tracker reconciles provisional estimates to exact termina
   attempt.reportProgress({ ...createEmptyAgentUsage(), output: 10, total: 10 });
   const exactUsage = { ...createEmptyAgentUsage(), input: 4, output: 3, total: 7, cost: 0.2 };
   attempt.reportTerminal(exactUsage);
-  assert.deepEqual(attempt.commitWithFallback(99), { tokens: 7, terminalUsage: exactUsage });
+  assert.deepEqual(attempt.commitWithFallback(99), { tokens: 7, tokenUsage: exactUsage });
   attempt.reportProgress({ ...createEmptyAgentUsage(), output: 100, total: 100 });
 
   assert.deepEqual(updates, [
@@ -49,13 +49,18 @@ test("agent call usage tracker accumulates retries and exposes each committed de
   const tracker = createAgentCallUsageTracker((update) => updates.push(update));
 
   const firstAttempt = tracker.startAttempt();
-  firstAttempt.reportTerminal({ ...createEmptyAgentUsage(), output: 40, total: 40 });
-  firstAttempt.commitWithFallback(1);
+  const firstTerminal = { ...createEmptyAgentUsage(), output: 40, total: 40 };
+  firstAttempt.reportTerminal(firstTerminal);
+  assert.deepEqual(firstAttempt.commitWithFallback(1), { tokens: 40, tokenUsage: firstTerminal });
 
   const secondAttempt = tracker.startAttempt();
   secondAttempt.reportProgress({ ...createEmptyAgentUsage(), output: 30, total: 30 });
-  secondAttempt.reportTerminal({ ...createEmptyAgentUsage(), output: 25, total: 25 });
-  secondAttempt.commitWithFallback(1);
+  const secondTerminal = { ...createEmptyAgentUsage(), output: 25, total: 25 };
+  secondAttempt.reportTerminal(secondTerminal);
+  assert.deepEqual(secondAttempt.commitWithFallback(1), {
+    tokens: 65,
+    tokenUsage: { ...createEmptyAgentUsage(), output: 65, total: 65 },
+  });
 
   assert.deepEqual(
     updates.filter((update) => update.committedUsage).map((update) => update.committedUsage?.total),
@@ -77,7 +82,7 @@ test("agent call usage tracker aborts estimates but commits cost-only terminal u
   costOnlyAttempt.reportTerminal({ ...createEmptyAgentUsage(), cost: 0.5 });
   assert.deepEqual(costOnlyAttempt.commitTerminalUsage(), {
     tokens: 0,
-    terminalUsage: { ...createEmptyAgentUsage(), cost: 0.5 },
+    tokenUsage: { ...createEmptyAgentUsage(), cost: 0.5 },
   });
 
   assert.deepEqual(

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -371,6 +371,84 @@ test("WorkflowAgent.run(): tier routing resolves correctly through the real (non
   }
 });
 
+test("WorkflowAgent.run() reports in-flight usage without changing terminal onUsage semantics", async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-live-usage-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-live-usage-cwd-"));
+  const core = createFauxCore({
+    provider: "fauxtest-live-usage",
+    models: [{ id: "faux-model", name: "Faux Model", contextWindow: 128000, maxTokens: 4096 }],
+    tokenSize: { min: 1, max: 1 },
+    tokensPerSecond: 200,
+  });
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const runtime = await ModelRuntime.create({ authPath: join(home, "auth.json"), modelsPath: null });
+      runtime.registerProvider("fauxtest-live-usage", {
+        name: "Faux Test Live Usage",
+        baseUrl: "http://127.0.0.1:9/faux",
+        apiKey: "faux-dummy-key-not-used",
+        api: core.api,
+        streamSimple: core.streamSimple,
+        models: core.models.map((model) => ({
+          id: model.id,
+          name: model.name ?? model.id,
+          reasoning: false,
+          input: ["text" as const],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: model.contextWindow ?? 128000,
+          maxTokens: model.maxTokens ?? 4096,
+        })),
+      });
+      core.setResponses([fauxAssistantMessage("streaming output proves this agent is active", { stopReason: "stop" })]);
+
+      const registry = new ModelRegistry(runtime);
+      const agent = new WorkflowAgent({
+        cwd,
+        modelRegistry: registry,
+        mainModel: "fauxtest-live-usage/faux-model",
+      });
+      let settled = false;
+      let terminalCalls = 0;
+      let resolveFirstProgress: (usage: AgentUsage) => void = () => {};
+      const firstProgress = new Promise<AgentUsage>((resolve) => {
+        resolveFirstProgress = resolve;
+      });
+
+      const run = agent
+        .run("respond slowly", {
+          onUsageProgress: (usage) => {
+            if (usage.total > 0) {
+              resolveFirstProgress(usage);
+            }
+          },
+          onUsage: () => {
+            terminalCalls++;
+          },
+        })
+        .finally(() => {
+          settled = true;
+        });
+      let progressTimeout: ReturnType<typeof setTimeout> | undefined;
+      const missingProgress = new Promise<never>((resolve, reject) => {
+        void resolve;
+        progressTimeout = setTimeout(() => reject(new Error("No in-flight usage was reported")), 30_000);
+      });
+      const progress = await Promise.race([firstProgress, missingProgress]);
+      if (progressTimeout) {
+        clearTimeout(progressTimeout);
+      }
+
+      assert.equal(settled, false, "progress must arrive before the subagent settles");
+      assert.ok(progress.output > 0, "streaming text should produce a positive output estimate");
+      await run;
+      assert.equal(terminalCalls, 1, "onUsage remains a once-only terminal callback");
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
 // ═══════════════════════════════════════════════════════════════════════════
 // WorkflowAgent.run(): opts.schema must be a top-level JSON object schema
 // (#330 audit) — a non-object schema (e.g. array/primitive) would otherwise

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -421,6 +421,7 @@ test("WorkflowAgent.run() reports per-turn in-flight usage for a named thread", 
       const run = agent
         .run("respond slowly", {
           thread,
+          model: "fauxtest-live-usage/faux-model",
           onUsageProgress: (usage) => {
             if (usage.total > 0) {
               resolveFirstProgress(usage);
@@ -452,6 +453,7 @@ test("WorkflowAgent.run() reports per-turn in-flight usage for a named thread", 
       let secondTerminal: AgentUsage | undefined;
       await agent.run("continue in the same thread", {
         thread,
+        model: "fauxtest-live-usage/faux-model",
         onUsageProgress: (usage) => secondProgress.push(usage),
         onUsage: (usage) => {
           secondTerminal = usage;

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -371,7 +371,7 @@ test("WorkflowAgent.run(): tier routing resolves correctly through the real (non
   }
 });
 
-test("WorkflowAgent.run() reports in-flight usage without changing terminal onUsage semantics", async () => {
+test("WorkflowAgent.run() reports per-turn in-flight usage for a named thread", async () => {
   const home = mkdtempSync(join(tmpdir(), "pi-dw-live-usage-home-"));
   const cwd = mkdtempSync(join(tmpdir(), "pi-dw-live-usage-cwd-"));
   const core = createFauxCore({
@@ -399,7 +399,10 @@ test("WorkflowAgent.run() reports in-flight usage without changing terminal onUs
           maxTokens: model.maxTokens ?? 4096,
         })),
       });
-      core.setResponses([fauxAssistantMessage("streaming output proves this agent is active", { stopReason: "stop" })]);
+      core.setResponses([
+        fauxAssistantMessage("streaming output proves this agent is active", { stopReason: "stop" }),
+        fauxAssistantMessage("the second threaded turn has independent usage", { stopReason: "stop" }),
+      ]);
 
       const registry = new ModelRegistry(runtime);
       const agent = new WorkflowAgent({
@@ -414,8 +417,10 @@ test("WorkflowAgent.run() reports in-flight usage without changing terminal onUs
         resolveFirstProgress = resolve;
       });
 
+      const thread = "live-usage-thread";
       const run = agent
         .run("respond slowly", {
+          thread,
           onUsageProgress: (usage) => {
             if (usage.total > 0) {
               resolveFirstProgress(usage);
@@ -442,6 +447,23 @@ test("WorkflowAgent.run() reports in-flight usage without changing terminal onUs
       assert.ok(progress.output > 0, "streaming text should produce a positive output estimate");
       await run;
       assert.equal(terminalCalls, 1, "onUsage remains a once-only terminal callback");
+
+      const secondProgress: AgentUsage[] = [];
+      let secondTerminal: AgentUsage | undefined;
+      await agent.run("continue in the same thread", {
+        thread,
+        onUsageProgress: (usage) => secondProgress.push(usage),
+        onUsage: (usage) => {
+          secondTerminal = usage;
+        },
+      });
+
+      assert.ok(secondProgress.length > 0, "the second turn should stream usage");
+      assert.deepEqual(
+        secondProgress.at(-1),
+        secondTerminal,
+        "the last live update must describe this turn only, matching its terminal usage",
+      );
     });
   } finally {
     rmSync(home, { recursive: true, force: true });

--- a/tests/run-persistence.test.ts
+++ b/tests/run-persistence.test.ts
@@ -309,7 +309,13 @@ test(
       agents: [],
       logs: [],
       journal: [
-        { index: 0, hash: "abc123", result: { ok: true } },
+        {
+          index: 0,
+          callId: "journal-test:0",
+          hash: "abc123",
+          result: { ok: true },
+          storeDelta: { answer: 42 },
+        },
         { index: 1, hash: "def456", result: { value: 42 } },
       ],
       startedAt: "2024-01-01T00:00:00.000Z",
@@ -319,8 +325,10 @@ test(
     const loaded = rp.load("journal-test");
     assert.equal(loaded?.journal?.length, 2);
     assert.equal(loaded?.journal?.[0].index, 0);
+    assert.equal(loaded?.journal?.[0].callId, "journal-test:0");
     assert.equal(loaded?.journal?.[0].hash, "abc123");
     assert.deepEqual(loaded?.journal?.[0].result, { ok: true });
+    assert.deepEqual(loaded?.journal?.[0].storeDelta, { answer: 42 });
   }),
 );
 

--- a/tests/workflow-manager-abort.test.ts
+++ b/tests/workflow-manager-abort.test.ts
@@ -28,20 +28,50 @@ function fakeAgent(usage: Partial<AgentUsage> = {}, result: unknown = "ok") {
   };
 }
 
-/** Agent that stays running until a deferred resolve is called externally. */
+/** Agent that stays running until resolved externally or its attempt is aborted. */
 function deferredAgent() {
-  let deferredResolve: ((value: unknown) => void) | null = null;
-  let deferredReject: ((err: Error) => void) | null = null;
-  const promise = new Promise((resolve, reject) => {
-    deferredResolve = resolve;
-    deferredReject = reject;
-  });
+  interface PendingAttempt {
+    resolve: (value: unknown) => void;
+    reject: (error: Error) => void;
+    signal?: AbortSignal;
+    onAbort: () => void;
+  }
+
+  const pendingAttempts = new Set<PendingAttempt>();
+  const settleAttempt = (attempt: PendingAttempt, settle: () => void) => {
+    attempt.signal?.removeEventListener("abort", attempt.onAbort);
+    pendingAttempts.delete(attempt);
+    settle();
+  };
   return {
-    resolve: (value: unknown = "done") => deferredResolve?.(value),
-    reject: (err: Error) => deferredReject?.(err),
+    resolve: (value: unknown = "done") => {
+      for (const attempt of [...pendingAttempts]) {
+        settleAttempt(attempt, () => attempt.resolve(value));
+      }
+    },
+    reject: (error: Error) => {
+      for (const attempt of [...pendingAttempts]) {
+        settleAttempt(attempt, () => attempt.reject(error));
+      }
+    },
     runner: {
-      async run(_prompt: string, _options?: { onUsage?: (u: AgentUsage) => void }) {
-        return promise;
+      async run(prompt: string, options?: { onUsage?: (usage: AgentUsage) => void; signal?: AbortSignal }) {
+        void prompt;
+        return new Promise((resolve, reject) => {
+          const attempt: PendingAttempt = {
+            resolve,
+            reject,
+            signal: options?.signal,
+            onAbort: () => {},
+          };
+          attempt.onAbort = () => settleAttempt(attempt, () => reject(new Error("deferred agent aborted")));
+          pendingAttempts.add(attempt);
+          if (attempt.signal?.aborted) {
+            attempt.onAbort();
+          } else {
+            attempt.signal?.addEventListener("abort", attempt.onAbort, { once: true });
+          }
+        });
       },
     },
   };
@@ -480,12 +510,10 @@ test(
     const { runId, promise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
     manager.pause(runId);
-
-    assert.ok(pausedEvent, "paused event should fire");
-    assert.equal(pausedEvent?.runId, runId);
-
-    da.resolve("done");
     await promise.catch(() => {});
+
+    assert.ok(pausedEvent, "paused event should fire after the paused execution settles");
+    assert.equal(pausedEvent?.runId, runId);
   }),
 );
 
@@ -604,6 +632,10 @@ return { a, b }`;
       // Resume
       const resumed = await manager.resume(runId);
       assert.equal(resumed, true);
+      while ((manager.getRun(runId)?.snapshot.agents.length ?? 0) < 2) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      da.resolve("second-result");
 
       // Wait for resumed run to complete (agent 1 replayed from journal, agent 2 live)
       await new Promise((r) => setTimeout(r, 50));

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -27,20 +27,50 @@ function fakeAgent(usage: Partial<AgentUsage> = {}, result: unknown = "ok") {
   };
 }
 
-/** Agent that stays running until a deferred resolve is called externally. */
+/** Agent that stays running until resolved externally or its attempt is aborted. */
 function deferredAgent() {
-  let deferredResolve: ((value: unknown) => void) | null = null;
-  let deferredReject: ((err: Error) => void) | null = null;
-  const promise = new Promise((resolve, reject) => {
-    deferredResolve = resolve;
-    deferredReject = reject;
-  });
+  interface PendingAttempt {
+    resolve: (value: unknown) => void;
+    reject: (error: Error) => void;
+    signal?: AbortSignal;
+    onAbort: () => void;
+  }
+
+  const pendingAttempts = new Set<PendingAttempt>();
+  const settleAttempt = (attempt: PendingAttempt, settle: () => void) => {
+    attempt.signal?.removeEventListener("abort", attempt.onAbort);
+    pendingAttempts.delete(attempt);
+    settle();
+  };
   return {
-    resolve: (value: unknown = "done") => deferredResolve?.(value),
-    reject: (err: Error) => deferredReject?.(err),
+    resolve: (value: unknown = "done") => {
+      for (const attempt of [...pendingAttempts]) {
+        settleAttempt(attempt, () => attempt.resolve(value));
+      }
+    },
+    reject: (error: Error) => {
+      for (const attempt of [...pendingAttempts]) {
+        settleAttempt(attempt, () => attempt.reject(error));
+      }
+    },
     runner: {
-      async run(_prompt: string, _options?: { onUsage?: (u: AgentUsage) => void }) {
-        return promise;
+      async run(prompt: string, options?: { onUsage?: (usage: AgentUsage) => void; signal?: AbortSignal }) {
+        void prompt;
+        return new Promise((resolve, reject) => {
+          const attempt: PendingAttempt = {
+            resolve,
+            reject,
+            signal: options?.signal,
+            onAbort: () => {},
+          };
+          attempt.onAbort = () => settleAttempt(attempt, () => reject(new Error("deferred agent aborted")));
+          pendingAttempts.add(attempt);
+          if (attempt.signal?.aborted) {
+            attempt.onAbort();
+          } else {
+            attempt.signal?.addEventListener("abort", attempt.onAbort, { once: true });
+          }
+        });
       },
     },
   };
@@ -139,6 +169,409 @@ test(
     assert.equal(runs[0].workflowName, "tracked_demo");
     assert.equal(runs[0].status, "completed");
     assert.equal(runs[0].tokenUsage?.total, 140, "token usage is persisted for the navigator");
+  }),
+);
+
+test(
+  "manager exposes live token usage while an agent is still running",
+  withTempCwd(async (cwd) => {
+    let release: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt, options) {
+          void prompt;
+          options?.onUsageProgress?.({
+            input: 20,
+            output: 10,
+            total: 30,
+            cost: 0.01,
+            cacheRead: 0,
+            cacheWrite: 0,
+          });
+          await blocked;
+          options?.onUsage?.({
+            input: 20,
+            output: 10,
+            total: 30,
+            cost: 0.01,
+            cacheRead: 0,
+            cacheWrite: 0,
+          });
+          return "done";
+        },
+      },
+    });
+
+    let tokenUsageEvents = 0;
+    manager.on("tokenUsage", () => {
+      tokenUsageEvents++;
+    });
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    while ((manager.getRun(runId)?.snapshot.agents[0]?.tokens ?? 0) < 30) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const live = manager.getRun(runId);
+    assert.equal(live?.status, "running");
+    assert.equal(live?.snapshot.agents[0]?.status, "running");
+    assert.equal(live?.snapshot.agents[0]?.tokens, 30);
+    assert.equal(live?.snapshot.tokenUsage, undefined, "in-flight estimates must not alter finalized run accounting");
+    assert.ok(tokenUsageEvents > 0, "live task-panel listeners should be notified before agent completion");
+
+    assert.ok(release);
+    release();
+    await promise;
+    assert.equal(manager.getRun(runId)?.snapshot.tokenUsage?.total, 30);
+  }),
+);
+
+test(
+  "manager persists exact terminal usage from an aborted attempt",
+  withTempCwd(async (cwd) => {
+    const exactUsage = { input: 20, output: 5, total: 25, cost: 0.1, cacheRead: 0, cacheWrite: 0 };
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt, options) {
+          void prompt;
+          await new Promise<void>((resolve, reject) => {
+            void resolve;
+            const abort = () => {
+              options?.onUsage?.(exactUsage);
+              reject(new Error("aborted after exact usage"));
+            };
+            if (options?.signal?.aborted) {
+              abort();
+            } else {
+              options?.signal?.addEventListener("abort", abort, { once: true });
+            }
+          });
+          return "unreachable";
+        },
+      },
+    });
+    manager.on("error", () => {});
+
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    while (manager.getRun(runId)?.snapshot.agents.length !== 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    assert.equal(manager.pause(runId), true);
+    await assert.rejects(promise);
+
+    const persisted = manager.getPersistence().load(runId);
+    assert.equal(persisted?.status, "paused");
+    assert.equal(persisted?.tokenUsage?.total, 25);
+    assert.equal(persisted?.tokenUsage?.cost, 0.1);
+  }),
+);
+
+test(
+  "paused event is emitted after exact abort usage is persisted",
+  withTempCwd(async (cwd) => {
+    const exactUsage: AgentUsage = {
+      input: 20,
+      output: 5,
+      total: 25,
+      cost: 0.1,
+      cacheRead: 0,
+      cacheWrite: 0,
+    };
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt, options) {
+          void prompt;
+          return new Promise((resolve, reject) => {
+            void resolve;
+            options?.signal?.addEventListener(
+              "abort",
+              () => {
+                setTimeout(() => {
+                  options.onUsage?.(exactUsage);
+                  reject(new Error("aborted after exact usage"));
+                }, 20);
+              },
+              { once: true },
+            );
+          });
+        },
+      },
+    });
+    manager.on("error", () => {});
+    let usageAtPausedEvent: number | undefined;
+    manager.on("paused", ({ runId }: { runId: string }) => {
+      usageAtPausedEvent = manager.getPersistence().load(runId)?.tokenUsage?.total;
+    });
+
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    while (manager.getRun(runId)?.snapshot.agents.length !== 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    assert.equal(manager.pause(runId), true);
+    await assert.rejects(promise);
+
+    assert.equal(usageAtPausedEvent, 25);
+  }),
+);
+
+test(
+  "immediate resume waits for paused execution usage to settle",
+  withTempCwd(async (cwd) => {
+    let markFirstAttemptStarted: () => void = () => {};
+    const firstAttemptStarted = new Promise<void>((resolve) => {
+      markFirstAttemptStarted = resolve;
+    });
+    let attempts = 0;
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt, options) {
+          void prompt;
+          attempts++;
+          if (attempts === 1) {
+            markFirstAttemptStarted();
+            await new Promise<void>((resolve, reject) => {
+              void resolve;
+              options?.signal?.addEventListener(
+                "abort",
+                () => {
+                  setTimeout(() => {
+                    options.onUsage?.({
+                      input: 20,
+                      output: 5,
+                      total: 25,
+                      cost: 0.1,
+                      cacheRead: 0,
+                      cacheWrite: 0,
+                    });
+                    reject(new Error("first attempt aborted"));
+                  }, 20);
+                },
+                { once: true },
+              );
+            });
+          }
+          options?.onUsage?.({ input: 8, output: 2, total: 10, cost: 0.01, cacheRead: 0, cacheWrite: 0 });
+          return "resumed";
+        },
+      },
+    });
+    manager.on("error", () => {});
+
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    promise.catch(() => {});
+    await firstAttemptStarted;
+    assert.equal(manager.pause(runId), true);
+    assert.equal(await manager.resume(runId), true);
+    while (manager.getRun(runId)?.status === "running") {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const persisted = manager.getPersistence().load(runId);
+    assert.equal(persisted?.status, "completed");
+    assert.equal(persisted?.tokenUsage?.total, 35);
+    assert.equal(attempts, 2);
+  }),
+);
+
+test(
+  "resume refuses to overlap pause teardown that exceeds the settlement grace period",
+  withTempCwd(async (cwd) => {
+    let markFirstAttemptStarted: () => void = () => {};
+    const firstAttemptStarted = new Promise<void>((resolve) => {
+      markFirstAttemptStarted = resolve;
+    });
+    let attempts = 0;
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt, options) {
+          void prompt;
+          attempts++;
+          if (attempts === 1) {
+            markFirstAttemptStarted();
+            return new Promise((resolve, reject) => {
+              void resolve;
+              options?.signal?.addEventListener(
+                "abort",
+                () => {
+                  setTimeout(() => {
+                    options.onUsage?.({
+                      input: 20,
+                      output: 5,
+                      total: 25,
+                      cost: 0.1,
+                      cacheRead: 0,
+                      cacheWrite: 0,
+                    });
+                    reject(new Error("first attempt finished slow abort teardown"));
+                  }, 1_100);
+                },
+                { once: true },
+              );
+            });
+          }
+          options?.onUsage?.({ input: 8, output: 2, total: 10, cost: 0.01, cacheRead: 0, cacheWrite: 0 });
+          return "resumed";
+        },
+      },
+    });
+    manager.on("error", () => {});
+
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    await firstAttemptStarted;
+    assert.equal(manager.pause(runId), true);
+    assert.equal(await manager.resume(runId), false, "resume must not overlap an execution still tearing down");
+    assert.equal(attempts, 1, "no replacement agent may start before pause teardown settles");
+    await assert.rejects(promise);
+
+    const paused = manager.getPersistence().load(runId);
+    assert.equal(paused?.tokenUsage?.total, 25);
+    assert.equal(await manager.resume(runId), true);
+    while (manager.getRun(runId)?.status === "running") {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const completed = manager.getPersistence().load(runId);
+    assert.equal(completed?.status, "completed");
+    assert.equal(completed?.tokenUsage?.total, 35);
+    assert.equal(attempts, 2);
+  }),
+);
+
+test(
+  "manager attributes concurrent same-label usage by call identity",
+  withTempCwd(async (cwd) => {
+    let started = 0;
+    let releaseBothStarted: () => void = () => {};
+    const bothStarted = new Promise<void>((resolve) => {
+      releaseBothStarted = resolve;
+    });
+    let releaseAgents: () => void = () => {};
+    const agentsReleased = new Promise<void>((resolve) => {
+      releaseAgents = resolve;
+    });
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt, options) {
+          started++;
+          if (started === 2) {
+            releaseBothStarted();
+          }
+          await bothStarted;
+          const total = prompt === "first" ? 10 : 100;
+          options?.onUsageProgress?.({
+            input: 0,
+            output: total,
+            total,
+            cost: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+          });
+          await agentsReleased;
+          return prompt;
+        },
+      },
+    });
+    const script = `export const meta = { name: 'same_label', description: 'same labels in parallel' }
+const results = await parallel([
+  () => agent('first', { label: 'worker' }),
+  () => agent('second', { label: 'worker' }),
+])
+return results`;
+
+    const { runId, promise } = manager.startInBackground(script);
+    while (true) {
+      const liveAgents = manager.getRun(runId)?.snapshot.agents;
+      if (liveAgents?.length === 2 && liveAgents.every((agent) => agent.tokens !== undefined)) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const agents = manager.getRun(runId)?.snapshot.agents;
+    assert.deepEqual(
+      agents?.map((agent) => [agent.prompt, agent.tokens]),
+      [
+        ["first", 10],
+        ["second", 100],
+      ],
+    );
+
+    releaseAgents();
+    await promise;
+  }),
+);
+
+test(
+  "manager attributes concurrent parent and nested agents by opaque agent identity",
+  withTempCwd(async (cwd) => {
+    let started = 0;
+    let releaseBothStarted: () => void = () => {};
+    const bothStarted = new Promise<void>((resolve) => {
+      releaseBothStarted = resolve;
+    });
+    let releaseAgents: () => void = () => {};
+    const agentsReleased = new Promise<void>((resolve) => {
+      releaseAgents = resolve;
+    });
+    const childScript = `export const meta = { name: 'child', description: 'nested child' }
+return await agent('child work', { label: 'worker' })`;
+    const manager = new WorkflowManager({
+      cwd,
+      loadSavedWorkflow: (name) => (name === "child" ? childScript : undefined),
+      agent: {
+        async run(prompt, options) {
+          started++;
+          if (started === 2) {
+            releaseBothStarted();
+          }
+          await bothStarted;
+          const total = prompt === "parent work" ? 10 : 100;
+          const usage = { input: 0, output: total, total, cost: 0, cacheRead: 0, cacheWrite: 0 };
+          options?.onUsageProgress?.(usage);
+          await agentsReleased;
+          options?.onUsage?.(usage);
+          return prompt;
+        },
+      },
+    });
+    const parentScript = `export const meta = { name: 'parent', description: 'parent and nested child' }
+const results = await parallel([
+  () => agent('parent work', { label: 'worker' }),
+  () => workflow('child'),
+])
+return results`;
+
+    const { runId, promise } = manager.startInBackground(parentScript);
+    while (true) {
+      const agents = manager.getRun(runId)?.snapshot.agents;
+      if (agents?.length === 2 && agents.every((agent) => agent.tokens !== undefined)) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    assert.deepEqual(
+      manager.getRun(runId)?.snapshot.agents.map((agent) => [agent.prompt, agent.tokens]),
+      [
+        ["parent work", 10],
+        ["child work", 100],
+      ],
+    );
+
+    releaseAgents();
+    await promise;
+    assert.equal(
+      manager.getRun(runId)?.snapshot.agents.every((agent) => agent.status === "done"),
+      true,
+    );
+    assert.equal(manager.getRun(runId)?.snapshot.tokenUsage?.total, 110);
   }),
 );
 
@@ -263,9 +696,14 @@ test(
     // which point attempt 2 resolves immediately.
     let secondAttempts = 0;
     const agent = {
-      async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+      async run(prompt: string, options?: { onUsage?: (usage: AgentUsage) => void; signal?: AbortSignal }) {
         options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 100, cost: 0 });
-        if (prompt === "second" && ++secondAttempts === 1) return new Promise(() => {});
+        if (prompt === "second" && ++secondAttempts === 1) {
+          return new Promise((resolve, reject) => {
+            void resolve;
+            options?.signal?.addEventListener("abort", () => reject(new Error("paused")), { once: true });
+          });
+        }
         return "ok";
       },
     };
@@ -540,13 +978,18 @@ test(
     let secondAttempts = 0;
     const zeroUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 };
     const agent = {
-      async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+      async run(prompt: string, options?: { onUsage?: (usage: AgentUsage) => void; signal?: AbortSignal }) {
         if (prompt === "first") {
           options?.onUsage?.({ ...zeroUsage, total: 100 });
           return "first-result";
         }
         if (prompt === "second") {
-          if (++secondAttempts === 1) return new Promise(() => {}); // hang until paused
+          if (++secondAttempts === 1) {
+            return new Promise((resolve, reject) => {
+              void resolve;
+              options?.signal?.addEventListener("abort", () => reject(new Error("paused")), { once: true });
+            });
+          }
           options?.onUsage?.({ ...zeroUsage, total: 60 });
           return "second-result";
         }
@@ -596,12 +1039,8 @@ test(
   withTempCwd(async (cwd) => {
     // 'a's first attempt spends 40 tokens then fails with an empty output
     // (recoverable -> retried); its second attempt spends 25 more and
-    // succeeds. onAgentEnd only ever reports the FINAL attempt's tokens (25)
-    // — the first attempt's 40 would be invisible to a persisted total built
-    // purely from onAgentEnd. 'b' then hangs so we can pause() and inspect
-    // the persisted state BEFORE the run fully completes (a full completion
-    // would paper over the gap via workflow.ts's own final onTokenUsage,
-    // which always includes every attempt's spend regardless of this fix).
+    // succeeds. Live usage must preserve both attempts before 'b' hangs and
+    // we pause, rather than waiting for workflow.ts's final onTokenUsage.
     let aAttempts = 0;
     const agent = {
       async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
@@ -1330,12 +1769,10 @@ test(
     const { runId, promise } = manager.startInBackground(oneAgentScript);
     await new Promise((r) => setTimeout(r, 20));
     manager.pause(runId);
-
-    assert.ok(pausedEvent, "paused event should fire");
-    assert.equal(pausedEvent?.runId, runId);
-
-    da.resolve("done");
     await promise.catch(() => {});
+
+    assert.ok(pausedEvent, "paused event should fire after the paused execution settles");
+    assert.equal(pausedEvent?.runId, runId);
   }),
 );
 
@@ -1454,6 +1891,10 @@ return { a, b }`;
       // Resume
       const resumed = await manager.resume(runId);
       assert.equal(resumed, true);
+      while ((manager.getRun(runId)?.snapshot.agents.length ?? 0) < 2) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      da.resolve("second-result");
 
       // Wait for resumed run to complete (agent 1 replayed from journal, agent 2 live)
       await new Promise((r) => setTimeout(r, 50));
@@ -1464,6 +1905,142 @@ return { a, b }`;
     }
 
     await origPromise.catch(() => {});
+  }),
+);
+
+test(
+  "resume replays parent and nested journals without duplicate token spend",
+  withTempCwd(async (cwd) => {
+    let parentRuns = 0;
+    let childRuns = 0;
+    let afterRuns = 0;
+    let markAfterStarted: () => void = () => {};
+    const afterStarted = new Promise<void>((resolve) => {
+      markAfterStarted = resolve;
+    });
+    const manager = new WorkflowManager({
+      cwd,
+      loadSavedWorkflow: (name) =>
+        name === "child"
+          ? `export const meta = { name: 'child', description: 'nested child' }
+return await agent('child', { label: 'child' })`
+          : undefined,
+      agent: {
+        async run(prompt, options) {
+          if (prompt === "parent") {
+            parentRuns++;
+            options?.onUsage?.({ input: 8, output: 2, total: 10, cost: 0.01, cacheRead: 0, cacheWrite: 0 });
+            return "parent-result";
+          }
+          if (prompt === "child") {
+            childRuns++;
+            options?.onUsage?.({ input: 30, output: 10, total: 40, cost: 0.04, cacheRead: 0, cacheWrite: 0 });
+            return "child-result";
+          }
+          afterRuns++;
+          if (afterRuns === 1) {
+            markAfterStarted();
+            return new Promise((resolve, reject) => {
+              void resolve;
+              options?.signal?.addEventListener("abort", () => reject(new Error("paused after nested work")), {
+                once: true,
+              });
+            });
+          }
+          options?.onUsage?.({ input: 4, output: 1, total: 5, cost: 0.005, cacheRead: 0, cacheWrite: 0 });
+          return "after-result";
+        },
+      },
+    });
+    manager.on("error", () => {});
+    const script = `export const meta = { name: 'nested_resume', description: 'nested journal resume' }
+const parent = await agent('parent', { label: 'parent' })
+const child = await workflow('child')
+const after = await agent('after', { label: 'after' })
+return { parent, child, after }`;
+
+    const { runId, promise } = manager.startInBackground(script);
+    await afterStarted;
+    assert.equal(manager.pause(runId), true);
+    await assert.rejects(promise);
+    assert.equal(manager.getPersistence().load(runId)?.tokenUsage?.total, 50);
+
+    assert.equal(await manager.resume(runId), true);
+    while (manager.getRun(runId)?.status === "running") {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const completed = manager.getPersistence().load(runId);
+    assert.equal(completed?.status, "completed");
+    assert.equal(completed?.tokenUsage?.total, 55);
+    assert.equal(parentRuns, 1);
+    assert.equal(childRuns, 1);
+    assert.equal(afterRuns, 2);
+  }),
+);
+
+test(
+  "edited parent call invalidates nested and suffix journal replay",
+  withTempCwd(async (cwd) => {
+    const runs = { parent: 0, child: 0, after: 0 };
+    let markAfterStarted: () => void = () => {};
+    const afterStarted = new Promise<void>((resolve) => {
+      markAfterStarted = resolve;
+    });
+    const manager = new WorkflowManager({
+      cwd,
+      loadSavedWorkflow: () => `export const meta = { name: 'child', description: 'nested child' }
+return await agent('child', { label: 'child' })`,
+      agent: {
+        async run(prompt, options) {
+          if (prompt.startsWith("parent")) {
+            runs.parent++;
+            options?.onUsage?.({ input: 8, output: 2, total: 10, cost: 0.01, cacheRead: 0, cacheWrite: 0 });
+            return prompt;
+          }
+          if (prompt === "child") {
+            runs.child++;
+            options?.onUsage?.({ input: 30, output: 10, total: 40, cost: 0.04, cacheRead: 0, cacheWrite: 0 });
+            return "child-result";
+          }
+          runs.after++;
+          if (runs.after === 1) {
+            markAfterStarted();
+            return new Promise((resolve, reject) => {
+              void resolve;
+              options?.signal?.addEventListener("abort", () => reject(new Error("paused after nested work")), {
+                once: true,
+              });
+            });
+          }
+          options?.onUsage?.({ input: 4, output: 1, total: 5, cost: 0.005, cacheRead: 0, cacheWrite: 0 });
+          return "after-result";
+        },
+      },
+    });
+    manager.on("error", () => {});
+    const script = (
+      parentPrompt: string,
+    ) => `export const meta = { name: 'nested_edit', description: 'nested edit resume' }
+const parent = await agent('${parentPrompt}', { label: 'parent' })
+const child = await workflow('child')
+const after = await agent('after', { label: 'after' })
+return { parent, child, after }`;
+
+    const { runId, promise } = manager.startInBackground(script("parent"));
+    await afterStarted;
+    assert.equal(manager.pause(runId), true);
+    await assert.rejects(promise);
+    assert.equal(manager.getPersistence().load(runId)?.tokenUsage?.total, 50);
+
+    assert.equal(await manager.resume(runId, { script: script("parent-edited") }), true);
+    while (manager.getRun(runId)?.status === "running") {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    const completed = manager.getPersistence().load(runId);
+    assert.equal(completed?.tokenUsage?.total, 105);
+    assert.deepEqual(runs, { parent: 2, child: 2, after: 2 });
   }),
 );
 
@@ -3670,7 +4247,13 @@ test(
     // the one evicted — proving stop() itself recorded it terminal-eligible
     // (without that, it would sit in `runs` forever: no pending tail left to
     // ever call recordTerminalRun() for it).
-    const other = await manager.runSync(oneAgentScript);
+    // The deferred-agent helper creates a per-attempt promise (aborted attempts
+    // reject rather than stay pending), so start the runSync first and resolve
+    // once its fresh attempt has registered.
+    const pendingSync = manager.runSync(oneAgentScript);
+    await new Promise((r) => setTimeout(r, 50));
+    da.resolve("done");
+    const other = await pendingSync;
     assert.ok(manager.getRun(other.runId), "the newest terminal run is in memory");
     assert.equal(
       manager.getRun(pausedId),

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -173,7 +173,7 @@ test(
 );
 
 test(
-  "manager exposes live token usage while an agent is still running",
+  "manager replaces a high live estimate with settled agent usage",
   withTempCwd(async (cwd) => {
     let release: (() => void) | undefined;
     const blocked = new Promise<void>((resolve) => {
@@ -186,8 +186,8 @@ test(
           void prompt;
           options?.onUsageProgress?.({
             input: 20,
-            output: 10,
-            total: 30,
+            output: 80,
+            total: 100,
             cost: 0.01,
             cacheRead: 0,
             cacheWrite: 0,
@@ -211,21 +211,24 @@ test(
       tokenUsageEvents++;
     });
     const { runId, promise } = manager.startInBackground(oneAgentScript);
-    while ((manager.getRun(runId)?.snapshot.agents[0]?.tokens ?? 0) < 30) {
+    while ((manager.getRun(runId)?.snapshot.agents[0]?.tokens ?? 0) < 100) {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
 
     const live = manager.getRun(runId);
     assert.equal(live?.status, "running");
     assert.equal(live?.snapshot.agents[0]?.status, "running");
-    assert.equal(live?.snapshot.agents[0]?.tokens, 30);
+    assert.equal(live?.snapshot.agents[0]?.tokens, 100);
     assert.equal(live?.snapshot.tokenUsage, undefined, "in-flight estimates must not alter finalized run accounting");
     assert.ok(tokenUsageEvents > 0, "live task-panel listeners should be notified before agent completion");
 
     assert.ok(release);
     release();
     await promise;
-    assert.equal(manager.getRun(runId)?.snapshot.tokenUsage?.total, 30);
+    const settled = manager.getRun(runId);
+    assert.equal(settled?.snapshot.agents[0]?.tokens, 30);
+    assert.equal(settled?.snapshot.agents[0]?.tokenUsage?.total, 30);
+    assert.equal(settled?.snapshot.tokenUsage?.total, 30);
   }),
 );
 
@@ -271,7 +274,7 @@ test(
 );
 
 test(
-  "paused event is emitted after exact abort usage is persisted",
+  "manual pause settles with exact abort usage and never emits 'error'",
   withTempCwd(async (cwd) => {
     const exactUsage: AgentUsage = {
       input: 20,
@@ -303,9 +306,11 @@ test(
       },
     });
     manager.on("error", () => {});
-    let usageAtPausedEvent: number | undefined;
-    manager.on("paused", ({ runId }: { runId: string }) => {
-      usageAtPausedEvent = manager.getPersistence().load(runId)?.tokenUsage?.total;
+    // pause() announces "paused" synchronously (lifecycle control); the exact
+    // abort-teardown usage lands later, when executeRun() settles and persists.
+    let errorEvents = 0;
+    manager.on("error", () => {
+      errorEvents++;
     });
 
     const { runId, promise } = manager.startInBackground(oneAgentScript);
@@ -315,7 +320,11 @@ test(
     assert.equal(manager.pause(runId), true);
     await assert.rejects(promise);
 
-    assert.equal(usageAtPausedEvent, 25);
+    const settled = manager.getPersistence().load(runId);
+    assert.equal(settled?.status, "paused");
+    assert.equal(settled?.tokenUsage?.total, 25);
+    assert.equal(settled?.tokenUsage?.cost, 0.1);
+    assert.equal(errorEvents, 0, "a manual pause must not surface as an error");
   }),
 );
 

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -4271,3 +4271,58 @@ test(
     );
   }),
 );
+
+test(
+  "manager rolls back provisional agent usage when pause aborts without terminal usage",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt, options) {
+          void prompt;
+          options?.onUsageProgress?.({
+            input: 20,
+            output: 80,
+            total: 100,
+            cost: 0.01,
+            cacheRead: 0,
+            cacheWrite: 0,
+          });
+          return new Promise((resolve, reject) => {
+            void resolve;
+            const abort = () => reject(new Error("aborted without terminal usage"));
+            if (options?.signal?.aborted) {
+              abort();
+            } else {
+              options?.signal?.addEventListener("abort", abort, { once: true });
+            }
+          });
+        },
+      },
+    });
+    manager.on("error", () => {});
+
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    while ((manager.getRun(runId)?.snapshot.agents[0]?.tokens ?? 0) < 100) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    assert.equal(manager.pause(runId), true);
+    await assert.rejects(promise);
+
+    const live = manager.getRun(runId);
+    assert.equal(live?.status, "paused");
+    assert.equal(live?.snapshot.agents[0]?.tokens, 0, "the in-memory agent must discard provisional usage");
+    assert.equal(live?.snapshot.agents[0]?.tokenUsage?.total, 0);
+    assert.equal(live?.snapshot.tokenUsage, undefined, "abandoned usage must not enter run accounting");
+
+    const persisted = manager.getPersistence().load(runId);
+    assert.equal(persisted?.status, "paused");
+    assert.equal(persisted?.agents[0]?.tokens, 0, "the persisted agent must discard provisional usage");
+    assert.equal(persisted?.agents[0]?.tokenUsage?.total, 0);
+    assert.equal(persisted?.tokenUsage, undefined);
+
+    const statusRow = new NavigatorModel(manager).runs().find((run) => run.runId === runId);
+    assert.equal(statusRow?.fresh, 0, "status-facing usage must reflect committed usage only");
+    assert.equal(statusRow?.cacheRead, 0);
+  }),
+);

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -457,6 +457,38 @@ test("runWorkflow streams cumulative token usage before an agent returns", async
   assert.equal(result.tokenUsage?.total, 20, "the exact terminal total must replace the progress estimate");
 });
 
+test("onAgentEnd reports cumulative settled usage across retries", async () => {
+  let attempts = 0;
+  let endedTokens: number | undefined;
+  let endedUsage: AgentUsage | undefined;
+  const result = await runWorkflow(
+    `export const meta = { name: 'retry_usage', description: 'retry usage' }
+     return await agent('work', { label: 'worker', retries: 1 })`,
+    {
+      agent: {
+        async run(prompt, options) {
+          void prompt;
+          attempts++;
+          const total = attempts === 1 ? 40 : 25;
+          options?.onUsageProgress?.({ input: 0, output: 100, total: 100, cost: 0, cacheRead: 0, cacheWrite: 0 });
+          options?.onUsage?.({ input: 0, output: total, total, cost: 0, cacheRead: 0, cacheWrite: 0 });
+          return attempts === 1 ? "" : "done";
+        },
+      },
+      persistLogs: false,
+      onAgentEnd: (event) => {
+        endedTokens = event.tokens;
+        endedUsage = event.tokenUsage;
+      },
+    },
+  );
+
+  assert.equal(result.result, "done");
+  assert.equal(attempts, 2);
+  assert.equal(endedTokens, 65);
+  assert.equal(endedUsage?.total, 65);
+});
+
 test("meta.model is parsed and routes as the default model for agents", async () => {
   let seenModel: string | undefined;
   const recorder = {

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
-import type { AgentUsage } from "../src/agent.js";
+import type { AgentRunOptions, AgentUsage } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { type JournalEntry, parseWorkflowScript, runWorkflow } from "../src/workflow.js";
 
@@ -243,6 +243,85 @@ return a`,
   assert.equal(journal.length, 1, "only the final success is journaled");
 });
 
+test("runWorkflow reconciles timeout fallback with exact abort-teardown usage", { timeout: 2_500 }, async () => {
+  const exactUsage: AgentUsage = {
+    input: 900,
+    output: 100,
+    total: 1_000,
+    cost: 0.5,
+    cacheRead: 0,
+    cacheWrite: 0,
+  };
+  const result = await runWorkflow(
+    `export const meta = { name: 'timeout_usage', description: 'timeout usage' }
+return await agent('short prompt', { label: 'slow', timeoutMs: 5 })`,
+    {
+      agent: {
+        async run(prompt: string, options?: AgentRunOptions) {
+          void prompt;
+          return new Promise((resolve, reject) => {
+            void resolve;
+            options?.signal?.addEventListener(
+              "abort",
+              () => {
+                setTimeout(() => {
+                  options.onUsage?.(exactUsage);
+                  reject(new Error("aborted after exact usage"));
+                }, 1_100);
+              },
+              { once: true },
+            );
+          });
+        },
+      },
+      persistLogs: false,
+    },
+  );
+
+  assert.equal(result.result, null);
+  assert.deepEqual(result.tokenUsage, exactUsage);
+});
+
+test("runWorkflow waits for timed-out teardown before starting a retry", { timeout: 3_000 }, async () => {
+  let calls = 0;
+  let active = 0;
+  let maxActive = 0;
+  const releaseFirstAttempt = createDeferred<void>();
+  const run = runWorkflow(
+    `export const meta = { name: 'slow_teardown', description: 'slow timeout teardown' }
+return await agent('stuck', { label: 'stuck', timeoutMs: 5, retries: 1 })`,
+    {
+      agent: {
+        async run(prompt: string) {
+          void prompt;
+          calls++;
+          active++;
+          maxActive = Math.max(maxActive, active);
+          try {
+            if (calls === 1) {
+              await releaseFirstAttempt.promise;
+              throw new Error("aborted after slow teardown");
+            }
+            return "retry-result";
+          } finally {
+            active--;
+          }
+        },
+      },
+      persistLogs: false,
+    },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 1_050));
+  assert.equal(calls, 1, "a retry must not overlap a timed-out runner still tearing down");
+  releaseFirstAttempt.resolve(undefined);
+  const result = await run;
+
+  assert.equal(result.result, "retry-result");
+  assert.equal(calls, 2);
+  assert.equal(maxActive, 1);
+});
+
 test("runWorkflow returns null when recoverable retries are exhausted", async () => {
   let calls = 0;
   const logs: string[] = [];
@@ -339,6 +418,45 @@ test("runWorkflow accumulates real per-agent usage (incl. cost + cache tokens)",
   assert.equal(result.tokenUsage?.cacheWrite, 20, "cacheWrite accumulates across agents");
 });
 
+test("runWorkflow streams cumulative token usage before an agent returns", async () => {
+  const release = createDeferred<void>();
+  const usageEvents: number[] = [];
+  const finalizedUsageEvents: number[] = [];
+  let settled = false;
+  const run = runWorkflow(
+    `export const meta = { name: 'live_usage', description: 'live token usage' }
+     return await agent('work', { label: 'worker' })`,
+    {
+      agent: {
+        async run(prompt, options) {
+          void prompt;
+          options?.onUsageProgress?.({ input: 7, output: 3, total: 10, cost: 0.01, cacheRead: 0, cacheWrite: 0 });
+          options?.onUsageProgress?.({ input: 17, output: 8, total: 25, cost: 0.02, cacheRead: 0, cacheWrite: 0 });
+          await release.promise;
+          options?.onUsage?.({ input: 12, output: 8, total: 20, cost: 0.02, cacheRead: 0, cacheWrite: 0 });
+          return "done";
+        },
+      },
+      persistLogs: false,
+      onAgentUsage: (event) => usageEvents.push(event.tokenUsage.total),
+      onTokenUsage: (usage) => finalizedUsageEvents.push(usage.total),
+    },
+  ).finally(() => {
+    settled = true;
+  });
+
+  while (usageEvents.length < 2) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  assert.equal(settled, false, "usage should be observable while the agent is still running");
+  assert.deepEqual(usageEvents, [10, 25]);
+  assert.deepEqual(finalizedUsageEvents, [], "progress estimates must not change finalized budget accounting");
+
+  release.resolve();
+  const result = await run;
+  assert.equal(result.tokenUsage?.total, 20, "the exact terminal total must replace the progress estimate");
+});
+
 test("meta.model is parsed and routes as the default model for agents", async () => {
   let seenModel: string | undefined;
   const recorder = {
@@ -352,6 +470,20 @@ await agent('x', { label: 'x' })
 return 1`;
   await runWorkflow(script, { agent: recorder, persistLogs: false });
   assert.equal(seenModel, "meta/default-model", "an agent with no model/tier/phase route uses meta.model");
+});
+
+test("runWorkflow preserves authoritative cost-only terminal usage", async () => {
+  const result = await runWorkflow(
+    `export const meta = { name: 'cost_only', description: 'cost-only provider usage' }
+     return await agent('work', { label: 'worker' })`,
+    {
+      agent: fakeAgent({ input: 0, output: 0, total: 0, cost: 0.25, cacheRead: 0, cacheWrite: 0 }),
+      persistLogs: false,
+    },
+  );
+
+  assert.equal(result.tokenUsage?.total, 0);
+  assert.equal(result.tokenUsage?.cost, 0.25);
 });
 
 test("runWorkflow falls back to an estimate when provider reports total === 0", async () => {
@@ -715,6 +847,49 @@ return await agent('threaded child', { thread: 'implementer' })`;
   assert.equal(resumed.state.calls, 2, "the child thread and later parent agent both run live");
   assert.equal(confirmations, 1, "the later parent checkpoint also runs live");
   assert.equal(result.result.confirmed, false);
+});
+
+test("sequential nested workflows assign distinct opaque agent identities", async () => {
+  const agentIds: string[] = [];
+  const childScript = `export const meta = { name: 'child', description: 'one child agent' }
+return await agent('child work', { label: 'worker' })`;
+  await runWorkflow(
+    `export const meta = { name: 'parent', description: 'two sequential child workflows' }
+const first = await workflow('child')
+const second = await workflow('child')
+return [first, second]`,
+    {
+      agent: fakeAgent(),
+      loadSavedWorkflow: (name) => (name === "child" ? childScript : undefined),
+      onAgentStart: (event) => agentIds.push(event.id),
+      persistLogs: false,
+    },
+  );
+
+  assert.equal(agentIds.length, 2);
+  assert.equal(new Set(agentIds).size, 2);
+});
+
+test("parallel sibling workflows can each use the one allowed nesting level", async () => {
+  const agentIds: string[] = [];
+  const childScript = `export const meta = { name: 'child', description: 'parallel child' }
+return await agent('child work', { label: 'worker' })`;
+  const result = await runWorkflow<string[]>(
+    `export const meta = { name: 'parent', description: 'parallel child workflows' }
+return await parallel([
+  () => workflow('child'),
+  () => workflow('child'),
+])`,
+    {
+      agent: fakeAgent({}, "child-result"),
+      loadSavedWorkflow: (name) => (name === "child" ? childScript : undefined),
+      onAgentStart: (event) => agentIds.push(event.id),
+      persistLogs: false,
+    },
+  );
+
+  assert.deepEqual(result.result, ["child-result", "child-result"]);
+  assert.equal(new Set(agentIds).size, 2);
 });
 
 test("workflow() nesting is one level deep (second level throws)", async () => {


### PR DESCRIPTION
## What changed

- Stream token estimates while an agent is responding, then replace them with exact provider usage when the response settles.
- Keep provisional usage out of budgets and persisted totals.
- Track concurrent, retried, nested, timed-out, paused, and resumed agents without losing or double-counting usage.
- Preserve the existing once-per-run `onTokenUsage` callback and once-per-agent terminal `onUsage` callback.

## Why

Long-running agents previously showed no token movement until they finished. The live totals now distinguish an active agent from a stalled one without changing final accounting.

## Validation

- `npm run check`
- `npm run build`
- 226 focused runtime, manager, abort, and persistence tests
- `npm run release:verify` — 0 warnings
- Real Pi session streamed 7 updates before settlement, then committed the exact 8,371-token provider total.
- Real Pi timeout returned `AGENT_TIMEOUT` and settled teardown in 522 ms.
- Full suite: 1,071 of 1,072 tests passed. The remaining provider-dependent schema test also fails on unchanged `origin/main` because the model returns an instruction request instead of `{ verdict: "ok" }`.
