### PR TITLE
feat(workflows): add navigator filter, rename, and confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Pi can manage background runs directly with the `workflow_control` tool instead 
 | `/ultracode [off]` | Toggle exhaustive automatic workflows |
 | `/effort off\|high\|ultra` | Set the standing orchestration effort |
 
-In the navigator: `↑/↓` select · `enter/→` open · `esc/←` back · `p` pause · `x` stop · `r` restart · `s` save · `q` quit.
+In the navigator: `↑/↓` select · `PgUp/PgDn` page · `Home/End` jump · `/` filter runs by name, ID, or status and saved workflows by name or description · `enter/→` open · `esc/←` back. Filter text updates the visible list immediately; `enter` commits the draft filter. In filter-edit mode, `esc` cancels the draft and keeps the committed query; in browse mode, `esc` first clears an existing filter without closing the navigator, and only a second `esc` with no filter backs/closes normally. On a run, `p` pauses (press `p` again to confirm), `x` stops (press `x` again to confirm), `r` restarts, and `s` saves; these lifecycle controls remain bound to the run while viewing its phases, agents, or detail. On a saved workflow (including its detail view), `r` renames and `x` deletes (press `x` again to confirm). Rename `enter` commits and `esc` cancels; names cannot contain whitespace, controls, or path separators. `q` quits.
 
 Agent details use a compact summary by default: completed agents show their final result, while active agents show the prompt and two latest history events. Press `enter` to open the full syntax-highlighted pager. In the pager, use `j/k` or `↑/↓` for lines, `PgUp/PgDn` for pages, `g/G` for the ends, and `t` to toggle live tail mode.
 

--- a/src/builtin-commands.ts
+++ b/src/builtin-commands.ts
@@ -15,6 +15,7 @@ import type { ExtensionAPI, ExtensionCommandContext, ToolDefinition } from "@ear
 import type { BuiltinWorkflowInvocation } from "./builtin-workflows.js";
 import { findBuiltinWorkflow } from "./builtin-workflows.js";
 import { MAX_DIFF_CHARS } from "./code-review.js";
+import { claimCommand, isCommandRegistered } from "./command-registry.js";
 import { parseCommandArgs } from "./saved-commands.js";
 import type { WorkflowManager } from "./workflow-manager.js";
 import { createWorkflowStorage, type WorkflowStorage } from "./workflow-saved.js";
@@ -259,11 +260,7 @@ function shortError(error: unknown): string {
 }
 
 function alreadyRegistered(pi: ExtensionAPI, name: string): boolean {
-  try {
-    return (pi.getCommands?.() ?? []).some((c: { name: string }) => c.name === name);
-  } catch {
-    return false;
-  }
+  return isCommandRegistered(pi, name);
 }
 
 /** Split a command argument string into tokens, respecting single/double quotes. */
@@ -401,6 +398,7 @@ export function registerBuiltinWorkflows(
         );
       },
     });
+    claimCommand(pi, "deep-research", "builtin");
   }
 
   if (!alreadyRegistered(pi, "adversarial-review")) {
@@ -415,6 +413,7 @@ export function registerBuiltinWorkflows(
         startBackground(getManager(), ctx, "adversarial-review", resolved.script, { task });
       },
     });
+    claimCommand(pi, "adversarial-review", "builtin");
   }
 
   if (!alreadyRegistered(pi, "code-review")) {
@@ -534,6 +533,7 @@ export function registerBuiltinWorkflows(
         startBackground(getManager(), ctx, "code-review", resolved.script, { diff, diffSource });
       },
     });
+    claimCommand(pi, "code-review", "builtin");
   }
 
   if (!alreadyRegistered(pi, "multi-perspective")) {
@@ -552,6 +552,7 @@ export function registerBuiltinWorkflows(
         startBackground(getManager(), ctx, "multi-perspective", resolved.script);
       },
     });
+    claimCommand(pi, "multi-perspective", "builtin");
   }
 
   if (!alreadyRegistered(pi, "codebase-audit")) {
@@ -568,5 +569,6 @@ export function registerBuiltinWorkflows(
         startBackground(getManager(), ctx, "codebase-audit", resolved.script);
       },
     });
+    claimCommand(pi, "codebase-audit", "builtin");
   }
 }

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1,0 +1,54 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export type CommandOwner = "builtin" | "saved";
+
+type CommandOwners = Map<string, CommandOwner>;
+type RegistryCarrier = { [commandOwnersKey]?: CommandOwners };
+
+const commandOwnersKey = Symbol.for("pi-dynamic-workflows.command-owners");
+const fallbackRegistries = new WeakMap<object, CommandOwners>();
+
+function registryFor(pi: ExtensionAPI): CommandOwners {
+  const carrier = pi as unknown as RegistryCarrier;
+  const existing = carrier[commandOwnersKey];
+  if (existing) return existing;
+
+  const registry: CommandOwners = new Map();
+  try {
+    Object.defineProperty(carrier, commandOwnersKey, {
+      configurable: false,
+      enumerable: false,
+      value: registry,
+      writable: false,
+    });
+    return registry;
+  } catch {
+    // A frozen or host-provided API object cannot carry the reload-stable symbol;
+    // retain ownership for the lifetime of this API object as a safe fallback.
+    const fallback = fallbackRegistries.get(pi as object);
+    if (fallback) return fallback;
+    fallbackRegistries.set(pi as object, registry);
+    return registry;
+  }
+}
+
+export function isCommandRegistered(pi: ExtensionAPI, name: string): boolean {
+  try {
+    return (pi.getCommands?.() ?? []).some((command: { name: string }) => command.name === name);
+  } catch {
+    return false;
+  }
+}
+
+export function commandOwner(pi: ExtensionAPI, name: string): CommandOwner | undefined {
+  return registryFor(pi).get(name);
+}
+
+/** Claim a command only after this extension has successfully registered it. */
+export function claimCommand(pi: ExtensionAPI, name: string, owner: CommandOwner): boolean {
+  const registry = registryFor(pi);
+  const current = registry.get(name);
+  if (current && current !== owner) return false;
+  registry.set(name, owner);
+  return true;
+}

