### PR TITLE
fix(workflow): preserve lifecycle control semantics

### DIFF
--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -19,6 +19,17 @@ import {
 } from "./run-persistence.js";
 import { type JournalEntry, parseWorkflowScript, runWorkflow, type WorkflowRunResult } from "./workflow.js";
 
+/** Per-execution identity for an abort initiated by pause()/stop(). */
+interface LifecycleControl {
+  action: "pause" | "stop";
+  abortReason: object;
+}
+
+/** Per-execution identity for an abort received from the host/tool signal. */
+interface ExternalAbort {
+  abortReason: object;
+}
+
 export interface ManagedRun {
   runId: string;
   status: RunStatus;
@@ -61,6 +72,31 @@ export interface ManagedRun {
    * Undefined means eligible (default-on); false opts out.
    */
   autoResume?: boolean;
+  /**
+   * A user-requested lifecycle transition that aborted this exact execution.
+   *
+   * `pause` and `stop` already emit their own semantic events synchronously.
+   * Their later cooperative AbortError is teardown, not an unexpected workflow
+   * failure, so executeRun() must not emit a second generic `error` event (which
+   * would otherwise cause background-result delivery to start a new turn). The
+   * reason identity is compared with AbortSignal.reason: a later lifecycle action
+   * must never mask an error that had already escaped the workflow.
+   * This is deliberately transient: the status is the durable lifecycle fact.
+   */
+  lifecycleControl?: LifecycleControl;
+  /**
+   * External abort that owns this execution. Its identity keeps a provider,
+   * timeout, or other late agent result from reviving an already-aborted run.
+   */
+  externalAbort?: ExternalAbort;
+  /**
+   * Provider limit that escaped the top-level workflow before any manager
+   * lifecycle control could race with runWorkflow's cooperative sibling drain.
+   * This preserves the true terminal cause if pause()/stop() arrives later.
+   */
+  usageLimitEscapedBeforeLifecycleControl?: WorkflowError;
+  /** A provider-limit pause accepted as this run's durable pause reason. */
+  usageLimitPause?: WorkflowError;
   /**
    * The run's resolved hard token budget (per-run value, else the manager
    * default), fixed at run start and carried through resume() — a resumed run
@@ -711,11 +747,26 @@ export class WorkflowManager extends EventEmitter {
       if (this.isCurrent(managed)) onProgress?.(managed.snapshot);
     };
     // Let a host abort (e.g. Esc during a blocking tool call) cancel this run.
-    if (externalSignal) {
-      if (externalSignal.aborted) managed.controller.abort();
-      else externalSignal.addEventListener("abort", () => managed.controller.abort(), { once: true });
-    }
+    // Own this listener for exactly this executeRun() invocation: a reused host
+    // signal must not retain a settled manager/run closure or abort it later.
+    let externalAbortListener: (() => void) | undefined;
     try {
+      if (externalSignal) {
+        externalAbortListener = () => this.abortForExternalSignal(managed);
+        if (externalSignal.aborted) {
+          externalAbortListener();
+        } else {
+          try {
+            externalSignal.addEventListener("abort", externalAbortListener, { once: true });
+          } catch (error) {
+            throw new WorkflowError(
+              `Failed to register external abort listener: ${error instanceof Error ? error.message : String(error)}`,
+              WorkflowErrorCode.AGENT_EXECUTION_ERROR,
+              { recoverable: false, details: error },
+            );
+          }
+        }
+      }
       const result = await runWorkflow(script, {
         cwd: this.cwd,
         args,
@@ -847,6 +898,18 @@ export class WorkflowManager extends EventEmitter {
           this.emitLive(managed, "agentHistory", { runId: managed.runId, agentId: agent?.id, ...event });
           progress();
         },
+        onRunFatal: (error) => {
+          // Capture only provider limits that escaped BEFORE a manager lifecycle
+          // action. runWorkflow calls this before draining run-fatal siblings;
+          // a later pause()/stop() must not erase the quota checkpoint.
+          if (
+            isProviderUsageLimit(error) &&
+            !managed.controller.signal.aborted &&
+            managed.lifecycleControl === undefined
+          ) {
+            managed.usageLimitEscapedBeforeLifecycleControl = error;
+          }
+        },
         onTokenUsage: (usage) => {
           managed.snapshot.tokenUsage = usage;
           this.emitLive(managed, "tokenUsage", { runId: managed.runId, usage });
@@ -887,21 +950,50 @@ export class WorkflowManager extends EventEmitter {
               { recoverable: true },
             );
 
-      const usageLimitPaused = !managed.controller.signal.aborted && isProviderUsageLimit(workflowError);
-      if (managed.controller.signal.aborted) {
-        // Intentional abort (pause/stop/Esc) — preserve status set by pause()/stop()
-        if (managed.status === "running") {
-          managed.status = "aborted";
-        }
-      } else if (usageLimitPaused) {
-        // Provider quota/usage limit: NOT a failure. Checkpoint the run as paused so
-        // the persisted journal (completed agent results) is replayed by resume()
-        // once the budget refills — instead of the user starting from scratch.
+      const escapedUsageLimit = managed.usageLimitEscapedBeforeLifecycleControl;
+      const usageLimitPaused =
+        isProviderUsageLimit(workflowError) &&
+        (escapedUsageLimit === workflowError ||
+          (!managed.controller.signal.aborted && managed.lifecycleControl === undefined));
+      const lifecycleControlOwnsExecution =
+        managed.lifecycleControl !== undefined &&
+        managed.controller.signal.reason === managed.lifecycleControl.abortReason;
+      const externalAbortOwnsExecution =
+        managed.externalAbort !== undefined && managed.controller.signal.reason === managed.externalAbort.abortReason;
+      const lifecycleControlledAbort =
+        workflowError.code === WorkflowErrorCode.WORKFLOW_ABORTED && lifecycleControlOwnsExecution;
+      const lateUsageLimitAfterLifecycleControl =
+        isProviderUsageLimit(workflowError) && lifecycleControlOwnsExecution && !usageLimitPaused;
+      const externalAbortError = externalAbortOwnsExecution
+        ? new WorkflowError("workflow aborted", WorkflowErrorCode.WORKFLOW_ABORTED, { recoverable: true })
+        : undefined;
+      const terminalError = externalAbortError ?? workflowError;
+      if (usageLimitPaused) {
+        // A provider limit that escaped before a later pause()/stop() remains a
+        // quota checkpoint. Preserve its reset hint and scheduler path instead
+        // of letting the later control reclassify it as an ordinary failure.
         managed.status = "paused";
+        managed.usageLimitPause = workflowError;
+      } else if (externalAbortOwnsExecution) {
+        // The host signal happened first. Its cancellation remains the terminal
+        // cause; a non-cooperative agent's late provider/fatal/timeout result
+        // must not turn the aborted run into a failure or quota checkpoint.
+        managed.status = "aborted";
+      } else if (lifecycleControlledAbort || lateUsageLimitAfterLifecycleControl) {
+        // pause()/stop() already announced the requested state. Suppress only
+        // their own AbortError, plus a provider result that arrived AFTER this
+        // control cancelled the execution. The latter cannot revive a stop or
+        // arm quota auto-resume after a human intentionally paused/stopped.
+      } else if (managed.controller.signal.aborted && workflowError.code === WorkflowErrorCode.WORKFLOW_ABORTED) {
+        // A host/external abort remains observable, but is not a failed workflow.
+        managed.status = "aborted";
       } else {
+        // A real failure wins even when the user requested pause/stop after it
+        // escaped (for example, while runWorkflow is cooperatively draining a
+        // run-fatal sibling). Never let a late control marker hide that failure.
         managed.status = "failed";
       }
-      managed.error = workflowError;
+      managed.error = terminalError;
       // Both branches gated via emitLive() (see its doc comment) — a stale
       // execution's "paused"/"error" is equally misleading once superseded.
       if (usageLimitPaused) {
@@ -911,11 +1003,13 @@ export class WorkflowManager extends EventEmitter {
           error: workflowError,
           resetHint: workflowError.resetHint,
         });
-      } else if (this.listenerCount("error") > 0) {
+      } else if (!lifecycleControlledAbort && !lateUsageLimitAfterLifecycleControl && this.listenerCount("error") > 0) {
         // Guarded: EventEmitter throws on an unlistened "error" emit, which
         // would abort this catch block mid-way — skipping the final persist,
-        // the lease release, and the real error rethrow below.
-        this.emitLive(managed, "error", { runId: managed.runId, error: workflowError });
+        // the lease release, and the real error rethrow below. Only the
+        // AbortError proven to originate from pause()/stop() is excluded;
+        // failures that raced with a later lifecycle control still surface.
+        this.emitLive(managed, "error", { runId: managed.runId, error: terminalError });
       }
 
       // Persist final state (see the success-path comment above for the
@@ -933,6 +1027,21 @@ export class WorkflowManager extends EventEmitter {
       }
 
       throw workflowError;
+    } finally {
+      // AbortSignal's once listener is removed when it fires, but explicit
+      // removal is still required for normal/failing/paused executions where
+      // it never fires. removeEventListener is idempotent for already-fired
+      // listeners, so this is also safe across every terminal path.
+      if (externalSignal && externalAbortListener) {
+        try {
+          externalSignal.removeEventListener("abort", externalAbortListener);
+        } catch (error) {
+          // Cleanup must never replace the workflow's real result/error. Keep a
+          // diagnostic for broken host signal implementations without changing
+          // lifecycle state, persistence, lease handling, or delivery.
+          console.warn("[workflow-manager] Failed to remove external abort listener:", error);
+        }
+      }
     }
   }
 
@@ -1030,6 +1139,28 @@ export class WorkflowManager extends EventEmitter {
       usage.cacheWrite += tokenUsage.cacheWrite;
     }
     managed.snapshot.tokenUsage = usage;
+  }
+
+  /** Abort this execution for a host/tool signal, retaining provenance so a
+   * non-cooperative agent's late result cannot overwrite the external abort. */
+  private abortForExternalSignal(managed: ManagedRun): void {
+    if (managed.controller.signal.aborted) return;
+    const abortReason = {};
+    managed.externalAbort = { abortReason };
+    managed.controller.abort(abortReason);
+  }
+
+  /** Abort this execution for an explicit user lifecycle action.
+   *
+   * AbortSignal.reason is an execution-scoped identity token. If the controller
+   * had already been aborted externally, do not replace or annotate it: the
+   * original external failure must remain observable when executeRun() settles.
+   */
+  private abortForLifecycleControl(managed: ManagedRun, action: LifecycleControl["action"]): void {
+    if (managed.controller.signal.aborted) return;
+    const abortReason = {};
+    managed.lifecycleControl = { action, abortReason };
+    managed.controller.abort(abortReason);
   }
 
   private releaseRunLease(managed: ManagedRun): void {
@@ -1147,11 +1278,12 @@ export class WorkflowManager extends EventEmitter {
         agentTimeoutMs: managed.agentTimeoutMs,
         concurrency: managed.concurrency,
         agentRetries: managed.agentRetries,
-        // Why a usage-limit pause happened, so the navigator / a future cold start
-        // can show it and (eventually) re-arm resume after the budget refills.
-        pauseReason: managed.status === "paused" && isProviderUsageLimit(managed.error) ? "usage_limit" : undefined,
+        // Set only when this execution actually accepted a provider-limit
+        // checkpoint. A late provider result after manual pause/stop must not
+        // manufacture a usage-limit resume path from managed.error alone.
+        pauseReason: managed.status === "paused" && managed.usageLimitPause ? "usage_limit" : undefined,
         resetHint:
-          managed.status === "paused" && isProviderUsageLimit(managed.error) ? managed.error.resetHint : undefined,
+          managed.status === "paused" && managed.usageLimitPause ? managed.usageLimitPause.resetHint : undefined,
         phases: managed.snapshot.phases,
         currentPhase: managed.snapshot.currentPhase,
         // Real per-agent timestamps only (see agentTimestamps) — never the run's
@@ -1201,8 +1333,8 @@ export class WorkflowManager extends EventEmitter {
     const managed = this.runs.get(runId);
     if (managed?.status !== "running") return false;
 
-    managed.controller.abort();
     managed.status = "paused";
+    this.abortForLifecycleControl(managed, "pause");
     this.emit("paused", { runId });
     this.persistRun(managed);
     this.releaseRunLease(managed);
@@ -1416,8 +1548,8 @@ export class WorkflowManager extends EventEmitter {
       // `runs` forever (no future tail to mark it eviction-eligible) — a
       // small leak in exactly the class this manager otherwise bounds.
       const hadNoPendingSettle = managed.status === "paused";
-      managed.controller.abort();
       managed.status = "aborted";
+      this.abortForLifecycleControl(managed, "stop");
       this.emit("stopped", { runId });
       this.persistRun(managed);
       this.releaseRunLease(managed);

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -279,6 +279,13 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
     cacheRead?: number;
     cacheWrite?: number;
   }) => void;
+  /**
+   * Top-level workflow error observed before runWorkflow drains in-flight agents.
+   * This preserves error provenance for hosts whose own lifecycle control can race
+   * with that cooperative drain. Observational only: callback failures (sync or
+   * async) are ignored.
+   */
+  onRunFatal?: (error: unknown) => void | PromiseLike<void>;
 }
 
 export interface WorkflowRunResult<T = unknown> {
@@ -1363,7 +1370,23 @@ export async function runWorkflow<T = unknown>(
     // journal — this stops burning an already-exhausted budget right now, at
     // the cost of that sibling's work being thrown away and re-run live when
     // the paused run resumes (it was never journaled, so it isn't cached).
-    if (isTopLevelRun) shared.runFatalController.abort();
+    if (isTopLevelRun) {
+      // Notify the host before the cooperative drain below. A pause/stop can be
+      // requested while siblings settle, but it must not erase a provider-limit
+      // error that had already escaped this top-level workflow.
+      try {
+        const observation = options.onRunFatal?.(error);
+        // The hook is observational, but consumers can still accidentally
+        // return a rejecting thenable. Explicitly consume it so it cannot turn
+        // a workflow's own failure into an unhandled rejection.
+        if (observation != null && typeof (observation as { then?: unknown }).then === "function") {
+          void Promise.resolve(observation).catch(() => {});
+        }
+      } catch {
+        // Instrumentation must never mask the workflow's own terminal error.
+      }
+      shared.runFatalController.abort();
+    }
     throw error;
   } finally {
     // Only the top-level frame drains/disposes (see isTopLevelRun) — a nested

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -1,15 +1,186 @@
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { before, beforeEach, describe, it } from "node:test";
 import { AgentSession, type ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
+import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
+import { UsageLimitScheduler } from "../src/usage-limit-scheduler.js";
+import { WorkflowManager } from "../src/workflow-manager.js";
 
 type DeliveryCall = { content: string; customType?: string; triggerTurn?: boolean };
 type StableSend = (
   msg: { customType?: string; content?: string; display?: boolean },
   opts?: { triggerTurn?: boolean; deliverAs?: string },
 ) => unknown;
+
+const lifecycleScript = `export const meta = { name: 'lifecycle_delivery', description: 'delivery lifecycle test' }
+const result = await agent('wait for control')
+return { result }`;
+
+function controlledAgent() {
+  const resolvers: Array<(value: unknown) => void> = [];
+  let calls = 0;
+  return {
+    runner: {
+      async run() {
+        calls++;
+        return new Promise<unknown>((resolve) => resolvers.push(resolve));
+      },
+    },
+    calls: () => calls,
+    resolve(index: number, value = "done") {
+      resolvers[index]?.(value);
+    },
+    async waitForCalls(expected: number) {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (calls >= expected) return;
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+      assert.fail(`agent did not reach ${expected} calls (saw ${calls})`);
+    },
+  };
+}
+
+const fatalControlRaceScript = `export const meta = { name: 'fatal_control_race', description: 'run-fatal lifecycle race' }
+await parallel([
+  () => agent('fatal', { label: 'fatal' }),
+  () => agent('sibling', { label: 'sibling' }),
+])
+return 'unreachable'`;
+
+function fatalThenDrainAgent() {
+  let siblingAbortObserved = false;
+  let rejectSibling: ((reason?: unknown) => void) | undefined;
+  return {
+    runner: {
+      async run(prompt: string, options: { signal?: AbortSignal } = {}) {
+        if (prompt === "fatal") {
+          throw new WorkflowError("fatal sibling failure", WorkflowErrorCode.AGENT_EXECUTION_ERROR, {
+            recoverable: false,
+          });
+        }
+        return new Promise<unknown>((_resolve, reject) => {
+          rejectSibling = reject;
+          options.signal?.addEventListener(
+            "abort",
+            () => {
+              siblingAbortObserved = true;
+            },
+            { once: true },
+          );
+        });
+      },
+    },
+    async waitForSiblingAbort() {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (siblingAbortObserved) return;
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+      assert.fail("run-fatal signal did not reach the sibling");
+    },
+    settleSibling() {
+      rejectSibling?.(new Error("sibling drained after run-fatal"));
+    },
+  };
+}
+
+const usageLimitControlRaceScript = `export const meta = { name: 'usage_limit_control_race', description: 'usage-limit lifecycle race' }
+await parallel([
+  () => agent('quota', { label: 'quota' }),
+  () => agent('sibling', { label: 'sibling' }),
+])
+return 'unreachable'`;
+
+function usageLimitThenDrainAgent() {
+  let siblingAbortObserved = false;
+  let rejectSibling: ((reason?: unknown) => void) | undefined;
+  return {
+    runner: {
+      async run(prompt: string, options: { signal?: AbortSignal } = {}) {
+        if (prompt === "quota") {
+          throw new WorkflowError("quota exhausted", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, {
+            recoverable: false,
+            resetHint: "Resets in 1m",
+          });
+        }
+        return new Promise<unknown>((_resolve, reject) => {
+          rejectSibling = reject;
+          options.signal?.addEventListener(
+            "abort",
+            () => {
+              siblingAbortObserved = true;
+            },
+            { once: true },
+          );
+        });
+      },
+    },
+    async waitForSiblingAbort() {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (siblingAbortObserved) return;
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+      assert.fail("usage-limit fatal signal did not reach the sibling");
+    },
+    settleSibling() {
+      rejectSibling?.(new Error("sibling drained after usage limit"));
+    },
+  };
+}
+
+function lateUsageLimitAgent() {
+  let rejectAgent: ((reason?: unknown) => void) | undefined;
+  return {
+    runner: {
+      async run() {
+        return new Promise<unknown>((_resolve, reject) => {
+          rejectAgent = reject;
+        });
+      },
+    },
+    async waitForStart() {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (rejectAgent) return;
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+      assert.fail("late provider-limit agent did not start");
+    },
+    rejectWithUsageLimit() {
+      rejectAgent?.(
+        new WorkflowError("late quota exhausted", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, {
+          recoverable: false,
+          resetHint: "Resets in 1m",
+        }),
+      );
+    },
+  };
+}
+
+function lateErrorAgent() {
+  let rejectAgent: ((reason?: unknown) => void) | undefined;
+  return {
+    runner: {
+      async run() {
+        return new Promise<unknown>((_resolve, reject) => {
+          rejectAgent = reject;
+        });
+      },
+    },
+    async waitForStart() {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (rejectAgent) return;
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+      assert.fail("late-error agent did not start");
+    },
+    rejectWith(error: Error) {
+      rejectAgent?.(error);
+    },
+  };
+}
 
 type TaskPanelModule = {
   installResultDelivery: (pi: ExtensionAPI, manager: unknown, opts?: unknown) => void;
@@ -679,6 +850,279 @@ describe("installResultDelivery", () => {
     const calls = piCalls(pi);
     assert.equal(calls.length, 0);
   });
+
+  it("does not deliver or trigger a turn when a real background run is manually paused, then resumes only explicitly", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-dw-pause-delivery-"));
+    const agent = controlledAgent();
+    const manager = new WorkflowManager({ cwd, agent: agent.runner });
+    const pi = createMockPi();
+    const errors: unknown[] = [];
+    manager.on("error", (event) => errors.push(event));
+
+    try {
+      mod.installResultDelivery(pi, manager);
+      manager.setSessionId(SESSION);
+      mod.bindSessionDelivery(SESSION, pi, { manager, stableSend: recordingStableSend(pi) });
+
+      const { runId, promise } = manager.startInBackground(lifecycleScript);
+      await agent.waitForCalls(1);
+
+      assert.equal(manager.pause(runId), true);
+      agent.resolve(0);
+      await promise.catch(() => {});
+      await Promise.resolve();
+
+      assert.equal(manager.getRun(runId)?.status, "paused");
+      assert.equal(agent.calls(), 1, "pause must not restart the workflow");
+      assert.equal(errors.length, 0, "manual pause teardown is not an unexpected error");
+      assert.equal(piCalls(pi).length, 0, "manual pause must not deliver a failed background result");
+
+      assert.equal(await manager.resume(runId), true, "only an explicit resume restarts the workflow");
+      await agent.waitForCalls(2);
+      agent.resolve(1, "resumed");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const calls = piCalls(pi);
+      assert.equal(calls.length, 1, "the explicitly resumed completion is delivered once");
+      assert.equal(calls[0].triggerTurn, true, "only the real completion continues the conversation");
+      assert.match(calls[0].content, /finished/);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("does not deliver or trigger a turn when a real background run is manually stopped", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-dw-stop-delivery-"));
+    const agent = controlledAgent();
+    const manager = new WorkflowManager({ cwd, agent: agent.runner });
+    const pi = createMockPi();
+    const errors: unknown[] = [];
+    manager.on("error", (event) => errors.push(event));
+
+    try {
+      mod.installResultDelivery(pi, manager);
+      manager.setSessionId(SESSION);
+      mod.bindSessionDelivery(SESSION, pi, { manager, stableSend: recordingStableSend(pi) });
+
+      const { runId, promise } = manager.startInBackground(lifecycleScript);
+      await agent.waitForCalls(1);
+
+      assert.equal(manager.stop(runId), true);
+      agent.resolve(0);
+      await promise.catch(() => {});
+      await Promise.resolve();
+
+      assert.equal(manager.getRun(runId)?.status, "aborted");
+      assert.equal(errors.length, 0, "manual stop teardown is not an unexpected error");
+      assert.equal(piCalls(pi).length, 0, "manual stop must not deliver a failed background result");
+      assert.equal(await manager.resume(runId), false, "a stopped run remains non-resumable");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("still delivers an external abort when a later manual pause races its teardown", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-dw-external-abort-delivery-"));
+    const agent = controlledAgent();
+    const manager = new WorkflowManager({ cwd, agent: agent.runner });
+    const pi = createMockPi();
+    const errors: unknown[] = [];
+    manager.on("error", (event) => errors.push(event));
+    const external = new AbortController();
+
+    try {
+      mod.installResultDelivery(pi, manager);
+      manager.setSessionId(SESSION);
+      mod.bindSessionDelivery(SESSION, pi, { manager, stableSend: recordingStableSend(pi) });
+
+      const { runId, promise } = manager.startInBackground(lifecycleScript, undefined, {
+        externalSignal: external.signal,
+      });
+      await agent.waitForCalls(1);
+
+      external.abort();
+      assert.equal(manager.pause(runId), true, "a late pause must not reclassify the external abort");
+      agent.resolve(0);
+      await promise.catch(() => {});
+      await Promise.resolve();
+
+      assert.equal(manager.getRun(runId)?.status, "aborted");
+      assert.equal(errors.length, 1, "an external abort remains observable as an error");
+      const calls = piCalls(pi);
+      assert.equal(calls.length, 1, "an external abort remains visible to the originating conversation");
+      assert.equal(calls[0].triggerTurn, true);
+      assert.match(calls[0].content, /failed: workflow aborted/i);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  for (const lateError of [
+    new WorkflowError("late quota exhausted", WorkflowErrorCode.PROVIDER_USAGE_LIMIT, {
+      recoverable: false,
+      resetHint: "Resets in 1m",
+    }),
+    new WorkflowError("late fatal failure", WorkflowErrorCode.AGENT_EXECUTION_ERROR, { recoverable: false }),
+    new WorkflowError("late timeout", WorkflowErrorCode.AGENT_TIMEOUT, { recoverable: true }),
+  ]) {
+    it(`keeps an external abort terminal when a non-cooperative agent later returns ${lateError.code}`, async () => {
+      const cwd = mkdtempSync(join(tmpdir(), `pi-dw-external-before-${lateError.code}-`));
+      const agent = lateErrorAgent();
+      const manager = new WorkflowManager({ cwd, agent: agent.runner });
+      const pi = createMockPi();
+      const external = new AbortController();
+      const errors: Array<{ error?: WorkflowError }> = [];
+      manager.on("error", (event) => errors.push(event));
+
+      try {
+        mod.installResultDelivery(pi, manager);
+        manager.setSessionId(SESSION);
+        mod.bindSessionDelivery(SESSION, pi, { manager, stableSend: recordingStableSend(pi) });
+
+        const { runId, promise } = manager.startInBackground(lifecycleScript, undefined, {
+          externalSignal: external.signal,
+        });
+        await agent.waitForStart();
+        external.abort();
+        agent.rejectWith(lateError);
+        await promise.catch(() => {});
+        await Promise.resolve();
+
+        assert.equal(manager.getRun(runId)?.status, "aborted");
+        assert.equal(manager.getPersistence().load(runId)?.pauseReason, undefined);
+        assert.equal(errors.length, 1);
+        assert.equal(errors[0]?.error?.code, WorkflowErrorCode.WORKFLOW_ABORTED);
+        const calls = piCalls(pi);
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].triggerTurn, true);
+        assert.match(calls[0].content, /failed: workflow aborted/i);
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  for (const action of ["pause", "stop"] as const) {
+    it(`does not let a late ${action} hide a run-fatal error while a sibling drains`, async () => {
+      const cwd = mkdtempSync(join(tmpdir(), `pi-dw-fatal-${action}-`));
+      const agent = fatalThenDrainAgent();
+      const manager = new WorkflowManager({ cwd, agent: agent.runner });
+      const pi = createMockPi();
+      const errors: Array<{ error?: WorkflowError }> = [];
+      manager.on("error", (event) => errors.push(event));
+
+      try {
+        mod.installResultDelivery(pi, manager);
+        manager.setSessionId(SESSION);
+        mod.bindSessionDelivery(SESSION, pi, { manager, stableSend: recordingStableSend(pi) });
+
+        const { runId, promise } = manager.startInBackground(fatalControlRaceScript);
+        await agent.waitForSiblingAbort();
+        assert.equal(manager[action](runId), true, `late ${action} request is accepted while the sibling drains`);
+
+        agent.settleSibling();
+        await promise.catch(() => {});
+        await Promise.resolve();
+
+        assert.equal(manager.getRun(runId)?.status, "failed", "the earlier run-fatal error wins the lifecycle state");
+        assert.equal(errors.length, 1, "the earlier run-fatal error remains observable");
+        assert.equal(errors[0]?.error?.code, WorkflowErrorCode.AGENT_EXECUTION_ERROR);
+        const calls = piCalls(pi);
+        assert.equal(calls.length, 1, "the real failure is delivered to the originating conversation");
+        assert.equal(calls[0].triggerTurn, true);
+        assert.match(calls[0].content, /fatal sibling failure/);
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  for (const action of ["pause", "stop"] as const) {
+    it(`keeps an earlier usage-limit checkpoint through a late ${action}`, async () => {
+      const cwd = mkdtempSync(join(tmpdir(), `pi-dw-usage-before-${action}-`));
+      const agent = usageLimitThenDrainAgent();
+      const manager = new WorkflowManager({ cwd, agent: agent.runner });
+      const pi = createMockPi();
+      const errors: unknown[] = [];
+      let arms = 0;
+      const scheduler = new UsageLimitScheduler(manager, {
+        setTimer: () => {
+          arms++;
+          return {};
+        },
+        clearTimer: () => {},
+      });
+      manager.on("error", (event) => errors.push(event));
+
+      try {
+        mod.installResultDelivery(pi, manager);
+        manager.setSessionId(SESSION);
+        mod.bindSessionDelivery(SESSION, pi, { manager, stableSend: recordingStableSend(pi) });
+
+        const { runId, promise } = manager.startInBackground(usageLimitControlRaceScript);
+        await agent.waitForSiblingAbort();
+        assert.equal(manager[action](runId), true, `late ${action} is accepted while the sibling drains`);
+
+        agent.settleSibling();
+        await promise.catch(() => {});
+        await Promise.resolve();
+
+        assert.equal(manager.getRun(runId)?.status, "paused", "the earlier quota checkpoint wins the final state");
+        assert.equal(errors.length, 0, "a usage limit is not delivered as a generic error");
+        const persisted = manager.getPersistence().load(runId);
+        assert.equal(persisted?.pauseReason, "usage_limit");
+        assert.equal(persisted?.resetHint, "Resets in 1m");
+        assert.equal(arms, 1, "the usage-limit scheduler is armed after the final pause");
+        const calls = piCalls(pi);
+        assert.equal(calls.length, 1, "the quota checkpoint is delivered once");
+        assert.equal(calls[0].triggerTurn, true);
+        assert.match(calls[0].content, /paused.*Resets in 1m/i);
+      } finally {
+        scheduler.dispose();
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+  }
+
+  for (const action of ["pause", "stop"] as const) {
+    it(`does not let a late usage-limit result revive an earlier ${action}`, async () => {
+      const cwd = mkdtempSync(join(tmpdir(), `pi-dw-${action}-before-usage-`));
+      const agent = lateUsageLimitAgent();
+      const manager = new WorkflowManager({ cwd, agent: agent.runner });
+      const pi = createMockPi();
+      let arms = 0;
+      const scheduler = new UsageLimitScheduler(manager, {
+        setTimer: () => {
+          arms++;
+          return {};
+        },
+        clearTimer: () => {},
+      });
+
+      try {
+        mod.installResultDelivery(pi, manager);
+        manager.setSessionId(SESSION);
+        mod.bindSessionDelivery(SESSION, pi, { manager, stableSend: recordingStableSend(pi) });
+
+        const { runId, promise } = manager.startInBackground(lifecycleScript);
+        await agent.waitForStart();
+        assert.equal(manager[action](runId), true);
+
+        agent.rejectWithUsageLimit();
+        await promise.catch(() => {});
+        await Promise.resolve();
+
+        const expectedStatus = action === "pause" ? "paused" : "aborted";
+        assert.equal(manager.getRun(runId)?.status, expectedStatus);
+        assert.equal(manager.getPersistence().load(runId)?.pauseReason, undefined);
+        assert.equal(arms, 0, "a late quota result after user control must not arm auto-resume");
+        assert.equal(piCalls(pi).length, 0, "a late quota result after user control must not trigger a turn");
+      } finally {
+        scheduler.dispose();
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    });
+  }
 
   it("skips usage-limit pause delivery for foreground runs", () => {
     const pi = createMockPi();

--- a/tests/workflow-manager-abort.test.ts
+++ b/tests/workflow-manager-abort.test.ts
@@ -47,10 +47,202 @@ function deferredAgent() {
   };
 }
 
+/** AbortSignal wrapper that exposes listeners manager code retains. */
+function trackingAbortSignal(options: { throwOnAdd?: boolean; throwOnRemove?: boolean } = {}) {
+  const controller = new AbortController();
+  const listeners = new Set<EventListenerOrEventListenerObject>();
+  let addCalls = 0;
+  let removeCalls = 0;
+  const signal = {
+    get aborted() {
+      return controller.signal.aborted;
+    },
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      eventOptions?: AddEventListenerOptions,
+    ) {
+      addCalls++;
+      if (options.throwOnAdd) throw new Error("add listener failed");
+      if (type === "abort" && listener) listeners.add(listener);
+      controller.signal.addEventListener(type, listener, eventOptions);
+    },
+    removeEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      eventOptions?: EventListenerOptions,
+    ) {
+      removeCalls++;
+      if (options.throwOnRemove) throw new Error("remove listener failed");
+      if (type === "abort" && listener) listeners.delete(listener);
+      controller.signal.removeEventListener(type, listener, eventOptions);
+    },
+  } as unknown as AbortSignal;
+  return {
+    signal,
+    abort: () => controller.abort(),
+    listenerCount: () => listeners.size,
+    addCalls: () => addCalls,
+    removeCalls: () => removeCalls,
+  };
+}
+
 const oneAgentScript = `export const meta = { name: 'tracked_demo', description: 'one agent' }
 phase('Work')
 const a = await agent('do it', { label: 'a' })
 return { a }`;
+
+test(
+  "externalSignal listener is released after normal, failed, paused/resumed, and externally aborted executions",
+  withTempCwd(async (cwd) => {
+    // Normal completion.
+    const normalSignal = trackingAbortSignal();
+    const normalManager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    await normalManager.runSync(oneAgentScript, undefined, { externalSignal: normalSignal.signal });
+    assert.equal(normalSignal.listenerCount(), 0);
+
+    // Failure before the signal aborts.
+    const failedSignal = trackingAbortSignal();
+    const failedManager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          throw new WorkflowError("fatal", WorkflowErrorCode.AGENT_EXECUTION_ERROR, { recoverable: false });
+        },
+      },
+    });
+    failedManager.on("error", () => {});
+    await assert.rejects(failedManager.runSync(oneAgentScript, undefined, { externalSignal: failedSignal.signal }));
+    assert.equal(failedSignal.listenerCount(), 0);
+
+    // Manual pause leaves the old execution settling; after it settles, its
+    // listener is gone and an explicit resume starts a fresh execution safely.
+    const pausedSignal = trackingAbortSignal();
+    const pausedAgent = deferredAgent();
+    const pausedManager = new WorkflowManager({ cwd, agent: pausedAgent.runner });
+    pausedManager.on("error", () => {});
+    const { runId: pausedRunId, promise: pausedPromise } = pausedManager.startInBackground(oneAgentScript, undefined, {
+      externalSignal: pausedSignal.signal,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(pausedManager.pause(pausedRunId), true);
+    pausedAgent.resolve();
+    await pausedPromise.catch(() => {});
+    assert.equal(pausedSignal.listenerCount(), 0);
+    assert.equal(await pausedManager.resume(pausedRunId), true);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(pausedSignal.listenerCount(), 0);
+
+    // A fired signal still reaches a settled execution through its own listener,
+    // which the finally path removes even though EventTarget's once handling is
+    // implementation-owned.
+    const abortedSignal = trackingAbortSignal();
+    const abortedAgent = deferredAgent();
+    const abortedManager = new WorkflowManager({ cwd, agent: abortedAgent.runner });
+    abortedManager.on("error", () => {});
+    const { promise: abortedPromise } = abortedManager.startInBackground(oneAgentScript, undefined, {
+      externalSignal: abortedSignal.signal,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    abortedSignal.abort();
+    abortedAgent.resolve();
+    await abortedPromise.catch(() => {});
+    assert.equal(abortedSignal.listenerCount(), 0);
+
+    // Already-aborted signals never register a listener.
+    const alreadyAbortedSignal = trackingAbortSignal();
+    alreadyAbortedSignal.abort();
+    const alreadyAbortedManager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    alreadyAbortedManager.on("error", () => {});
+    await assert.rejects(
+      alreadyAbortedManager.runSync(oneAgentScript, undefined, { externalSignal: alreadyAbortedSignal.signal }),
+    );
+    assert.equal(alreadyAbortedSignal.listenerCount(), 0);
+  }),
+);
+
+test(
+  "external signal registration and cleanup failures converge without replacing execution outcomes",
+  withTempCwd(async (cwd) => {
+    // Cleanup failure after a successful synchronous run is diagnostic-only.
+    const successfulCleanupSignal = trackingAbortSignal({ throwOnRemove: true });
+    const successfulManager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    const successfulResult = await successfulManager.runSync(oneAgentScript, undefined, {
+      externalSignal: successfulCleanupSignal.signal,
+    });
+    assert.equal((successfulResult.result as { a?: unknown }).a, "ok");
+    assert.equal(successfulManager.getRun(successfulResult.runId ?? "")?.status, "completed");
+    assert.equal(successfulCleanupSignal.removeCalls(), 1);
+
+    // Cleanup failure must not replace the original workflow error.
+    const failedCleanupSignal = trackingAbortSignal({ throwOnRemove: true });
+    const failedManager = new WorkflowManager({
+      cwd,
+      agent: {
+        async run() {
+          throw new WorkflowError("original workflow failure", WorkflowErrorCode.AGENT_EXECUTION_ERROR, {
+            recoverable: false,
+          });
+        },
+      },
+    });
+    failedManager.on("error", () => {});
+    await assert.rejects(
+      failedManager.runSync(oneAgentScript, undefined, { externalSignal: failedCleanupSignal.signal }),
+      /original workflow failure/,
+    );
+    assert.equal(failedManager.listRuns()[0]?.status, "failed");
+    assert.equal(failedCleanupSignal.removeCalls(), 1);
+
+    // Background completion also survives a throwing cleanup implementation.
+    const backgroundCleanupSignal = trackingAbortSignal({ throwOnRemove: true });
+    const backgroundManager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    const { runId: backgroundRunId, promise: backgroundPromise } = backgroundManager.startInBackground(
+      oneAgentScript,
+      undefined,
+      {
+        externalSignal: backgroundCleanupSignal.signal,
+      },
+    );
+    await backgroundPromise;
+    assert.equal(backgroundManager.getRun(backgroundRunId)?.status, "completed");
+    assert.equal(backgroundCleanupSignal.removeCalls(), 1);
+
+    // Registration failure enters executeRun's normal error convergence path for
+    // both synchronous and background callers: status/persistence/lease/error
+    // are all finalized rather than leaving a permanently-running row.
+    const syncRegistrationSignal = trackingAbortSignal({ throwOnAdd: true });
+    const syncRegistrationManager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    syncRegistrationManager.on("error", () => {});
+    await assert.rejects(
+      syncRegistrationManager.runSync(oneAgentScript, undefined, { externalSignal: syncRegistrationSignal.signal }),
+      /Failed to register external abort listener: add listener failed/,
+    );
+    assert.equal(syncRegistrationManager.listRuns()[0]?.status, "failed");
+    assert.equal(syncRegistrationSignal.addCalls(), 1);
+    assert.equal(syncRegistrationSignal.removeCalls(), 1);
+
+    const backgroundRegistrationSignal = trackingAbortSignal({ throwOnAdd: true });
+    const backgroundRegistrationManager = new WorkflowManager({ cwd, agent: fakeAgent() });
+    const observedErrors: WorkflowError[] = [];
+    backgroundRegistrationManager.on("error", (event: { error: WorkflowError }) => observedErrors.push(event.error));
+    const { runId: registrationRunId, promise: registrationPromise } = backgroundRegistrationManager.startInBackground(
+      oneAgentScript,
+      undefined,
+      { externalSignal: backgroundRegistrationSignal.signal },
+    );
+    await assert.rejects(registrationPromise, /Failed to register external abort listener: add listener failed/);
+    assert.equal(backgroundRegistrationManager.getRun(registrationRunId)?.status, "failed");
+    assert.equal(
+      backgroundRegistrationManager.listRuns().find((run) => run.runId === registrationRunId)?.status,
+      "failed",
+    );
+    assert.equal(observedErrors.length, 1);
+    assert.match(observedErrors[0]?.message ?? "", /Failed to register external abort listener/);
+    assert.equal(backgroundRegistrationSignal.addCalls(), 1);
+    assert.equal(backgroundRegistrationSignal.removeCalls(), 1);
+  }),
+);
 
 /** Run each manager test with isolated cwd and HOME so workflow state is isolated. */
 function withTempCwd(fn: (cwd: string) => Promise<void>) {

--- a/tests/workflow-runtime.test.ts
+++ b/tests/workflow-runtime.test.ts
@@ -1383,6 +1383,40 @@ function abortAwareAgent(delayMs: number) {
   };
 }
 
+test("onRunFatal consumes an asynchronous observer rejection without masking the workflow error", async () => {
+  let unhandled: unknown;
+  const onUnhandled = (reason: unknown) => {
+    unhandled = reason;
+  };
+  process.on("unhandledRejection", onUnhandled);
+  const script = `export const meta = { name: 'fatal_observer', description: 'fatal observer' }
+await agent('failer')`;
+  const runner = {
+    async run() {
+      throw new WorkflowError("primary workflow failure", WorkflowErrorCode.AGENT_EXECUTION_ERROR, {
+        recoverable: false,
+      });
+    },
+  };
+
+  try {
+    await assert.rejects(
+      runWorkflow(script, {
+        agent: runner,
+        persistLogs: false,
+        onRunFatal: async () => {
+          throw new Error("observer rejection");
+        },
+      }),
+      /primary workflow failure/,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.equal(unhandled, undefined, "observer rejection must be consumed");
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+});
+
 test("a run-fatal error aborts in-flight parallel() siblings instead of letting them run to completion", async () => {
   const { state, runner } = abortAwareAgent(200);
   const script = `export const meta = { name: 'fatal_abort', description: 'sibling abort' }


### PR DESCRIPTION
## Summary

- distinguish explicit pause/stop teardown from unexpected workflow failures
- preserve first-cause precedence across provider usage limits, external aborts, fatal errors, and timeouts
- prevent lifecycle teardown from emitting failed background delivery or triggering a new model turn
- release external abort listeners and converge listener setup/cleanup failures

## Why

Pausing a background workflow could correctly leave the run paused while also emitting `Background workflow ... failed: workflow aborted`. That failed delivery could trigger a new model turn and start the workflow again. Races between lifecycle controls and real failures could also overwrite the true terminal cause.

## Validation

- `npm test` — 1,231/1,231 tests passed
- targeted lifecycle, runtime, delivery, and usage-limit scheduler coverage
- `npm run release:verify` — 0 warnings
- real Pi RPC smoke — paused a live background run without failed delivery or an extra triggered turn, then explicitly resumed the same run to `PAUSE_RESUME_OK`

Closes #150
