### PR TITLE
feat: show a running agent's real model in /workflows

### DIFF
--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -51,6 +51,8 @@ export interface PersistedJournalEntry {
   hash: string;
   result: unknown;
   storeDelta?: Record<string, unknown>;
+  /** The model the call ran on; absent on journals written before this field existed. */
+  model?: string;
 }
 
 export interface PersistedRunState {

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -36,6 +36,7 @@ import { shortModel } from "./workflow-ui.js";
 // it redraws identical content.
 const RUN_EVENTS = [
   "agentStart",
+  "agentModel",
   "agentEnd",
   "phase",
   "log",

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -869,6 +869,20 @@ export class WorkflowManager extends EventEmitter {
           this.emitLive(managed, "agentStart", { runId: managed.runId, ...event });
           progress();
         },
+        onAgentModel: (event) => {
+          // The ONLY mid-run correction of a running agent's displayed model.
+          // agentsById is keyed by the per-CALL id (never the label), so a
+          // concurrent same-label sibling can't be misattributed.
+          const agent = managed.agentsById.get(event.id);
+          if (!agent) {
+            return;
+          }
+          agent.model = event.model;
+          // No persistRun() here: this fires once per attempt, and the throttled
+          // progress persist plus every terminal persist already pick the field up.
+          this.emitLive(managed, "agentModel", { runId: managed.runId, agentId: agent.id, ...event });
+          progress();
+        },
         onAgentUsage: (event) => {
           const agent = managed.agentsById.get(event.id);
           if (!agent) {

--- a/src/workflow-ui.ts
+++ b/src/workflow-ui.ts
@@ -1946,6 +1946,7 @@ export function openWorkflowNavigator(
       const renderCache = new NavigatorTextRenderCache();
       const events = [
         "agentStart",
+        "agentModel",
         "agentEnd",
         "phase",
         "log",

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -84,6 +84,13 @@ export interface JournalEntry {
    * which agent finished first. Absent on older journal entries.
    */
   storeDelta?: Record<string, unknown>;
+  /**
+   * The model this call actually ran on, captured post-resolution so a replayed
+   * cache hit displays what really ran instead of the pre-resolution guess.
+   * Absent on journal entries persisted before this field existed (and on
+   * checkpoints, which run no model) — those degrade to the old behavior.
+   */
+  model?: string;
 }
 
 /**
@@ -266,6 +273,19 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
     committedUsage?: AgentUsage;
   }) => void;
   onAgentHistory?: (event: { id: string; label: string; phase?: string; history: AgentHistoryEntry[] }) => void;
+  /**
+   * The agent's REAL model, pushed the moment WorkflowAgent resolves it — mid-run,
+   * long before onAgentEnd. onAgentStart can only carry the pre-resolution guess
+   * (this call's explicit/phase spec, else the session's main model), which is wrong
+   * for every tier-routed agent: an explicit `tier` deliberately defers the choice to
+   * the agent layer, and an untagged agent is implicitly routed through the "medium"
+   * tier whenever model-tiers.json exists (see resolveAgentModelSpec). Without this
+   * channel those agents display the main session model for their whole lifetime and
+   * only flip to the truth once they finish. Fires once per ATTEMPT (and per turn for
+   * a named thread), so treat it as idempotent, not once-per-agent. `id` is the same
+   * per-CALL id as onAgentStart/onAgentEnd/onAgentHistory/onAgentUsage.
+   */
+  onAgentModel?: (event: { id: string; label: string; phase?: string; model: string }) => void;
   onTokenUsage?: (usage: {
     input: number;
     output: number;
@@ -694,9 +714,12 @@ export async function runWorkflow<T = unknown>(
     const explicitModel = agentOptions.model ?? agentDef?.model;
     const modelSpec =
       explicitModel ?? (agentOptions.tier ? undefined : resolveModelForPhase(assignedPhase, routingConfig));
-    // For display in /workflows: the model this agent runs on — its explicit/phase
-    // spec, else the session's main model. The real resolved id overrides this via
-    // onModelResolved once the subagent session is created.
+    // For display in /workflows: a PRE-RESOLUTION guess — this agent's explicit/phase
+    // spec, else the session's main model. It is only a guess: a `tier` deliberately
+    // leaves modelSpec undefined so the agent layer picks, and an untagged agent is
+    // implicitly routed through the "medium" tier when model-tiers.json exists. The
+    // real resolved id replaces it via onModelResolved below, which also pushes the
+    // correction out on onAgentModel so a RUNNING agent's row stops showing the guess.
     let displayModel = modelSpec ?? options.mainModel;
 
     // Deterministic resume key: assigned at lexical call time, before the limiter,
@@ -738,14 +761,18 @@ export async function runWorkflow<T = unknown>(
     const hashMatches = cached != null && cached.hash === callHash;
     const cachedEmptyOutput = hashMatches && isEmptyTextAgentResult(cached.result, agentOptions.schema);
     if (!shared.resumeBarrierReached && hashMatches && !cachedEmptyOutput && callIndex < state.firstMiss) {
-      options.onAgentStart?.({ id: deltaKey, label, phase: assignedPhase, prompt, model: displayModel });
+      // A replayed call never runs an agent, so onModelResolved never fires for it.
+      // Use the model journaled when it originally ran; legacy entries have none and
+      // fall back to the pre-resolution guess, exactly as before this field existed.
+      const replayModel = cached.model ?? displayModel;
+      options.onAgentStart?.({ id: deltaKey, label, phase: assignedPhase, prompt, model: replayModel });
       options.onAgentEnd?.({
         id: deltaKey,
         label,
         phase: assignedPhase,
         result: cached.result,
         tokens: 0,
-        model: displayModel,
+        model: replayModel,
       });
       // Apply this agent's write delta so live agents later in the run see a
       // consistent store. Additive apply preserves parallel-agent writes that
@@ -846,6 +873,10 @@ export async function runWorkflow<T = unknown>(
               cwd: runCwd,
               onModelResolved: (id: string) => {
                 displayModel = id;
+                // Correct what /workflows shows for an agent that is STILL RUNNING.
+                // onAgentEnd keeps carrying the same value so late subscribers and
+                // the persisted snapshot stay consistent with this push.
+                options.onAgentModel?.({ id: deltaKey, label, phase: assignedPhase, model: id });
               },
               onModelFallback: ({ tier, requestedSpec }: { tier: string; requestedSpec: string }) => {
                 // Untagged agents' implicit default tier degrading to the session
@@ -881,6 +912,11 @@ export async function runWorkflow<T = unknown>(
                 runId,
                 hash: callHash,
                 result,
+                // displayModel is post-resolution here; recording it keeps a
+                // resumed run's replayed rows from regressing to mainModel.
+                // Deliberately NOT part of callHash (see hashAgentCall): the
+                // cache key stays spec-level, so no cached agent is invalidated.
+                model: displayModel,
                 storeDelta: store.commitDelta(deltaKey),
               });
             } else {

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -18,7 +18,7 @@ import {
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { resolveModelSpecWithThinking } from "../src/model-spec.js";
 import type { ModelTierConfig } from "../src/model-tier-config.js";
-import { runWorkflow } from "../src/workflow.js";
+import { type JournalEntry, runWorkflow } from "../src/workflow.js";
 import { withFakeHome, withFakeHomeAsync } from "./helpers/fake-home.js";
 
 // Private methods used for testing - cast to this type to access them without `any`
@@ -1496,6 +1496,132 @@ test("agent() passes onModelResolved callback for display model updates", async 
     },
   );
   assert.ok(rec.calls.length > 0, "rec.calls should not be empty");
+});
+
+test("onAgentModel corrects a RUNNING agent's model, not just the finished one", async () => {
+  const rec = new CallRecordingAgent();
+  const order: string[] = [];
+  let startEvent: { id: string; model?: string } | undefined;
+  let modelEvent: { id: string; model: string } | undefined;
+  let endModel: string | undefined;
+  await runWorkflow(
+    `export const meta = { name: 'test', description: 't' }
+     await agent('task', { label: 't' })
+     return 1`,
+    {
+      agent: rec,
+      persistLogs: false,
+      mainModel: "main-prov/main-model",
+      onAgentStart: (e) => {
+        order.push("start");
+        startEvent = { id: e.id, model: e.model };
+      },
+      onAgentModel: (e) => {
+        order.push("model");
+        modelEvent = { id: e.id, model: e.model };
+      },
+      onAgentEnd: (e) => {
+        order.push("end");
+        endModel = e.model;
+      },
+    },
+  );
+  assert.equal(startEvent?.model, "main-prov/main-model", "onAgentStart can only carry the pre-resolution guess");
+  assert.equal(modelEvent?.model, "openai/gpt-4.1-mini", "onAgentModel carries the id the agent actually runs on");
+  assert.equal(modelEvent?.id, startEvent?.id, "same per-call id, so the host can match it to the started row");
+  assert.deepEqual(order, ["start", "model", "end"], "the correction must land BEFORE the agent finishes");
+  assert.equal(endModel, "openai/gpt-4.1-mini", "onAgentEnd still carries the resolved model");
+});
+
+test("onAgentModel fires for a tier-tagged agent, whose start event cannot know the tier's model", async () => {
+  const rec = new CallRecordingAgent();
+  const models: string[] = [];
+  let startModel: string | undefined;
+  await runWorkflow(
+    `export const meta = { name: 'test', description: 't' }
+     await agent('task', { label: 't', tier: 'big' })
+     return 1`,
+    {
+      agent: rec,
+      persistLogs: false,
+      mainModel: "main-prov/main-model",
+      onAgentStart: (e) => {
+        startModel = e.model;
+      },
+      onAgentModel: (e) => models.push(e.model),
+    },
+  );
+  // A tier defers the choice to the agent layer, so agent() deliberately passes
+  // model: undefined and the start event falls back to the session's main model.
+  assert.equal(rec.calls[0].options.model, undefined, "a tier must not be pre-resolved into an explicit model");
+  assert.equal(rec.calls[0].options.tier, "big");
+  assert.equal(startModel, "main-prov/main-model");
+  assert.deepEqual(models, ["openai/gpt-4.1-mini"], "the tier's real model is pushed while the agent runs");
+});
+
+test("a replayed (cache-hit) agent reports the model it actually ran on, not the main model", async () => {
+  const rec = new CallRecordingAgent();
+  const journal: JournalEntry[] = [];
+  const script = `export const meta = { name: 'test', description: 't' }
+     await agent('task', { label: 't' })
+     return 1`;
+  await runWorkflow(script, {
+    agent: rec,
+    persistLogs: false,
+    runId: "replay-model-run",
+    mainModel: "main-prov/main-model",
+    onAgentJournal: (e) => journal.push(e),
+  });
+  assert.equal(journal.length, 1);
+  assert.equal(journal[0].model, "openai/gpt-4.1-mini", "the resolved model is journaled with the result");
+
+  const replayed: Array<string | undefined> = [];
+  const secondRec = new CallRecordingAgent();
+  await runWorkflow(script, {
+    agent: secondRec,
+    persistLogs: false,
+    runId: "replay-model-run",
+    mainModel: "main-prov/main-model",
+    resumeJournal: new Map(journal.map((e) => [`${e.runId}:${e.index}`, e] as const)),
+    onAgentStart: (e) => replayed.push(e.model),
+    onAgentEnd: (e) => replayed.push(e.model),
+  });
+  assert.equal(secondRec.calls.length, 0, "the call must cache-hit, so nothing re-resolves the model");
+  assert.deepEqual(
+    replayed,
+    ["openai/gpt-4.1-mini", "openai/gpt-4.1-mini"],
+    "resume must not regress a replayed row back to the main model",
+  );
+});
+
+test("a legacy journal entry with no model degrades to the pre-resolution guess", async () => {
+  const rec = new CallRecordingAgent();
+  const journal: JournalEntry[] = [];
+  const script = `export const meta = { name: 'test', description: 't' }
+     await agent('task', { label: 't' })
+     return 1`;
+  await runWorkflow(script, {
+    agent: rec,
+    persistLogs: false,
+    runId: "legacy-model-run",
+    mainModel: "main-prov/main-model",
+    onAgentJournal: (e) => journal.push(e),
+  });
+  const legacy = journal.map(({ model: _dropped, ...rest }) => rest as JournalEntry);
+  const replayed: Array<string | undefined> = [];
+  await runWorkflow(script, {
+    agent: new CallRecordingAgent(),
+    persistLogs: false,
+    runId: "legacy-model-run",
+    mainModel: "main-prov/main-model",
+    resumeJournal: new Map(legacy.map((e) => [`${e.runId}:${e.index}`, e] as const)),
+    onAgentStart: (e) => replayed.push(e.model),
+  });
+  assert.deepEqual(
+    replayed,
+    ["main-prov/main-model"],
+    "no journaled model => same behavior as before the field existed",
+  );
 });
 
 test("agent() accumulates usage across multiple agents", async () => {

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -1448,6 +1448,42 @@ describe("installTaskPanel", () => {
     assert.equal(registeredPlacement, "belowEditor");
   });
 
+  it("repaints on agentModel, so a running agent's corrected model reaches the panel", () => {
+    // The manager corrects agent.model IN PLACE on the live snapshot, so without a
+    // repaint subscription the panel keeps showing the pre-resolution model until
+    // some unrelated event happens to fire.
+    const manager = new EventEmitter() as ReturnType<typeof EventEmitter> & {
+      getRun: (...args: unknown[]) => unknown;
+      listRuns: () => unknown[];
+    };
+    manager.getRun = () => undefined;
+    manager.listRuns = () => [];
+
+    let factory: ((tui: { requestRender(): void }, theme: unknown) => { dispose?(): void }) | undefined;
+    const ui = {
+      setWidget: (_name: string, registeredFactory: typeof factory) => {
+        factory = registeredFactory;
+      },
+    };
+
+    mod.installTaskPanel(null, manager, ui);
+    let renders = 0;
+    const component = factory?.(
+      { requestRender: () => renders++ },
+      {
+        fg: (_c: string, t: string) => t,
+        bold: (t: string) => t,
+      },
+    );
+
+    manager.emit("agentModel", { runId: "a", agentId: 1, id: "a:0", label: "x", model: "prov/real-model" });
+    assert.equal(renders, 1, "agentModel must be in RUN_EVENTS");
+
+    component?.dispose?.();
+    manager.emit("agentModel", { runId: "a", agentId: 1, id: "a:0", label: "x", model: "prov/real-model" });
+    assert.equal(renders, 1, "dispose must unsubscribe it again (symmetric with RUN_EVENTS)");
+  });
+
   it("passes the render width through to the task panel", () => {
     const manager = new EventEmitter() as ReturnType<typeof EventEmitter> & {
       getRun: (...args: unknown[]) => unknown;

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -1180,6 +1180,46 @@ return { a, b }`;
 );
 
 test(
+  "the live snapshot shows a running agent's REAL model, corrected before it finishes",
+  withTempCwd(async (cwd) => {
+    const holder: { manager?: WorkflowManager; runId?: string } = {};
+    /** Reads back what /workflows would display while this very agent is still running. */
+    let modelWhileRunning: string | undefined;
+    const resolvingAgent = {
+      async run(_prompt: string, options: { onModelResolved?: (id: string) => void }) {
+        options.onModelResolved?.("tier-prov/tier-model");
+        // Read the LIVE in-memory snapshot — exactly what the panel and the
+        // navigator render from — while this agent is still inside run().
+        const snapshot = holder.runId ? holder.manager?.getRun(holder.runId)?.snapshot : undefined;
+        modelWhileRunning = snapshot?.agents.find((a) => a.label === "a")?.model;
+        return "ok";
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent: resolvingAgent, mainModel: "main-prov/main-model" });
+    holder.manager = manager;
+    manager.on("agentStart", (e: { runId: string }) => {
+      holder.runId = e.runId;
+    });
+
+    const events: Array<{ agentId?: number; model?: string }> = [];
+    manager.on("agentModel", (e: { agentId?: number; model?: string }) => events.push(e));
+
+    const result = await manager.runSync(oneAgentScript);
+
+    assert.equal(
+      modelWhileRunning,
+      "tier-prov/tier-model",
+      "an in-flight agent must not display the session's main model once its own is known",
+    );
+    assert.equal(events.length, 1, "the correction is broadcast live for panel repaints");
+    assert.equal(events[0]?.agentId, 1, "keyed to the agent row the panel already created");
+    assert.equal(events[0]?.model, "tier-prov/tier-model");
+    const persisted = manager.getPersistence().load(result.runId);
+    assert.equal(persisted?.agents.find((a) => a.label === "a")?.model, "tier-prov/tier-model");
+  }),
+);
+
+test(
   "runSync persists recoverable agent error details for /workflows",
   withTempCwd(async (cwd) => {
     const manager = new WorkflowManager({


### PR DESCRIPTION
Fixes #166.

While a subagent is **running**, `/workflows` shows the **main session model** instead of the model it actually runs on; the display only becomes correct once the agent finishes. See #166 for the full analysis — short version: `onAgentStart` is necessarily emitted before `agentRunner.run()`, so it can only carry a pre-resolution guess (`modelSpec ?? options.mainModel`), and `onModelResolved` (src/workflow.ts:847) only mutated a closure local. `agent.model` had exactly two writers — the manager's `onAgentStart` and `onAgentEnd` handlers — so the snapshot field was physically unwritable mid-run.

This hits **tier-tagged agents always** (`agent()` deliberately passes `modelSpec: undefined` when `opts.tier` is set) and **every untagged agent** once `model-tiers.json` exists (`resolveAgentModelSpec` implicitly routes untagged agents through the `"medium"` tier).

## What this does

1. **`WorkflowRunOptions.onAgentModel`** (`src/workflow.ts`) — new *optional* callback, fired from the existing `onModelResolved` hook with the same per-call `id` as `onAgentStart`/`onAgentEnd`/`onAgentUsage`/`onAgentHistory`.
2. **`WorkflowManager`** — handler writes `agent.model` into the live snapshot and re-emits `"agentModel"`. Shaped exactly like the existing `agentHistory` emit (`{ runId, agentId, ...event }`). No `persistRun()` — the throttled progress persist and every terminal persist already pick the field up.
3. **Repaint** — `"agentModel"` added to `RUN_EVENTS` (`src/task-panel.ts`) and the navigator's `events` list (`src/workflow-ui.ts`). `workflow-commands.ts`'s `progressEvents` is deliberately untouched: that surface renders no model.
4. **Resume** — `JournalEntry` / `PersistedJournalEntry` gain an optional `model`, recorded at `onAgentJournal` and used by the replay branch, so replayed rows stop showing the main model forever. Entries without it degrade to exactly the old behaviour.

Side benefit: an agent aborted mid-run never reaches `onAgentEnd`, so its stale model used to be persisted forever; it is now already correct when the abort lands.

## Deliberately not done

- **`model` is not added to `hashAgentCall`.** The cache key stays spec-level, so **no cached agent is invalidated** and no paid work is replayed. The journaled model is a record of what ran, not an identity input.
- **No eager `resolveAgentModelSpec` in `workflow.ts`.** It would duplicate the precedence ladder from `src/agent.ts:190-209`, could not canonicalize a fuzzy spec (`"opus"`, `"gpt-5.5:xhigh"`) without the registry that is only built asynchronously at `src/agent.ts:858`, and would actively *lie* in the untagged-degrade path at `src/agent.ts:900-910`, where the requested tier model is unavailable and the session default is used instead.
- **`onAgentStart` is not moved after resolution.** `onModelResolved` lives inside `if (modelSpec)`, so on a fresh install with no tiers configured it never fires — the agent row would never be created at all. It would also corrupt per-agent `startedAt` and let `onAgentUsage`/`onAgentHistory` arrive before the row exists, where both are silently dropped.
- **No emit on the `onModelFallback` path.** It is reachable only for an untagged agent, and in exactly that case `displayModel` is already `options.mainModel` — the session default it degrades to — so the event would carry no new information. Happy to add it with a `degraded: true` flag if you'd prefer the UI to mark it.

## Back-compat

Optional callback, so no embedder implementing `WorkflowRunOptions` breaks. `WorkflowAgentRunner` is untouched — a custom runner that never calls `onModelResolved` simply keeps the old display. Old journals on disk degrade via `cached.model ?? displayModel` (covered by a test); an old build reading a new journal ignores the extra key.

One deliberate semantic: if the user edits `model-tiers.json` between pause and resume, a replayed row shows the model that **actually produced the cached result**, not a fresh guess. That is strictly more accurate than the old behaviour, which showed whatever `mainModel` happened to be at resume time.

## Verification

`npm test` — Biome, tsc, build, `docs:check`, `context:check`, `release:verify` all green; **1283/1283** unit tests pass.

No generated surface needed regenerating: `onAgentModel` adds no workflow-script capability, no `workflow` tool parameter and no `~/.pi/workflows/settings.json` key, so the capability contract, authoring reference, skills and the README config sections are unaffected (`docs:check` / `context:check` / `guidance:check` all confirm "unchanged"). `README.md:83`'s existing claim that the panel tracks models becomes true rather than needing an edit.

**Six new tests**, each mutation-verified (reverting the corresponding line makes exactly that test fail):

- `onAgentModel` fires with the resolved id and lands **before** `onAgentEnd` (asserts the `start → model → end` order);
- same for a `tier`-tagged agent, and that a tier is still not pre-resolved into an explicit `model` (guards the `src/workflow.ts` half of the contract);
- a replayed cache hit reports the journaled model, and the runner is never called;
- a legacy journal entry with no `model` degrades to the old behaviour;
- the live snapshot is corrected while the agent is still inside `run()`, the `"agentModel"` event is broadcast, and the corrected value is persisted;
- `installTaskPanel` repaints on `"agentModel"` and unsubscribes on dispose (pins `RUN_EVENTS` membership, which nothing previously covered).

**End-to-end against real subagent sessions** (per CONTRIBUTING — real `createAgentSession`, real model, no fake agent; throwaway harness deleted before commit). Session model `openai-codex/gpt-5.6-sol`, tiers `{small: …:medium, medium: …:high, big: …:max}`:

```
--- LIVE RUN (real subagent sessions) ---
  start  untagged  model=openai-codex/gpt-5.6-sol
  MODEL  untagged  model=openai-codex/gpt-5.6-sol:high   <- pushed WHILE RUNNING
  end    untagged  model=openai-codex/gpt-5.6-sol:high  result="pong"
  start  tier-big  model=openai-codex/gpt-5.6-sol
  MODEL  tier-big  model=openai-codex/gpt-5.6-sol:max    <- pushed WHILE RUNNING
  end    tier-big  model=openai-codex/gpt-5.6-sol:max   result="pong."

journaled models: ["openai-codex/gpt-5.6-sol:high","openai-codex/gpt-5.6-sol:max"]

--- RESUME / REPLAY (cache hits, no model resolution happens) ---
  start  untagged  model=openai-codex/gpt-5.6-sol:high
  end    untagged  model=openai-codex/gpt-5.6-sol:high
  start  tier-big  model=openai-codex/gpt-5.6-sol:max
  end    tier-big  model=openai-codex/gpt-5.6-sol:max
```

Also verified by probe harness (deleted): retries re-emit with the same `deltaKey` (idempotent overwrite, journal and `onAgentEnd` agree on the last value); named threads get one emit per turn on that turn's own row and correctly never journal a model; nested `workflow()` inherits the callback through the `...options` spread and its ids stay namespaced by `${runId}-nested${n}`; `checkpoint()` journal entries legitimately carry no model and cannot collide with an agent entry because the hashes differ.

## Typed `feat:`, not `fix:`

Per CONTRIBUTING — it adds a new exported option (`WorkflowRunOptions.onAgentModel`) — even though its purpose is a bug fix.

## Unrelated pre-existing flake (not from this PR)

`tests/workflow-manager-abort.test.ts` → "external signal registration and cleanup failures converge without replacing execution outcomes" fails intermittently. It fails at the same rate on unmodified `origin/main` (3/6 runs there, 4/6 on this branch). Cause: the test creates five managers sharing one `cwd` and then asserts on `listRuns()[0]`, which `RunPersistence.list()` sorts by `updatedAt` **descending** (`src/run-persistence.ts:364`) — when two runs land in the same millisecond the ordering flips and `[0]` is a different manager's completed run. Left alone here to keep this PR to one concern; happy to send a separate PR keying those assertions by `runId`.
