### PR TITLE
fix: raise maxAgents on resume without replaying paid work (#146)

### DIFF
--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from "node:events";
 import type { ModelRegistry, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { WorkflowAgent } from "./agent.js";
 import { preview, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
+import { MAX_AGENTS_PER_RUN } from "./config.js";
 import { isProviderUsageLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import {
   createRunPersistence,
@@ -1186,7 +1187,10 @@ export class WorkflowManager extends EventEmitter {
    * UsageLimitScheduler) unchanged. `opts.args` overrides the persisted args
    * only when provided; otherwise the persisted args are kept.
    */
-  async resume(runId: string, opts?: { script?: string; args?: unknown }): Promise<boolean> {
+  async resume(
+    runId: string,
+    opts?: { script?: string; args?: unknown; maxAgents?: number },
+  ): Promise<boolean> {
     // Guard: refuse to resume a run that is already running, or one that was
     // intentionally aborted (pause/stop/Esc). Paused and failed runs can restart.
     const active = this.runs.get(runId);
@@ -1215,6 +1219,24 @@ export class WorkflowManager extends EventEmitter {
           cacheWrite: persisted.tokenUsage.cacheWrite ?? 0,
         }
       : undefined;
+
+    // maxAgents: omit keeps the persisted cap (undefined means runWorkflow's
+    // MAX_AGENTS_PER_RUN default). A finite opts.maxAgents is increase-only vs
+    // that effective prior — never pin a lower ceiling onto a never-set run.
+    // A non-raise request refuses the whole resume so callers don't think
+    // recovery worked.
+    const priorMaxAgents = persisted.maxAgents;
+    const requestedMaxAgents = opts?.maxAgents;
+    let resolvedMaxAgents = priorMaxAgents;
+    if (typeof requestedMaxAgents === "number" && Number.isFinite(requestedMaxAgents)) {
+      const raised = Math.floor(requestedMaxAgents);
+      const effectivePrior = priorMaxAgents ?? MAX_AGENTS_PER_RUN;
+      if (raised <= effectivePrior) {
+        this.persistence.releaseRunLease(lease);
+        return false;
+      }
+      resolvedMaxAgents = raised;
+    }
 
     const controller = new AbortController();
     const managed: ManagedRun = {
@@ -1259,10 +1281,12 @@ export class WorkflowManager extends EventEmitter {
       // Restore the same start-time execution context for the other four
       // per-run knobs (see ManagedRun doc comments) — same rationale as
       // tokenBudget: never re-resolve against the manager's CURRENT defaults.
-      // maxAgents: legacy/never-set runs resume with no cap carried forward
-      // (runWorkflow's own MAX_AGENTS_PER_RUN default applies), exactly as if
-      // maxAgents had never been passed at all.
-      maxAgents: persisted.maxAgents,
+      // maxAgents: omit keeps the persisted cap (undefined means runWorkflow's
+      // MAX_AGENTS_PER_RUN default). A finite opts.maxAgents is increase-only vs
+      // that effective prior — never pin a lower ceiling onto a never-set run.
+      // A non-raise request refuses the whole resume so callers don't think
+      // recovery worked.
+      maxAgents: resolvedMaxAgents,
       // agentTimeoutMs: unlike tokenBudget, a legacy run's real timeout at
       // start was never "no timeout" by omission — it was always
       // this.defaultAgentTimeoutMs, because pre-A1 resume() never threaded

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -5,8 +5,8 @@
 import { EventEmitter } from "node:events";
 import type { ModelRegistry, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { WorkflowAgent } from "./agent.js";
-import { preview, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
 import { MAX_AGENTS_PER_RUN } from "./config.js";
+import { preview, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
 import { isProviderUsageLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import {
   createRunPersistence,
@@ -1187,10 +1187,7 @@ export class WorkflowManager extends EventEmitter {
    * UsageLimitScheduler) unchanged. `opts.args` overrides the persisted args
    * only when provided; otherwise the persisted args are kept.
    */
-  async resume(
-    runId: string,
-    opts?: { script?: string; args?: unknown; maxAgents?: number },
-  ): Promise<boolean> {
+  async resume(runId: string, opts?: { script?: string; args?: unknown; maxAgents?: number }): Promise<boolean> {
     // Guard: refuse to resume a run that is already running, or one that was
     // intentionally aborted (pause/stop/Esc). Paused and failed runs can restart.
     const active = this.runs.get(runId);

--- a/src/workflow-tool.ts
+++ b/src/workflow-tool.ts
@@ -2,6 +2,7 @@ import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { BUILTIN_WORKFLOW_NAMES, resolveWorkflowInvocation } from "./builtin-workflows.js";
+import { MAX_AGENTS_PER_RUN } from "./config.js";
 import {
   createToolUpdateWorkflowDisplay,
   createWorkflowSnapshot,
@@ -225,9 +226,15 @@ export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefin
       // detached and its result is delivered back into the conversation).
       if (params.resumeFromRunId) {
         const runId = params.resumeFromRunId;
-        const resumed = await manager.resume(runId, { script, args: params.args });
+        const resumed = await manager.resume(runId, {
+          script,
+          args: params.args,
+          // Explicit raise only — resume keeps the start-time cap unless the
+          // caller passes a higher maxAgents (see WorkflowManager.resume, #146).
+          maxAgents: params.maxAgents,
+        });
         if (!resumed) {
-          throw new Error(resumeFailureText(manager, runId));
+          throw new Error(resumeFailureText(manager, runId, params.maxAgents));
         }
         return {
           content: [{ type: "text", text: resumedText(parsed.meta.name, runId) }],
@@ -439,7 +446,7 @@ export function resumedText(name: string, runId: string): string {
  * tool error instead of a silent failure. Inspects live + persisted state to
  * name the concrete reason (not found / running / completed / stopped).
  */
-export function resumeFailureText(manager: WorkflowManager, runId: string): string {
+export function resumeFailureText(manager: WorkflowManager, runId: string, requestedMaxAgents?: number): string {
   const active = manager.getRun(runId);
   if (active?.status === "running") {
     return `Cannot resume workflow run "${runId}": it is still running. Wait for it to finish (or /workflows stop ${runId}) before resuming with an edited script.`;
@@ -456,6 +463,12 @@ export function resumeFailureText(manager: WorkflowManager, runId: string): stri
   }
   if (!persisted.script) {
     return `Cannot resume workflow run "${runId}": it has no persisted script to resume. Start a new run instead (omit resumeFromRunId).`;
+  }
+  if (typeof requestedMaxAgents === "number" && Number.isFinite(requestedMaxAgents)) {
+    const effectivePrior = persisted.maxAgents ?? MAX_AGENTS_PER_RUN;
+    if (Math.floor(requestedMaxAgents) <= effectivePrior) {
+      return `Cannot resume workflow run "${runId}": cannot lower or keep maxAgents at ${effectivePrior}; pass maxAgents > ${effectivePrior}.`;
+    }
   }
   return `Cannot resume workflow run "${runId}": it is not currently resumable (it may be busy under another process). Try again shortly, or start a new run.`;
 }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -515,7 +515,7 @@ export async function runWorkflow<T = unknown>(
 
   const agentLimitError = () =>
     new WorkflowError(
-      `Agent limit exceeded (${maxAgents}). Use maxAgents option to increase the limit.`,
+      `Agent limit exceeded (${shared.agentCount}/${maxAgents}). Re-call workflow with resumeFromRunId="${runId}", the same script, and maxAgents: N (N>${maxAgents}) — journaled prefix replays free. /workflows resume alone cannot raise the cap.`,
       WorkflowErrorCode.AGENT_LIMIT_EXCEEDED,
       { recoverable: false },
     );

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -350,19 +350,19 @@ return { a, b, synthesis }`;
       new RegExp(`resumeFromRunId="${runId}".*same script.*maxAgents: N \\(N>2\\)`),
       "AGENT_LIMIT text must include the concrete resume recipe",
     );
-    const failed = manager.getPersistence().load(runId!);
+    const failed = manager.getPersistence().load(runId);
     assert.equal(failed?.status, "failed");
     assert.equal(failed?.maxAgents, 2);
     assert.ok((failed?.journal?.length ?? 0) >= 2, "workers should be journaled before the cap error");
     const liveBeforeResume = livePrompts.length;
     assert.equal(liveBeforeResume, 2, "only the two workers should have run live");
 
-    assert.equal(await manager.resume(runId!, { maxAgents: 3 }), true);
-    for (let i = 0; i < 200 && manager.getRun(runId!)?.status === "running"; i++) {
+    assert.equal(await manager.resume(runId, { maxAgents: 3 }), true);
+    for (let i = 0; i < 200 && manager.getRun(runId)?.status === "running"; i++) {
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
 
-    const done = manager.getPersistence().load(runId!);
+    const done = manager.getPersistence().load(runId);
     assert.equal(done?.status, "completed", "raised ceiling must let synthesis finish");
     assert.equal(done?.maxAgents, 3, "raised maxAgents must persist for later resumes");
     assert.deepEqual(
@@ -372,7 +372,7 @@ return { a, b, synthesis }`;
     );
 
     // Omit override → keep raised cap; a lower request must not shrink it.
-    const again = manager.getPersistence().load(runId!);
+    const again = manager.getPersistence().load(runId);
     assert.equal(again?.maxAgents, 3);
     // Build a fresh failed-at-cap run to assert a non-raise is refused.
     livePrompts.length = 0;
@@ -381,8 +381,8 @@ return { a, b, synthesis }`;
     await secondManager.runSync(script, undefined, { maxAgents: 2 }).catch(() => {});
     const runId2 = secondManager.listRuns().find((r) => r.workflowName === "raise_cap")?.runId;
     assert.ok(runId2);
-    assert.equal(await secondManager.resume(runId2!, { maxAgents: 1 }), false);
-    const notLowered = secondManager.getPersistence().load(runId2!);
+    assert.equal(await secondManager.resume(runId2, { maxAgents: 1 }), false);
+    const notLowered = secondManager.getPersistence().load(runId2);
     assert.equal(notLowered?.maxAgents, 2, "resume must never lower the persisted ceiling");
     assert.equal(notLowered?.status, "failed", "non-raise resume is refused; run stays failed at the old cap");
 

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -319,6 +319,100 @@ test(
 );
 
 test(
+  "resume with a higher maxAgents raises the persisted ceiling and finishes the journaled suffix",
+  withTempCwd(async (cwd) => {
+    // Sequential workers fill the cap; synthesis needs one more slot. Without an
+    // explicit raise, resume keeps maxAgents: 2 and fails again; with raise, the
+    // two workers replay from the journal and only synthesis runs live.
+    const livePrompts: string[] = [];
+    const agent = {
+      async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+        livePrompts.push(prompt);
+        options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 1, cost: 0 });
+        return `${prompt}-ok`;
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent });
+    manager.on("error", () => {});
+    const script = `export const meta = { name: 'raise_cap', description: 'raise maxAgents on resume' }
+const a = await agent('worker-a', { label: 'a' })
+const b = await agent('worker-b', { label: 'b' })
+const synthesis = await agent('synthesis', { label: 'synthesis' })
+return { a, b, synthesis }`;
+
+    const first = await manager.runSync(script, undefined, { maxAgents: 2 }).catch((err: unknown) => err);
+    assert.ok(first instanceof WorkflowError);
+    assert.equal(first.code, WorkflowErrorCode.AGENT_LIMIT_EXCEEDED);
+    const runId = manager.listRuns().find((r) => r.workflowName === "raise_cap")?.runId;
+    assert.ok(runId, "failed run should still be listed");
+    assert.match(
+      first.message,
+      new RegExp(`resumeFromRunId="${runId}".*same script.*maxAgents: N \\(N>2\\)`),
+      "AGENT_LIMIT text must include the concrete resume recipe",
+    );
+    const failed = manager.getPersistence().load(runId!);
+    assert.equal(failed?.status, "failed");
+    assert.equal(failed?.maxAgents, 2);
+    assert.ok((failed?.journal?.length ?? 0) >= 2, "workers should be journaled before the cap error");
+    const liveBeforeResume = livePrompts.length;
+    assert.equal(liveBeforeResume, 2, "only the two workers should have run live");
+
+    assert.equal(await manager.resume(runId!, { maxAgents: 3 }), true);
+    for (let i = 0; i < 200 && manager.getRun(runId!)?.status === "running"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    const done = manager.getPersistence().load(runId!);
+    assert.equal(done?.status, "completed", "raised ceiling must let synthesis finish");
+    assert.equal(done?.maxAgents, 3, "raised maxAgents must persist for later resumes");
+    assert.deepEqual(
+      livePrompts.slice(liveBeforeResume),
+      ["synthesis"],
+      "workers must replay from journal; only synthesis runs live",
+    );
+
+    // Omit override → keep raised cap; a lower request must not shrink it.
+    const again = manager.getPersistence().load(runId!);
+    assert.equal(again?.maxAgents, 3);
+    // Build a fresh failed-at-cap run to assert a non-raise is refused.
+    livePrompts.length = 0;
+    const secondManager = new WorkflowManager({ cwd, agent });
+    secondManager.on("error", () => {});
+    await secondManager.runSync(script, undefined, { maxAgents: 2 }).catch(() => {});
+    const runId2 = secondManager.listRuns().find((r) => r.workflowName === "raise_cap")?.runId;
+    assert.ok(runId2);
+    assert.equal(await secondManager.resume(runId2!, { maxAgents: 1 }), false);
+    const notLowered = secondManager.getPersistence().load(runId2!);
+    assert.equal(notLowered?.maxAgents, 2, "resume must never lower the persisted ceiling");
+    assert.equal(notLowered?.status, "failed", "non-raise resume is refused; run stays failed at the old cap");
+
+    // prior === undefined: effective prior is MAX_AGENTS_PER_RUN. Resume with 50
+    // must refuse rather than pin a lower ceiling onto a never-set run.
+    const uncapped = new WorkflowManager({ cwd, agent });
+    uncapped.on("error", () => {});
+    const uncappedId = "uncapped-max-agents";
+    uncapped.getPersistence().save({
+      runId: uncappedId,
+      workflowName: "raise_cap",
+      script,
+      args: undefined,
+      status: "failed",
+      phases: [],
+      agents: [],
+      logs: [],
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    assert.equal(await uncapped.resume(uncappedId, { maxAgents: 50 }), false);
+    assert.equal(
+      uncapped.getPersistence().load(uncappedId)?.maxAgents,
+      undefined,
+      "resume must not pin 50 over an implicit 1000 default",
+    );
+  }),
+);
+
+test(
   "resume re-resolves the run's maxAgents/agentTimeoutMs and keeps its start-time values (#A1)",
   withTempCwd(async (cwd) => {
     // 'a' hangs on its first invocation (pause point), then on its second

--- a/tests/workflow-tool.test.ts
+++ b/tests/workflow-tool.test.ts
@@ -470,6 +470,56 @@ return { a, b }`;
   }),
 );
 
+test(
+  "createWorkflowTool resumeFromRunId forwards maxAgents and finishes a failed-at-cap run",
+  withToolTempCwd(async (cwd) => {
+    const livePrompts: string[] = [];
+    const manager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run(prompt: string, options?: { onUsage?: (u: AgentUsage) => void }) {
+          livePrompts.push(prompt);
+          options?.onUsage?.({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 1, cost: 0 });
+          return `${prompt}-ok`;
+        },
+      },
+    });
+    manager.on("error", () => {});
+    const tool = createWorkflowTool({ cwd, manager });
+    const script = `export const meta = { name: 'raise_cap_tool', description: 'raise via tool resume' }
+const a = await agent('worker-a', { label: 'a' })
+const b = await agent('worker-b', { label: 'b' })
+const synthesis = await agent('synthesis', { label: 'synthesis' })
+return { a, b, synthesis }`;
+
+    const { runId, promise } = manager.startInBackground(script, undefined, { maxAgents: 2 });
+    await promise.catch(() => {});
+    assert.equal(manager.getRun(runId)?.status, "failed");
+    assert.equal(manager.getPersistence().load(runId)?.maxAgents, 2);
+    const liveBefore = livePrompts.length;
+    assert.equal(liveBefore, 2);
+
+    const res = await tool.execute(
+      "t-raise",
+      { script, resumeFromRunId: runId, maxAgents: 3 },
+      undefined,
+      undefined,
+      undefined,
+    );
+    const details = res.details as { runId?: string; resumedFrom?: string };
+    assert.equal(details.runId, runId);
+    assert.equal(details.resumedFrom, runId);
+
+    for (let i = 0; i < 200 && manager.getRun(runId)?.status === "running"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const done = manager.getPersistence().load(runId);
+    assert.equal(done?.status, "completed");
+    assert.equal(done?.maxAgents, 3);
+    assert.deepEqual(livePrompts.slice(liveBefore), ["synthesis"]);
+  }),
+);
+
 // ─── `name`: reach a saved or built-in workflow without writing a script ───────
 
 const validArgsByBuiltinName: Record<string, unknown> = {


### PR DESCRIPTION
## Summary

Hitting `maxAgents` failed the run after completed agents had already spent tokens. Resume kept the original cap, and starting over replayed that paid prefix.

`resumeFromRunId` can now pass a higher `maxAgents`. The journaled prefix still replays; only the remainder runs live. Omitting `maxAgents` keeps the original cap. A lower or equal value is refused (the tool says to pass `maxAgents > N`) so a no-op raise cannot look like a successful resume.

The limit error includes the run id and the resume recipe. `/workflows resume` alone still cannot raise the cap.

## Test plan

- [x] Fail at cap 2, resume with 3 → completes; only the suffix runs live
- [x] Resume with a lower cap is refused; persisted cap unchanged
- [x] Never-set cap: resume(50) does not pin 50 over the implicit 1000 default
- [x] Tool `resumeFromRunId` forwards `maxAgents`
- [x] Omit override still keeps the start-time cap