--- a/src/fs-persistence.ts
+++ b/src/fs-persistence.ts
@@ -67,9 +67,26 @@ export function ensureDir(fs: PersistenceFsLayer, dir: string): void {
  * power loss on a filesystem/OS combination where rename isn't fully atomic).
  */
 export function writeJsonAtomicWithBackup(fs: PersistenceFsLayer, path: string, data: unknown): void {
+  writeJsonAtomic(fs, path, data, false);
+}
+
+/**
+ * The same tmp-write + atomic-rename protocol, but reports a backup-write
+ * failure. Mutations that must retain a source record until a replacement is
+ * fully recoverable (notably saved-workflow rename) use this stricter variant.
+ */
+export function writeJsonAtomicWithBackupStrict(fs: PersistenceFsLayer, path: string, data: unknown): void {
+  writeJsonAtomic(fs, path, data, true);
+}
+
+function writeJsonAtomic(fs: PersistenceFsLayer, path: string, data: unknown, strictBackup: boolean): void {
   const json = JSON.stringify(data, null, 2);
   fs.writeFileSync(`${path}.tmp`, json);
   fs.renameSync(`${path}.tmp`, path);
+  if (strictBackup) {
+    fs.writeFileSync(`${path}.bak`, json);
+    return;
+  }
   try {
     fs.writeFileSync(`${path}.bak`, json);
   } catch {

--- a/src/saved-commands.ts
+++ b/src/saved-commands.ts
@@ -4,16 +4,26 @@
  */
 
 import { createCodingTools, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { claimCommand, commandOwner, isCommandRegistered } from "./command-registry.js";
 import { runWorkflow, type WorkflowRunResult } from "./workflow.js";
 import type { WorkflowManager } from "./workflow-manager.js";
 import type { SavedWorkflow, WorkflowStorage } from "./workflow-saved.js";
 
-function isRegistered(pi: ExtensionAPI, name: string): boolean {
-  try {
-    return (pi.getCommands?.() ?? []).some((c: { name: string }) => c.name === name);
-  } catch {
-    return false;
-  }
+function savedCommandOwnedByExtension(pi: ExtensionAPI, name: string): boolean {
+  const owner = commandOwner(pi, name);
+  return owner === "builtin" || owner === "saved";
+}
+
+/**
+ * Pi cannot unregister a slash command. Distinguish commands this extension
+ * owns from built-ins/other extensions before a save or rename reaches disk.
+ */
+export function savedWorkflowCommandAvailability(
+  pi: ExtensionAPI,
+  name: string,
+): { ok: true } | { ok: false; message: string } {
+  if (!isCommandRegistered(pi, name) || savedCommandOwnedByExtension(pi, name)) return { ok: true };
+  return { ok: false, message: `/${name} is already provided by Pi or another extension.` };
 }
 
 function reportText(result: WorkflowRunResult): string {
@@ -22,18 +32,13 @@ function reportText(result: WorkflowRunResult): string {
   return JSON.stringify(result.result, null, 2);
 }
 
-/**
- * Parse a command argument string into an `args` object for the script.
- * Supports `key=value` tokens; everything else collects into `_` (and `_raw`).
- * Declared parameter defaults fill in missing keys.
- */
 export function parseCommandArgs(raw: string, parameters?: SavedWorkflow["parameters"]): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   const positional: string[] = [];
-  for (const tok of raw.trim().split(/\s+/).filter(Boolean)) {
-    const eq = tok.indexOf("=");
-    if (eq > 0) out[tok.slice(0, eq)] = tok.slice(eq + 1);
-    else positional.push(tok);
+  for (const token of raw.trim().split(/\s+/).filter(Boolean)) {
+    const eq = token.indexOf("=");
+    if (eq > 0) out[token.slice(0, eq)] = token.slice(eq + 1);
+    else positional.push(token);
   }
   out._ = positional.join(" ");
   out._raw = raw.trim();
@@ -43,92 +48,74 @@ export function parseCommandArgs(raw: string, parameters?: SavedWorkflow["parame
   return out;
 }
 
-/** Register one saved workflow as a `/<name>` command (idempotent).
- * When a WorkflowManager is provided, the workflow runs through it (visible in
- * /workflows TUI, background execution, task panel). Otherwise falls back to
- * the inline runWorkflow() (foreground, no TUI tracking).
- *
- * Pi has no `unregisterCommand`, so a command cannot be removed mid-session
- * after its workflow is deleted (it is correctly gone on next launch, since
- * registerAllSavedWorkflows only registers what's in storage). The optional
- * `exists` predicate lets the handler detect that case at invocation time and
- * tell the user to reload rather than silently re-running a deleted workflow. */
+/** Register one saved workflow as a dynamically loaded slash command. */
 export function registerSavedWorkflow(
   pi: ExtensionAPI,
   cwd: string | (() => string),
   wf: Pick<SavedWorkflow, "name" | "description" | "script" | "parameters">,
   manager?: WorkflowManager | (() => WorkflowManager | undefined),
   exists?: () => boolean,
-  /**
-   * Live loader for this command's workflow. Prefer this over the registration-
-   * time `wf` snapshot: after an in-process project switch the same slash
-   * command name may resolve to a different script (or nothing) in the new
-   * project's storage. When omitted, `wf` is used as a frozen snapshot.
-   */
   loadWorkflow?: () => Pick<SavedWorkflow, "name" | "description" | "script" | "parameters"> | null | undefined,
-): void {
-  if (isRegistered(pi, wf.name)) return;
+): { ok: true } | { ok: false; message: string } {
+  const availability = savedWorkflowCommandAvailability(pi, wf.name);
+  if (!availability.ok) return availability;
+  if (isCommandRegistered(pi, wf.name)) return { ok: true };
   const getCwd = typeof cwd === "function" ? cwd : () => cwd;
   const getManager = typeof manager === "function" ? manager : () => manager;
-  pi.registerCommand(wf.name, {
-    description: wf.description || `Saved workflow: ${wf.name}`,
-    async handler(args: string, ctx: ExtensionCommandContext) {
-      // Resolve the workflow at invocation time so a cross-project session
-      // switch picks up the target project's script (or reports deletion)
-      // instead of replaying the source project's registration-time snapshot.
-      const liveWf = loadWorkflow ? loadWorkflow() : exists && !exists() ? null : wf;
-      if (!liveWf) {
-        ctx.ui.notify(
-          `/${wf.name} is not available in this project — reload the session to drop the stale command.`,
-          "warning",
-        );
-        return;
-      }
-      try {
-        const liveManager = getManager();
-        if (liveManager) {
-          // Run through the WorkflowManager's background path: the handler
-          // returns immediately (awaiting the promise here would block the whole
-          // session, #104), progress shows in the /workflows TUI and task panel,
-          // and installResultDelivery posts the result back into the
-          // conversation on completion — sending it here too would duplicate it.
-          const { runId } = liveManager.startInBackground(liveWf.script, parseCommandArgs(args, liveWf.parameters));
+  try {
+    pi.registerCommand(wf.name, {
+      description: wf.description || `Saved workflow: ${wf.name}`,
+      async handler(args: string, ctx: ExtensionCommandContext) {
+        // The loader is deliberately evaluated at invocation. After rename/delete
+        // the old unavoidable Pi registration cannot execute a frozen script.
+        const liveWorkflow = loadWorkflow ? loadWorkflow() : exists && !exists() ? null : wf;
+        if (!liveWorkflow) {
           ctx.ui.notify(
-            `/${liveWf.name} running in the background (${runId}) — watch the task panel or /workflows; the result is posted here when it finishes.`,
-            "info",
+            `/${wf.name} is not available in this project — reload the session to drop the stale command.`,
+            "warning",
           );
           return;
         }
-        // Fallback: inline runWorkflow (foreground, no TUI tracking, blocks).
-        const liveCwd = getCwd();
-        ctx.ui.notify(`Starting /${liveWf.name}…`, "info");
-        const result = await runWorkflow(liveWf.script, {
-          cwd: liveCwd,
-          args: parseCommandArgs(args, liveWf.parameters),
-          tools: createCodingTools(liveCwd),
-          onPhase: (title) => ctx.ui.setStatus(`wf:${liveWf.name}`, `${liveWf.name}: ${title}`),
-        });
-        ctx.ui.setStatus(`wf:${liveWf.name}`, undefined);
-        await pi.sendMessage({
-          customType: `workflow:${liveWf.name}`,
-          content: reportText(result),
-          display: true,
-        });
-      } catch (error) {
-        ctx.ui.setStatus(`wf:${liveWf.name}`, undefined);
-        ctx.ui.notify(`/${liveWf.name} failed: ${error instanceof Error ? error.message : error}`, "error");
-      }
-    },
-  });
+        try {
+          const liveManager = getManager();
+          if (liveManager) {
+            const { runId } = liveManager.startInBackground(
+              liveWorkflow.script,
+              parseCommandArgs(args, liveWorkflow.parameters),
+            );
+            ctx.ui.notify(
+              `/${liveWorkflow.name} running in the background (${runId}) — watch the task panel or /workflows; the result is posted here when it finishes.`,
+              "info",
+            );
+            return;
+          }
+          const liveCwd = getCwd();
+          ctx.ui.notify(`Starting /${liveWorkflow.name}…`, "info");
+          const result = await runWorkflow(liveWorkflow.script, {
+            cwd: liveCwd,
+            args: parseCommandArgs(args, liveWorkflow.parameters),
+            tools: createCodingTools(liveCwd),
+            onPhase: (title) => ctx.ui.setStatus(`wf:${liveWorkflow.name}`, `${liveWorkflow.name}: ${title}`),
+          });
+          ctx.ui.setStatus(`wf:${liveWorkflow.name}`, undefined);
+          await pi.sendMessage({
+            customType: `workflow:${liveWorkflow.name}`,
+            content: reportText(result),
+            display: true,
+          });
+        } catch (error) {
+          ctx.ui.setStatus(`wf:${liveWorkflow.name}`, undefined);
+          ctx.ui.notify(`/${liveWorkflow.name} failed: ${error instanceof Error ? error.message : error}`, "error");
+        }
+      },
+    });
+    claimCommand(pi, wf.name, "saved");
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, message: error instanceof Error ? error.message : String(error) };
+  }
 }
 
-/** Register every saved workflow found in storage.
- * When a WorkflowManager is provided, workflows run through it (visible in
- * /workflows TUI, background execution, task panel). Idempotent: names already
- * registered (including from a previous project) are skipped at registration
- * time, but each handler re-loads by name from the live storage so a later
- * project switch executes the target project's script. Call again after a
- * cross-project session_start to pick up target-only names. */
 export function registerAllSavedWorkflows(
   pi: ExtensionAPI,
   cwd: string | (() => string),
@@ -137,12 +124,12 @@ export function registerAllSavedWorkflows(
 ): void {
   const getStorage = typeof storage === "function" ? storage : () => storage;
   const getCwd = typeof cwd === "function" ? cwd : () => cwd;
-  for (const wf of getStorage().list()) {
-    const name = wf.name;
+  for (const workflow of getStorage().list()) {
+    const name = workflow.name;
     registerSavedWorkflow(
       pi,
       getCwd,
-      wf,
+      workflow,
       manager,
       () => getStorage().load(name) != null,
       () => getStorage().load(name),

--- a/src/workflow-saved.ts
+++ b/src/workflow-saved.ts
@@ -2,6 +2,7 @@
  * Save and load reusable workflow commands.
  */
 
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import {
   ensureDir as ensureDirFs,
@@ -9,10 +10,12 @@ import {
   type PersistenceFsLayer,
   readJsonWithBackupRecovery,
   resolvePersistenceFs,
-  unlinkIfExistsSafe,
   writeJsonAtomicWithBackup,
+  writeJsonAtomicWithBackupStrict,
 } from "./fs-persistence.js";
 import { workflowProjectPaths, workflowUserSavedDir } from "./workflow-paths.js";
+
+export type SavedWorkflowSource = "project" | "legacy" | "user";
 
 export interface SavedWorkflow {
   /** Command name (filename without extension). */
@@ -23,158 +26,333 @@ export interface SavedWorkflow {
   script: string;
   /** Optional parameter schema for parameterized workflows. */
   parameters?: Record<string, { type: string; description?: string; required?: boolean; default?: unknown }>;
-  /** Where this workflow is saved. */
+  /** Display location retained for compatibility with existing callers. */
   location: "project" | "user";
-  /** Full file path. */
+  /** Exact persistence tier that supplied this row. */
+  source: SavedWorkflowSource;
+  /** Full file path. This is part of the row's identity, not display metadata. */
   path: string;
   /** When it was saved. */
   savedAt: string;
 }
 
-export interface WorkflowStorage {
-  /** Save a workflow. */
-  save(workflow: Omit<SavedWorkflow, "path" | "savedAt">, location?: "project" | "user"): SavedWorkflow;
-  /** Load a workflow by name. */
-  load(name: string): SavedWorkflow | null;
-  /** List all saved workflows. */
-  list(): SavedWorkflow[];
-  /** Delete a saved workflow. */
-  delete(name: string, location?: "project" | "user"): boolean;
+export type SavedWorkflowMutationResult =
+  | { ok: true; workflow?: SavedWorkflow }
+  | {
+      ok: false;
+      code: "missing" | "stale" | "conflict" | "invalid" | "io-error";
+      message: string;
+    };
+
+/** Stable content fingerprint used to guard mutations against same-path races. */
+export function savedWorkflowRevision(
+  workflow: Pick<SavedWorkflow, "name" | "description" | "script" | "parameters" | "savedAt">,
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        name: workflow.name,
+        description: workflow.description,
+        script: workflow.script,
+        parameters: workflow.parameters ?? null,
+        savedAt: workflow.savedAt,
+      }),
+    )
+    .digest("hex");
 }
 
+export interface WorkflowStorage {
+  /** Save a workflow. New saves default to the current project tier. */
+  save(workflow: Omit<SavedWorkflow, "path" | "savedAt" | "source">, location?: "project" | "user"): SavedWorkflow;
+  /** Load a workflow by name according to project > legacy > user precedence. */
+  load(name: string): SavedWorkflow | null;
+  /** List visible workflows, one highest-precedence row per command name. */
+  list(): SavedWorkflow[];
+  /** Delete precisely the source represented by the visible row. */
+  delete(workflow: SavedWorkflow | string, location?: "project" | "user"): SavedWorkflowMutationResult | boolean;
+  /** Rename precisely the source represented by the visible row. */
+  rename(workflow: SavedWorkflow, name: string): SavedWorkflowMutationResult;
+}
+
+/**
+ * Saved workflow names are Pi slash-command names as well as filenames. Keep the
+ * validation in one place so `/workflows save`, rename, and command registration
+ * have the same reachability boundary. Whitespace, controls, Unicode format
+ * characters (including bidi controls), and path separators never form a safe
+ * command/file identity.
+ */
 export function isSafeSavedWorkflowName(name: string): boolean {
   return (
     name.length > 0 &&
     name.length <= 128 &&
     name.trim() === name &&
+    !/[\s/\\\0]/u.test(name) &&
+    !/[\p{Cc}\p{Cf}]/u.test(name) &&
     name !== "." &&
-    name !== ".." &&
-    !/[/\\\0]/.test(name)
+    name !== ".."
   );
 }
 
 export function assertSafeSavedWorkflowName(name: string): void {
   if (!isSafeSavedWorkflowName(name)) {
-    throw new Error("Saved workflow name must be a non-empty path-safe name without slashes.");
+    throw new Error(
+      "Saved workflow name must be a non-empty path-safe name usable as a slash command, without whitespace, controls, or paths.",
+    );
   }
 }
 
 export function createWorkflowStorage(cwd: string, fsOverride?: Partial<PersistenceFsLayer>): WorkflowStorage {
   const fs = resolvePersistenceFs(fsOverride);
   const paths = workflowProjectPaths(cwd);
-  const projectDir = paths.savedDir;
-  const legacyProjectDir = paths.legacySavedDir;
-  const userDir = workflowUserSavedDir();
+  const dirs: Record<SavedWorkflowSource, string> = {
+    project: paths.savedDir,
+    legacy: paths.legacySavedDir,
+    user: workflowUserSavedDir(),
+  };
 
   const ensureDir = (dir: string) => ensureDirFs(fs, dir);
-
-  const workflowPath = (name: string, location: "project" | "user") => {
+  const locationFor = (source: SavedWorkflowSource): "project" | "user" => (source === "user" ? "user" : "project");
+  const sourcePath = (name: string, source: SavedWorkflowSource): string => {
     assertSafeSavedWorkflowName(name);
-    const dir = location === "project" ? projectDir : userDir;
-    return join(dir, `${name}.json`);
+    return join(dirs[source], `${name}.json`);
   };
-  const legacyProjectWorkflowPath = (name: string) => {
-    assertSafeSavedWorkflowName(name);
-    return join(legacyProjectDir, `${name}.json`);
+  const sourceFor = (workflow: SavedWorkflow): SavedWorkflowSource => {
+    if (workflow.source === "project" || workflow.source === "legacy" || workflow.source === "user")
+      return workflow.source;
+    // Defensive compatibility for records supplied by older callers. Real rows
+    // always carry source and are still checked against their exact path below.
+    if (workflow.path.startsWith(dirs.legacy)) return "legacy";
+    return workflow.location === "user" ? "user" : "project";
   };
-
-  // Same atomic-write-with-backup + corrupt-file recovery contract as
-  // run-persistence.ts (see fs-persistence.ts) — a saved workflow is a
-  // user-authored artifact just as worth protecting from a crash mid-write
-  // or a truncated file as a run's resumable state is.
-  const loadFromFile = (path: string, location: "project" | "user"): SavedWorkflow | null => {
+  const loadFromFile = (path: string, source: SavedWorkflowSource): SavedWorkflow | null => {
     const data = readJsonWithBackupRecovery<Record<string, unknown>>(fs, path);
-    if (!data || typeof data !== "object" || !isSafeSavedWorkflowName((data as { name?: string }).name ?? "")) {
+    if (!data || typeof data !== "object" || !isSafeSavedWorkflowName((data as { name?: string }).name ?? ""))
       return null;
-    }
     return {
-      ...(data as Omit<SavedWorkflow, "location" | "path">),
-      location,
+      ...(data as Omit<SavedWorkflow, "location" | "source" | "path">),
+      location: locationFor(source),
+      source,
       path,
     };
+  };
+  const hasRecord = (path: string): boolean => {
+    try {
+      return fs.existsSync(path) || fs.existsSync(`${path}.bak`);
+    } catch {
+      return true; // unreadable means do not overwrite something we cannot verify
+    }
+  };
+  type ExactCurrentResult = Exclude<SavedWorkflowMutationResult, { ok: true }> | { ok: true; workflow: SavedWorkflow };
+  const exactCurrent = (workflow: SavedWorkflow): ExactCurrentResult => {
+    const source = sourceFor(workflow);
+    let expected: string;
+    try {
+      expected = sourcePath(workflow.name, source);
+    } catch (error) {
+      return { ok: false, code: "invalid", message: error instanceof Error ? error.message : String(error) };
+    }
+    if (workflow.path !== expected) {
+      return {
+        ok: false,
+        code: "stale",
+        message: "Saved workflow source changed; refresh the navigator before retrying.",
+      };
+    }
+    const current = loadFromFile(expected, source);
+    if (!current) {
+      return hasRecord(expected)
+        ? { ok: false, code: "stale", message: "Saved workflow source is unreadable or no longer valid." }
+        : { ok: false, code: "missing", message: "Saved workflow no longer exists." };
+    }
+    if (
+      current.source !== source ||
+      current.name !== workflow.name ||
+      savedWorkflowRevision(current) !== savedWorkflowRevision(workflow)
+    ) {
+      return { ok: false, code: "stale", message: "Saved workflow changed; refresh the navigator before retrying." };
+    }
+    return { ok: true, workflow: current };
+  };
+  type FileSnapshot = { path: string; existed: boolean; contents?: string };
+  const snapshotFile = (path: string): FileSnapshot => {
+    const existed = fs.existsSync(path);
+    return existed ? { path, existed, contents: fs.readFileSync(path, "utf-8") } : { path, existed };
+  };
+  const restoreFile = (snapshot: FileSnapshot): void => {
+    if (snapshot.existed) fs.writeFileSync(snapshot.path, snapshot.contents ?? "");
+    else if (fs.existsSync(snapshot.path)) fs.unlinkSync(snapshot.path);
+  };
+  const cleanupTarget = (path: string): void => {
+    // Failure injection is intentionally transient. Retry cleanup so a failed
+    // transaction cannot leave a target that blocks the next attempt.
+    for (const candidate of [`${path}.tmp`, path, `${path}.bak`]) {
+      for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+          if (!fs.existsSync(candidate)) break;
+          fs.unlinkSync(candidate);
+          break;
+        } catch {
+          if (attempt === 1) break;
+        }
+      }
+    }
+  };
+  const removeSource = (path: string): SavedWorkflowMutationResult => {
+    let primary: FileSnapshot;
+    let backup: FileSnapshot;
+    try {
+      primary = snapshotFile(path);
+      backup = snapshotFile(`${path}.bak`);
+    } catch (error) {
+      return { ok: false, code: "io-error", message: error instanceof Error ? error.message : String(error) };
+    }
+    if (!primary.existed && !backup.existed)
+      return { ok: false, code: "missing", message: "Saved workflow no longer exists." };
+    try {
+      // Remove recovery first. If primary removal fails, restore the sidecar so
+      // neither deletion nor a later recovery read can observe a half-state.
+      if (backup.existed) fs.unlinkSync(backup.path);
+      if (primary.existed) fs.unlinkSync(primary.path);
+      return { ok: true };
+    } catch (error) {
+      try {
+        restoreFile(primary);
+        restoreFile(backup);
+      } catch {
+        // Preserve the original I/O error; the source is restored when the
+        // injected failure is transient, and retry remains safe either way.
+      }
+      return { ok: false, code: "io-error", message: error instanceof Error ? error.message : String(error) };
+    }
   };
 
   return {
     save(workflow, location = "project") {
       assertSafeSavedWorkflowName(workflow.name);
-      const dir = location === "project" ? projectDir : userDir;
-      ensureDir(dir);
-
-      const path = workflowPath(workflow.name, location);
+      const source: SavedWorkflowSource = location === "user" ? "user" : "project";
+      ensureDir(dirs[source]);
+      const path = sourcePath(workflow.name, source);
       const saved: SavedWorkflow = {
         ...workflow,
         location,
+        source,
         path,
         savedAt: new Date().toISOString(),
       };
-
       writeJsonAtomicWithBackup(fs, path, saved);
       return saved;
     },
 
     load(name: string): SavedWorkflow | null {
       if (!isSafeSavedWorkflowName(name)) return null;
-      // Project takes precedence over user
-      const projectPath = workflowPath(name, "project");
-      const project = loadFromFile(projectPath, "project");
-      if (project) return project;
-
-      const legacyProject = loadFromFile(legacyProjectWorkflowPath(name), "project");
-      if (legacyProject) return legacyProject;
-
-      const userPath = workflowPath(name, "user");
-      return loadFromFile(userPath, "user");
+      return (
+        loadFromFile(sourcePath(name, "project"), "project") ??
+        loadFromFile(sourcePath(name, "legacy"), "legacy") ??
+        loadFromFile(sourcePath(name, "user"), "user")
+      );
     },
 
     list(): SavedWorkflow[] {
       const workflows: SavedWorkflow[] = [];
-
       const seen = new Set<string>();
-      const addDir = (dir: string, location: "project" | "user") => {
-        // A missing or unreadable directory (not yet created, deleted
-        // mid-race, permission-denied) degrades to "no files" here — same
-        // guard run-persistence.ts's list() uses — rather than throwing and
-        // taking down the whole listing over one bad storage location.
-        for (const file of listJsonFilesSafe(fs, dir)) {
-          const wf = loadFromFile(join(dir, file), location);
-          if (wf && !seen.has(wf.name)) {
-            seen.add(wf.name);
-            workflows.push(wf);
+      const addDir = (source: SavedWorkflowSource) => {
+        for (const file of listJsonFilesSafe(fs, dirs[source])) {
+          const workflow = loadFromFile(join(dirs[source], file), source);
+          if (workflow && !seen.has(workflow.name)) {
+            seen.add(workflow.name);
+            workflows.push(workflow);
           }
         }
       };
-
-      // Priority order mirrors load(): project > legacy project > user.
-      addDir(projectDir, "project");
-      addDir(legacyProjectDir, "project");
-      addDir(userDir, "user");
-
+      addDir("project");
+      addDir("legacy");
+      addDir("user");
       return workflows.sort((a, b) => a.name.localeCompare(b.name));
     },
 
-    delete(name: string, location?: "project" | "user"): boolean {
-      if (!isSafeSavedWorkflowName(name)) return false;
-      const locations = location ? [location] : (["project", "user"] as const);
-      let deleted = false;
-
-      for (const loc of locations) {
-        const path = workflowPath(name, loc);
-        // Clean up the .bak sidecar too, mirroring run-persistence.ts's delete()
-        // (sidecar cleanup does not by itself count as "deleted the workflow").
-        unlinkIfExistsSafe(fs, `${path}.bak`);
-        if (unlinkIfExistsSafe(fs, path)) {
+    delete(workflow: SavedWorkflow | string, location?: "project" | "user"): SavedWorkflowMutationResult | boolean {
+      if (typeof workflow === "string") {
+        if (!isSafeSavedWorkflowName(workflow)) return false;
+        const sources: SavedWorkflowSource[] =
+          location === "user"
+            ? ["user"]
+            : location === "project"
+              ? ["project", "legacy"]
+              : ["project", "legacy", "user"];
+        let deleted = false;
+        for (const source of sources) {
+          const current = loadFromFile(sourcePath(workflow, source), source);
+          if (!current) continue;
+          const result = removeSource(current.path);
+          if (!result.ok) return false;
           deleted = true;
         }
-        if (loc === "project") {
-          const legacyPath = legacyProjectWorkflowPath(name);
-          unlinkIfExistsSafe(fs, `${legacyPath}.bak`);
-          if (unlinkIfExistsSafe(fs, legacyPath)) {
-            deleted = true;
-          }
+        return deleted;
+      }
+      const current = exactCurrent(workflow);
+      if (!current.ok) return current;
+      return removeSource(current.workflow.path);
+    },
+
+    rename(workflow, name): SavedWorkflowMutationResult {
+      if (!isSafeSavedWorkflowName(name)) {
+        return {
+          ok: false,
+          code: "invalid",
+          message:
+            "Saved workflow name must be a non-empty slash-command-safe name without whitespace, controls, or paths.",
+        };
+      }
+      const current = exactCurrent(workflow);
+      if (!current.ok) return current;
+      if (name === current.workflow.name) return { ok: true, workflow: current.workflow };
+
+      // A command name is globally resolved by precedence, so a target that is
+      // occupied in any tier is ambiguous even when the current row is hidden by
+      // another tier. Reject before writing instead of mutating a fallback by name.
+      for (const source of ["project", "legacy", "user"] as const) {
+        const target = sourcePath(name, source);
+        if (hasRecord(target)) {
+          return { ok: false, code: "conflict", message: `A saved workflow named /${name} already exists.` };
         }
       }
 
-      return deleted;
+      const source = sourceFor(current.workflow);
+      const targetPath = sourcePath(name, source);
+      const renamed: SavedWorkflow = {
+        ...current.workflow,
+        name,
+        source,
+        location: locationFor(source),
+        path: targetPath,
+        savedAt: new Date().toISOString(),
+      };
+      let sourcePrimary: FileSnapshot;
+      let sourceBackup: FileSnapshot;
+      try {
+        ensureDir(dirs[source]);
+        sourcePrimary = snapshotFile(current.workflow.path);
+        sourceBackup = snapshotFile(`${current.workflow.path}.bak`);
+        // The replacement must have both primary and backup before the source
+        // can be touched. A failed strict write is cleaned before returning.
+        writeJsonAtomicWithBackupStrict(fs, targetPath, renamed);
+      } catch (error) {
+        cleanupTarget(targetPath);
+        return { ok: false, code: "io-error", message: error instanceof Error ? error.message : String(error) };
+      }
+      const removed = removeSource(current.workflow.path);
+      if (!removed.ok) {
+        cleanupTarget(targetPath);
+        try {
+          restoreFile(sourcePrimary);
+          restoreFile(sourceBackup);
+        } catch {
+          // The original bytes are restored whenever the injected failure is
+          // transient; cleanup makes the next retry deterministic.
+        }
+        return removed;
+      }
+      return { ok: true, workflow: renamed };
     },
   };
 }

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -27,9 +27,15 @@ import type { AgentUsage } from "./agent.js";
 import type { ThemeLike, WorkflowAgentSnapshot, WorkflowSnapshot } from "./display.js";
 import { aggregateAgentUsage, fmtCost, fmtTokenSegment, tokenFigures } from "./display.js";
 import type { PersistedRunState } from "./run-persistence.js";
-import { registerSavedWorkflow } from "./saved-commands.js";
+import { registerSavedWorkflow, savedWorkflowCommandAvailability } from "./saved-commands.js";
 import type { WorkflowManager } from "./workflow-manager.js";
-import type { SavedWorkflow, WorkflowStorage } from "./workflow-saved.js";
+import {
+  isSafeSavedWorkflowName,
+  type SavedWorkflow,
+  type SavedWorkflowMutationResult,
+  savedWorkflowRevision,
+  type WorkflowStorage,
+} from "./workflow-saved.js";
 
 const STATUS_ICON: Record<string, string> = {
   pending: "·",
@@ -101,6 +107,31 @@ const BOX_BORDER_OVERHEAD = BOX_BORDER_LEFT.length + BOX_BORDER_RIGHT.length;
 export type ViewKind = "runs" | "phases" | "agents" | "detail" | "savedDetail";
 
 export type ItemKind = "run" | "saved";
+export type NavigatorInputMode = "browse" | "filter" | "rename" | "confirm";
+
+export type ItemIdentity =
+  | { kind: "run"; runId: string }
+  | { kind: "saved"; path: string; source: SavedWorkflow["source"]; name: string; revision: string };
+
+export interface VisibleRunItem {
+  kind: "run";
+  identity: Extract<ItemIdentity, { kind: "run" }>;
+  row: RunRow;
+}
+
+export interface VisibleSavedItem {
+  kind: "saved";
+  identity: Extract<ItemIdentity, { kind: "saved" }>;
+  workflow: SavedWorkflow;
+}
+
+export type VisibleNavigatorItem = VisibleRunItem | VisibleSavedItem;
+
+/** One coherent, filtered source of truth for every runs-pane operation. */
+export interface NavigatorSnapshot {
+  filter: string;
+  items: VisibleNavigatorItem[];
+}
 
 interface RunRow {
   runId: string;
@@ -176,12 +207,19 @@ export function shortModel(model: string | undefined): string | undefined {
 export class NavigatorModel {
   private frameDepth = 0;
   private frameRuns: PersistedRunState[] | undefined;
+  private frameSaved: SavedWorkflow[] | undefined;
   private readonly frameSnapshots = new Map<string, { snapshot: WorkflowSnapshot; status: string } | undefined>();
+
+  private readonly getStorage: () => Pick<WorkflowStorage, "list" | "delete" | "rename"> | undefined;
 
   constructor(
     private readonly manager: Pick<WorkflowManager, "listRuns" | "getRun">,
-    private readonly storage?: { list(): SavedWorkflow[]; delete(name: string, location?: string): boolean },
-  ) {}
+    storage?:
+      | Pick<WorkflowStorage, "list" | "delete" | "rename">
+      | (() => Pick<WorkflowStorage, "list" | "delete" | "rename"> | undefined),
+  ) {
+    this.getStorage = typeof storage === "function" ? storage : () => storage;
+  }
 
   /** Share persisted data across all model lookups performed by one render. */
   withRenderFrame<T>(render: () => T): T {
@@ -193,6 +231,7 @@ export class NavigatorModel {
       this.frameDepth--;
       if (outermost) {
         this.frameRuns = undefined;
+        this.frameSaved = undefined;
         this.frameSnapshots.clear();
       }
     }
@@ -249,14 +288,53 @@ export class NavigatorModel {
 
   /** Return saved workflows sorted by name, or [] when no storage configured. */
   saved(): SavedWorkflow[] {
-    if (!this.storage) return [];
-    return this.storage.list().sort((a, b) => a.name.localeCompare(b.name));
+    const storage = this.getStorage();
+    if (!storage) return [];
+    if (this.frameDepth === 0) return storage.list().sort((a, b) => a.name.localeCompare(b.name));
+    if (!this.frameSaved) this.frameSaved = storage.list().sort((a, b) => a.name.localeCompare(b.name));
+    return this.frameSaved;
   }
 
-  /** Delete a saved workflow by name. */
-  deleteSaved(name: string): boolean {
-    if (!this.storage) return false;
-    return this.storage.delete(name);
+  /** Build the sole filtered item list used by list rendering, footer, drill, and actions. */
+  visible(filter: string): NavigatorSnapshot {
+    const needle = filter.toLocaleLowerCase();
+    const contains = (...values: unknown[]) =>
+      !needle || values.some((value) => asText(value).toLocaleLowerCase().includes(needle));
+    const items: VisibleNavigatorItem[] = [];
+    for (const row of this.runs()) {
+      if (contains(row.name, row.runId, row.status)) {
+        items.push({ kind: "run", identity: { kind: "run", runId: row.runId }, row });
+      }
+    }
+    for (const workflow of this.saved()) {
+      if (contains(workflow.name, workflow.description)) {
+        items.push({
+          kind: "saved",
+          identity: savedIdentity(workflow),
+          workflow,
+        });
+      }
+    }
+    return { filter, items };
+  }
+
+  /** Delete exactly the currently visible saved source. */
+  deleteSaved(workflow: SavedWorkflow): SavedWorkflowMutationResult {
+    const storage = this.getStorage();
+    if (!storage) return { ok: false, code: "io-error", message: "Saving is not available (no storage)." };
+    const result = storage.delete(workflow);
+    return typeof result === "boolean"
+      ? result
+        ? { ok: true }
+        : { ok: false, code: "missing", message: "Saved workflow no longer exists." }
+      : result;
+  }
+
+  /** Rename exactly the currently visible saved source. */
+  renameSaved(workflow: SavedWorkflow, name: string): SavedWorkflowMutationResult {
+    const storage = this.getStorage();
+    if (!storage) return { ok: false, code: "io-error", message: "Saving is not available (no storage)." };
+    return storage.rename(workflow, name);
   }
 
   runName(runId: string): string {
@@ -333,15 +411,6 @@ export class NavigatorModel {
   }
 }
 
-type StackFrame = {
-  kind: ViewKind;
-  cursor: number;
-  runId?: string;
-  phase?: string;
-  agentId?: number;
-  savedName?: string;
-};
-
 function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
   // Array guards (#110): structurally corrupt persisted arrays must not crash
   // the overlay. Resumable runs also avoid duplicating full results in agents[]
@@ -393,14 +462,129 @@ function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
   };
 }
 
-/** Navigation state machine: a stack of (view, cursor) frames plus detail scroll. */
+/** Navigation state machine. Runs-pane selection is an item identity; cursor is
+ * only the location where that identity is rendered. */
+type StackFrame = {
+  kind: ViewKind;
+  cursor: number;
+  runId?: string;
+  phase?: string;
+  agentId?: number;
+  savedName?: string;
+  savedIdentity?: Extract<ItemIdentity, { kind: "saved" }>;
+  selected?: ItemIdentity;
+};
+
+type ConfirmKind = "pause" | "stop" | "deleteSaved";
+type ConfirmationContext = {
+  kind: ViewKind;
+  runId?: string;
+  phase?: string;
+  agentId?: number;
+  savedIdentity?: Extract<ItemIdentity, { kind: "saved" }>;
+};
+type PendingConfirmation = {
+  action: ConfirmKind;
+  target: ItemIdentity;
+  cursor: number;
+  filter: string;
+  context: ConfirmationContext;
+};
+
+function savedIdentity(workflow: SavedWorkflow): Extract<ItemIdentity, { kind: "saved" }> {
+  return {
+    kind: "saved",
+    path: workflow.path,
+    source: workflow.source,
+    name: workflow.name,
+    revision: savedWorkflowRevision(workflow),
+  };
+}
+
+function sameIdentity(a: ItemIdentity | undefined, b: ItemIdentity | undefined): boolean {
+  if (!a || !b || a.kind !== b.kind) return false;
+  if (a.kind === "run" && b.kind === "run") return a.runId === b.runId;
+  const left = a as Extract<ItemIdentity, { kind: "saved" }>;
+  const right = b as Extract<ItemIdentity, { kind: "saved" }>;
+  return (
+    left.path === right.path &&
+    left.source === right.source &&
+    left.name === right.name &&
+    left.revision === right.revision
+  );
+}
+function graphemes(text: string): string[] {
+  const Segmenter = Intl.Segmenter;
+  return Segmenter ? [...new Segmenter().segment(text)].map((entry) => entry.segment) : Array.from(text);
+}
+
+/** Remove terminal control sequences while preserving ordinary pasted text. */
+export function safeInputText(data: string): string {
+  let out = "";
+  let index = 0;
+  while (index < data.length) {
+    if (data.charCodeAt(index) === 0x1b) {
+      const next = data[index + 1];
+      if (next === "[") {
+        // CSI: consume through its final byte (0x40–0x7e).
+        index += 2;
+        while (index < data.length) {
+          const code = data.charCodeAt(index++);
+          if (code >= 0x40 && code <= 0x7e) break;
+        }
+        continue;
+      }
+      if (next === "]") {
+        // OSC: consume the command, payload, and either BEL or ST terminator.
+        // An unterminated OSC is discarded through the end rather than leaking
+        // its title/parameters into the user's filter or rename.
+        index += 2;
+        while (index < data.length) {
+          if (data.charCodeAt(index) === 0x07) {
+            index++;
+            break;
+          }
+          if (data.charCodeAt(index) === 0x1b && data[index + 1] === "\\") {
+            index += 2;
+            break;
+          }
+          index++;
+        }
+        continue;
+      }
+      // Drop a bare ESC and an ST terminator; neither is user text.
+      index += next === "\\" ? 2 : 1;
+      continue;
+    }
+
+    const codePoint = data.codePointAt(index) ?? 0;
+    const char = String.fromCodePoint(codePoint);
+    if (codePoint === 0x7f || codePoint < 0x20 || (codePoint >= 0x80 && codePoint <= 0x9f)) {
+      index += char.length;
+      continue;
+    }
+    if (/\p{Cf}/u.test(char)) {
+      index += char.length;
+      continue;
+    }
+    out += char;
+    index += char.length;
+  }
+  return out;
+}
+
 export class NavigatorState {
   private stack: StackFrame[] = [{ kind: "runs", cursor: 0 }];
+  private pending?: PendingConfirmation;
+  private renameTarget?: Extract<ItemIdentity, { kind: "saved" }>;
+  private filterSelection?: ItemIdentity;
+  mode: NavigatorInputMode = "browse";
+  filter = "";
+  draft = "";
   scroll = 0;
   tailing = false;
   pagerOpen = false;
   private pageSize = 1;
-
   private top(): StackFrame {
     return this.stack[this.stack.length - 1];
   }
@@ -411,6 +595,7 @@ export class NavigatorState {
     return this.top().cursor;
   }
   set cursor(val: number) {
+    this.cancelConfirmation();
     this.top().cursor = val;
   }
   get runId(): string | undefined {
@@ -422,30 +607,59 @@ export class NavigatorState {
   get agentId(): number | undefined {
     return this.top().agentId;
   }
-  /** The saved workflow name at the cursor in savedDetail view */
   get savedName(): string | undefined {
     return this.top().savedName;
   }
   get depth(): number {
     return this.stack.length;
   }
+  get confirmationAction(): ConfirmKind | undefined {
+    return this.pending?.action;
+  }
 
-  /**
-   * Determine what kind of item is at the given cursor position in the
-   * runs view. Positions before runs.length are "run"; after are "saved".
-   */
+  /** Reconcile selection after any list/filter/manager change without drifting. */
+  reconcile(snapshot: NavigatorSnapshot, managerEvent = false): void {
+    if (this.kind !== "runs") return;
+    if (managerEvent) this.cancelConfirmation();
+    const top = this.top();
+    const index = snapshot.items.findIndex((item) => sameIdentity(top.selected, item.identity));
+    if (index >= 0) {
+      top.cursor = index;
+      return;
+    }
+    // Preserve the nearest row when filtering, deletion, rename, or a manager
+    // refresh removes the previous identity. A non-empty list always has one.
+    top.selected = undefined;
+    top.cursor = snapshot.items.length ? Math.max(0, Math.min(top.cursor, snapshot.items.length - 1)) : 0;
+    if (snapshot.items.length) top.selected = snapshot.items[top.cursor]?.identity;
+  }
+  noteManagerEvent(snapshot: NavigatorSnapshot): void {
+    this.reconcile(snapshot, true);
+  }
+  currentItem(snapshot: NavigatorSnapshot): VisibleNavigatorItem | undefined {
+    this.reconcile(snapshot);
+    return snapshot.items.find((item) => sameIdentity(this.top().selected, item.identity));
+  }
   itemKindAt(model: NavigatorModel, cursor: number): ItemKind {
-    const runCount = model.runs().length;
-    return cursor < runCount ? "run" : "saved";
+    const snapshot = model.visible(this.filter);
+    this.reconcile(snapshot);
+    return snapshot.items[cursor]?.kind ?? "run";
   }
-
-  /** Clamp the cursor to [0, count). */
   clamp(count: number) {
-    const t = this.top();
-    t.cursor = count <= 0 ? 0 : Math.max(0, Math.min(t.cursor, count - 1));
+    const top = this.top();
+    top.cursor = count <= 0 ? 0 : Math.max(0, Math.min(top.cursor, count - 1));
   }
-
-  move(delta: number, count: number) {
+  moveRuns(delta: number, snapshot: NavigatorSnapshot): void {
+    this.cancelConfirmation();
+    this.reconcile(snapshot);
+    if (!snapshot.items.length) return;
+    const current = snapshot.items.findIndex((item) => sameIdentity(this.top().selected, item.identity));
+    const base = current >= 0 ? current : this.cursor;
+    const next = (base + delta + snapshot.items.length) % snapshot.items.length;
+    this.top().cursor = next;
+    this.top().selected = snapshot.items[next]?.identity;
+  }
+  move(delta: number, count: number, snapshot?: NavigatorSnapshot) {
     if (this.kind === "detail" || this.kind === "savedDetail") {
       if (this.kind === "detail") this.pagerOpen = true;
       if (delta < 0) this.tailing = false;
@@ -453,17 +667,15 @@ export class NavigatorState {
       return;
     }
     if (count <= 0) return;
-    const t = this.top();
-    t.cursor = (t.cursor + delta + count) % count;
+    this.cancelConfirmation();
+    const top = this.top();
+    top.cursor = (top.cursor + delta + count) % count;
+    if (this.kind === "runs" && snapshot) top.selected = snapshot.items[top.cursor]?.identity;
   }
-
-  /** Update the amount moved by page keys to match the rendered viewport. */
   setPageSize(rows: number) {
     this.pageSize = Math.max(1, rows);
   }
-
-  /** Move by almost one viewport, retaining one line of reading context. */
-  movePage(direction: -1 | 1, count: number) {
+  movePage(direction: -1 | 1, count: number, snapshot?: NavigatorSnapshot) {
     const delta = direction * Math.max(1, this.pageSize - 1);
     if (this.kind === "detail" || this.kind === "savedDetail") {
       if (this.kind === "detail") this.pagerOpen = true;
@@ -471,23 +683,22 @@ export class NavigatorState {
       this.scroll = Math.max(0, this.scroll + delta);
       return;
     }
-    if (count > 0) this.cursor = Math.max(0, Math.min(count - 1, this.cursor + delta));
+    if (count <= 0) return;
+    this.cancelConfirmation();
+    this.top().cursor = Math.max(0, Math.min(count - 1, this.cursor + delta));
+    if (this.kind === "runs" && snapshot) this.top().selected = snapshot.items[this.cursor]?.identity;
   }
-
-  /** Jump to the beginning or end of the current list/detail. End also enables
-   * follow mode for a live agent detail; start disables it. */
-  jump(edge: "start" | "end", count: number) {
+  jump(edge: "start" | "end", count: number, snapshot?: NavigatorSnapshot) {
     if (this.kind === "detail" || this.kind === "savedDetail") {
       if (this.kind === "detail") this.pagerOpen = true;
       this.tailing = this.kind === "detail" && edge === "end";
-      // renderNavigator knows the body length and clamps this sentinel.
       this.scroll = edge === "start" ? 0 : Number.MAX_SAFE_INTEGER;
       return;
     }
+    this.cancelConfirmation();
     this.cursor = edge === "start" || count <= 0 ? 0 : count - 1;
+    if (this.kind === "runs" && snapshot) this.top().selected = snapshot.items[this.cursor]?.identity;
   }
-
-  /** Open the full pager without closing an already-open pager. */
   openPager(): boolean {
     if (this.kind !== "detail") return false;
     if (!this.pagerOpen) {
@@ -496,8 +707,6 @@ export class NavigatorState {
     }
     return true;
   }
-
-  /** Toggle the full pager while retaining the compact agent summary view. */
   togglePager(): boolean {
     if (this.kind !== "detail") return false;
     if (!this.pagerOpen) return this.openPager();
@@ -506,8 +715,6 @@ export class NavigatorState {
     this.tailing = false;
     return false;
   }
-
-  /** Toggle live follow mode in an agent detail pager. */
   toggleTail(): boolean {
     if (this.kind !== "detail") return false;
     this.pagerOpen = true;
@@ -515,51 +722,60 @@ export class NavigatorState {
     if (this.tailing) this.scroll = Number.MAX_SAFE_INTEGER;
     return this.tailing;
   }
-
-  /** Drill into the selected item. Returns true if the view changed. */
-  drill(model: NavigatorModel): boolean {
-    const t = this.top();
-    if (t.kind === "runs") {
-      const runs = model.runs();
-      const saved = model.saved();
-      if (t.cursor < runs.length) {
-        // Drilling into a run
-        const run = runs[t.cursor];
-        if (!run) return false;
-        this.stack.push({ kind: "phases", cursor: 0, runId: run.runId });
-        return true;
-      }
-      // Drilling into a saved workflow
-      const item = saved[t.cursor - runs.length];
+  drill(model: NavigatorModel, provided?: NavigatorSnapshot): boolean {
+    const top = this.top();
+    if (top.kind === "runs") {
+      const snapshot = provided ?? model.visible(this.filter);
+      const item = this.currentItem(snapshot);
       if (!item) return false;
+      this.cancelConfirmation();
+      if (item.kind === "run") {
+        this.filter = "";
+        this.mode = "browse";
+        this.stack.push({ kind: "phases", cursor: 0, runId: item.row.runId });
+      } else {
+        this.scroll = 0;
+        this.tailing = false;
+        this.pagerOpen = false;
+        this.stack.push({
+          kind: "savedDetail",
+          cursor: 0,
+          savedName: item.workflow.name,
+          savedIdentity: item.identity,
+        });
+      }
+      return true;
+    }
+    if (top.kind === "phases" && top.runId) {
+      const phase = model.phases(top.runId)[top.cursor];
+      if (!phase) return false;
+      this.stack.push({ kind: "agents", cursor: 0, runId: top.runId, phase: phase.title });
+      return true;
+    }
+    if (top.kind === "agents" && top.runId && top.phase) {
+      const agent = model.agents(top.runId, top.phase)[top.cursor];
+      if (!agent) return false;
       this.scroll = 0;
       this.tailing = false;
       this.pagerOpen = false;
-      this.stack.push({ kind: "savedDetail", cursor: 0, savedName: item.name });
-      return true;
-    }
-    if (t.kind === "phases" && t.runId) {
-      const phases = model.phases(t.runId);
-      const ph = phases[t.cursor];
-      if (!ph) return false;
-      this.stack.push({ kind: "agents", cursor: 0, runId: t.runId, phase: ph.title });
-      return true;
-    }
-    if (t.kind === "agents" && t.runId && t.phase) {
-      const agents = model.agents(t.runId, t.phase);
-      const ag = agents[t.cursor];
-      if (!ag) return false;
-      this.scroll = 0;
-      this.tailing = false;
-      this.pagerOpen = false;
-      this.stack.push({ kind: "detail", cursor: 0, runId: t.runId, phase: t.phase, agentId: ag.id });
+      this.stack.push({ kind: "detail", cursor: 0, runId: top.runId, phase: top.phase, agentId: agent.id });
       return true;
     }
     return false;
   }
-
-  /** Pop one level. Returns false when already at the top (caller should close). */
   back(): boolean {
+    this.cancelConfirmation();
+    if (this.mode === "filter" || this.mode === "rename") {
+      this.cancelInput();
+      return true;
+    }
+    // Esc first clears an applied filter while keeping the navigator open. A
+    // second Esc with no filter follows the ordinary stack/back behavior.
+    if (this.kind === "runs" && this.filter) {
+      this.filter = "";
+      this.draft = "";
+      return true;
+    }
     if (this.kind === "detail" && this.pagerOpen) {
       this.pagerOpen = false;
       this.scroll = 0;
@@ -573,15 +789,141 @@ export class NavigatorState {
     this.pagerOpen = false;
     return true;
   }
-
-  /** The runId at cursor, or undefined when on a saved item. */
-  activeRunId(model: NavigatorModel): string | undefined {
+  activeRunId(model: NavigatorModel, snapshot?: NavigatorSnapshot): string | undefined {
     if (this.runId) return this.runId;
+    if (this.kind !== "runs") return undefined;
+    const item = this.currentItem(snapshot ?? model.visible(this.filter));
+    return item?.kind === "run" ? item.row.runId : undefined;
+  }
+  activeSaved(snapshot: NavigatorSnapshot, allSaved: SavedWorkflow[]): SavedWorkflow | undefined {
     if (this.kind === "runs") {
-      const runs = model.runs();
-      if (this.cursor < runs.length) return runs[this.cursor]?.runId;
+      const item = this.currentItem(snapshot);
+      return item?.kind === "saved" ? item.workflow : undefined;
+    }
+    if (this.kind === "savedDetail") {
+      const identity = this.top().savedIdentity;
+      return allSaved.find((workflow) => sameIdentity(identity, savedIdentity(workflow)));
     }
     return undefined;
+  }
+  beginFilter(): void {
+    if (this.kind !== "runs") return;
+    this.cancelConfirmation();
+    this.mode = "filter";
+    this.draft = this.filter;
+    this.filterSelection = this.top().selected;
+  }
+  /** Query used to render the live draft while filter text is being edited. */
+  effectiveFilter(): string {
+    return this.mode === "filter" ? this.draft : this.filter;
+  }
+  beginRename(workflow: SavedWorkflow): void {
+    this.cancelConfirmation();
+    this.mode = "rename";
+    this.draft = workflow.name;
+    this.renameTarget = savedIdentity(workflow);
+  }
+  appendInput(data: string): void {
+    if (this.mode === "filter" || this.mode === "rename") this.draft += safeInputText(data);
+  }
+  backspaceInput(): void {
+    if (this.mode === "filter" || this.mode === "rename") this.draft = graphemes(this.draft).slice(0, -1).join("");
+  }
+  applyFilter(model: NavigatorModel): NavigatorSnapshot {
+    this.filter = this.draft;
+    this.mode = "browse";
+    this.draft = "";
+    const snapshot = model.visible(this.filter);
+    this.reconcile(snapshot);
+    this.filterSelection = undefined;
+    return snapshot;
+  }
+  takeRename(): { target: Extract<ItemIdentity, { kind: "saved" }>; name: string } | undefined {
+    if (this.mode !== "rename" || !this.renameTarget) return undefined;
+    const result = { target: this.renameTarget, name: this.draft };
+    this.mode = "browse";
+    this.draft = "";
+    this.renameTarget = undefined;
+    return result;
+  }
+  replaceSavedIdentity(previous: Extract<ItemIdentity, { kind: "saved" }>, workflow: SavedWorkflow): void {
+    const next = savedIdentity(workflow);
+    for (const frame of this.stack) {
+      if (frame.selected && sameIdentity(frame.selected, previous)) frame.selected = next;
+      if (frame.savedIdentity && sameIdentity(frame.savedIdentity, previous)) {
+        frame.savedIdentity = next;
+        frame.savedName = workflow.name;
+      }
+    }
+  }
+
+  cancelInput(): void {
+    // Canceling a filter edit must never discard the last query that was
+    // applied. Restore the identity selected when editing began as well; the
+    // draft may briefly have filtered it out while the user was typing.
+    if (this.mode === "filter" && this.filterSelection) this.top().selected = this.filterSelection;
+    this.mode = "browse";
+    this.draft = "";
+    this.filterSelection = undefined;
+    this.renameTarget = undefined;
+  }
+  private confirmationContext(): ConfirmationContext {
+    const frame = this.top();
+    return {
+      kind: frame.kind,
+      runId: frame.runId,
+      phase: frame.phase,
+      agentId: frame.agentId,
+      savedIdentity: frame.savedIdentity,
+    };
+  }
+  private sameConfirmationContext(context: ConfirmationContext): boolean {
+    const current = this.confirmationContext();
+    return (
+      current.kind === context.kind &&
+      current.runId === context.runId &&
+      current.phase === context.phase &&
+      current.agentId === context.agentId &&
+      ((!current.savedIdentity && !context.savedIdentity) || sameIdentity(current.savedIdentity, context.savedIdentity))
+    );
+  }
+  beginConfirmation(action: ConfirmKind, target: ItemIdentity, snapshot: NavigatorSnapshot): boolean {
+    if (this.mode !== "browse") return false;
+    this.pending = {
+      action,
+      target,
+      cursor: this.cursor,
+      filter: snapshot.filter,
+      context: this.confirmationContext(),
+    };
+    this.mode = "confirm";
+    return true;
+  }
+  confirm(action: ConfirmKind, snapshot: NavigatorSnapshot): ItemIdentity | undefined {
+    const pending = this.pending;
+    this.pending = undefined;
+    this.mode = "browse";
+    if (
+      !pending ||
+      pending.action !== action ||
+      pending.cursor !== this.cursor ||
+      pending.filter !== snapshot.filter ||
+      !this.sameConfirmationContext(pending.context)
+    )
+      return undefined;
+    if (this.kind === "savedDetail") {
+      return sameIdentity(this.top().savedIdentity, pending.target) ? pending.target : undefined;
+    }
+    if (this.kind === "runs") {
+      const current = this.currentItem(snapshot);
+      return sameIdentity(current?.identity, pending.target) ? pending.target : undefined;
+    }
+    // Drilled views are bound to the immutable frame runId, not runs selection.
+    return pending.target.kind === "run" && pending.target.runId === this.runId ? pending.target : undefined;
+  }
+  cancelConfirmation(): void {
+    if (this.mode === "confirm") this.mode = "browse";
+    this.pending = undefined;
   }
 }
 
@@ -744,7 +1086,7 @@ function rightAgentRow(
   const statsStyled = theme.fg("dim", stats);
 
   // Assemble with explicit cell padding (visibleWidth-driven gaps).
-  let out = marker + dot + " " + nameStyled;
+  let out = `${marker + dot} ${nameStyled}`;
   const afterName = nameStart + visibleWidth(nameOut);
   if (modelOut) {
     out += " ".repeat(Math.max(0, modelStart - afterName)) + modelStyled;
@@ -1011,16 +1353,23 @@ function renderNavigatorFrame(
   renderCache: NavigatorTextRenderCache | undefined,
 ): string[] {
   const lines: string[] = [];
+  let visibleSnapshot: NavigatorSnapshot | undefined;
   state.setPageSize(Math.max(1, viewportRows - 5));
-  const sel = (i: number, text: string) =>
-    i === state.cursor ? theme.fg("accent", theme.bold(`❯ ${text}`)) : `  ${text}`;
+  const sel = (i: number, text: string) => {
+    const selected =
+      state.kind !== "runs" ||
+      (visibleSnapshot !== undefined &&
+        sameIdentity(visibleSnapshot.items[i]?.identity, state.currentItem(visibleSnapshot)?.identity));
+    return selected ? theme.fg("accent", theme.bold(`❯ ${text}`)) : `  ${text}`;
+  };
   const dim = (t: string) => theme.fg("dim", t);
 
   // Render a detail body inside a FIXED-height viewport so j/k scrolls within a
   // stable box (clamping state.scroll) instead of slicing to the end — which
   // shrank the overlay and looked like it was collapsing.
   const pushScrollable = (body: string[]) => {
-    const viewport = Math.max(1, viewportRows - 4); // reserve title + blank + footer + indicator
+    const confirmationRows = state.mode === "confirm" ? 1 : 0;
+    const viewport = Math.max(1, viewportRows - 4 - confirmationRows); // title + blank + footer + indicator + confirm
     state.setPageSize(viewport);
     const maxScroll = Math.max(0, body.length - viewport);
     if (state.kind === "detail" && state.tailing) state.scroll = maxScroll;
@@ -1048,42 +1397,50 @@ function renderNavigatorFrame(
   };
 
   if (state.kind === "runs") {
-    const runs = model.runs();
-    const saved = model.saved();
-    const total = runs.length + saved.length;
-    state.clamp(total);
-
-    // Keep the selected run visible when history exceeds the overlay height.
-    const bodyCap = Math.max(1, viewportRows - 3); // title + blank + footer
+    // One immutable visible list for this render: every range, separator, row,
+    // footer and later input action uses its identities rather than re-reading
+    // runs/saved independently while the manager is changing underneath us.
+    const activeFilter = state.effectiveFilter();
+    visibleSnapshot = model.visible(activeFilter);
+    state.reconcile(visibleSnapshot);
+    const total = visibleSnapshot.items.length;
+    const confirmationRows = state.mode === "confirm" || state.mode === "rename" ? 1 : 0;
+    const bodyCap = Math.max(1, viewportRows - 3 - confirmationRows);
     let win = scrollWindow(total, state.cursor, bodyCap);
     const windowEnd = () => win.start + win.count;
-    const crossesSavedBoundary = () =>
-      runs.length > 0 && saved.length > 0 && win.start < runs.length && windowEnd() > runs.length;
-    if (crossesSavedBoundary() && bodyCap > 1) win = scrollWindow(total, state.cursor, bodyCap - 1);
+    const crossesBoundary = () => {
+      const slice = visibleSnapshot?.items.slice(win.start, windowEnd()) ?? [];
+      return slice.some((item, index) => index > 0 && item.kind !== slice[index - 1]?.kind);
+    };
+    if (crossesBoundary() && bodyCap > 1) win = scrollWindow(total, state.cursor, bodyCap - 1);
     const up = win.start > 0 ? "↑" : " ";
     const down = windowEnd() < total ? "↓" : " ";
     const range =
       win.start > 0 || windowEnd() < total ? dim(`  [${up} ${win.start + 1}-${windowEnd()} / ${total} ${down}]`) : "";
-    lines.push(theme.bold(`Workflows${range}`));
-
-    if (total === 0) {
-      lines.push(dim("  No runs yet. Start one with a background workflow."));
-    }
+    const filterLabel = state.mode === "filter" ? `  / ${state.draft}` : state.filter ? `  / ${state.filter}` : "";
+    lines.push(theme.bold(`Workflows${filterLabel}${range}`));
+    if (total === 0)
+      lines.push(
+        dim(activeFilter ? "  No matching workflows." : "  No runs yet. Start one with a background workflow."),
+      );
     for (let i = win.start; i < windowEnd(); i++) {
-      if (i === runs.length && runs.length > 0 && saved.length > 0) lines.push(dim("  ── saved ──"));
-      if (i < runs.length) {
-        const r = runs[i];
-        if (!r) continue;
-        const icon = STATUS_ICON[r.status] ?? "?";
-        const tok = fmtTokenSegment(r, pad);
-        const meta = [`${r.done}/${r.total}`, tok, r.cost > 0 ? fmtCost(r.cost) : ""].filter(Boolean).join(" · ");
-        lines.push(sel(i, `${icon} ${r.name}  ${dim(`${r.runId} · ${r.status} · ${meta}`)}`));
+      const item = visibleSnapshot.items[i];
+      if (!item) continue;
+      if (i > win.start && item.kind === "saved" && visibleSnapshot.items[i - 1]?.kind === "run")
+        lines.push(dim("  ── saved ──"));
+      if (item.kind === "run") {
+        const row = item.row;
+        const icon = STATUS_ICON[row.status] ?? "?";
+        const tok = fmtTokenSegment(row, pad);
+        const meta = [`${row.done}/${row.total}`, tok, row.cost > 0 ? fmtCost(row.cost) : ""]
+          .filter(Boolean)
+          .join(" · ");
+        lines.push(sel(i, `${icon} ${row.name}  ${dim(`${row.runId} · ${row.status} · ${meta}`)}`));
       } else {
-        const w = saved[i - runs.length];
-        if (!w) continue;
-        const loc = w.location === "user" ? "~" : ".";
-        const desc = w.description ? dim(`  ${w.description}`) : "";
-        lines.push(sel(i, `${w.name}${desc}  ${dim(loc)}`));
+        const workflow = item.workflow;
+        const loc = workflow.location === "user" ? "~" : ".";
+        const desc = workflow.description ? dim(`  ${workflow.description}`) : "";
+        lines.push(sel(i, `${workflow.name}${desc}  ${dim(loc)}`));
       }
     }
   } else if (state.kind === "phases" && state.runId) {
@@ -1162,7 +1519,7 @@ function renderNavigatorFrame(
     }
   } else if (state.kind === "savedDetail" && state.savedName) {
     const saved = model.saved();
-    const w = saved.find((s) => s.name === state.savedName);
+    const w = state.activeSaved(model.visible(state.filter), saved);
     lines.push(theme.bold(w ? w.name : "saved workflow"));
     if (w) {
       const body: string[] = [];
@@ -1177,9 +1534,17 @@ function renderNavigatorFrame(
     }
   }
 
+  if (state.mode === "confirm") {
+    const verb =
+      state.confirmationAction === "pause" ? "pause" : state.confirmationAction === "stop" ? "stop" : "delete";
+    const key = state.confirmationAction === "pause" ? "p" : "x";
+    lines.push(theme.fg("warning", `  Press ${key} again to confirm ${verb}, or Esc to cancel.`));
+  } else if (state.mode === "rename") {
+    lines.push(theme.fg("accent", `  Rename: ${state.draft}`));
+  }
   lines.push("");
-  lines.push(footerHint(state, model, theme));
-  return lines;
+  lines.push(footerHint(state, model, theme, visibleSnapshot));
+  return lines.slice(0, Math.max(0, viewportRows));
 }
 
 /**
@@ -1330,7 +1695,12 @@ function renderHistoryEntryLines(
   ];
 }
 
-function footerHint(state: NavigatorState, model: NavigatorModel, theme: ThemeLike): string {
+function footerHint(
+  state: NavigatorState,
+  model: NavigatorModel,
+  theme: ThemeLike,
+  snapshot?: NavigatorSnapshot,
+): string {
   const parts: string[] = [];
   switch (state.kind) {
     case "detail":
@@ -1348,15 +1718,15 @@ function footerHint(state: NavigatorState, model: NavigatorModel, theme: ThemeLi
       }
       break;
     case "savedDetail":
-      parts.push("↑/↓ line", "PgUp/PgDn page", "g/G ends", "esc back", "x delete");
+      parts.push("↑/↓ line", "PgUp/PgDn page", "g/G ends", "esc back", "r rename", "x delete");
       break;
     case "runs": {
-      const itemKind = model.saved().length > 0 ? state.itemKindAt(model, state.cursor) : "run";
-      parts.push("↑/↓ select", "enter open", "esc back");
-      if (itemKind === "run") {
+      const item = state.currentItem(snapshot ?? model.visible(state.filter));
+      parts.push("↑/↓ select", "/ filter", "enter open", "esc back");
+      if (item?.kind === "run") {
         parts.push("p pause", "x stop", "r restart", "s save");
-      } else {
-        parts.push("x delete");
+      } else if (item?.kind === "saved") {
+        parts.push("r rename", "x delete");
       }
       parts.push("q quit");
       break;
@@ -1465,6 +1835,8 @@ export type NavAction =
   | { type: "restart" }
   | { type: "save" }
   | { type: "deleteSaved" }
+  | { type: "filter" }
+  | { type: "rename" }
   | { type: "none" };
 
 export function keyToAction(keyId: string | undefined, kind: ViewKind, itemKind?: "run" | "saved"): NavAction {
@@ -1516,8 +1888,10 @@ export function keyToAction(keyId: string | undefined, kind: ViewKind, itemKind?
     case "x":
       if (kind === "savedDetail" || itemKind === "saved") return { type: "deleteSaved" };
       return { type: "stop" };
+    case "/":
+      return kind === "runs" ? { type: "filter" } : { type: "none" };
     case "r":
-      return { type: "restart" };
+      return kind === "savedDetail" || itemKind === "saved" ? { type: "rename" } : { type: "restart" };
     case "s":
       if (itemKind === "saved") return { type: "none" };
       return { type: "save" };
@@ -1527,7 +1901,7 @@ export function keyToAction(keyId: string | undefined, kind: ViewKind, itemKind?
 }
 
 function currentCount(state: NavigatorState, model: NavigatorModel): number {
-  if (state.kind === "runs") return model.runs().length + model.saved().length;
+  if (state.kind === "runs") return model.visible(state.filter).items.length;
   if (state.kind === "phases" && state.runId) return model.phases(state.runId).length;
   if (state.kind === "agents" && state.runId && state.phase) return model.agents(state.runId, state.phase).length;
   return 0;
@@ -1562,7 +1936,7 @@ export function openWorkflowNavigator(
   ui: ExtensionUIContext,
   opts: NavigatorOptions = {},
 ): Promise<void> {
-  const model = new NavigatorModel(manager, opts.storage);
+  const model = new NavigatorModel(manager, () => opts.getStorage?.() ?? opts.storage);
   const state = new NavigatorState();
 
   return ui.custom<void>(
@@ -1571,7 +1945,10 @@ export function openWorkflowNavigator(
       const markdownTheme = getMarkdownTheme();
       const renderCache = new NavigatorTextRenderCache();
       const events = ["agentStart", "agentEnd", "phase", "log", "complete", "error", "stopped", "paused", "resumed"];
-      const onEvent = () => rerender();
+      const onEvent = () => {
+        if (state.kind === "runs") state.noteManagerEvent(model.visible(state.filter));
+        rerender();
+      };
       for (const ev of events) manager.on(ev, onEvent);
 
       // Histories can update several times per second for every parallel agent.
@@ -1615,20 +1992,122 @@ export function openWorkflowNavigator(
       };
 
       const act = (data: string) => {
-        const itemKind = state.kind === "runs" ? state.itemKindAt(model, state.cursor) : undefined;
-        const action = keyToAction(parseKey(data), state.kind, itemKind);
-        // Keep the whole dispatch behind one error boundary so corrupt on-disk
-        // data or persistence failures cannot crash the overlay input handler.
+        const key = parseKey(data);
+        const snapshot = () => model.visible(state.effectiveFilter());
+        const notifyMutation = (verb: string, result: SavedWorkflowMutationResult) => {
+          if (result.ok) ui.notify(verb, "info");
+          else ui.notify(result.message, "error");
+        };
+        const executeConfirmed = (action: ConfirmKind, target: ItemIdentity) => {
+          if (target.kind === "run") {
+            const item = model.runs().find((candidate) => candidate.runId === target.runId);
+            if (!item) return;
+            const status = item.status;
+            if (action === "pause") {
+              if (status !== "running") {
+                ui.notify(`Cannot pause ${target.runId}`, "warning");
+                return;
+              }
+              ui.notify(
+                manager.pause(target.runId) ? `Paused ${target.runId}` : `Cannot pause ${target.runId}`,
+                "info",
+              );
+            } else if (action === "stop") {
+              if (status !== "running" && status !== "paused") {
+                ui.notify(`Cannot stop ${target.runId}`, "warning");
+                return;
+              }
+              ui.notify(manager.stop(target.runId) ? `Stopped ${target.runId}` : `Cannot stop ${target.runId}`, "info");
+            }
+            return;
+          }
+          if (action !== "deleteSaved") return;
+          const workflow = model.saved().find((candidate) => sameIdentity(target, savedIdentity(candidate)));
+          if (!workflow) {
+            ui.notify("Saved workflow no longer exists.", "warning");
+            return;
+          }
+          const result = model.deleteSaved(workflow);
+          notifyMutation(`Deleted /${workflow.name}`, result);
+          if (result.ok && state.kind === "savedDetail") state.back();
+        };
         try {
+          // Text modes own all keystrokes. This prevents pasted text, Unicode, or
+          // control sequences from leaking through to destructive browse bindings.
+          if (state.mode === "filter" || state.mode === "rename") {
+            if (key === "escape" || key === "esc") state.cancelInput();
+            else if (key === "backspace" || data === String.fromCharCode(127) || data === "\b") state.backspaceInput();
+            else if (key === "enter" || key === "return") {
+              if (state.mode === "filter") state.applyFilter(model);
+              else if (!isSafeSavedWorkflowName(state.draft)) {
+                ui.notify(
+                  "Saved workflow name must be a non-empty slash-command-safe name without whitespace, controls, or paths.",
+                  "warning",
+                );
+              } else {
+                const rename = state.takeRename();
+                if (rename) {
+                  const workflow = model
+                    .saved()
+                    .find((candidate) => sameIdentity(rename.target, savedIdentity(candidate)));
+                  if (!workflow) ui.notify("Saved workflow no longer exists.", "warning");
+                  else if (rename.name === workflow.name) ui.notify(`Kept /${workflow.name}`, "info");
+                  else {
+                    const availability = savedWorkflowCommandAvailability(pi, rename.name);
+                    if (!availability.ok) ui.notify(availability.message, "error");
+                    else {
+                      const result = model.renameSaved(workflow, rename.name);
+                      if (!result.ok) ui.notify(result.message, "error");
+                      else if (!result.workflow) ui.notify("Rename did not return a saved workflow.", "error");
+                      else {
+                        const saved = result.workflow;
+                        state.replaceSavedIdentity(rename.target, saved);
+                        const registered = registerSavedWorkflow(
+                          pi,
+                          opts.getCwd ?? (() => opts.cwd ?? process.cwd()),
+                          saved,
+                          opts.getManager ?? (() => manager),
+                          () => (opts.getStorage?.() ?? opts.storage)?.load(saved.name) != null,
+                          () => (opts.getStorage?.() ?? opts.storage)?.load(saved.name),
+                        );
+                        if (!registered.ok)
+                          ui.notify(`Renamed /${workflow.name} to /${saved.name}, but ${registered.message}`, "error");
+                        else ui.notify(`Renamed /${workflow.name} to /${saved.name}`, "info");
+                      }
+                    }
+                  }
+                }
+              }
+            } else state.appendInput(data);
+            rerender();
+            return;
+          }
+          if (state.mode === "confirm") {
+            const pendingAction = state.confirmationAction;
+            const action: ConfirmKind | undefined =
+              (pendingAction === "pause" && key === "p") ||
+              ((pendingAction === "stop" || pendingAction === "deleteSaved") && key === "x")
+                ? pendingAction
+                : undefined;
+            const target = action ? state.confirm(action, snapshot()) : undefined;
+            if (target && action) executeConfirmed(action, target);
+            else state.cancelConfirmation();
+            rerender();
+            return;
+          }
+
+          const item = state.kind === "runs" ? state.currentItem(snapshot()) : undefined;
+          const action = keyToAction(key, state.kind, item?.kind);
           switch (action.type) {
             case "move":
-              state.move(action.delta, currentCount(state, model));
+              if (state.kind === "runs") state.moveRuns(action.delta, snapshot());
+              else state.move(action.delta, currentCount(state, model), snapshot());
               break;
             case "page":
-              state.movePage(action.direction, currentCount(state, model));
+              state.movePage(action.direction, currentCount(state, model), snapshot());
               break;
             case "jump":
-              state.jump(action.edge, currentCount(state, model));
+              state.jump(action.edge, currentCount(state, model), snapshot());
               break;
             case "toggleTail":
               state.toggleTail();
@@ -1639,8 +2118,16 @@ export function openWorkflowNavigator(
             case "openPager":
               state.openPager();
               break;
+            case "filter":
+              state.beginFilter();
+              break;
+            case "rename": {
+              const workflow = state.activeSaved(snapshot(), model.saved());
+              if (workflow) state.beginRename(workflow);
+              break;
+            }
             case "drill":
-              state.drill(model);
+              state.drill(model, snapshot());
               break;
             case "back":
               if (!state.back()) {
@@ -1653,87 +2140,73 @@ export function openWorkflowNavigator(
               done(undefined);
               return;
             case "deleteSaved": {
-              if (state.kind === "runs") {
-                const saved = model.saved();
-                const runCount = model.runs().length;
-                const item = saved[state.cursor - runCount];
-                if (item) {
-                  model.deleteSaved(item.name);
-                  ui.notify(`Deleted /${item.name}`, "info");
-                }
-              } else if (state.kind === "savedDetail" && state.savedName) {
-                model.deleteSaved(state.savedName);
-                ui.notify(`Deleted /${state.savedName}`, "info");
-                state.back();
-              }
+              const workflow = state.activeSaved(snapshot(), model.saved());
+              if (workflow) state.beginConfirmation("deleteSaved", savedIdentity(workflow), snapshot());
               break;
             }
             case "pause": {
-              const id = state.activeRunId(model);
-              if (id) ui.notify(manager.pause(id) ? `Paused ${id}` : `Cannot pause ${id}`, "info");
+              const runId = state.activeRunId(model, snapshot());
+              if (runId) state.beginConfirmation("pause", { kind: "run", runId }, snapshot());
               break;
             }
             case "stop": {
-              const id = state.activeRunId(model);
-              if (id) ui.notify(manager.stop(id) ? `Stopped ${id}` : `Cannot stop ${id}`, "info");
+              const runId = state.activeRunId(model, snapshot());
+              if (runId) state.beginConfirmation("stop", { kind: "run", runId }, snapshot());
               break;
             }
             case "restart": {
-              const id = state.activeRunId(model);
-              const run = id ? manager.listRuns().find((r) => r.runId === id) : undefined;
-              if (!run?.script) {
+              const id = state.activeRunId(model, snapshot());
+              const run = id ? manager.listRuns().find((candidate) => candidate.runId === id) : undefined;
+              if (!run?.script)
                 ui.notify(id ? `Cannot restart ${id} (no script saved)` : "No run selected to restart", "warning");
-                break;
-              }
-              try {
-                const { runId: newId } = manager.startInBackground(run.script, run.args);
-                ui.notify(`Restarted ${run.workflowName || "workflow"} as ${newId}`, "info");
-              } catch (error) {
-                ui.notify(
-                  `Failed to restart ${run.workflowName || "workflow"}: ${error instanceof Error ? error.message : error}`,
-                  "error",
-                );
+              else {
+                try {
+                  const { runId: newId } = manager.startInBackground(run.script, run.args);
+                  ui.notify(`Restarted ${run.workflowName || "workflow"} as ${newId}`, "info");
+                } catch (error) {
+                  ui.notify(
+                    `Failed to restart ${run.workflowName || "workflow"}: ${error instanceof Error ? error.message : error}`,
+                    "error",
+                  );
+                }
               }
               break;
             }
             case "save": {
-              const id = state.activeRunId(model);
-              const run = id ? manager.listRuns().find((r) => r.runId === id) : undefined;
+              const id = state.activeRunId(model, snapshot());
+              const run = id ? manager.listRuns().find((candidate) => candidate.runId === id) : undefined;
               const storage = opts.getStorage?.() ?? opts.storage;
-              if (!run?.script) {
-                ui.notify("No saved run script to save", "warning");
-              } else if (!storage) {
-                ui.notify("Saving is not available (no storage)", "error");
-              } else {
+              if (!run?.script) ui.notify("No saved run script to save", "warning");
+              else if (!storage) ui.notify("Saving is not available (no storage)", "error");
+              else {
                 const name = run.workflowName || "workflow";
-                let saved: ReturnType<WorkflowStorage["save"]>;
+                const availability = savedWorkflowCommandAvailability(pi, name);
+                if (!availability.ok) {
+                  ui.notify(availability.message, "error");
+                  break;
+                }
                 try {
-                  saved = storage.save({
+                  const saved = storage.save({
                     name,
                     description: run.workflowName,
                     script: run.script,
                     location: "project",
                   });
+                  const registered = registerSavedWorkflow(
+                    pi,
+                    opts.getCwd ?? (() => opts.cwd ?? process.cwd()),
+                    saved,
+                    opts.getManager ?? (() => manager),
+                    () => (opts.getStorage?.() ?? opts.storage)?.load(saved.name) != null,
+                    () => (opts.getStorage?.() ?? opts.storage)?.load(saved.name),
+                  );
+                  ui.notify(
+                    registered.ok ? `Saved /${name}` : `Saved /${name}, but ${registered.message}`,
+                    registered.ok ? "info" : "error",
+                  );
                 } catch (error) {
                   ui.notify(error instanceof Error ? error.message : String(error), "error");
-                  break;
                 }
-                // Match /workflows save and registerAllSavedWorkflows: live
-                // getters + load-by-name so a same-name overwrite executes the
-                // latest script via the manager background path (not a frozen
-                // registration-time snapshot / inline fallback).
-                const getCwd = opts.getCwd ?? (() => opts.cwd ?? process.cwd());
-                const getManager = opts.getManager ?? (() => manager);
-                const getLiveStorage = () => opts.getStorage?.() ?? opts.storage ?? storage;
-                registerSavedWorkflow(
-                  pi,
-                  getCwd,
-                  saved,
-                  getManager,
-                  () => getLiveStorage()?.load(saved.name) != null,
-                  () => getLiveStorage()?.load(saved.name),
-                );
-                ui.notify(`Saved /${name}`, "info");
               }
               break;
             }
@@ -1741,10 +2214,7 @@ export function openWorkflowNavigator(
               return;
           }
         } catch (error) {
-          ui.notify(
-            `Workflow action "${action.type}" failed: ${error instanceof Error ? error.message : error}`,
-            "error",
-          );
+          ui.notify(`Workflow action failed: ${error instanceof Error ? error.message : error}`, "error");
         }
         rerender();
       };

--- a/tests/builtin-commands.test.ts
+++ b/tests/builtin-commands.test.ts
@@ -11,6 +11,7 @@ import {
   registerBuiltinWorkflows,
 } from "../src/builtin-commands.js";
 import { MAX_DIFF_CHARS } from "../src/code-review.js";
+import { registerSavedWorkflow, savedWorkflowCommandAvailability } from "../src/saved-commands.js";
 import { parseWorkflowScript } from "../src/workflow.js";
 import type { WorkflowManager } from "../src/workflow-manager.js";
 import type { SavedWorkflow, WorkflowStorage } from "../src/workflow-saved.js";
@@ -248,6 +249,45 @@ test("registerBuiltinWorkflows is idempotent — skips already registered comman
   ]);
   registerBuiltinWorkflows(pi, { cwd: "/tmp", manager: makeFakeManager().manager });
   assert.equal(commands.length, 0, "should not re-register when already present");
+});
+
+test("saved workflow cannot claim built-in names occupied by third-party commands", () => {
+  for (const name of ["code-review", "deep-research"]) {
+    const { pi, commands } = makeCommandRegistryPi([name]);
+    const availability = savedWorkflowCommandAvailability(pi, name);
+    assert.equal(availability.ok, false);
+    const result = registerSavedWorkflow(pi, "/tmp", {
+      name,
+      description: "third-party collision",
+      script: "export THIRD_PARTY_COLLISION",
+    });
+    assert.equal(result.ok, false);
+    assert.equal(commands.length, 0, "the rejected command must not be registered");
+  }
+});
+
+test("saved workflow may shadow a built-in only after this extension owns its handler", () => {
+  const { pi, commands } = makeCommandRegistryPi();
+  registerBuiltinWorkflows(pi, { cwd: "/tmp", manager: makeFakeManager().manager });
+  assert.equal(savedWorkflowCommandAvailability(pi, "code-review").ok, true);
+  const result = registerSavedWorkflow(pi, "/tmp", {
+    name: "code-review",
+    description: "saved shadow",
+    script: "export SAVED_SHADOW",
+  });
+  assert.equal(result.ok, true);
+  assert.equal(commands.filter((command) => command.name === "code-review").length, 1);
+});
+
+test("saved workflow rejects an ordinary third-party command name", () => {
+  const { pi, commands } = makeCommandRegistryPi(["ordinary-command"]);
+  const result = registerSavedWorkflow(pi, "/tmp", {
+    name: "ordinary-command",
+    description: "collision",
+    script: "export COLLISION",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(commands.length, 0);
 });
 
 test("registerBuiltinWorkflows registers only missing commands", () => {

--- a/tests/workflow-saved.test.ts
+++ b/tests/workflow-saved.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
 import test from "node:test";
@@ -397,5 +397,78 @@ test(
     const storage = createWorkflowStorage(cwd);
     assert.equal(existsSync(workflowProjectPaths(cwd).savedDir), false, "directory really doesn't exist yet");
     assert.deepEqual(storage.list(), []);
+  }),
+);
+
+test(
+  "strict rename rolls back target and restores source after injected failures",
+  withIsolatedHome(async (cwd) => {
+    const good = createWorkflowStorage(cwd);
+    const source = good.save({ name: "source", description: "source", script: "source" });
+    let failBackup = true;
+    const flakyBackup = createWorkflowStorage(cwd, {
+      writeFileSync: ((path, data, options) => {
+        if (failBackup && String(path).endsWith("target.json.bak")) {
+          failBackup = false;
+          throw new Error("backup write failed");
+        }
+        return writeFileSync(path, data, options);
+      }) as typeof writeFileSync,
+    });
+    assert.equal(flakyBackup.rename(source, "target").ok, false);
+    assert.equal(existsSync(join(workflowProjectPaths(cwd).savedDir, "target.json")), false);
+    assert.equal(existsSync(source.path), true);
+    assert.equal(existsSync(`${source.path}.bak`), true);
+    assert.equal(flakyBackup.rename(source, "target").ok, true);
+
+    const source2 = good.save({ name: "source2", description: "source2", script: "source2" });
+    let failDelete = true;
+    const flakyDelete = createWorkflowStorage(cwd, {
+      unlinkSync: ((path) => {
+        if (failDelete && String(path) === source2.path) {
+          failDelete = false;
+          throw new Error("source delete failed");
+        }
+        return unlinkSync(path);
+      }) as typeof unlinkSync,
+    });
+    assert.equal(flakyDelete.rename(source2, "target2").ok, false);
+    assert.equal(existsSync(source2.path), true);
+    assert.equal(existsSync(`${source2.path}.bak`), true);
+    assert.equal(existsSync(join(workflowProjectPaths(cwd).savedDir, "target2.json")), false);
+    assert.equal(flakyDelete.rename(source2, "target2").ok, true);
+  }),
+);
+
+test(
+  "string delete project covers project and legacy while omitted delete also covers user",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    storage.save({ name: "layers", description: "project", script: "p" });
+    const legacyDir = workflowProjectPaths(cwd).legacySavedDir;
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(
+      join(legacyDir, "layers.json"),
+      JSON.stringify({ name: "layers", description: "legacy", script: "l", savedAt: "2025-01-01" }),
+    );
+    storage.save({ name: "layers", description: "user", script: "u" }, "user");
+    assert.equal(storage.delete("layers", "project"), true);
+    assert.equal(storage.load("layers")?.location, "user");
+    assert.equal(storage.delete("layers"), true);
+    assert.equal(storage.load("layers"), null);
+  }),
+);
+
+test(
+  "saved mutations reject a same-path external overwrite as stale",
+  withIsolatedHome(async (cwd) => {
+    const storage = createWorkflowStorage(cwd);
+    const source = storage.save({ name: "race", description: "old", script: "old" });
+    writeFileSync(source.path, JSON.stringify({ ...source, script: "new" }));
+    const renamed = storage.rename(source, "moved");
+    const deleted = storage.delete(source);
+    assert.equal(renamed.ok, false);
+    assert.equal(deleted.ok, false);
+    assert.equal(storage.load("race")?.script, "new");
   }),
 );

--- a/tests/workflow-ui.test.ts
+++ b/tests/workflow-ui.test.ts
@@ -1,19 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { ExtensionAPI, ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import { type ExtensionAPI, type ExtensionUIContext, initTheme } from "@earendil-works/pi-coding-agent";
 import type { Component } from "@earendil-works/pi-tui";
 import type { WorkflowSnapshot } from "../src/display.js";
 import { WorkflowErrorCode } from "../src/errors.js";
 import type { PersistedRunState } from "../src/run-persistence.js";
 import { parseWorkflowScript } from "../src/workflow.js";
 import type { ManagedRun, WorkflowManager } from "../src/workflow-manager.js";
-import type { SavedWorkflow } from "../src/workflow-saved.js";
+import type { SavedWorkflow, WorkflowStorage } from "../src/workflow-saved.js";
 import {
   keyToAction,
   NavigatorModel,
   NavigatorState,
   openWorkflowNavigator,
   renderNavigator,
+  safeInputText,
 } from "../src/workflow-ui.js";
 
 /** Fake manager exposing one running run with two phases. */
@@ -578,7 +579,7 @@ test("NavigatorState activeRunId returns run at cursor on runs view", () => {
   const model = new NavigatorModel(multiRunManager());
   const state = new NavigatorState();
   assert.equal(state.activeRunId(model), "r1");
-  state.move(1, 2);
+  state.moveRuns(1, model.visible(state.filter));
   assert.equal(state.activeRunId(model), "r2");
 });
 
@@ -901,7 +902,7 @@ test("renderNavigator footer hint changes based on item under cursor", () => {
   assert.notEqual(runText.indexOf("x stop"), -1, "run item should show x stop");
 
   // Cursor on a saved item (position 1)
-  state.cursor = 1;
+  state.moveRuns(1, model.visible(state.filter));
   const savedText = renderNavigator(state, model, 80).join("\n");
   assert.notEqual(savedText.indexOf("x delete"), -1, "saved item should show x delete");
   assert.equal(savedText.indexOf("x stop"), -1, "saved item should NOT show x stop");
@@ -1164,11 +1165,12 @@ test("deleting a saved workflow whose storage.delete throws (e.g. EACCES) notifi
 
   const component = getComponent();
   assert.ok(component, "openWorkflowNavigator should have produced a component");
-  assert.doesNotThrow(() => component?.handleInput("x"), "deleteSaved must not throw/crash the overlay");
+  assert.doesNotThrow(() => component?.handleInput("x"), "first delete only asks for confirmation");
+  assert.doesNotThrow(() => component?.handleInput("x"), "confirmed delete must not throw/crash the overlay");
 
   assert.equal(notifications.length, 1);
   assert.equal(notifications[0].type, "error");
-  assert.match(notifications[0].message, /deleteSaved.*failed/);
+  assert.match(notifications[0].message, /Workflow action failed/);
   assert.match(notifications[0].message, /EACCES/);
 });
 
@@ -1194,11 +1196,12 @@ test("stopping a run whose manager.stop throws (cold-run lease/persistence failu
 
   const component = getComponent();
   assert.ok(component, "openWorkflowNavigator should have produced a component");
-  assert.doesNotThrow(() => component?.handleInput("x"), "stop must not throw/crash the overlay");
+  assert.doesNotThrow(() => component?.handleInput("x"), "first stop only asks for confirmation");
+  assert.doesNotThrow(() => component?.handleInput("x"), "confirmed stop must not throw/crash the overlay");
 
   assert.equal(notifications.length, 1);
   assert.equal(notifications[0].type, "error");
-  assert.match(notifications[0].message, /stop.*failed/);
+  assert.match(notifications[0].message, /Workflow action failed/);
   assert.match(notifications[0].message, /ENOSPC/);
 });
 
@@ -1305,4 +1308,358 @@ test("navigator save registers via manager + live loadWorkflow so a same-name ov
     ["export SCRIPT_V2"],
     "handler must execute the second save's script via manager.startInBackground (not the frozen first snapshot / inline path)",
   );
+});
+
+test("component input keeps filtered and jumped selection identity and confirms drilled lifecycle targets", async () => {
+  const { ui, notifications, getComponent } = fakeUiCapturingComponent();
+  let stopped = 0;
+  const runs = ["a", "b", "c", "d"].map((name) => ({
+    runId: `run-${name}`,
+    workflowName: name,
+    status: "running",
+    phases: ["P"],
+    agents: [],
+    logs: [],
+  })) as unknown as PersistedRunState[];
+  const manager = {
+    on: () => {},
+    off: () => {},
+    listRuns: () => runs,
+    getRun: (runId: string) =>
+      runs.some((run) => run.runId === runId)
+        ? ({
+            runId,
+            status: "running",
+            snapshot: { name: runId, phases: ["P"], agents: [], logs: [] },
+          } as unknown as ManagedRun)
+        : undefined,
+    stop: (runId: string) => {
+      assert.equal(runId, "run-d");
+      stopped++;
+      return true;
+    },
+  } as unknown as WorkflowManager;
+  openWorkflowNavigator({} as ExtensionAPI, manager, ui).catch(() => {});
+  await Promise.resolve();
+  await Promise.resolve();
+  const component = getComponent();
+  assert.ok(component);
+
+  component.handleInput("/");
+  component.handleInput("d");
+  component.handleInput("\r");
+  assert.match((component.render?.(80) ?? []).join("\n"), /❯ ◆ run-d/);
+  component.handleInput("G");
+  assert.match((component.render?.(80) ?? []).join("\n"), /❯ ◆ run-d/);
+
+  component.handleInput("\r");
+  assert.equal((component.render?.(80) ?? []).join("\n").includes("P"), true);
+  component.handleInput("x");
+  assert.match((component.render?.(80) ?? []).join("\n"), /confirm stop/);
+  component.handleInput("p");
+  assert.equal(stopped, 0, "a different key cannot confirm stop");
+  component.handleInput("x");
+  assert.equal(stopped, 0, "the mismatched key cancels instead of confirming");
+  component.handleInput("x");
+  assert.equal(stopped, 1, "the drilled frame run is stopped by matching x/x");
+  assert.equal(
+    notifications.some((notice) => notice.message.includes("Stopped run-d")),
+    true,
+  );
+});
+
+test("renderNavigator honors every small direct viewport", () => {
+  const model = new NavigatorModel(multiRunManager());
+  const state = new NavigatorState();
+  for (let rows = 1; rows <= 5; rows++) {
+    assert.ok(renderNavigator(state, model, 80, undefined, rows).length <= rows);
+  }
+});
+
+test("component filter renders the draft live, commits on Enter, and Esc preserves the applied query", async () => {
+  const { ui, getComponent } = fakeUiCapturingComponent();
+  const runs = ["alpha", "beta"].map((name) => ({
+    runId: `run-${name}`,
+    workflowName: name,
+    status: "completed",
+    phases: [],
+    agents: [],
+    logs: [],
+  })) as unknown as PersistedRunState[];
+  const manager = {
+    on: () => {},
+    off: () => {},
+    listRuns: () => runs,
+    getRun: () => undefined,
+  } as unknown as WorkflowManager;
+
+  openWorkflowNavigator({} as ExtensionAPI, manager, ui).catch(() => {});
+  await Promise.resolve();
+  await Promise.resolve();
+  const component = getComponent();
+  assert.ok(component);
+
+  component.handleInput("/");
+  component.handleInput("b");
+  let text = (component.render?.(80) ?? []).join("\n");
+  assert.match(text, /Workflows {2}\/ b/);
+  assert.match(text, /run-beta/);
+  assert.doesNotMatch(text, /run-alpha/);
+
+  component.handleInput("\r");
+  text = (component.render?.(80) ?? []).join("\n");
+  assert.match(text, /Workflows {2}\/ b/);
+  assert.match(text, /run-beta/);
+
+  // A draft that has no matches must not erase the already-applied query when
+  // Esc cancels editing, nor should it lose the selected identity.
+  component.handleInput("/");
+  component.handleInput("x");
+  const unmatchedDraft = (component.render?.(80) ?? []).join("\n");
+  assert.doesNotMatch(unmatchedDraft, /run-beta/);
+  assert.match(unmatchedDraft, /No matching workflows\./);
+  component.handleInput(String.fromCharCode(0x1b));
+  text = (component.render?.(80) ?? []).join("\n");
+  assert.match(text, /Workflows {2}\/ b/);
+  assert.match(text, /❯ .*run-beta/);
+});
+
+test("safeInputText removes complete OSC/CSI sequences without leaking payload", () => {
+  const esc = String.fromCharCode(0x1b);
+  const bel = String.fromCharCode(0x07);
+  assert.equal(safeInputText(`left${esc}]0;BEL payload${bel}mid${esc}]1;ST payload${esc}\\right`), "leftmidright");
+  assert.equal(safeInputText(`a${esc}]first${bel}b${esc}[31mc${esc}]second${esc}\\d`), "abcd");
+  assert.equal(safeInputText("普通文本é paste"), "普通文本é paste");
+  assert.equal(safeInputText("left\u{E0001}right"), "leftright");
+  assert.equal(safeInputText("left🙂right"), "left🙂right");
+  assert.equal(safeInputText(`a${esc}[2Kb`), "ab");
+});
+
+test("component rename strips astral format characters and keeps the same safe name", async () => {
+  const { ui, notifications, getComponent } = fakeUiCapturingComponent();
+  const workflow = {
+    name: "safe",
+    description: "safe workflow",
+    script: "export SAFE",
+    location: "project" as const,
+    source: "project" as const,
+    path: "/safe.json",
+    savedAt: "2025-01-01",
+  } as SavedWorkflow;
+  let renameCalls = 0;
+  const storage = {
+    list: () => [workflow],
+    rename: () => {
+      renameCalls++;
+      return { ok: true as const, workflow };
+    },
+    delete: () => true,
+  };
+  const manager = {
+    on: () => {},
+    off: () => {},
+    listRuns: () => [] as PersistedRunState[],
+    getRun: () => undefined,
+  } as unknown as WorkflowManager;
+
+  openWorkflowNavigator({} as ExtensionAPI, manager, ui, { storage: storage as unknown as WorkflowStorage }).catch(
+    () => {},
+  );
+  await Promise.resolve();
+  await Promise.resolve();
+  const component = getComponent();
+  assert.ok(component);
+
+  component.handleInput("r");
+  component.handleInput(String.fromCodePoint(0xe0001));
+  component.handleInput("\r");
+  assert.equal(renameCalls, 0, "same-name rename should not reach storage");
+  assert.ok(notifications.some((notice) => notice.message === "Kept /safe"));
+  assert.ok(notifications.every((notice) => !notice.message.includes("invalid")));
+});
+
+test("component manager refresh invalidates a stale confirmation instead of acting on the new row", async () => {
+  const { ui, getComponent } = fakeUiCapturingComponent();
+  const run = {
+    runId: "run-old",
+    workflowName: "old",
+    status: "running",
+    phases: [],
+    agents: [],
+    logs: [],
+  } as unknown as PersistedRunState;
+  let rows: PersistedRunState[] = [run];
+  const listeners = new Map<string, () => void>();
+  let stopped = 0;
+  let deleted = 0;
+  const storage = {
+    list: () =>
+      rows.length
+        ? []
+        : [
+            {
+              name: "replacement",
+              description: "",
+              script: "saved",
+              location: "project" as const,
+              source: "project" as const,
+              path: "/replacement.json",
+              savedAt: "2025-01-01",
+            },
+          ],
+    delete: () => {
+      deleted++;
+      return true;
+    },
+  };
+  const manager = {
+    on: (event: string, listener: () => void) => listeners.set(event, listener),
+    off: () => {},
+    listRuns: () => rows,
+    getRun: () => undefined,
+    stop: () => {
+      stopped++;
+      return true;
+    },
+  } as unknown as WorkflowManager;
+
+  openWorkflowNavigator({} as ExtensionAPI, manager, ui, { storage: storage as unknown as WorkflowStorage }).catch(
+    () => {},
+  );
+  await Promise.resolve();
+  await Promise.resolve();
+  const component = getComponent();
+  assert.ok(component);
+
+  component.handleInput("x");
+  assert.match((component.render?.(80) ?? []).join("\n"), /confirm stop/);
+  rows = [];
+  listeners.get("agentEnd")?.();
+  component.handleInput("x");
+  assert.equal(stopped, 0, "the second x must not stop the replacement row");
+  assert.equal(deleted, 0, "the second x must not delete the replacement row");
+});
+
+test("component rename handles a legacy source and live-loads only the new slash command", async () => {
+  const { ui, getComponent } = fakeUiCapturingComponent();
+  type Stored = SavedWorkflow;
+  const oldWorkflow: Stored = {
+    name: "legacy-old",
+    description: "legacy",
+    script: "export LEGACY_OLD",
+    location: "project",
+    source: "legacy",
+    path: "/legacy-old.json",
+    savedAt: "2025-01-01",
+  };
+  let current: Stored | null = oldWorkflow;
+  const storage = {
+    list: () => (current ? [current] : []),
+    load: (name: string) => (current?.name === name ? current : null),
+    save: () => oldWorkflow,
+    delete: () => true,
+    rename: (_workflow: SavedWorkflow, name: string) => {
+      current = { ...oldWorkflow, name, path: `/${name}.json`, script: "export RENAMED_NEW" };
+      return { ok: true as const, workflow: current };
+    },
+  };
+  const started: string[] = [];
+  const manager = {
+    on: () => {},
+    off: () => {},
+    listRuns: () => [] as PersistedRunState[],
+    getRun: () => undefined,
+    startInBackground: (script: string) => {
+      started.push(script);
+      return { runId: `run-${started.length}`, promise: new Promise(() => {}) };
+    },
+  } as unknown as WorkflowManager;
+  const pi = {
+    getCommands: () => commands.map((command) => ({ name: command.name })),
+    registerCommand: (
+      name: string,
+      spec: { description?: string; handler: (args: string, ctx: unknown) => unknown },
+    ) => {
+      commands.push({ name, handler: spec.handler });
+    },
+  } as unknown as ExtensionAPI;
+  const commands: Array<{ name: string; handler: (args: string, ctx: unknown) => unknown }> = [];
+
+  const { registerSavedWorkflow } = await import("../src/saved-commands.js");
+  registerSavedWorkflow(
+    pi,
+    "/cwd",
+    oldWorkflow,
+    manager,
+    () => current?.name === "legacy-old",
+    () => (current?.name === "legacy-old" ? current : null),
+  );
+  openWorkflowNavigator(pi, manager, ui, { storage: storage as unknown as WorkflowStorage }).catch(() => {});
+  await Promise.resolve();
+  await Promise.resolve();
+  const component = getComponent();
+  assert.ok(component);
+
+  component.handleInput("r");
+  component.handleInput("\b");
+  component.handleInput("\b");
+  component.handleInput("\b");
+  component.handleInput("\b");
+  component.handleInput("\b");
+  component.handleInput("\b");
+  component.handleInput("\b");
+  component.handleInput("\b");
+  component.handleInput("\b");
+  component.handleInput("\b");
+  component.handleInput("renamed");
+  component.handleInput("\r");
+
+  const oldCommand = commands.find((command) => command.name === "legacy-old");
+  const newCommand = commands.find((command) => command.name === "renamed");
+  assert.ok(oldCommand);
+  assert.ok(newCommand);
+  await oldCommand.handler("", { ui: { notify: () => {}, setStatus: () => {} } });
+  await newCommand.handler("", { ui: { notify: () => {}, setStatus: () => {} } });
+  assert.deepEqual(started, ["export RENAMED_NEW"]);
+});
+
+test("component saved detail exposes confirmation before delete", async () => {
+  initTheme("dark");
+  const { ui, getComponent } = fakeUiCapturingComponent();
+  let deleted = 0;
+  const workflow = {
+    name: "保存",
+    description: "Unicode",
+    script: "export const meta = {}",
+    location: "project" as const,
+    source: "project" as const,
+    path: "/saved/保存.json",
+    savedAt: "2025-01-01",
+  } as SavedWorkflow;
+  const storage = {
+    list: () => [workflow],
+    delete: () => {
+      deleted++;
+      return true;
+    },
+  };
+  const manager = {
+    on: () => {},
+    off: () => {},
+    listRuns: () => [] as PersistedRunState[],
+    getRun: () => undefined,
+  } as unknown as WorkflowManager;
+  openWorkflowNavigator({} as ExtensionAPI, manager, ui, { storage: storage as unknown as WorkflowStorage }).catch(
+    () => {},
+  );
+  await Promise.resolve();
+  await Promise.resolve();
+  const component = getComponent();
+  assert.ok(component);
+  component.handleInput("\r");
+  component.handleInput("x");
+  const confirming = component.render?.(80) ?? [];
+  assert.match(confirming.join("\n"), /confirm delete/);
+  component.handleInput("x");
+  assert.equal(deleted, 1);
 });


### PR DESCRIPTION
## Summary

- add live filtering across run names, run IDs, statuses, and saved workflow metadata
- keep navigator selection bound to stable run/saved identities across filtering, refreshes, paging, and mutations
- rename project, legacy, and user saved workflows without losing backup or slash-command behavior
- require identity-bound confirmation before pausing, stopping, or deleting
- preserve saved-workflow shadowing of built-in commands while rejecting third-party command conflicts

## Why

The navigator previously had no filtering or rename support, and destructive actions executed immediately. Cursor-based actions could also drift to a different row when live workflow events changed the list.

The new state machine keeps selection and pending actions tied to immutable targets, and saved-workflow mutations use the existing atomic persistence and recovery layer.

## Attribution

Builds on Clark Everson's original work in #45.

## Validation

- `npm test` — 1,254/1,254 tests passed
- targeted navigator, saved-storage, pager, and command-registration coverage
- `npm run release:verify` — 0 warnings
- real Pi TUI smoke — live filter, saved-workflow rename, delete confirmation, and cancellation verified in the actual `/workflows` overlay

Closes #39
Closes #40
Closes #41
