### PR TITLE
fix: refresh workflow mainModel on session model change (#148)

### DIFF
--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -335,4 +335,12 @@ export default function extension(pi: ExtensionAPI) {
       armingInstalled = true;
     }
   });
+
+  // Keep mainModel in sync with mid-session /model (and cycle/restore). Without
+  // this, workflow subagents that fall through to mainModel keep the frozen
+  // session_start value for the rest of the process lifetime.
+  pi.on("model_select", (event) => {
+    const m = event.model;
+    manager.setMainModel(m ? `${m.provider}/${m.id}` : undefined);
+  });
 }

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -149,6 +149,14 @@ test("resolveAgentModelSpec: unconfigured tier falls back to the main model", ()
   assert.equal(resolveAgentModelSpec({ tier: "unknown-tier" }, "main/model", loadCfg), "main/model");
 });
 
+test("resolveAgentModelSpec: no model-tiers.json — after mainModel refresh, tier:medium uses the NEW mainModel", () => {
+  // #148: /model then /code-review with no model-tiers.json. Agents tagged
+  // { tier: "medium" } fall through to mainModel, which must be the post-/model
+  // value — not a session-start snapshot.
+  assert.equal(resolveAgentModelSpec({ tier: "medium" }, "start-prov/model-a", noCfg), "start-prov/model-a");
+  assert.equal(resolveAgentModelSpec({ tier: "medium" }, "live-prov/model-b", noCfg), "live-prov/model-b");
+});
+
 test("resolveAgentModelSpec: untagged agent defaults to the configured medium tier", () => {
   // The "set tier but nothing changed" fix: an agent with no model and no tier
   // falls back to the user's medium tier when a config exists.

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -901,6 +901,33 @@ return { a }`;
     await manager.runSync(script);
     const run = manager.listRuns().find((r) => r.workflowName === "mm_test");
     assert.ok(run, "run should exist");
+    const agentSnap = run?.agents.find((ag) => ag.label === "a");
+    assert.equal(agentSnap?.model, "anthropic/claude-sonnet-4", "untagged agents display the session mainModel");
+  }),
+);
+
+test(
+  "setMainModel after a prior run reaches subsequent untagged agents (mid-session /model)",
+  withTempCwd(async (cwd) => {
+    const manager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    const script = `export const meta = { name: 'mm_refresh', description: 'main model refresh' }
+const a = await agent('test', { label: 'a' })
+return { a }`;
+
+    manager.setMainModel("start-prov/model-a");
+    const firstResult = await manager.runSync(script);
+    const first = manager.getPersistence().load(firstResult.runId);
+    assert.equal(first?.agents.find((ag) => ag.label === "a")?.model, "start-prov/model-a");
+
+    manager.setMainModel("live-prov/model-b");
+    const secondResult = await manager.runSync(script);
+    const second = manager.getPersistence().load(secondResult.runId);
+    assert.notEqual(firstResult.runId, secondResult.runId);
+    assert.equal(
+      second?.agents.find((ag) => ag.label === "a")?.model,
+      "live-prov/model-b",
+      "a later setMainModel must win for new runs (model_select path)",
+    );
   }),
 );
 

--- a/tests/workflow-tools-available.test.ts
+++ b/tests/workflow-tools-available.test.ts
@@ -808,6 +808,73 @@ describe("workflow extension - control tool availability", () => {
     }
   });
 
+  it("wires model_select to manager.setMainModel", async () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-control-extension-model-select-"));
+    try {
+      await withFakeHomeAsync(fakeHome, async () => {
+        discardWorkflowRuntime(process.cwd());
+        const { WorkflowManager } = await import("../src/workflow-manager.js");
+        const seen: Array<string | undefined> = [];
+        const original = WorkflowManager.prototype.setMainModel;
+        WorkflowManager.prototype.setMainModel = function setMainModelSpy(spec: string | undefined) {
+          seen.push(spec);
+          return original.call(this, spec);
+        };
+        try {
+          const activeTools = ["bash", "read"];
+          const handlers: Record<string, Array<(...args: any[]) => any>> = {};
+          const pi = {
+            registerTool: () => {},
+            registerCommand: () => {},
+            getCommands: () => [],
+            on: (event: string, handler: (...args: any[]) => any) => {
+              if (!handlers[event]) handlers[event] = [];
+              handlers[event].push(handler);
+            },
+            getActiveTools: () => [...activeTools],
+            setActiveTools: (tools: string[]) => {
+              activeTools.splice(0, activeTools.length, ...tools);
+            },
+            sendMessage: () => {},
+          } as unknown as ExtensionAPI;
+          const { default: installExtension } = await import("../extensions/workflow.js");
+          installExtension(pi);
+
+          assert.equal(handlers.model_select?.length, 1, "must listen for model_select");
+
+          handlers.session_start[0](
+            {},
+            {
+              cwd: process.cwd(),
+              model: { provider: "start-prov", id: "model-a" },
+              modelRegistry: {},
+              sessionManager: { getSessionId: () => "session-model" },
+              ui: { setWidget: () => {}, notify: () => {} },
+            },
+          );
+          assert.ok(seen.includes("start-prov/model-a"), "session_start should seed mainModel from ctx.model");
+
+          handlers.model_select[0]({
+            type: "model_select",
+            model: { provider: "live-prov", id: "model-b" },
+            previousModel: { provider: "start-prov", id: "model-a" },
+            source: "set",
+          });
+          assert.ok(
+            seen.includes("live-prov/model-b"),
+            "model_select must call setMainModel with the newly selected spec",
+          );
+
+          discardWorkflowRuntime(process.cwd());
+        } finally {
+          WorkflowManager.prototype.setMainModel = original;
+        }
+      });
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
   it("queues completions that land before session_start and flushes them after", async () => {
     const fakeHome = mkdtempSync(join(tmpdir(), "pi-dw-control-extension-prebind-"));
     try {


### PR DESCRIPTION
## Summary

Workflow subagents that fall through to the session model were stuck on whatever model the session had at start. `/model` never updated that value.

Listen for Pi's `model_select` event and refresh `mainModel` so the next run (including tier fallthrough when no model-tiers.json is set) uses the current session model.

## Test plan

- [x] Extension wires `model_select` to `setMainModel`
- [x] Untagged agents pick up a later `setMainModel`
- [x] `resolveAgentModelSpec({ tier: "medium" })` with no tier config follows the new mainModel