### PR TITLE
fix: deliver background results to the originating session (#147)

### DIFF
--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -350,14 +350,12 @@ export default function extension(pi: ExtensionAPI) {
       armingInstalled = true;
     }
   });
-}
-)
 
-// Keep mainModel in sync with mid-session /model (and cycle/restore). Without
-// this, workflow subagents that fall through to mainModel keep the frozen
-// session_start value for the rest of the process lifetime.
-pi.on("model_select", (event) => {
-  const m = event.model;
-  manager.setMainModel(m ? `${m.provider}/${m.id}` : undefined);
-});
+  // Keep mainModel in sync with mid-session /model (and cycle/restore). Without
+  // this, workflow subagents that fall through to mainModel keep the frozen
+  // session_start value for the rest of the process lifetime.
+  pi.on("model_select", (event) => {
+    const m = event.model;
+    manager.setMainModel(m ? `${m.provider}/${m.id}` : undefined);
+  });
 }

--- a/extensions/workflow.ts
+++ b/extensions/workflow.ts
@@ -12,11 +12,13 @@ import {
   type WorkflowReloadRuntime,
 } from "../src/extension-reload.js";
 import {
+  bindSessionDelivery,
   createEffortState,
   createWebTools,
   createWorkflowControlTool,
   createWorkflowStorage,
   createWorkflowTool,
+  dropSessionDelivery,
   type EffortState,
   installResultDelivery,
   installTaskPanel,
@@ -27,7 +29,6 @@ import {
   registerEffortCommand,
   registerWorkflowCommands,
   registerWorkflowModelsCommand,
-  resumeResultDelivery,
   saveWorkflowSettingsForCwd,
   suspendResultDelivery,
   UsageLimitScheduler,
@@ -153,11 +154,10 @@ export default function extension(pi: ExtensionAPI) {
   const getCwd = () => cwd;
   const getStorage = () => storage;
 
-  // Install delivery listeners once. Keep suspended until session_start —
-  // factory runs before Pi bindCore(), so sendMessage is still the
-  // "runtime not initialized" stub. Flushing here would re-queue forever.
+  // Install delivery listeners once. Delivery is fail-closed until
+  // session_start binds a per-session endpoint (no "latest pi wins"). Completions
+  // that race before bind leave a disk pending marker and flush on bind.
   installResultDelivery(pi, manager, { loadSettings: () => loadWorkflowSettings({ cwd: getCwd() }) });
-  suspendResultDelivery(manager);
 
   const workflowTool = createWorkflowTool({
     getManager,
@@ -186,6 +186,7 @@ export default function extension(pi: ExtensionAPI) {
     // lost). Replacement reasons stage the runtime for the next generation
     // only when the destination is the same project; quit/unknown/cross-project
     // pause in-flight runs onto the journal path.
+    const outgoingSessionId = manager.getSessionId?.();
     suspendResultDelivery(manager);
 
     const reason = event?.reason;
@@ -210,6 +211,7 @@ export default function extension(pi: ExtensionAPI) {
         if (targetCwd !== cwd) {
           pauseStrandedWorkflowRuntime(runtime);
           discardWorkflowRuntime(cwd, runtime);
+          dropSessionDelivery(outgoingSessionId);
           return;
         }
         handoffWorkflowRuntime(runtime);
@@ -220,6 +222,7 @@ export default function extension(pi: ExtensionAPI) {
         if (targetCwd && targetCwd !== cwd) {
           pauseStrandedWorkflowRuntime(runtime);
           discardWorkflowRuntime(cwd, runtime);
+          dropSessionDelivery(outgoingSessionId);
           return;
         }
         handoffWorkflowRuntime(runtime);
@@ -231,6 +234,7 @@ export default function extension(pi: ExtensionAPI) {
 
     pauseStrandedWorkflowRuntime(runtime);
     discardWorkflowRuntime(cwd, runtime);
+    dropSessionDelivery(outgoingSessionId);
   });
 
   registerWorkflowCommands(pi, getManager, {
@@ -304,21 +308,32 @@ export default function extension(pi: ExtensionAPI) {
     const missing = workflowTools.filter((name) => !active.includes(name));
     if (missing.length) pi.setActiveTools([...active, ...missing]);
 
-    // Bind + adopt before resuming delivery so a flushed completion is tagged
-    // with this session and visible in its panel.
+    // Bind + adopt before binding delivery so a flushed completion is tagged
+    // with this session and visible in its panel. Capture the previous id first
+    // so completed-with-pending can be re-homed across /new / fork / switch.
     let sessionId: string | undefined;
     try {
       sessionId = ctx.sessionManager?.getSessionId();
     } catch {
       // sessionManager may be unavailable — fall back to global history.
     }
+    const previousSessionId = manager.getSessionId();
+    manager.adoptLiveRunsToSession(sessionId, previousSessionId);
     manager.setSessionId(sessionId);
-    manager.adoptLiveRunsToSession(sessionId);
 
-    // Runtime is bound now (session_start fires after bindCore). Unsuspend and
-    // flush anything queued while the previous ctx was dying or this factory
-    // was still loading.
-    resumeResultDelivery(manager);
+    // Runtime is bound now (session_start fires after bindCore). Register a
+    // session-stable delivery endpoint for THIS session only, then flush any
+    // disk/memory pending for this sessionId (parallel siblings never share it).
+    if (sessionId) {
+      bindSessionDelivery(sessionId, pi, {
+        loadSettings: () => loadWorkflowSettings({ cwd: getCwd() }),
+        manager,
+        sessionManager: ctx.sessionManager,
+      });
+      if (previousSessionId && previousSessionId !== sessionId) {
+        dropSessionDelivery(previousSessionId);
+      }
+    }
 
     installTaskPanel(pi, manager, ctx.ui, {
       storage,
@@ -335,12 +350,14 @@ export default function extension(pi: ExtensionAPI) {
       armingInstalled = true;
     }
   });
+}
+)
 
-  // Keep mainModel in sync with mid-session /model (and cycle/restore). Without
-  // this, workflow subagents that fall through to mainModel keep the frozen
-  // session_start value for the rest of the process lifetime.
-  pi.on("model_select", (event) => {
-    const m = event.model;
-    manager.setMainModel(m ? `${m.provider}/${m.id}` : undefined);
-  });
+// Keep mainModel in sync with mid-session /model (and cycle/restore). Without
+// this, workflow subagents that fall through to mainModel keep the frozen
+// session_start value for the rest of the process lifetime.
+pi.on("model_select", (event) => {
+  const m = event.model;
+  manager.setMainModel(m ? `${m.provider}/${m.id}` : undefined);
+});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export {
   saveModelTierConfig,
   sortedTierNames,
 } from "./model-tier-config.js";
-export type { PersistedRunState, RunPersistence, RunStatus } from "./run-persistence.js";
+export type { PendingDeliveryMarker, PersistedRunState, RunPersistence, RunStatus } from "./run-persistence.js";
 export { createRunPersistence, generateRunId } from "./run-persistence.js";
 export {
   parseCommandArgs,
@@ -77,11 +77,15 @@ export { SharedStore } from "./shared-store.js";
 export type { StructuredOutputCapture, StructuredOutputToolOptions } from "./structured-output.js";
 export { createStructuredOutputTool } from "./structured-output.js";
 export {
+  bindSessionDelivery,
   deliverText,
+  dropSessionDelivery,
   installResultDelivery,
   installTaskPanel,
   resumeResultDelivery,
+  resumeSessionDelivery,
   suspendResultDelivery,
+  suspendSessionDelivery,
   type TaskPanelOptions,
 } from "./task-panel.js";
 export type {

--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -142,7 +142,20 @@ export interface PersistedRunState {
    * auto-resume attempt has been recorded yet.
    */
   autoResumeAttempts?: number;
+  /**
+   * Undelivered background-result payload waiting for the originating session's
+   * delivery endpoint. Written before the send attempt (fail-closed); cleared
+   * only after a successful session-routed delivery. `complete` recomputes text
+   * from the persisted result on flush so we don't retain a second full copy.
+   */
+  pendingDelivery?: PendingDeliveryMarker;
 }
+
+/**
+ * Disk/memory marker for a background result that still needs conversation
+ * delivery. Kept small on purpose — never store full agent transcripts here.
+ */
+export type PendingDeliveryMarker = { kind: "complete" } | { kind: "text"; text: string };
 
 export interface RunPersistence {
   /** Save current run state. */

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -7,7 +7,13 @@
  */
 
 import { join } from "node:path";
-import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
+import {
+  AgentSession,
+  type ExtensionAPI,
+  ExtensionRunner,
+  type ExtensionUIContext,
+  type Theme,
+} from "@earendil-works/pi-coding-agent";
 import { type Component, type TUI, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import {
   aggregateAgentUsage,
@@ -19,6 +25,7 @@ import {
   type WorkflowAgentSnapshot,
   type WorkflowSnapshot,
 } from "./display.js";
+import type { PendingDeliveryMarker, PersistedRunState } from "./run-persistence.js";
 import type { ManagedRun, WorkflowManager } from "./workflow-manager.js";
 import type { WorkflowStorage } from "./workflow-saved.js";
 import type { WorkflowSettings } from "./workflow-settings.js";
@@ -138,176 +145,619 @@ function deliveredMaxChars(opts: { loadSettings?: () => WorkflowSettings }): num
 }
 
 /**
- * Generation-bound delivery state lives on the manager so listeners registered
- * once can keep working across session replacements (/reload, /new, resume,
- * fork). See installResultDelivery / suspendResultDelivery.
+ * Session-routed background result delivery.
+ *
+ * Root cause (#147): pi-coding-agent's ExtensionRunner.bindCore() writes
+ * `runtime.sendMessage` on a shared runtime object (last-bindCore-wins). Calling
+ * `pi.sendMessage` at completion time therefore delivers into whichever session
+ * was constructed last — not the session that started the workflow. #143 only
+ * covered same-manager session *replacement*; parallel sibling sessions steal
+ * the route without any shutdown on the origin.
+ *
+ * Fix: process-wide endpoint registry keyed by sessionId. Each session_start
+ * registers a session-stable send captured from the *host* AgentSession's
+ * sendCustomMessage (returns a real Promise — unlike actions.sendMessage
+ * which is void and swallows rejects). Completions resolve `run.sessionId`,
+ * persist a pending marker first, then deliver only via that session's
+ * endpoint. Clear the marker only after the send Promise settles successfully.
+ * Missing/suspended endpoint or non-thenable send → leave pending (fail
+ * closed). Never fall back to shared `pi.sendMessage` / runtime.sendMessage,
+ * and never ACK on a durable append (that writes history without triggerTurn).
  */
-interface DeliveryHolder {
-  pi: ExtensionAPI;
+
+type DeliverySend = (
+  message: { customType: string; content: string; display: boolean },
+  options: { triggerTurn: boolean; deliverAs: "followUp" },
+) => unknown;
+
+interface SessionDeliveryEndpoint {
+  sessionId: string;
+  /**
+   * Session-stable send that MUST return a thenable for ACK. Captured from
+   * the host AgentSession.sendCustomMessage (not the void actions.sendMessage
+   * wrapper, and not a durable-only append).
+   */
+  send?: DeliverySend;
   loadSettings?: () => WorkflowSettings;
   /**
-   * When true, do not call pi.sendMessage — only enqueue. Set for the whole
-   * window between session_shutdown and the next generation's install, so a
-   * completion cannot land on a dying session (or a just-invalidated ctx).
+   * When true, do not call send — leave disk pending. Set for the whole window
+   * between session_shutdown and the next bind for this sessionId so a
+   * completion cannot land on a dying session.
    */
   suspended: boolean;
-  /** Contents that failed to send or arrived while suspended; flushed on resume. */
-  pending: string[];
   /**
-   * Generation counter bumped on every install/refresh. An in-flight send's
-   * rejection handler captures the generation it started under; if a newer
-   * generation has already installed by the time the rejection lands, the
-   * handler must flush immediately — otherwise the content sits in `pending`
-   * until some later install happens to run.
+   * Generation counter bumped on every bind. An in-flight send captures the
+   * generation it started under; on failure, if a newer generation has already
+   * bound, we re-flush disk pending onto it.
    */
   generation: number;
+  /** Owning manager used to recompute complete-text and clear pending markers. */
+  manager?: WorkflowManager;
 }
+
+/** Process-wide: one live endpoint per pi session id. */
+const sessionEndpoints = new Map<string, SessionDeliveryEndpoint>();
+
+/**
+ * Session-stable thenable sends (host AgentSession.sendCustomMessage). Keyed
+ * by host sessionId only — workflow children (in-memory, noExtensions, or
+ * named `workflow:…`) must never enter this map (#109).
+ */
+const boundSessionSends = new Map<string, DeliverySend>();
+
+/** runIds with an in-flight deliver-and-ack so bind flush does not double-send. */
+const inFlightDeliveries = new Set<string>();
+
+let agentSessionPatched = false;
+let bindCoreObserved = false;
+
+interface StealCandidate {
+  sendCustomMessage?: DeliverySend;
+  sessionManager?: {
+    persist?: boolean;
+    getSessionId?: () => string;
+    getSessionName?: () => string | undefined;
+  };
+  _resourceLoader?: { noExtensions?: boolean };
+}
+
+/**
+ * Host Pi session only. Child workflow agents must not be pinned:
+ *  - SessionManager.inMemory() → persist === false
+ *  - shared noExtensions loader (persistAgentSessions children included)
+ *  - persisted children named `workflow:<runId> …` (set after construction;
+ *    still filters a later re-bindCore)
+ */
+function hostSessionIdToSteal(session: StealCandidate): string | undefined {
+  const sm = session.sessionManager;
+  if (!sm) return undefined;
+  if (sm.persist === false) return undefined;
+  if (session._resourceLoader?.noExtensions === true) return undefined;
+  try {
+    const name = sm.getSessionName?.();
+    if (typeof name === "string" && name.startsWith("workflow:")) return undefined;
+  } catch {
+    // getSessionName unavailable — keep evaluating
+  }
+  if (typeof session.sendCustomMessage !== "function") return undefined;
+  try {
+    const sid = sm.getSessionId?.();
+    if (typeof sid === "string" && sid) return sid;
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function captureHostSessionSend(session: StealCandidate): void {
+  const sid = hostSessionIdToSteal(session);
+  if (!sid) return;
+  boundSessionSends.set(sid, (message, options) => session.sendCustomMessage!(message, options));
+}
+
+/**
+ * Capture a Promise-returning send from the *host* AgentSession. bindCore's
+ * `actions.sendMessage` is fire-and-forget (void + swallowed reject) and must
+ * not be treated as an ACK channel. Child sessions never enter the map.
+ */
+function patchAgentSessionCapture(): void {
+  if (agentSessionPatched) return;
+  agentSessionPatched = true;
+  try {
+    const proto = AgentSession.prototype as unknown as {
+      _bindExtensionCore?: (runner: unknown) => unknown;
+    } & StealCandidate;
+    const original = proto._bindExtensionCore;
+    if (typeof original !== "function") return;
+    proto._bindExtensionCore = function patchedBindExtensionCore(this: StealCandidate, runner: unknown) {
+      try {
+        captureHostSessionSend(this);
+      } catch {
+        // never break session construction
+      }
+      return original.apply(this, [runner]);
+    };
+  } catch {
+    // AgentSession unavailable or shape changed — bind stays fail-closed without steal
+  }
+}
+
+/** Keep ExtensionRunner observed so module load order cannot skip the patch arm. */
+function patchBindCoreObserve(): void {
+  if (bindCoreObserved) return;
+  bindCoreObserved = true;
+  try {
+    const proto = ExtensionRunner.prototype as unknown as {
+      bindCore: (...args: unknown[]) => unknown;
+    };
+    const original = proto.bindCore;
+    if (typeof original !== "function") return;
+    // No capture of void actions.sendMessage — that path is not an ACK.
+    proto.bindCore = function patchedBindCore(this: unknown, ...args: unknown[]) {
+      return original.apply(this, args);
+    };
+  } catch {
+    // ignore
+  }
+}
+
+patchAgentSessionCapture();
+patchBindCoreObserve();
 
 type DeliveryManager = WorkflowManager & {
   __deliveryInstalled?: boolean;
-  __holder?: DeliveryHolder;
+  /** Last loadSettings seen on install — used when binding endpoints. */
+  __deliveryLoadSettings?: () => WorkflowSettings;
 };
 
 function deliveryManager(manager: WorkflowManager): DeliveryManager {
   return manager as DeliveryManager;
 }
 
-function enqueuePending(holder: DeliveryHolder, content: string): void {
-  // Soft-cap only: warn loudly, never drop. The full result is also on disk
-  // via the run JSON pointer in deliverText, but conversation delivery is the
-  // contract the tool promises — silent shift() would break it.
-  if (holder.pending.length >= 32) {
-    console.warn(
-      `[workflow-delivery] pending queue at ${holder.pending.length} entries; ` +
-        "delivery is stalled (no successful flush since suspend/failure). " +
-        "Results remain on disk via /workflows.",
-    );
-  }
-  holder.pending.push(content);
+function resolveDeliverySessionId(run: ManagedRun, manager: WorkflowManager): string | undefined {
+  // Originating run wins; manager binding is legacy fallback only when the run
+  // predates per-run sessionId. Never invent a session.
+  return run.sessionId ?? manager.getSessionId?.();
 }
 
-function trySend(holder: DeliveryHolder, content: string): void {
-  const startedGeneration = holder.generation;
+function markRunPending(run: ManagedRun, marker: PendingDeliveryMarker): void {
+  run.pendingDelivery = marker;
+}
+
+function clearRunPending(manager: WorkflowManager, runId: string, run?: ManagedRun): void {
+  if (run?.pendingDelivery) {
+    run.pendingDelivery = undefined;
+  }
+  // Also clear on disk for runs already written / evicted from memory. Best-effort:
+  // a missing persistence layer (unit tests) is fine — memory clear is enough.
   try {
-    const ret = holder.pi.sendMessage(
-      { customType: "workflow-result", content, display: true },
-      { triggerTurn: true, deliverAs: "followUp" },
-    );
-    // sendMessage may return a promise (defensive — current pi types it void).
-    // On rejection: re-queue, and if a newer generation already installed
-    // while we were in flight, flush now so the content is not stranded.
-    void Promise.resolve(ret).catch((err: unknown) => {
-      enqueuePending(holder, content);
-      const msg = err instanceof Error ? err.message : String(err);
-      console.warn(`[workflow-delivery] async send failed; queued for retry: ${msg}`);
-      if (holder.generation !== startedGeneration && !holder.suspended) {
-        flushPending(holder);
-      }
-    });
-  } catch (err) {
-    enqueuePending(holder, content);
-    const msg = err instanceof Error ? err.message : String(err);
-    console.warn(`[workflow-delivery] send failed; queued for retry: ${msg}`);
+    const persistence = manager.getPersistence?.();
+    if (!persistence) return;
+    const state = persistence.load(runId);
+    if (!state?.pendingDelivery) return;
+    const { pendingDelivery: _drop, ...rest } = state;
+    persistence.save(rest as PersistedRunState);
+    // If the live run still exists, keep it aligned without a full persistRace.
+    const live = run ?? manager.getRun(runId);
+    if (live) live.pendingDelivery = undefined;
+  } catch {
+    // ignore persistence errors — conversation delivery already succeeded
   }
 }
 
-function flushPending(holder: DeliveryHolder): void {
-  if (holder.suspended || holder.pending.length === 0) return;
-  const queued = holder.pending.splice(0, holder.pending.length);
-  for (const content of queued) trySend(holder, content);
+function persistRunPendingBestEffort(manager: WorkflowManager, run: ManagedRun): void {
+  try {
+    // Prefer merging into an existing on-disk record so we don't clobber the
+    // manager's richer write that follows the complete/error emit. When no
+    // record exists yet (complete fires before manager.persistRun), seed a
+    // minimal marker-bearing record; the subsequent manager write overwrites.
+    const persistence = manager.getPersistence?.();
+    if (!persistence) return;
+    const existing = persistence.load(run.runId);
+    if (existing) {
+      persistence.save({ ...existing, pendingDelivery: run.pendingDelivery, sessionId: run.sessionId });
+      return;
+    }
+    if (run.pendingDelivery) {
+      persistence.save({
+        runId: run.runId,
+        workflowName: run.snapshot.name,
+        script: run.script ?? "",
+        sessionId: run.sessionId,
+        status: run.status,
+        phases: run.snapshot.phases ?? [],
+        agents: [],
+        logs: run.snapshot.logs ?? [],
+        result: run.result?.result,
+        tokenUsage: run.result?.tokenUsage ?? run.snapshot.tokenUsage,
+        durationMs: run.result?.durationMs,
+        startedAt: run.startedAt?.toISOString?.() ?? new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        pendingDelivery: run.pendingDelivery,
+      });
+    }
+  } catch {
+    // best-effort
+  }
+}
+
+function contentForPending(
+  manager: WorkflowManager,
+  runId: string,
+  marker: PendingDeliveryMarker,
+  loadSettings?: () => WorkflowSettings,
+  run?: ManagedRun,
+  persisted?: PersistedRunState,
+): string | undefined {
+  if (marker.kind === "text") return marker.text;
+  // complete — recompute from live run or disk so we never store the body twice
+  if (run) {
+    return deliverText(run, {
+      resultPath: persistedResultPath(manager, runId),
+      maxChars: deliveredMaxChars({ loadSettings }),
+    });
+  }
+  if (persisted) {
+    return deliverText(
+      {
+        snapshot: { name: persisted.workflowName, agentCount: persisted.agents?.length ?? 0 },
+        result: {
+          result: persisted.result,
+          tokenUsage: persisted.tokenUsage,
+          agentCount: persisted.agents?.length ?? 0,
+          durationMs: persisted.durationMs,
+        },
+      } as ManagedRun,
+      {
+        resultPath: persistedResultPath(manager, runId),
+        maxChars: deliveredMaxChars({ loadSettings }),
+      },
+    );
+  }
+  return undefined;
 }
 
 /**
- * Stop live sends on this manager. In-flight completions only enqueue until
- * {@link resumeResultDelivery} runs (from session_start, after Pi has bound
- * the extension runtime) or the process exits (quit — results stay on disk).
+ * Attempt session-routed delivery. Resolves true only after a thenable
+ * host sendCustomMessage / stableSend settles on a live endpoint. Void /
+ * fire-and-forget sends and durable appends are NOT success (append writes
+ * history without triggerTurn). Does not clear pending markers.
+ */
+function tryDeliverEndpoint(endpoint: SessionDeliveryEndpoint, content: string): Promise<boolean> {
+  if (endpoint.suspended) return Promise.resolve(false);
+  if (endpoint.sessionId && sessionEndpoints.get(endpoint.sessionId) !== endpoint) {
+    // Stale endpoint object after rebind/drop.
+    return Promise.resolve(false);
+  }
+
+  // Only a thenable session-stable send (host sendCustomMessage) may ACK.
+  if (typeof endpoint.send === "function") {
+    try {
+      const ret = endpoint.send(
+        { customType: "workflow-result", content, display: true },
+        { triggerTurn: true, deliverAs: "followUp" },
+      );
+      if (ret != null && typeof (ret as { then?: unknown }).then === "function") {
+        const startedGeneration = endpoint.generation;
+        const sessionId = endpoint.sessionId;
+        return Promise.resolve(ret).then(
+          () => {
+            const current = sessionEndpoints.get(sessionId);
+            // Succeeded under this or a newer live endpoint for the same session.
+            return !!current && !current.suspended;
+          },
+          (err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.warn(`[workflow-delivery] async send failed; left pending on disk: ${msg}`);
+            const current = sessionEndpoints.get(sessionId);
+            // If a newer generation already bound, caller may re-flush; signal failure.
+            if (current && current.generation !== startedGeneration && !current.suspended) {
+              // Return false so disk marker stays; flush path retries.
+            }
+            return false;
+          },
+        );
+      }
+      // Non-thenable send (void fire-and-forget) — do not trust as ACK.
+      console.warn(
+        `[workflow-delivery] send for session ${endpoint.sessionId} did not return a thenable; ` +
+          "not treating as delivered (fail closed).",
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[workflow-delivery] send failed; left pending on disk: ${msg}`);
+      return Promise.resolve(false);
+    }
+  }
+
+  return Promise.resolve(false);
+}
+
+function deliverAndAck(
+  manager: WorkflowManager,
+  runId: string,
+  sessionId: string,
+  content: string,
+  run?: ManagedRun,
+): void {
+  if (inFlightDeliveries.has(runId)) return;
+  const endpoint = sessionEndpoints.get(sessionId);
+  if (!endpoint || endpoint.suspended || endpoint.sessionId !== sessionId) return;
+
+  inFlightDeliveries.add(runId);
+  const startedGeneration = endpoint.generation;
+  void tryDeliverEndpoint(endpoint, content)
+    .then((ok) => {
+      if (ok) {
+        clearRunPending(manager, runId, run ?? manager.getRun?.(runId));
+        return;
+      }
+      // Release the in-flight lock before a generation-change retry so flush
+      // can actually pick this run back up.
+      inFlightDeliveries.delete(runId);
+      const current = sessionEndpoints.get(sessionId);
+      if (current && !current.suspended && current.generation !== startedGeneration && current.manager) {
+        flushSessionDiskPending(current.manager, sessionId, current);
+      }
+    })
+    .finally(() => {
+      inFlightDeliveries.delete(runId);
+    });
+}
+
+function routeBackgroundDelivery(
+  manager: WorkflowManager,
+  run: ManagedRun,
+  marker: PendingDeliveryMarker,
+  content: string,
+): void {
+  // 1. Mark pending first (fail closed / crash safe).
+  markRunPending(run, marker);
+  persistRunPendingBestEffort(manager, run);
+
+  const sessionId = resolveDeliverySessionId(run, manager);
+  if (!sessionId) {
+    console.warn(`[workflow-delivery] run ${run.runId} has no sessionId; leaving pending on disk (fail closed).`);
+    return;
+  }
+
+  // 2. Deliver only via the originating session's endpoint; clear after ACK.
+  deliverAndAck(manager, run.runId, sessionId, content, run);
+}
+
+/**
+ * Register or refresh the delivery endpoint for a pi session. Requires a
+ * session-stable thenable send (stolen host AgentSession.sendCustomMessage, or
+ * test DI). Never falls back to shared pi.sendMessage. A durable
+ * appendCustomMessageEntry is not an ACK (no triggerTurn).
+ *
+ * Call from session_start AFTER Pi bindCore. Unsuspends and flushes disk pending
+ * for this sessionId only.
+ */
+export function bindSessionDelivery(
+  sessionId: string,
+  _pi: ExtensionAPI,
+  opts: {
+    loadSettings?: () => WorkflowSettings;
+    manager?: WorkflowManager;
+    /**
+     * Optional explicit thenable send (tests / DI). Wins over the process-wide
+     * steal map when provided.
+     */
+    stableSend?: DeliverySend;
+    /**
+     * Optional sessionManager. getSessionId is identity only — append is not
+     * an ACK channel.
+     */
+    sessionManager?: {
+      getSessionId?: () => string;
+      appendCustomMessageEntry?: (
+        customType: string,
+        content: string | unknown[],
+        display: boolean,
+        details?: unknown,
+      ) => string;
+    };
+  } = {},
+): void {
+  if (!sessionId) return;
+  patchAgentSessionCapture();
+  patchBindCoreObserve();
+
+  const stolen = opts.stableSend ?? boundSessionSends.get(sessionId);
+
+  if (!stolen) {
+    console.warn(
+      `[workflow-delivery] no session-stable thenable send for session ${sessionId}; ` +
+        "endpoint registered fail-closed (completions stay on disk until a host send is captured).",
+    );
+  }
+
+  // Optional identity check — refuse to bind when sessionManager disagrees.
+  try {
+    const liveId = opts.sessionManager?.getSessionId?.();
+    if (liveId && liveId !== sessionId) {
+      console.warn(`[workflow-delivery] refusing bind: sessionManager id ${liveId} !== endpoint ${sessionId}`);
+      return;
+    }
+  } catch {
+    // getSessionId unavailable — continue
+  }
+
+  const prev = sessionEndpoints.get(sessionId);
+  const endpoint: SessionDeliveryEndpoint = {
+    sessionId,
+    send: stolen,
+    loadSettings: opts.loadSettings ?? prev?.loadSettings,
+    suspended: false,
+    generation: (prev?.generation ?? 0) + 1,
+    manager: opts.manager ?? prev?.manager,
+  };
+  sessionEndpoints.set(sessionId, endpoint);
+
+  if (endpoint.manager) flushSessionDiskPending(endpoint.manager, sessionId, endpoint);
+}
+
+/**
+ * Suspend delivery for a session. Completions only mark disk pending until
+ * {@link bindSessionDelivery} / {@link resumeSessionDelivery} runs again.
+ */
+export function suspendSessionDelivery(sessionId: string | undefined): void {
+  if (!sessionId) return;
+  const endpoint = sessionEndpoints.get(sessionId);
+  if (endpoint) endpoint.suspended = true;
+}
+
+/**
+ * Drop endpoint + stolen send for a session that will not come back (quit /
+ * discard, or the *old* id after a successful replacement bind). Releases the
+ * AgentSession closure retained by the steal map (#109).
+ */
+export function dropSessionDelivery(sessionId: string | undefined): void {
+  if (!sessionId) return;
+  sessionEndpoints.delete(sessionId);
+  boundSessionSends.delete(sessionId);
+}
+
+/**
+ * Unsuspend and flush one session's pending deliveries (disk). Prefer
+ * {@link bindSessionDelivery} on session_start (also refreshes send).
+ */
+export function resumeSessionDelivery(sessionId: string | undefined, manager?: WorkflowManager): void {
+  if (!sessionId) return;
+  const endpoint = sessionEndpoints.get(sessionId);
+  if (!endpoint) return;
+  endpoint.suspended = false;
+  if (manager) endpoint.manager = manager;
+  if (endpoint.manager) flushSessionDiskPending(endpoint.manager, sessionId, endpoint);
+}
+
+function flushSessionDiskPending(manager: WorkflowManager, sessionId: string, endpoint: SessionDeliveryEndpoint): void {
+  if (endpoint.suspended) return;
+
+  const tryOne = (runId: string, marker: PendingDeliveryMarker, run?: ManagedRun, persisted?: PersistedRunState) => {
+    if (inFlightDeliveries.has(runId)) return;
+    const content = contentForPending(manager, runId, marker, endpoint.loadSettings, run, persisted);
+    if (content === undefined) return;
+    deliverAndAck(manager, runId, sessionId, content, run);
+  };
+
+  // Live in-memory runs for this session. Null sessionId is claimable only for
+  // THIS manager's live runs (pre-bind completions) — never from a foreign manager.
+  try {
+    for (const run of manager.listLiveRuns?.() ?? []) {
+      if (!run.pendingDelivery) continue;
+      if (run.sessionId != null && run.sessionId !== sessionId) continue;
+      if (run.sessionId == null) run.sessionId = sessionId;
+      tryOne(run.runId, run.pendingDelivery, run);
+    }
+  } catch {
+    // listLiveRuns may be absent on stubs
+  }
+
+  // Disk runs (including terminal runs already evicted from memory). Require an
+  // exact sessionId match — do not claim null-sessionId disk rows (same-cwd dual
+  // manager race). Handoff re-homes previous-session pendings via adopt first.
+  try {
+    const persistence = manager.getPersistence?.();
+    if (!persistence) return;
+    for (const state of persistence.list()) {
+      if (!state.pendingDelivery) continue;
+      if (state.sessionId !== sessionId) continue;
+      // Skip if the live copy still carries the marker — the loop above owns it.
+      const live = manager.getRun?.(state.runId);
+      if (live?.pendingDelivery) continue;
+      tryOne(state.runId, state.pendingDelivery, live, state);
+    }
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Stop live sends for the manager's currently bound session. In-flight
+ * completions only leave disk pending until the next bind/resume.
  *
  * Call from session_shutdown BEFORE handoff or discard so a completion that
- * races the teardown cannot deliver into the outgoing session.
+ * races the teardown cannot deliver into the outgoing session (#143).
  */
 export function suspendResultDelivery(manager: WorkflowManager): void {
-  const holder = deliveryManager(manager).__holder;
-  if (holder) holder.suspended = true;
+  suspendSessionDelivery(manager.getSessionId?.());
 }
 
 /**
- * Unsuspend and flush any queued deliveries. Must run only after Pi has
- * finished constructing the AgentSession and bound sendMessage (i.e. from
- * session_start) — calling it from the extension factory hits the
- * "runtime not initialized" stub and re-queues forever.
+ * Unsuspend and flush queued deliveries for the manager's bound session.
+ * Must run only after Pi has finished bindCore (i.e. from session_start).
+ * Prefer {@link bindSessionDelivery} which also captures a fresh stable send.
  */
 export function resumeResultDelivery(manager: WorkflowManager): void {
-  const holder = deliveryManager(manager).__holder;
-  if (!holder) return;
-  holder.suspended = false;
-  flushPending(holder);
+  resumeSessionDelivery(manager.getSessionId?.(), manager);
 }
 
 /**
  * When a background run finishes (or fails), deliver its result back into the
- * conversation AND continue the turn so the assistant can act on it — without
- * blocking the user meanwhile:
+ * *originating* conversation AND continue the turn so the assistant can act on
+ * it — without blocking the user meanwhile:
  *
- *  - `triggerTurn: true` starts a fresh turn when the agent is idle, feeding the
- *    result to the model so the paused conversation continues.
- *  - `deliverAs: "followUp"` means that if the user is busy in another turn, the
- *    result is queued and picked up after that turn finishes — never interrupting.
+ *  - Delivery is routed by `run.sessionId` through the process-wide endpoint
+ *    registry (never "latest pi wins").
+ *  - `triggerTurn: true` starts a fresh turn when the agent is idle.
+ *  - `deliverAs: "followUp"` queues behind an in-flight turn — never interrupts.
+ *  - Durable pending marker clears only after verified delivery ACK.
  *
- * Set up once per extension; idempotent via an internal guard. Across session
- * replacement the manager (and this listener) survive via the handoff path;
- * each new generation only refreshes `holder.pi` and flushes any messages that
- * failed or arrived while delivery was suspended.
+ * Set up once per manager; idempotent via an internal guard. Across session
+ * replacement the manager (and these listeners) survive via the handoff path;
+ * each new generation calls {@link bindSessionDelivery} on session_start.
  */
 export function installResultDelivery(
-  pi: ExtensionAPI,
+  _pi: ExtensionAPI,
   manager: WorkflowManager,
   opts: { loadSettings?: () => WorkflowSettings } = {},
 ): void {
   const m = deliveryManager(manager);
+  m.__deliveryLoadSettings = opts.loadSettings;
+  patchAgentSessionCapture();
+  patchBindCoreObserve();
+
   if (m.__deliveryInstalled) {
-    // The manager and listeners survive session replacement. Refresh every
-    // generation-bound dependency and bump the generation (so in-flight
-    // rejects from the previous pi can self-flush once resumed). Do NOT
-    // unsuspend or flush here: the factory runs before Pi bindCore(), so
-    // sendMessage is still the "runtime not initialized" stub. session_start
-    // calls resumeResultDelivery() once the runtime is live.
-    if (m.__holder) {
-      m.__holder.pi = pi;
-      m.__holder.loadSettings = opts.loadSettings;
-      m.__holder.generation += 1;
+    // Listeners survive session replacement. Refresh loadSettings / manager
+    // pointers only — do NOT mutate send, generation, or suspended here.
+    // Factory runs before bindCore; session_start calls bindSessionDelivery.
+    const sid = manager.getSessionId?.();
+    if (sid) {
+      const endpoint = sessionEndpoints.get(sid);
+      if (endpoint) {
+        endpoint.loadSettings = opts.loadSettings ?? endpoint.loadSettings;
+        endpoint.manager = manager;
+      }
     }
     return;
   }
   m.__deliveryInstalled = true;
-  m.__holder = { pi, loadSettings: opts.loadSettings, suspended: false, pending: [], generation: 0 };
-
-  const deliver = (content: string) => {
-    const holder = m.__holder;
-    if (!holder) return;
-    if (holder.suspended) {
-      enqueuePending(holder, content);
-      return;
-    }
-    trySend(holder, content);
-  };
 
   manager.on("complete", ({ runId }: { runId: string }) => {
     const run = manager.getRun(runId);
     // Only background/resumed runs are delivered: a foreground (sync) run already
     // returns its result inline as the tool result, so re-delivering would dup it.
-    if (run?.background) {
-      deliver(
-        deliverText(run, {
-          resultPath: persistedResultPath(manager, runId),
-          maxChars: deliveredMaxChars({ loadSettings: m.__holder?.loadSettings }),
-        }),
-      );
-    }
+    if (!run?.background) return;
+    const sessionId = resolveDeliverySessionId(run, manager);
+    const endpoint = sessionId ? sessionEndpoints.get(sessionId) : undefined;
+    const content = deliverText(run, {
+      resultPath: persistedResultPath(manager, runId),
+      maxChars: deliveredMaxChars({
+        loadSettings: endpoint?.loadSettings ?? m.__deliveryLoadSettings,
+      }),
+    });
+    routeBackgroundDelivery(manager, run, { kind: "complete" }, content);
   });
+
   manager.on("error", ({ runId, error }: { runId: string; error?: { message?: string } }) => {
-    if (!manager.getRun(runId)?.background) return;
-    deliver(`✗ Background workflow ${runId} failed: ${error?.message ?? "unknown error"}`);
+    const run = manager.getRun(runId);
+    if (!run?.background) return;
+    const text = `✗ Background workflow ${runId} failed: ${error?.message ?? "unknown error"}`;
+    routeBackgroundDelivery(manager, run, { kind: "text", text }, text);
   });
+
   // A provider usage/quota limit checkpoints the run as paused (not failed): tell the
   // user it is resumable once their budget refills, rather than letting it look dead.
   // Manual pause() also emits "paused" but with no reason — guard so only the
@@ -326,15 +776,48 @@ export function installResultDelivery(
       resetHint?: string;
     }) => {
       if (reason !== "usage_limit") return;
-      if (!manager.getRun(runId)?.background) return;
+      const run = manager.getRun(runId);
+      if (!run?.background) return;
       const when = resetHint ? ` (${resetHint})` : "";
       const cause = error?.message ?? "provider usage limit reached";
-      deliver(
+      const text =
         `⏸ Background workflow ${runId} paused: ${cause}${when}. ` +
-          `Completed steps are saved — run /workflows resume ${runId} once your usage limit resets.`,
-      );
+        `Completed steps are saved — run /workflows resume ${runId} once your usage limit resets.`;
+      routeBackgroundDelivery(manager, run, { kind: "text", text }, text);
     },
   );
+}
+
+/** @internal test helper — reset process-wide delivery registries between cases. */
+export function _resetDeliveryRegistriesForTests(): void {
+  sessionEndpoints.clear();
+  boundSessionSends.clear();
+  inFlightDeliveries.clear();
+}
+
+/** @internal test helper — register a thenable session-stable send (steal map). */
+export function _registerBoundSessionSendForTests(sessionId: string, send: DeliverySend): void {
+  boundSessionSends.set(sessionId, send);
+}
+
+/** @internal test helper — whether the steal map holds a send for this session. */
+export function _hasBoundSessionSendForTests(sessionId: string): boolean {
+  return boundSessionSends.has(sessionId);
+}
+
+/** @internal test helper — inspect endpoint suspended flag. */
+export function _getSessionDeliveryEndpointForTests(
+  sessionId: string,
+): { suspended: boolean; generation: number; hasSend: boolean; hasAppend: boolean } | undefined {
+  const ep = sessionEndpoints.get(sessionId);
+  if (!ep) return undefined;
+  return {
+    suspended: ep.suspended,
+    generation: ep.generation,
+    hasSend: typeof ep.send === "function",
+    // Append is never an ACK; kept on the inspect shape so existing tests compile.
+    hasAppend: false,
+  };
 }
 
 export function renderPanel(manager: WorkflowManager, theme: Theme, width?: number): string[] {

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -5,12 +5,13 @@
 import { EventEmitter } from "node:events";
 import type { ModelRegistry, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { WorkflowAgent } from "./agent.js";
-import { MAX_AGENTS_PER_RUN } from "./config.js";
+import { MAX_AGENTS_PER_RUN, MAX_AGENTS_PER_RUN } from "./config.js";
 import { preview, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
 import { isProviderUsageLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import {
   createRunPersistence,
   generateRunId,
+  type PendingDeliveryMarker,
   type PersistedRunState,
   type RunLease,
   type RunPersistence,
@@ -48,6 +49,12 @@ export interface ManagedRun {
    * the run and hide it from stranded-pause / the originating session's panel.
    */
   sessionId?: string;
+  /**
+   * Background result still waiting for session-routed conversation delivery.
+   * Set before the send attempt and cleared only after a successful deliver so a
+   * missing/suspended endpoint cannot lose the result (see task-panel delivery).
+   */
+  pendingDelivery?: PendingDeliveryMarker;
   /**
    * Auto-resume eligibility for this run (see ExecOptions.autoResume). Set once
    * at creation and carried through resume() so it survives pause/resume cycles.
@@ -366,6 +373,11 @@ export class WorkflowManager extends EventEmitter {
     this.sessionId = id;
   }
 
+  /** Currently bound pi session id (set on session_start), if any. */
+  getSessionId(): string | undefined {
+    return this.sessionId;
+  }
+
   /** Project cwd this manager was constructed for (persistence + agent tools). */
   getCwd(): string {
     return this.cwd;
@@ -381,21 +393,43 @@ export class WorkflowManager extends EventEmitter {
   }
 
   /**
-   * After an in-process session replacement keeps this manager, re-home every
-   * still-running (or paused-in-memory) run onto the new session so the panel,
-   * workflow_control, and a later stranded-pause all see them. Completed runs
-   * keep their original sessionId so history stays with the session that ran
-   * them. No-op when `sessionId` is undefined.
+   * After an in-process session replacement keeps this manager, re-home work
+   * that still needs this conversation onto `sessionId`:
+   *  - still-running / paused-in-memory runs (panel, workflow_control, stranded-pause)
+   *  - any run (live or disk-only) with an undelivered `pendingDelivery` marker
+   *
+   * Terminal runs *without* pending keep their original sessionId so history
+   * stays with the session that ran them. `previousSessionId` scopes disk-only
+   * pending re-home so a parallel sibling in the same runsDir cannot steal
+   * another session's undelivered work. No-op when `sessionId` is undefined.
    */
-  adoptLiveRunsToSession(sessionId: string | undefined): number {
+  adoptLiveRunsToSession(sessionId: string | undefined, previousSessionId?: string): number {
     if (!sessionId) return 0;
+    const prev = previousSessionId !== undefined ? previousSessionId : this.sessionId;
     let adopted = 0;
     for (const managed of this.runs.values()) {
-      if (managed.status !== "running" && managed.status !== "paused") continue;
+      const active = managed.status === "running" || managed.status === "paused";
+      const undelivered = managed.pendingDelivery != null;
+      if (!active && !undelivered) continue;
       if (managed.sessionId === sessionId) continue;
       managed.sessionId = sessionId;
       this.persistRun(managed);
       adopted++;
+    }
+    // Disk-only undelivered rows (terminal runs already evicted from memory).
+    // Re-home markers tagged with the previous session id; never claim foreign
+    // or null sessionIds here (null live rows are claimed at bind flush).
+    try {
+      for (const state of this.persistence.list()) {
+        if (!state.pendingDelivery) continue;
+        if (this.runs.has(state.runId)) continue;
+        if (state.sessionId === sessionId) continue;
+        if (prev == null || state.sessionId !== prev) continue;
+        this.persistence.save({ ...state, sessionId });
+        adopted++;
+      }
+    } catch {
+      // best-effort — live adopt above is the critical path
     }
     return adopted;
   }
@@ -1098,6 +1132,8 @@ export class WorkflowManager extends EventEmitter {
         // setSessionId() (session replacement) must not re-home a still-running
         // run out from under stranded-pause / the originating panel.
         sessionId: managed.sessionId,
+        // Fail-closed delivery marker — survives endpoint gaps / process restart.
+        pendingDelivery: managed.pendingDelivery,
         journal: keepsResumeJournal ? managed.journal : undefined,
         status: managed.status,
         // Persisted every write (not just at pause) so a stale read during the
@@ -1265,6 +1301,9 @@ export class WorkflowManager extends EventEmitter {
       // Prefer the frozen owner on disk; fall back to the manager's current
       // session only for legacy runs that predate per-run sessionId.
       sessionId: persisted.sessionId ?? this.sessionId,
+      // Carry any undelivered conversation payload across resume so session_start
+      // flush can still re-inject after a pause/restart gap.
+      pendingDelivery: persisted.pendingDelivery,
       lease,
       // Carry the original opt-out forward across resumes; it's fixed at
       // run-start and persistRun() re-persists it on every subsequent write.

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -5,7 +5,7 @@
 import { EventEmitter } from "node:events";
 import type { ModelRegistry, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { WorkflowAgent } from "./agent.js";
-import { MAX_AGENTS_PER_RUN, MAX_AGENTS_PER_RUN } from "./config.js";
+import { MAX_AGENTS_PER_RUN } from "./config.js";
 import { preview, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
 import { isProviderUsageLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import {

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -1,15 +1,48 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { join } from "node:path";
-import { before, describe, it } from "node:test";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { before, beforeEach, describe, it } from "node:test";
+import { AgentSession, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
+
+type DeliveryCall = { content: string; customType?: string; triggerTurn?: boolean };
+type StableSend = (
+  msg: { customType?: string; content?: string; display?: boolean },
+  opts?: { triggerTurn?: boolean; deliverAs?: string },
+) => unknown;
 
 type TaskPanelModule = {
   installResultDelivery: (pi: ExtensionAPI, manager: unknown, opts?: unknown) => void;
+  bindSessionDelivery: (
+    sessionId: string,
+    pi: ExtensionAPI,
+    opts?: {
+      loadSettings?: () => unknown;
+      manager?: unknown;
+      stableSend?: StableSend;
+      sessionManager?: {
+        getSessionId?: () => string;
+        appendCustomMessageEntry?: (
+          customType: string,
+          content: string | unknown[],
+          display: boolean,
+          details?: unknown,
+        ) => string;
+      };
+    },
+  ) => void;
+  dropSessionDelivery: (sessionId: string | undefined) => void;
   suspendResultDelivery: (manager: unknown) => void;
   resumeResultDelivery: (manager: unknown) => void;
+  suspendSessionDelivery: (sessionId: string | undefined) => void;
+  resumeSessionDelivery: (sessionId: string | undefined, manager?: unknown) => void;
   installTaskPanel: (pi: ExtensionAPI | null, manager: unknown, ui: unknown) => void;
+  _resetDeliveryRegistriesForTests: () => void;
+  _registerBoundSessionSendForTests: (sessionId: string, send: StableSend) => void;
+  _hasBoundSessionSendForTests: (sessionId: string) => boolean;
+  _getSessionDeliveryEndpointForTests: (
+    sessionId: string,
+  ) => { suspended: boolean; generation: number; hasSend: boolean; hasAppend: boolean } | undefined;
 };
 
 // Loaded once before all tests
@@ -19,23 +52,85 @@ before(async () => {
   mod = (await import("../src/task-panel.js")) as TaskPanelModule;
 });
 
-// ─── Pure-function tests (tested indirectly via installResultDelivery) ─────────
+// ─── Session-routed background result delivery ─────────────────────────────────
 
 describe("installResultDelivery", () => {
-  function createMockManager(run?: unknown, runsDir?: string) {
+  const SESSION = "sess-test";
+
+  beforeEach(() => {
+    mod._resetDeliveryRegistriesForTests();
+  });
+
+  function createMockManager(run?: Record<string, unknown>, runsDir?: string) {
+    let sessionId: string | undefined = SESSION;
+    const runs = new Map<string, Record<string, unknown>>();
+    if (run) runs.set(String(run.runId ?? "test-run-1"), run);
+
+    const disk = new Map<string, Record<string, unknown>>();
+
     const manager = new EventEmitter() as ReturnType<typeof EventEmitter> & {
-      getRun: (...args: unknown[]) => unknown;
-      getPersistence?: () => { getRunsDir: () => string };
+      getRun: (id: string) => unknown;
+      getPersistence?: () => {
+        getRunsDir: () => string;
+        load: (id: string) => Record<string, unknown> | null;
+        save: (state: Record<string, unknown>) => void;
+        list: () => Record<string, unknown>[];
+      };
+      getSessionId: () => string | undefined;
+      setSessionId: (id: string | undefined) => void;
+      adoptLiveRunsToSession: (newId: string | undefined, previousSessionId?: string) => number;
+      listLiveRuns: () => unknown[];
       __deliveryInstalled?: boolean;
       listRuns?: () => unknown[];
     };
-    manager.getRun = () => run;
-    if (runsDir) manager.getPersistence = () => ({ getRunsDir: () => runsDir });
+    manager.getRun = (id: string) => runs.get(id);
+    manager.getSessionId = () => sessionId;
+    manager.setSessionId = (id) => {
+      sessionId = id;
+    };
+    manager.adoptLiveRunsToSession = (newId, previousSessionId) => {
+      if (!newId) return 0;
+      const prev = previousSessionId !== undefined ? previousSessionId : sessionId;
+      let adopted = 0;
+      for (const managed of runs.values()) {
+        const status = managed.status as string | undefined;
+        const active = status === "running" || status === "paused";
+        const undelivered = managed.pendingDelivery != null;
+        if (!active && !undelivered) continue;
+        if (managed.sessionId === newId) continue;
+        managed.sessionId = newId;
+        const existing = disk.get(String(managed.runId));
+        if (existing) disk.set(String(existing.runId), { ...existing, sessionId: newId });
+        adopted++;
+      }
+      for (const state of [...disk.values()]) {
+        if (!state.pendingDelivery) continue;
+        if (runs.has(String(state.runId))) continue;
+        if (state.sessionId === newId) continue;
+        if (prev == null || state.sessionId !== prev) continue;
+        disk.set(String(state.runId), { ...state, sessionId: newId });
+        adopted++;
+      }
+      return adopted;
+    };
+    manager.listLiveRuns = () => [...runs.values()];
+    manager.getPersistence = () => ({
+      getRunsDir: () => runsDir ?? "/runs",
+      load: (id: string) => disk.get(id) ?? null,
+      save: (state: Record<string, unknown>) => {
+        disk.set(String(state.runId), { ...state });
+        const live = runs.get(String(state.runId));
+        if (live && "pendingDelivery" in state) {
+          live.pendingDelivery = state.pendingDelivery;
+        }
+      },
+      list: () => [...disk.values()],
+    });
     return manager;
   }
 
-  function createMockPi(): ExtensionAPI & { _calls: { content: string; customType?: string }[] } {
-    const calls: { content: string; customType?: string }[] = [];
+  function createMockPi(): ExtensionAPI & { _calls: DeliveryCall[] } {
+    const calls: DeliveryCall[] = [];
     const obj = {
       sendMessage(msg: unknown, _opts?: unknown) {
         calls.push({
@@ -50,13 +145,37 @@ describe("installResultDelivery", () => {
       reload: () => Promise.resolve(),
       _calls: calls,
     };
-    return obj as unknown as ExtensionAPI & { _calls: { content: string; customType?: string }[] };
+    return obj as unknown as ExtensionAPI & { _calls: DeliveryCall[] };
+  }
+
+  /** Session-stable thenable send that records like the old sendMessage spy. */
+  function recordingStableSend(pi: { _calls: DeliveryCall[] }): StableSend {
+    return (msg, opts) => {
+      pi._calls.push({
+        content: msg.content ?? "",
+        customType: msg.customType,
+        triggerTurn: opts?.triggerTurn,
+      });
+      return Promise.resolve();
+    };
+  }
+
+  /** Drive the armed AgentSession._bindExtensionCore patch with a fake `this`. */
+  function invokePatchedBindCore(session: object): void {
+    const bind = (AgentSession.prototype as unknown as { _bindExtensionCore: (runner: unknown) => unknown })
+      ._bindExtensionCore;
+    bind.call(session, { bindCore() {} });
+  }
+
+  function piCalls(pi: ExtensionAPI): DeliveryCall[] {
+    return (pi as unknown as { _calls: DeliveryCall[] })._calls;
   }
 
   function makeRun(overrides: Record<string, unknown> = {}) {
     return {
       runId: "test-run-1",
       background: true,
+      sessionId: SESSION,
       snapshot: {
         name: "test-workflow",
         agentCount: 3,
@@ -80,16 +199,28 @@ describe("installResultDelivery", () => {
     };
   }
 
+  function setup(
+    pi: ExtensionAPI,
+    manager: ReturnType<typeof createMockManager>,
+    sessionId = SESSION,
+    bindOpts: { stableSend?: StableSend; loadSettings?: () => unknown } = {},
+  ) {
+    mod.installResultDelivery(pi, manager, bindOpts.loadSettings ? { loadSettings: bindOpts.loadSettings } : undefined);
+    manager.setSessionId(sessionId);
+    const stableSend = bindOpts.stableSend ?? recordingStableSend(pi as unknown as { _calls: DeliveryCall[] });
+    mod.bindSessionDelivery(sessionId, pi, { manager, ...bindOpts, stableSend });
+  }
+
   // ── deliverText: verdict path ──
 
   it("delivers verdict when result.result has verdict", () => {
     const pi = createMockPi();
     const manager = createMockManager(makeRun());
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("complete", { runId: "test-run-1" });
 
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    const calls = piCalls(pi);
     assert.equal(calls.length, 1);
     assert.equal(calls[0].customType, "workflow-result");
     assert.ok(calls[0].content.includes("All tests passed"), "should contain All tests passed");
@@ -115,10 +246,10 @@ describe("installResultDelivery", () => {
       }),
     );
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("complete", { runId: "test-run-1" });
 
-    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
+    const content = piCalls(pi)[0].content;
     assert.ok(content.includes("100.0K tok"), `fresh (input+output) should read as tok; got: ${content}`);
     assert.ok(content.includes("6.0M cached"), `cacheRead should read as cached; got: ${content}`);
     assert.ok(content.includes("$6.70"), `cost should be shown; got: ${content}`);
@@ -139,10 +270,10 @@ describe("installResultDelivery", () => {
       }),
     );
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("complete", { runId: "test-run-1" });
 
-    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
+    const content = piCalls(pi)[0].content;
     assert.ok(content.includes("800 tok"), `the estimate should survive as the token count; got: ${content}`);
     assert.ok(!/\b0 tok/.test(content), `must not render a zero breakdown; got: ${content}`);
   });
@@ -161,10 +292,10 @@ describe("installResultDelivery", () => {
       }),
     );
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("complete", { runId: "test-run-1" });
 
-    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
+    const content = piCalls(pi)[0].content;
     assert.ok(!/\b0 tok/.test(content), `an all-zero aggregate must not render "0 tok"; got: ${content}`);
     assert.ok(content.includes("3 agents"), "the rest of the line is intact");
   });
@@ -176,10 +307,10 @@ describe("installResultDelivery", () => {
     const run = makeRun({ result: { result: { report: "Report body", verdict: "" } } });
     const manager = createMockManager(run);
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("complete", { runId: "test-run-1" });
 
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    const calls = piCalls(pi);
     assert.ok(calls[0].content.includes("Report body"), "should contain Report body");
   });
 
@@ -188,10 +319,10 @@ describe("installResultDelivery", () => {
     const run = makeRun({ result: { result: { summary: "Short summary" } } });
     const manager = createMockManager(run);
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("complete", { runId: "test-run-1" });
 
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    const calls = piCalls(pi);
     assert.ok(calls[0].content.includes("Short summary"), "should contain Short summary");
   });
 
@@ -200,103 +331,82 @@ describe("installResultDelivery", () => {
     const run = makeRun({ result: { result: "Plain string result" } });
     const manager = createMockManager(run);
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("complete", { runId: "test-run-1" });
 
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    const calls = piCalls(pi);
     assert.ok(calls[0].content.includes("Plain string result"), "should contain Plain string result");
   });
 
-  it("falls back to truncated JSON when result is an object with no known key", () => {
+  it("falls back to synthesis when present", () => {
     const pi = createMockPi();
-    const run = makeRun({ result: { result: { foo: "x".repeat(500), bar: "y".repeat(500) } } });
+    const run = makeRun({ result: { result: { synthesis: "Synth body" } } });
     const manager = createMockManager(run);
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("complete", { runId: "test-run-1" });
 
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
-    assert.ok(calls[0].content.includes("foo"), "should contain foo");
-    assert.ok(/…\(truncated [\d.]+ (B|KB|MB)\)/.test(calls[0].content), "should note the dropped size on truncation");
+    const calls = piCalls(pi);
+    assert.ok(calls[0].content.includes("Synth body"), "should contain Synth body");
   });
 
-  it("falls back gracefully when result is nullish", () => {
+  it("JSON-dumps object results without preferred fields", () => {
     const pi = createMockPi();
-    const run = makeRun({ result: { result: undefined } });
+    const run = makeRun({ result: { result: { ok: true, n: 2 } } });
     const manager = createMockManager(run);
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("complete", { runId: "test-run-1" });
 
-    // Should not crash; should still deliver a message
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
-    assert.equal(calls.length, 1);
-    assert.ok(calls[0].content.includes("null"), "should contain null for undefined result");
+    const calls = piCalls(pi);
+    assert.ok(calls[0].content.includes('"ok": true'), "should dump JSON");
   });
 
-  // ── Full-result pointer + configurable threshold ──
-
-  it("appends a Full result pointer to <runsDir>/<runId>.json when persistence exists", () => {
+  it("truncates long JSON dumps and appends the result pointer", () => {
     const pi = createMockPi();
-    const manager = createMockManager(makeRun(), "/runs");
+    const run = makeRun({ result: { result: { note: "z".repeat(500) } } });
+    const manager = createMockManager(run, "/runs");
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("complete", { runId: "test-run-1" });
 
-    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
-    assert.ok(content.includes("Full result:"), "should include the pointer label");
-    assert.ok(content.includes(join("/runs", "test-run-1.json")), "should point at <runsDir>/<runId>.json");
-    // The verdict summary itself is unchanged apart from the appended pointer.
-    assert.ok(content.includes("All tests passed"), "verdict text preserved");
+    const content = piCalls(pi)[0].content;
+    assert.ok(content.includes("truncated"), "long dump is truncated");
+    assert.ok(content.includes(join("/runs", "test-run-1.json")), "pointer still appended");
   });
 
-  it("omits the pointer when the manager exposes no persistence layer", () => {
+  it("honours deliveredResultMaxChars from settings", () => {
     const pi = createMockPi();
-    const manager = createMockManager(makeRun()); // no runsDir
-
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
-    manager.emit("complete", { runId: "test-run-1" });
-
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
-    assert.equal(calls.length, 1, "the result is still delivered");
-    assert.ok(calls[0].content.includes("All tests passed"), "verdict body still intact");
-    assert.ok(!calls[0].content.includes("Full result:"), "no pointer without a persisted path");
-  });
-
-  it("honors deliveredResultMaxChars from loadSettings for the JSON-dump branch", () => {
-    const pi = createMockPi();
-    // ~216-char JSON dump: under the default 400, so it would NOT truncate by default
-    // — a truncation marker can therefore only come from the 50-char setting.
     const run = makeRun({ result: { result: { note: "z".repeat(200) } } });
     const manager = createMockManager(run, "/runs");
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager, {
-      loadSettings: () => ({ deliveredResultMaxChars: 50 }),
+    setup(pi as unknown as ExtensionAPI, manager, SESSION, {
+      loadSettings: () => ({ deliveredResultMaxChars: 40 }),
     });
     manager.emit("complete", { runId: "test-run-1" });
 
-    const content = (pi as unknown as { _calls: { content: string }[] })._calls[0].content;
-    assert.ok(/…\(truncated [\d.]+ (B|KB|MB)\)/.test(content), "the 50-char setting truncates a sub-400 dump");
+    const content = piCalls(pi)[0].content;
+    assert.ok(content.includes("truncated"), "settings threshold is applied");
     assert.ok(!content.includes("z".repeat(200)), "the body is cut at the configured threshold");
     assert.ok(content.includes(join("/runs", "test-run-1.json")), "pointer still appended");
   });
 
-  // ── installResultDelivery: guard / stale ctx ──
+  // ── installResultDelivery: guard / session routing ──
 
   it("installs delivery only once — second call skips listener registration", () => {
     const pi = createMockPi();
     const manager = createMockManager(makeRun());
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
-    // Second call: should only refresh holder.pi, not add another listener
+    setup(pi, manager);
+    // Second call: should not add another listener
     mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
 
     manager.emit("complete", { runId: "test-run-1" });
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    const calls = piCalls(pi);
     assert.equal(calls.length, 1); // exactly once, not twice
   });
 
-  it("does not crash when sendMessage throws (stale ctx); queues and flushes on refresh", () => {
+  it("does not crash when sendMessage throws (stale ctx); queues and flushes on rebind", async () => {
     const stalePi = {
       sendMessage: (_msg: unknown, _opts?: unknown) => {
         throw new Error("This extension ctx is stale");
@@ -311,49 +421,53 @@ describe("installResultDelivery", () => {
     const manager = createMockManager(makeRun());
 
     mod.installResultDelivery(stalePi as unknown as ExtensionAPI, manager);
-    // Must not throw — the failed send is queued for the next generation.
+    manager.setSessionId(SESSION);
+    mod.bindSessionDelivery(SESSION, stalePi as unknown as ExtensionAPI, {
+      manager,
+      stableSend: () => {
+        throw new Error("This extension ctx is stale");
+      },
+    });
+    // Must not throw — the failed send leaves disk/memory pending.
     manager.emit("complete", { runId: "test-run-1" });
+    // Sync throw still ACKs via a rejected/false thenable; wait out in-flight.
+    await Promise.resolve();
+    await Promise.resolve();
 
-    // Factory-time install only refreshes the holder; session_start resumes.
+    // Factory-time install only refreshes; session_start rebinds + flushes.
     mod.installResultDelivery(freshPi as unknown as ExtensionAPI, manager);
-    assert.equal(
-      (freshPi as unknown as { _calls: unknown[] })._calls.length,
-      0,
-      "install alone must not flush — runtime may still be unbound",
-    );
-    mod.resumeResultDelivery(manager);
-    const calls = (freshPi as unknown as { _calls: { content: string }[] })._calls;
-    assert.equal(calls.length, 1, "resume must flush onto the fresh pi");
+    assert.equal(piCalls(freshPi).length, 0, "install alone must not flush — runtime may still be unbound");
+    mod.bindSessionDelivery(SESSION, freshPi as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(freshPi),
+    });
+    const calls = piCalls(freshPi);
+    assert.equal(calls.length, 1, "rebind must flush onto the fresh pi");
     assert.ok(calls[0].content.includes("test-workflow"));
   });
 
-  it("suspends live sends and flushes the queue when the next generation installs", () => {
+  it("suspends live sends and flushes the queue when the next generation binds", () => {
     const pi1 = createMockPi();
     const pi2 = createMockPi();
     const manager = createMockManager(makeRun());
 
-    mod.installResultDelivery(pi1 as unknown as ExtensionAPI, manager);
+    setup(pi1, manager);
     mod.suspendResultDelivery(manager);
     manager.emit("complete", { runId: "test-run-1" });
-    assert.equal(
-      (pi1 as unknown as { _calls: unknown[] })._calls.length,
-      0,
-      "suspended delivery must not call the dying pi",
-    );
+    assert.equal(piCalls(pi1).length, 0, "suspended delivery must not call the dying pi");
 
     mod.installResultDelivery(pi2 as unknown as ExtensionAPI, manager);
-    assert.equal(
-      (pi2 as unknown as { _calls: unknown[] })._calls.length,
-      0,
-      "install alone must not flush before runtime bind",
-    );
-    mod.resumeResultDelivery(manager);
-    const calls = (pi2 as unknown as { _calls: { content: string }[] })._calls;
-    assert.equal(calls.length, 1, "resume must deliver pending completion into the new session");
+    assert.equal(piCalls(pi2).length, 0, "install alone must not flush before runtime bind");
+    mod.bindSessionDelivery(SESSION, pi2 as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(pi2),
+    });
+    const calls = piCalls(pi2);
+    assert.equal(calls.length, 1, "bind must deliver pending completion into the new session");
     assert.ok(calls[0].content.includes("All tests passed"));
   });
 
-  it("re-queues an async sendMessage rejection and flushes it on the next install", async () => {
+  it("re-queues an async sendMessage rejection and flushes it on the next bind", async () => {
     let rejectSend: ((err: Error) => void) | undefined;
     const failingPi = {
       sendMessage: (_msg: unknown, _opts?: unknown) =>
@@ -369,24 +483,31 @@ describe("installResultDelivery", () => {
     const freshPi = createMockPi();
     const manager = createMockManager(makeRun());
 
-    mod.installResultDelivery(failingPi as unknown as ExtensionAPI, manager);
+    setup(failingPi as unknown as ExtensionAPI, manager, SESSION, {
+      stableSend: () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSend = reject;
+        }),
+    });
     manager.emit("complete", { runId: "test-run-1" });
-    assert.ok(rejectSend, "sendMessage should have returned a pending promise");
-    rejectSend(new Error("network blip"));
+    assert.ok(rejectSend, "stableSend should have returned a pending promise");
+    rejectSend?.(new Error("network blip"));
     // Let the rejection microtask run and re-queue.
     await Promise.resolve();
     await Promise.resolve();
 
-    mod.installResultDelivery(freshPi as unknown as ExtensionAPI, manager);
-    mod.resumeResultDelivery(manager);
-    const calls = (freshPi as unknown as { _calls: { content: string }[] })._calls;
-    assert.equal(calls.length, 1, "async failure must be retried on the fresh pi after resume");
+    mod.bindSessionDelivery(SESSION, freshPi as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(freshPi),
+    });
+    const calls = piCalls(freshPi);
+    assert.equal(calls.length, 1, "async failure must be retried on the fresh pi after rebind");
   });
 
-  it("flushes immediately when an in-flight send rejects AFTER the next generation installed", async () => {
+  it("flushes immediately when an in-flight send rejects AFTER the next generation bound", async () => {
     // The real race: generation N's promise is still pending when generation
-    // N+1 installs and flushes (empty queue). N's rejection must not leave the
-    // content stranded until some later N+2 install.
+    // N+1 binds and flushes (empty queue). N's rejection must not leave the
+    // content stranded until some later N+2 bind.
     let rejectSend: ((err: Error) => void) | undefined;
     const failingPi = {
       sendMessage: (_msg: unknown, _opts?: unknown) =>
@@ -402,46 +523,59 @@ describe("installResultDelivery", () => {
     const freshPi = createMockPi();
     const manager = createMockManager(makeRun());
 
-    mod.installResultDelivery(failingPi as unknown as ExtensionAPI, manager);
+    setup(failingPi as unknown as ExtensionAPI, manager, SESSION, {
+      stableSend: () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSend = reject;
+        }),
+    });
     manager.emit("complete", { runId: "test-run-1" });
     assert.ok(rejectSend);
 
-    // Next generation installs + resumes BEFORE the rejection lands.
-    mod.installResultDelivery(freshPi as unknown as ExtensionAPI, manager);
-    mod.resumeResultDelivery(manager);
-    assert.equal(
-      (freshPi as unknown as { _calls: unknown[] })._calls.length,
-      0,
-      "nothing queued yet — the in-flight send has not rejected",
-    );
+    // Next generation binds BEFORE the rejection lands.
+    mod.bindSessionDelivery(SESSION, freshPi as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(freshPi),
+    });
+    assert.equal(piCalls(freshPi).length, 0, "nothing queued yet — the in-flight send has not rejected");
 
-    rejectSend(new Error("late network blip"));
+    rejectSend?.(new Error("late network blip"));
     await Promise.resolve();
     await Promise.resolve();
 
-    const calls = (freshPi as unknown as { _calls: { content: string }[] })._calls;
-    assert.equal(calls.length, 1, "late rejection must self-flush onto the already-resumed generation");
+    const calls = piCalls(freshPi);
+    assert.equal(calls.length, 1, "late rejection must self-flush onto the already-bound generation");
     assert.ok(calls[0].content.includes("test-workflow"));
   });
 
   it("never silently drops pending deliveries when the queue grows past the soft cap", () => {
     const pi1 = createMockPi();
     const pi2 = createMockPi();
-    const manager = createMockManager(makeRun());
+    // Distinct run ids so each complete has its own pending marker.
+    const runs = Array.from({ length: 40 }, (_, i) =>
+      makeRun({ runId: `run-${i}`, result: { result: { verdict: `v-${i}` }, agentCount: 1, durationMs: 1 } }),
+    );
+    const manager = createMockManager(runs[0]);
+    // Inject all runs into getRun/listLiveRuns
+    const byId = new Map(runs.map((r) => [r.runId as string, r]));
+    manager.getRun = (id: string) => byId.get(id);
+    manager.listLiveRuns = () => [...byId.values()];
 
-    mod.installResultDelivery(pi1 as unknown as ExtensionAPI, manager);
+    setup(pi1, manager);
     mod.suspendResultDelivery(manager);
-    for (let i = 0; i < 40; i++) {
-      manager.emit("complete", { runId: "test-run-1" });
+    for (const r of runs) {
+      manager.emit("complete", { runId: r.runId });
     }
 
-    mod.installResultDelivery(pi2 as unknown as ExtensionAPI, manager);
-    mod.resumeResultDelivery(manager);
-    const calls = (pi2 as unknown as { _calls: unknown[] })._calls;
+    mod.bindSessionDelivery(SESSION, pi2 as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(pi2),
+    });
+    const calls = piCalls(pi2);
     assert.equal(calls.length, 40, "soft-cap must warn, never shift() away a queued result");
   });
 
-  it("keeps delivery suspended across factory install until resumeResultDelivery", () => {
+  it("keeps delivery suspended across factory install until bindSessionDelivery", () => {
     const unboundPi = {
       sendMessage: () => {
         throw new Error("Extension runtime not initialized. Action methods cannot be called during extension loading.");
@@ -455,23 +589,21 @@ describe("installResultDelivery", () => {
     const boundPi = createMockPi();
     const manager = createMockManager(makeRun());
 
-    // Simulate extension factory: install then immediately suspend (as workflow.ts does).
+    // Simulate extension factory: install only (no endpoint yet — fail closed).
     mod.installResultDelivery(unboundPi as unknown as ExtensionAPI, manager);
-    mod.suspendResultDelivery(manager);
     manager.emit("complete", { runId: "test-run-1" });
     // Re-install as a fresh factory would (still pre-bindCore).
     mod.installResultDelivery(unboundPi as unknown as ExtensionAPI, manager);
-    assert.equal(
-      (boundPi as unknown as { _calls: unknown[] })._calls.length,
-      0,
-      "must not attempt send while runtime unbound",
-    );
+    assert.equal(piCalls(boundPi).length, 0, "must not attempt send while runtime unbound");
 
-    // session_start: swap in the bound pi via install, then resume.
-    mod.installResultDelivery(boundPi as unknown as ExtensionAPI, manager);
-    mod.resumeResultDelivery(manager);
-    const calls = (boundPi as unknown as { _calls: { content: string }[] })._calls;
-    assert.equal(calls.length, 1, "session_start resume flushes the pre-bind queue");
+    // session_start: bind the session endpoint with the live pi.
+    manager.setSessionId(SESSION);
+    mod.bindSessionDelivery(SESSION, boundPi as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(boundPi),
+    });
+    const calls = piCalls(boundPi);
+    assert.equal(calls.length, 1, "session_start bind flushes the pre-bind disk pending");
   });
 
   // ── Only background runs are delivered ──
@@ -481,10 +613,10 @@ describe("installResultDelivery", () => {
     const run = makeRun({ background: false });
     const manager = createMockManager(run);
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("complete", { runId: "test-run-1" });
 
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    const calls = piCalls(pi);
     assert.equal(calls.length, 0);
   });
 
@@ -494,10 +626,10 @@ describe("installResultDelivery", () => {
     const pi = createMockPi();
     const manager = createMockManager(makeRun());
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("error", { runId: "test-run-1", error: { message: "Something went wrong" } });
 
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    const calls = piCalls(pi);
     assert.equal(calls.length, 1);
     assert.ok(calls[0].content.includes("failed"), "should contain failed");
     assert.ok(calls[0].content.includes("Something went wrong"), "should contain Something went wrong");
@@ -508,10 +640,10 @@ describe("installResultDelivery", () => {
     const run = makeRun({ background: false });
     const manager = createMockManager(run);
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("error", { runId: "test-run-1", error: { message: "fail" } });
 
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    const calls = piCalls(pi);
     assert.equal(calls.length, 0);
   });
 
@@ -521,7 +653,7 @@ describe("installResultDelivery", () => {
     const pi = createMockPi();
     const manager = createMockManager(makeRun());
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("paused", {
       runId: "test-run-1",
       reason: "usage_limit",
@@ -529,7 +661,7 @@ describe("installResultDelivery", () => {
       resetHint: "Resets in ~3h",
     });
 
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    const calls = piCalls(pi);
     assert.equal(calls.length, 1);
     assert.ok(calls[0].content.includes("paused"), "should say paused");
     assert.ok(calls[0].content.includes("/workflows resume test-run-1"), "should name the resume command");
@@ -541,10 +673,10 @@ describe("installResultDelivery", () => {
     const pi = createMockPi();
     const manager = createMockManager(makeRun());
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("paused", { runId: "test-run-1" });
 
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    const calls = piCalls(pi);
     assert.equal(calls.length, 0);
   });
 
@@ -552,31 +684,273 @@ describe("installResultDelivery", () => {
     const pi = createMockPi();
     const manager = createMockManager(makeRun({ background: false }));
 
-    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    setup(pi, manager);
     manager.emit("paused", { runId: "test-run-1", reason: "usage_limit", error: { message: "usage limit" } });
 
-    const calls = (pi as unknown as { _calls: { content: string }[] })._calls;
+    const calls = piCalls(pi);
     assert.equal(calls.length, 0);
   });
 
-  // ── Holder refresh on re-call ──
+  // ── Session routing (#147) ──
 
-  it("refreshes holder.pi on second call for stale ctx recovery", () => {
+  it("session_start shape: steal map send without bind stableSend delivers + triggerTurn", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun());
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId(SESSION);
+    // Production session_start never passes stableSend — only the steal map.
+    mod._registerBoundSessionSendForTests(SESSION, recordingStableSend(pi));
+    mod.bindSessionDelivery(SESSION, pi as unknown as ExtensionAPI, { manager });
+
+    manager.emit("complete", { runId: "test-run-1" });
+    const calls = piCalls(pi);
+    assert.equal(calls.length, 1, "stolen send is the production ACK path");
+    assert.equal(calls[0].triggerTurn, true, "host sendCustomMessage must triggerTurn");
+    assert.ok(calls[0].content.includes("All tests passed"));
+  });
+
+  it("parallel sessions: last bindCore must not steal the other session's send", () => {
+    const piA = createMockPi();
+    const piB = createMockPi();
+    const managerA = createMockManager(makeRun({ sessionId: "sess-A", runId: "run-A" }));
+    const managerB = createMockManager(
+      makeRun({
+        sessionId: "sess-B",
+        runId: "run-B",
+        result: { result: { verdict: "from-B" }, agentCount: 1, durationMs: 1 },
+      }),
+    );
+    managerA.setSessionId("sess-A");
+    managerB.setSessionId("sess-B");
+
+    // Two host-shaped bindCores, B last — steal map must stay per-session.
+    invokePatchedBindCore({
+      sessionManager: {
+        persist: true,
+        getSessionId: () => "sess-A",
+        getSessionName: () => "host-A",
+      },
+      _resourceLoader: { noExtensions: false },
+      sendCustomMessage: recordingStableSend(piA),
+    });
+    invokePatchedBindCore({
+      sessionManager: {
+        persist: true,
+        getSessionId: () => "sess-B",
+        getSessionName: () => "host-B",
+      },
+      _resourceLoader: { noExtensions: false },
+      sendCustomMessage: recordingStableSend(piB),
+    });
+
+    mod.installResultDelivery(piA as unknown as ExtensionAPI, managerA);
+    // No stableSend — same as production session_start.
+    mod.bindSessionDelivery("sess-A", piA as unknown as ExtensionAPI, { manager: managerA });
+    mod.installResultDelivery(piB as unknown as ExtensionAPI, managerB);
+    mod.bindSessionDelivery("sess-B", piB as unknown as ExtensionAPI, { manager: managerB });
+
+    managerA.emit("complete", { runId: "run-A" });
+
+    assert.equal(piCalls(piA).length, 1, "origin A receives");
+    assert.equal(piCalls(piB).length, 0, "sibling B must not receive A's result");
+    assert.ok(piCalls(piA)[0].content.includes("All tests passed"));
+
+    managerB.emit("complete", { runId: "run-B" });
+    assert.equal(piCalls(piA).length, 1, "A must not receive B's result");
+    assert.equal(piCalls(piB).length, 1, "origin B receives its own result");
+    assert.ok(piCalls(piB)[0].content.includes("from-B"));
+  });
+
+  it("steal map pins only the host session; drop releases the host closure", () => {
+    invokePatchedBindCore({
+      sessionManager: {
+        persist: false,
+        getSessionId: () => "child-mem",
+        getSessionName: () => "",
+      },
+      sendCustomMessage: async () => {},
+    });
+    invokePatchedBindCore({
+      sessionManager: {
+        persist: true,
+        getSessionId: () => "child-noext",
+        getSessionName: () => "",
+      },
+      _resourceLoader: { noExtensions: true },
+      sendCustomMessage: async () => {},
+    });
+    invokePatchedBindCore({
+      sessionManager: {
+        persist: true,
+        getSessionId: () => "child-named",
+        getSessionName: () => "workflow:run-1 agent",
+      },
+      sendCustomMessage: async () => {},
+    });
+    invokePatchedBindCore({
+      sessionManager: {
+        persist: true,
+        getSessionId: () => "host-1",
+        getSessionName: () => "chat",
+      },
+      _resourceLoader: { noExtensions: false },
+      sendCustomMessage: async () => {},
+    });
+
+    assert.equal(mod._hasBoundSessionSendForTests("child-mem"), false, "in-memory child must not pin");
+    assert.equal(mod._hasBoundSessionSendForTests("child-noext"), false, "noExtensions child must not pin");
+    assert.equal(mod._hasBoundSessionSendForTests("child-named"), false, "workflow: child must not pin");
+    assert.equal(mod._hasBoundSessionSendForTests("host-1"), true, "host session is stolen");
+
+    mod.dropSessionDelivery("host-1");
+    assert.equal(mod._hasBoundSessionSendForTests("host-1"), false, "drop releases the host send closure");
+  });
+
+  it("append-only is not an ACK; pending stays until a thenable send exists", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun());
+    const appended: string[] = [];
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId(SESSION);
+    mod.bindSessionDelivery(SESSION, pi as unknown as ExtensionAPI, {
+      manager,
+      sessionManager: {
+        getSessionId: () => SESSION,
+        appendCustomMessageEntry: (_customType, content) => {
+          appended.push(typeof content === "string" ? content : JSON.stringify(content));
+          return "entry";
+        },
+      },
+    });
+    manager.emit("complete", { runId: "test-run-1" });
+
+    assert.equal(piCalls(pi).length, 0, "never fall back to pi.sendMessage");
+    assert.equal(appended.length, 0, "append must not be treated as delivery");
+    assert.ok(manager.getPersistence?.().load("test-run-1")?.pendingDelivery, "pending stays on disk");
+    assert.equal(mod._getSessionDeliveryEndpointForTests(SESSION)?.hasSend, false);
+  });
+
+  it("no endpoint → disk pending; later session_start bind flushes", async () => {
+    const pi = createMockPi();
+    const run = makeRun();
+    const manager = createMockManager(run);
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    // No bindSessionDelivery yet.
+    manager.emit("complete", { runId: "test-run-1" });
+    assert.equal(piCalls(pi).length, 0, "fail closed without endpoint");
+
+    const disk = manager.getPersistence?.().load("test-run-1");
+    assert.ok(disk?.pendingDelivery, "pending marker persisted to disk");
+
+    manager.setSessionId(SESSION);
+    mod.bindSessionDelivery(SESSION, pi as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(pi),
+    });
+    assert.equal(piCalls(pi).length, 1, "bind flushes disk pending");
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(manager.getPersistence?.().load("test-run-1")?.pendingDelivery, undefined, "cleared after flush");
+  });
+
+  it("bind without stableSend stays fail-closed and keeps pending", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun());
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId(SESSION);
+    // Registered fail-closed: steal map empty, no stableSend (and append is not ACK).
+    mod.bindSessionDelivery(SESSION, pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "test-run-1" });
+
+    assert.equal(piCalls(pi).length, 0, "no stableSend → never fall back to pi.sendMessage");
+    assert.ok(manager.getPersistence?.().load("test-run-1")?.pendingDelivery, "pending stays on disk");
+  });
+
+  it("suspended endpoint never sends", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun());
+    setup(pi, manager);
+    mod.suspendSessionDelivery(SESSION);
+    assert.equal(mod._getSessionDeliveryEndpointForTests(SESSION)?.suspended, true);
+
+    manager.emit("complete", { runId: "test-run-1" });
+    assert.equal(piCalls(pi).length, 0);
+  });
+
+  it("sessionId mismatch never sends to the wrong endpoint", () => {
+    const piA = createMockPi();
+    const piB = createMockPi();
+    // Run belongs to A, but only B is bound.
+    const manager = createMockManager(makeRun({ sessionId: "sess-A" }));
+    manager.setSessionId("sess-B");
+    mod.installResultDelivery(piB as unknown as ExtensionAPI, manager);
+    mod.bindSessionDelivery("sess-B", piB as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(piB),
+    });
+
+    manager.emit("complete", { runId: "test-run-1" });
+    assert.equal(piCalls(piB).length, 0, "B must not get A's run");
+    assert.equal(piCalls(piA).length, 0);
+
+    // Later A binds and receives the pending delivery.
+    mod.bindSessionDelivery("sess-A", piA as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(piA),
+    });
+    assert.equal(piCalls(piA).length, 1, "origin A flushes pending");
+  });
+
+  it("#143 suspend/resume still delivers after replacement bind", () => {
     const pi1 = createMockPi();
     const pi2 = createMockPi();
     const manager = createMockManager(makeRun());
 
-    // Install with first pi
-    mod.installResultDelivery(pi1 as unknown as ExtensionAPI, manager);
-    // Re-call with second pi (fresh after reload)
-    mod.installResultDelivery(pi2 as unknown as ExtensionAPI, manager);
+    setup(pi1, manager);
+    // session_shutdown
+    mod.suspendResultDelivery(manager);
+    manager.emit("complete", { runId: "test-run-1" });
+    assert.equal(piCalls(pi1).length, 0);
+
+    // New generation session_start: adopt then rebind (do not poke run.sessionId).
+    const newSession = "sess-replaced";
+    const previous = manager.getSessionId();
+    if (typeof manager.adoptLiveRunsToSession === "function") {
+      manager.adoptLiveRunsToSession(newSession, previous);
+    }
+    manager.setSessionId(newSession);
+    mod.bindSessionDelivery(newSession, pi2 as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(pi2),
+    });
+
+    assert.equal(piCalls(pi2).length, 1, "replacement session receives pending");
+    assert.equal(piCalls(pi1).length, 0, "old session stays silent");
+  });
+
+  // ── Holder refresh on re-call ──
+
+  it("rebinds send on bindSessionDelivery for stale ctx recovery", () => {
+    const pi1 = createMockPi();
+    const pi2 = createMockPi();
+    const manager = createMockManager(makeRun());
+
+    setup(pi1, manager);
+    // Re-bind with second pi (fresh after reload)
+    mod.bindSessionDelivery(SESSION, pi2 as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(pi2),
+    });
 
     manager.emit("complete", { runId: "test-run-1" });
 
-    const calls1 = (pi1 as unknown as { _calls: { content: string }[] })._calls;
-    const calls2 = (pi2 as unknown as { _calls: { content: string }[] })._calls;
-    assert.equal(calls1.length, 0, "pi1 should not be used after refresh");
-    assert.equal(calls2.length, 1, "pi2 should receive the delivery");
+    assert.equal(piCalls(pi1).length, 0, "pi1 should not be used after rebind");
+    assert.equal(piCalls(pi2).length, 1, "pi2 should receive the delivery");
   });
 
   it("refreshes the live delivery settings loader across reload generations", () => {
@@ -587,12 +961,20 @@ describe("installResultDelivery", () => {
     mod.installResultDelivery(pi1 as unknown as ExtensionAPI, manager, {
       loadSettings: () => ({ deliveredResultMaxChars: 400 }),
     });
-    mod.installResultDelivery(pi2 as unknown as ExtensionAPI, manager, {
+    manager.setSessionId(SESSION);
+    mod.bindSessionDelivery(SESSION, pi1 as unknown as ExtensionAPI, {
+      manager,
+      loadSettings: () => ({ deliveredResultMaxChars: 400 }),
+      stableSend: recordingStableSend(pi1),
+    });
+    mod.bindSessionDelivery(SESSION, pi2 as unknown as ExtensionAPI, {
+      manager,
       loadSettings: () => ({ deliveredResultMaxChars: 40 }),
+      stableSend: recordingStableSend(pi2),
     });
     manager.emit("complete", { runId: "test-run-1" });
 
-    const content = (pi2 as unknown as { _calls: { content: string }[] })._calls[0]?.content ?? "";
+    const content = piCalls(pi2)[0]?.content ?? "";
     assert.match(content, /truncated/, "the reused listener reads settings from the fresh generation");
   });
 });

--- a/tests/workflow-tools-available.test.ts
+++ b/tests/workflow-tools-available.test.ts
@@ -25,6 +25,7 @@ import {
   handoffWorkflowRuntime,
   takeWorkflowRuntime,
 } from "../src/extension-reload.js";
+import { _registerBoundSessionSendForTests, _resetDeliveryRegistriesForTests } from "../src/task-panel.js";
 import { buildArmedWorkflowPrompt, WORKFLOW_TOOL_NAME, type WorkflowModeState } from "../src/workflow-editor.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
@@ -525,13 +526,21 @@ describe("workflow extension - control tool availability", () => {
           installExtension(secondPi);
           assert.equal(takeWorkflowRuntime(process.cwd()), undefined, "second generation claims the staged runtime");
 
+          // Production session_start does not pass stableSend — steal map only.
+          _resetDeliveryRegistriesForTests();
+          _registerBoundSessionSendForTests(`session-${reason}`, (msg) => {
+            if (typeof msg.content === "string") secondDelivered.push(msg.content);
+            return Promise.resolve();
+          });
           secondHandlers.session_start?.[0]?.(
             { reason },
             {
               cwd: process.cwd(),
               model: undefined,
               modelRegistry: {},
-              sessionManager: { getSessionId: () => `session-${reason}` },
+              sessionManager: {
+                getSessionId: () => `session-${reason}`,
+              },
               ui: { setWidget: () => {}, notify: () => {} },
             },
           );
@@ -539,6 +548,7 @@ describe("workflow extension - control tool availability", () => {
           const fakeRun = {
             runId: "bg-1",
             background: true,
+            sessionId: `session-${reason}`,
             snapshot: { name: "t", agentCount: 0 },
             result: { agentCount: 0, result: { verdict: `ok-${reason}` } },
           };
@@ -548,7 +558,7 @@ describe("workflow extension - control tool availability", () => {
           staged.manager.emit("complete", { runId: "bg-1" });
           assert.ok(
             secondDelivered.some((c) => c.includes(`ok-${reason}`)),
-            `completion after ${reason} handoff must deliver via the new generation's pi`,
+            `completion after ${reason} handoff must deliver via the stolen host send`,
           );
           discardWorkflowRuntime(process.cwd());
         }
@@ -944,17 +954,30 @@ describe("workflow extension - control tool availability", () => {
         const origGet = mgr.getRun.bind(mgr);
         (mgr as { getRun: (id: string) => unknown }).getRun = (id: string) =>
           id === "bg-prebind" ? fakeRun : origGet(id);
+        // Ensure flush can see the in-memory pending marker (not only disk).
+        const origListLive = mgr.listLiveRuns?.bind(mgr);
+        (mgr as { listLiveRuns: () => unknown[] }).listLiveRuns = () => {
+          const live = origListLive ? origListLive() : [];
+          return live.some((r: { runId?: string }) => r?.runId === "bg-prebind") ? live : [...live, fakeRun];
+        };
         mgr.emit("complete", { runId: "bg-prebind" });
         assert.equal(delivered.length, 0, "must not deliver while runtime unbound");
 
         pi2._bound = true;
+        _resetDeliveryRegistriesForTests();
+        _registerBoundSessionSendForTests("s-prebind", (msg) => {
+          if (typeof msg.content === "string") delivered.push(msg.content);
+          return Promise.resolve();
+        });
         handlers2.session_start?.[0]?.(
           { reason: "reload" },
           {
             cwd: process.cwd(),
             model: undefined,
             modelRegistry: {},
-            sessionManager: { getSessionId: () => "s-prebind" },
+            sessionManager: {
+              getSessionId: () => "s-prebind",
+            },
             ui: { setWidget: () => {}, notify: () => {} },
           },
         );


### PR DESCRIPTION
## Summary

A background workflow's result could be sent to a later Pi session in the same process (or dropped) because delivery used the shared `sendMessage` slot at completion time.

Delivery is now keyed by the run's originating `sessionId`. Completions write a pending marker first and only clear it after a thenable host send acknowledges. In-process session replacement re-homes undelivered work onto the new session. If no host send is available, delivery stays on disk (fail closed) instead of going to whichever session bound last.

## Test plan

- [x] Parallel sessions: only the origin receives the result
- [x] Suspend during replacement, then bind the new session → pending flushes there
- [x] Missing host send leaves pending; does not call shared `sendMessage`
- [x] Child agent sessions are not retained in the steal map