### PR TITLE
fix(delivery): auto-deliver background workflow results in omp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -729,7 +729,6 @@
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.83.0.tgz",
       "integrity": "sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw==",
       "dev": true,
-      "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-agent-core": "^0.83.0",
@@ -1532,7 +1531,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2670,7 +2668,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3206,7 +3203,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4143,7 +4139,6 @@
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -4182,7 +4177,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -10,6 +10,7 @@ import {
   DefaultResourceLoader,
   getAgentDir,
   ModelRegistry,
+  type ModelRuntime,
   SessionManager,
   SettingsManager,
   type ToolDefinition,
@@ -251,32 +252,51 @@ export interface WorkflowAgentOptions {
 // runtime split): build it directly from the discovered AuthStorage. The
 // disk-backed fallback is built lazily; sync callers see [] until it resolves
 // and real specs on later reads.
-let fallbackRuntimePromise: Promise<ModelRegistry | undefined> | undefined;
+let fallbackRuntimePromise: Promise<ModelRegistry> | undefined;
 let fallbackRegistry: ModelRegistry | undefined;
 
 function ensureFallbackRegistry(): Promise<ModelRegistry> {
   if (!fallbackRuntimePromise) {
     const dir = getAgentDir();
     // Same auth.json/models.json createAgentSession uses by default, so a model
-    // resolved here carries valid credentials.
+    // resolved here carries valid credentials. Three host shapes, tried in
+    // order; only a real registry ever resolves:
+    // 1. omp's bundled pi exports discoverAuthStorage (auth-storage-backed
+    //    registry, no runtime split).
+    // 2. Legacy pi (< 0.80.8) had a static ModelRegistry.create({ dir }).
+    // 3. pi >= 0.80.8 splits registry/runtime: ModelRuntime.create() then
+    //    new ModelRegistry(runtime).
     fallbackRuntimePromise = (async () => {
-      // discoverAuthStorage is omp's bundled pi-coding-agent export; on other
-      // hosts (pi CLI, tests) fall back to the legacy static create, and if
-      // neither exists the fallback registry stays empty (listAvailableModels
-      // reports [] and tier ranking falls through to the main model).
-      const mod = await import("@earendil-works/pi-coding-agent").catch(() => undefined);
-      const discover = (mod as { discoverAuthStorage?: (dir: string) => unknown } | undefined)?.discoverAuthStorage;
-      if (typeof discover === "function") {
-        const authStorage = (await discover(dir)) as ConstructorParameters<typeof ModelRegistry>[0];
+      // Dynamic import on purpose: discoverAuthStorage exists only in omp's
+      // bundled pi; a static named import would fail to resolve on stock pi,
+      // and the host shape must be feature-detected at runtime.
+      const ompExports = (await import("@earendil-works/pi-coding-agent").catch(() => undefined)) as
+        | {
+            discoverAuthStorage?: (dir: string) => Promise<unknown>;
+            ModelRuntime?: { create?: (options?: unknown) => Promise<ModelRuntime> };
+          }
+        | undefined;
+      if (typeof ompExports?.discoverAuthStorage === "function") {
+        const authStorage = (await ompExports.discoverAuthStorage(dir)) as ConstructorParameters<
+          typeof ModelRegistry
+        >[0];
         return new ModelRegistry(authStorage);
       }
-      const create = (
+      const legacyCreate = (
         ModelRegistry as unknown as {
           create?: (opts: { dir: string }) => Promise<ModelRegistry>;
         }
       ).create;
-      if (typeof create === "function") return create({ dir });
-      return undefined;
+      if (typeof legacyCreate === "function") return legacyCreate({ dir });
+      const runtimeCreate = ompExports?.ModelRuntime?.create;
+      if (typeof runtimeCreate === "function") {
+        // No options: defaults to getAgentDir()/auth.json and models.json —
+        // the same disk layout the omp and legacy paths read.
+        return new ModelRegistry(await runtimeCreate());
+      }
+      throw new Error(
+        "[workflow] no ModelRegistry construction path in @earendil-works/pi-coding-agent (expected discoverAuthStorage, ModelRegistry.create, or ModelRuntime.create)",
+      );
     })();
     // Don't cache a rejection: a transient failure (e.g. auth.json lock) would
     // otherwise wedge the fallback for the rest of the process.
@@ -286,17 +306,17 @@ function ensureFallbackRegistry(): Promise<ModelRegistry> {
   }
   return fallbackRuntimePromise.then((registry) => {
     fallbackRegistry ??= registry;
-    return fallbackRegistry;
-  }) as Promise<ModelRegistry>;
+    return registry;
+  });
 }
 
 /**
  * The ModelRuntime behind a registry facade (pi >= 0.80.8 shape: ModelRegistry
  * wraps a ModelRuntime but exposes no getter). Subagent sessions need it to
- * share the host session's exact catalog and auth — createAgentSession takes
- * modelRuntime, not a registry, on that line. omp's fork is auth-storage-backed
- * (registry has no `runtime` field and createAgentSession takes modelRegistry
- * instead), so this returns undefined there and the handoff no-ops.
+ * share the host session's exact catalog and auth. omp's fork is
+ * auth-storage-backed (registry has no `runtime` field and createAgentSession
+ * takes modelRegistry instead), so this returns undefined there and callers
+ * pass the registry itself.
  */
 export function runtimeOf(registry: ModelRegistry): unknown {
   return (registry as unknown as { runtime?: unknown }).runtime;
@@ -937,6 +957,13 @@ export class WorkflowAgent {
     // temporary worktree paths.
     const sessionManager = this.createSessionManager(options.thread);
     const threadLeaf = options.thread ? sessionManager.getLeafId() : null;
+    // Host split: pi >= 0.80.8 createAgentSession takes modelRuntime, not a
+    // registry — hand over the registry's backing runtime so subagents share
+    // the host catalog and auth. omp's fork is auth-storage-backed (registry
+    // has no `.runtime`; it takes modelRegistry instead). Never spread
+    // `modelRuntime: undefined` — it would shadow createAgentSession's own
+    // default runtime.
+    const modelRuntime = runtimeOf(modelRegistry) as ModelRuntime | undefined;
     let session: Awaited<ReturnType<typeof createAgentSession>>["session"];
     try {
       ({ session } = await createAgentSession({
@@ -954,12 +981,10 @@ export class WorkflowAgent {
         // wins and skips the shared build entirely; the ...this.sessionOptions
         // spread below re-applies the same injected value harmlessly.
         resourceLoader: this.sessionOptions.resourceLoader ?? (await this.getSharedResourceLoader(agentDir)),
-        // pi >= 0.80.8: createAgentSession takes modelRuntime, not a registry
-        // (the registry option is ignored there). omp's fork has no `.runtime`,
-        // so this spread is a no-op on omp.
-        ...(modelRegistry
-          ? { modelRuntime: runtimeOf(modelRegistry) as CreateAgentSessionOptions["modelRuntime"] }
-          : {}),
+        // Host split (see modelRuntime above): stock pi takes modelRuntime;
+        // omp's fork takes modelRegistry. Spread-cast keeps the runtime value
+        // while satisfying the upstream CreateAgentSessionOptions type.
+        ...(modelRuntime ? { modelRuntime } : { modelRegistry }),
         ...this.sessionOptions,
         // The computed AgentRegistry id must win over any injected
         // sessionOptions value: a stable embedder-supplied agentId would

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -10,7 +10,6 @@ import {
   DefaultResourceLoader,
   getAgentDir,
   ModelRegistry,
-  ModelRuntime,
   SessionManager,
   SettingsManager,
   type ToolDefinition,
@@ -220,7 +219,7 @@ export interface WorkflowAgentOptions {
    * so a workflow subagent can't fan out through them either (#107).
    */
   excludeTools?: string[];
-  /** Override any createAgentSession option (model, modelRuntime, resourceLoader, etc.). */
+  /** Override any createAgentSession option (model, modelRegistry, resourceLoader, etc.). */
   session?: Partial<CreateAgentSessionOptions>;
   /** Extra system guidance prepended to every subagent task. */
   instructions?: string;
@@ -248,10 +247,11 @@ export interface WorkflowAgentOptions {
   persistAgentSessions?: boolean;
 }
 
-// pi >= 0.80.8: ModelRegistry is a sync facade over an async-created ModelRuntime
-// (AuthStorage/ModelRegistry.create are gone). The disk-backed fallback is built
-// lazily; sync callers see [] until it resolves and real specs on later reads.
-let fallbackRuntimePromise: Promise<ModelRuntime> | undefined;
+// omp's ModelRegistry is auth-storage-backed (no pi >= 0.80.8 sync-facade /
+// runtime split): build it directly from the discovered AuthStorage. The
+// disk-backed fallback is built lazily; sync callers see [] until it resolves
+// and real specs on later reads.
+let fallbackRuntimePromise: Promise<ModelRegistry | undefined> | undefined;
 let fallbackRegistry: ModelRegistry | undefined;
 
 function ensureFallbackRegistry(): Promise<ModelRegistry> {
@@ -260,14 +260,23 @@ function ensureFallbackRegistry(): Promise<ModelRegistry> {
     // Same auth.json/models.json createAgentSession uses by default, so a model
     // resolved here carries valid credentials.
     fallbackRuntimePromise = (async () => {
-      const runtime = await ModelRuntime.create({
-        authPath: join(dir, "auth.json"),
-        modelsPath: join(dir, "models.json"),
-      });
-      // Warm the availability snapshot so the facade's sync getAvailable() is
-      // populated immediately after this promise resolves.
-      await runtime.getAvailable().catch(() => {});
-      return runtime;
+      // discoverAuthStorage is omp's bundled pi-coding-agent export; on other
+      // hosts (pi CLI, tests) fall back to the legacy static create, and if
+      // neither exists the fallback registry stays empty (listAvailableModels
+      // reports [] and tier ranking falls through to the main model).
+      const mod = await import("@earendil-works/pi-coding-agent").catch(() => undefined);
+      const discover = (mod as { discoverAuthStorage?: (dir: string) => unknown } | undefined)?.discoverAuthStorage;
+      if (typeof discover === "function") {
+        const authStorage = (await discover(dir)) as ConstructorParameters<typeof ModelRegistry>[0];
+        return new ModelRegistry(authStorage);
+      }
+      const create = (
+        ModelRegistry as unknown as {
+          create?: (opts: { dir: string }) => Promise<ModelRegistry>;
+        }
+      ).create;
+      if (typeof create === "function") return create({ dir });
+      return undefined;
     })();
     // Don't cache a rejection: a transient failure (e.g. auth.json lock) would
     // otherwise wedge the fallback for the rest of the process.
@@ -275,34 +284,22 @@ function ensureFallbackRegistry(): Promise<ModelRegistry> {
       fallbackRuntimePromise = undefined;
     });
   }
-  return fallbackRuntimePromise.then((runtime) => {
-    fallbackRegistry ??= new ModelRegistry(runtime);
+  return fallbackRuntimePromise.then((registry) => {
+    fallbackRegistry ??= registry;
     return fallbackRegistry;
-  });
+  }) as Promise<ModelRegistry>;
 }
 
-let warnedNoRuntime = false;
-
 /**
- * The ModelRuntime behind a registry facade. pi's ModelRegistry does not expose
- * its runtime publicly, so reach into the private field (stable since 0.80.8);
- * subagent sessions need it to share the host session's exact catalog and auth
- * (createAgentSession takes modelRuntime, not a registry, since 0.80.8).
- *
- * Exported so the test suite can pin this pi-internals contract: the cast means
- * neither tsc nor mock-based tests would notice pi renaming the field, and the
- * runtime consequence is silent (subagents fall back to a default runtime and
- * extension-registered providers vanish from routing).
+ * The ModelRuntime behind a registry facade (pi >= 0.80.8 shape: ModelRegistry
+ * wraps a ModelRuntime but exposes no getter). Subagent sessions need it to
+ * share the host session's exact catalog and auth — createAgentSession takes
+ * modelRuntime, not a registry, on that line. omp's fork is auth-storage-backed
+ * (registry has no `runtime` field and createAgentSession takes modelRegistry
+ * instead), so this returns undefined there and the handoff no-ops.
  */
-export function runtimeOf(registry: ModelRegistry): ModelRuntime | undefined {
-  const runtime = (registry as unknown as { runtime?: ModelRuntime }).runtime;
-  if (!runtime && !warnedNoRuntime) {
-    warnedNoRuntime = true;
-    console.warn(
-      "[workflow] ModelRegistry no longer carries a private `runtime` field (pi internals changed); subagents fall back to a default-built runtime and may miss extension-registered providers",
-    );
-  }
-  return runtime;
+export function runtimeOf(registry: ModelRegistry): unknown {
+  return (registry as unknown as { runtime?: unknown }).runtime;
 }
 
 /**
@@ -580,6 +577,8 @@ export type AgentRunResult<TSchemaDef extends TSchema | undefined> = TSchemaDef 
  * additional tool names via WorkflowAgentOptions.excludeTools.
  */
 export const DEFAULT_EXCLUDED_SUBAGENT_TOOLS = ["workflow", "workflow_control"];
+/** Process-global subagent id counter: unique across concurrent workflow runs. */
+let workflowAgentSeq = 0;
 
 /**
  * The full subagent tool denylist: the always-on defaults plus any names the
@@ -632,6 +631,8 @@ export class WorkflowAgent {
    */
   private readonly threadSessions = new Map<string, SessionManager>();
   private readonly activeThreads = new Set<string>();
+  /** Unique per-instance identity: agent ids must never collide across WorkflowAgent instances. */
+  private readonly agentInstanceId = randomUUID();
 
   constructor(options: WorkflowAgentOptions = {}) {
     this.cwd = options.cwd ?? process.cwd();
@@ -694,8 +695,8 @@ export class WorkflowAgent {
   /**
    * Resolve the registry for a run: an explicit per-run registry wins, then the
    * constructor's shared registry, then a lazily-built disk registry (shared
-   * across calls once built). Async because pi >= 0.80.8 builds registries from
-   * an async-created ModelRuntime.
+   * shared across calls once built). Async because omp builds registries from an
+   * async-discovered AuthStorage.
    */
   private async getRegistry(perRunRegistry?: ModelRegistry): Promise<ModelRegistry> {
     if (perRunRegistry) {
@@ -788,6 +789,20 @@ export class WorkflowAgent {
     const probePath = join(dir, `.write-probe-${randomUUID()}`);
     writeFileSync(probePath, "");
     unlinkSync(probePath);
+  }
+  /**
+   * Unique AgentRegistry id for the next spawned subagent. Concurrent
+   * createAgentSession calls that omit agentId all default to "Main" and race
+   * on the process-global registry (omp: "Agent \"Main\" was replaced during
+   * session initialization"). Unthreaded calls embed a per-process monotonic
+   * sequence so retries and concurrent runs never reuse an id. Named threads
+   * stay stable within one WorkflowAgent instance (a thread is one continuing
+   * session) but embed the instance id, so separate instances/runs never
+   * collide in the process-global registry.
+   */
+  private agentIdFor(options: AgentRunOptions<any>, runCwd: string): string {
+    if (options.thread) return `workflow:${runCwd}:${this.agentInstanceId}:${options.thread}`;
+    return `workflow:${runCwd}:${process.pid}:${++workflowAgentSeq}`;
   }
 
   async run<TSchemaDef extends TSchema | undefined = undefined>(
@@ -916,9 +931,6 @@ export class WorkflowAgent {
     }
 
     const agentDir = getAgentDir();
-    // The runtime behind the resolved registry, handed to the subagent session
-    // below so it shares the host session's exact catalog and auth.
-    const modelRuntime = runtimeOf(modelRegistry);
     // Key persisted sessions by the runner's project cwd (this.cwd), NOT the
     // per-call runCwd: agents working in short-lived git worktrees should still
     // group under the project's session dir instead of scattering across
@@ -942,13 +954,25 @@ export class WorkflowAgent {
         // wins and skips the shared build entirely; the ...this.sessionOptions
         // spread below re-applies the same injected value harmlessly.
         resourceLoader: this.sessionOptions.resourceLoader ?? (await this.getSharedResourceLoader(agentDir)),
-        // Share the resolved registry's ModelRuntime (catalog + auth, including
-        // extension-registered providers) with the subagent session. pi >= 0.80.8
-        // takes modelRuntime here; the old modelRegistry option is gone.
-        ...(modelRuntime ? { modelRuntime } : {}),
+        // pi >= 0.80.8: createAgentSession takes modelRuntime, not a registry
+        // (the registry option is ignored there). omp's fork has no `.runtime`,
+        // so this spread is a no-op on omp.
+        ...(modelRegistry
+          ? { modelRuntime: runtimeOf(modelRegistry) as CreateAgentSessionOptions["modelRuntime"] }
+          : {}),
         ...this.sessionOptions,
-        // Named threads must retain their own manager even when an embedder supplied
-        // a default manager for ordinary one-shot calls.
+        // The computed AgentRegistry id must win over any injected
+        // sessionOptions value: a stable embedder-supplied agentId would
+        // collide across runs in the process-global registry. `agentId` is
+        // omp-fork-only (absent from upstream 0.83 types this package builds
+        // against); spread-cast keeps the runtime value while satisfying the
+        // upstream CreateAgentSessionOptions type.
+        ...{ agentId: this.agentIdFor(options, runCwd) },
+        // Named threads must retain their own manager even when an embedder
+        // supplied a default manager for ordinary one-shot calls — the
+        // sessionOptions spread above would otherwise overwrite the cached
+        // thread manager with the injected one, breaking turn continuity and
+        // failed-turn rollback.
         ...(options.thread ? { sessionManager } : {}),
         // Per-call model/thinking wins over any sessionOptions defaults.
         ...(resolvedModel ? { model: resolvedModel } : {}),

--- a/src/model-spec.ts
+++ b/src/model-spec.ts
@@ -1,5 +1,4 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
-import { modelsAreEqual } from "@earendil-works/pi-ai";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 
 export const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
@@ -208,7 +207,7 @@ function buildFallbackModel(provider: string, modelId: string, availableModels: 
  * the cross-check property test in tests/model-spec.test.ts, which runs both
  * implementations against the same fuzzed inputs and fails loudly the moment they
  * diverge (see that file for why we don't call pi's export directly: it requires
- * a real `ModelRuntime`, which has a private constructor pi doesn't expose a
+ * a real runtime class, which has a private constructor pi doesn't expose a
  * lightweight adapter for).
  */
 export function resolveModelSpecWithThinking(
@@ -269,7 +268,9 @@ export function resolveModelSpecWithThinking(
     // aggregator the caller actually has access to.
     if (inferredProvider && modelRegistry.hasConfiguredAuth && !modelRegistry.hasConfiguredAuth(model)) {
       const rawExactMatches = availableModels.filter(
-        (candidate) => candidate.id.toLowerCase() === requestedSpec.toLowerCase() && !modelsAreEqual(candidate, model),
+        (candidate) =>
+          candidate.id.toLowerCase() === requestedSpec.toLowerCase() &&
+          !(candidate.id === model.id && candidate.provider === model.provider),
       );
       const authenticatedRawMatches = rawExactMatches.filter((candidate) =>
         modelRegistry.hasConfiguredAuth?.(candidate),

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -209,6 +209,35 @@ const boundSessionSends = new Map<string, DeliverySend>();
 /** runIds with an in-flight deliver-and-ack so bind flush does not double-send. */
 const inFlightDeliveries = new Set<string>();
 
+/**
+ * Custom type for the one-shot session_start probe (see probeHostSessionSend).
+ * Invisible and turn-free on every supported host (pi 0.83/0.84, omp fork).
+ */
+export const DELIVERY_PROBE_CUSTOM_TYPE = "workflow-delivery-probe";
+
+/** Session ids already probed — one probe per session, never re-fires. */
+const probedSessionIds = new Set<string>();
+
+/**
+ * Quiet hosts (omp never sends custom messages itself) never trip the
+ * AgentSession.prototype patch, so no thenable send is ever captured. One
+ * probe through pi.sendMessage forces it: the host's void wrapper calls the
+ * live session's sendCustomMessage synchronously, the prototype patch captures
+ * the receiver, and boundSessionSends is populated by the time this returns.
+ * display:false + triggerTurn:false appends a durable invisible entry on every
+ * supported host and starts no turn.
+ */
+function probeHostSessionSend(pi: ExtensionAPI, sessionId: string): void {
+  if (probedSessionIds.has(sessionId)) return;
+  probedSessionIds.add(sessionId);
+  try {
+    pi.sendMessage({ customType: DELIVERY_PROBE_CUSTOM_TYPE, content: "", display: false }, { triggerTurn: false });
+  } catch (err) {
+    // Probe is best-effort; bind stays fail-closed without a captured send.
+    console.warn(`[workflow-delivery] delivery probe failed on session ${sessionId}:`, err);
+  }
+}
+
 let agentSessionPatched = false;
 let bindCoreObserved = false;
 
@@ -218,21 +247,15 @@ interface StealCandidate {
     persist?: boolean;
     getSessionId?: () => string;
     getSessionName?: () => string | undefined;
+    isPersisted?: () => boolean;
+    isSessionOnDisk?: () => boolean;
   };
   _resourceLoader?: { noExtensions?: boolean };
 }
 
-/**
- * Host Pi session only. Child workflow agents must not be pinned:
- *  - SessionManager.inMemory() → persist === false
- *  - shared noExtensions loader (persistAgentSessions children included)
- *  - persisted children named `workflow:<runId> …` (set after construction;
- *    still filters a later re-bindCore)
- */
-function hostSessionIdToSteal(session: StealCandidate): string | undefined {
+function hostSessionIdToSteal(session: StealCandidate, probe?: boolean): string | undefined {
   const sm = session.sessionManager;
   if (!sm) return undefined;
-  if (sm.persist === false) return undefined;
   if (session._resourceLoader?.noExtensions === true) return undefined;
   try {
     const name = sm.getSessionName?.();
@@ -241,19 +264,38 @@ function hostSessionIdToSteal(session: StealCandidate): string | undefined {
     // getSessionName unavailable — keep evaluating
   }
   if (typeof session.sendCustomMessage !== "function") return undefined;
-  try {
-    const sid = sm.getSessionId?.();
-    if (typeof sid === "string" && sid) return sid;
-  } catch {
-    return undefined;
+  const sid = sm.getSessionId?.();
+  if (typeof sid !== "string" || !sid) return undefined;
+  // omp's SessionManager (0.83) has no `persist` field — isPersisted() is the
+  // authoritative persisted check, so query it before falling back to the
+  // structural persist flag (#109). A host that IS persisted but structurally
+  // declares persist:false (in-memory host sessions that are the conversation)
+  // must still be stolen — the isPersisted() answer wins (#109).
+  // PROBE EXCEPTION: omp print-mode hosts report isSessionOnDisk()===false at
+  // session_start (persisted lazily after bind). The bind-time probe only ever
+  // fires on the session running this extension, and workflow-child sessions
+  // are already excluded by the workflow: name gate above — so a probe-bearing
+  // send skips the persistence gate.
+  if (!probe) {
+    try {
+      if (typeof sm.isPersisted === "function") {
+        if (!sm.isPersisted()) return undefined;
+      } else if (typeof sm.isSessionOnDisk === "function") {
+        if (!sm.isSessionOnDisk()) return undefined;
+      } else if (sm.persist !== true) {
+        return undefined;
+      }
+    } catch {
+      return undefined;
+    }
   }
-  return undefined;
+  return sid;
 }
 
-function captureHostSessionSend(session: StealCandidate): void {
-  const sid = hostSessionIdToSteal(session);
+function captureHostSessionSend(session: StealCandidate, probe?: boolean): void {
+  const sid = hostSessionIdToSteal(session, probe);
   if (!sid) return;
-  boundSessionSends.set(sid, (message, options) => session.sendCustomMessage!(message, options));
+  boundSessionSends.set(sid, (message, options) => session.sendCustomMessage?.(message, options));
 }
 
 /**
@@ -265,18 +307,29 @@ function patchAgentSessionCapture(): void {
   if (agentSessionPatched) return;
   agentSessionPatched = true;
   try {
-    const proto = AgentSession.prototype as unknown as {
-      _bindExtensionCore?: (runner: unknown) => unknown;
-    } & StealCandidate;
-    const original = proto._bindExtensionCore;
-    if (typeof original !== "function") return;
-    proto._bindExtensionCore = function patchedBindExtensionCore(this: StealCandidate, runner: unknown) {
+    const proto = AgentSession.prototype as unknown as StealCandidate;
+    const original = proto.sendCustomMessage;
+    if (typeof original !== "function") {
+      // AgentSession shape changed — bind stays fail-closed without steal.
+      return;
+    }
+    // Invoke the original with the runtime's live session as receiver. A
+    // `.bind(proto)` forward would freeze the receiver to the prototype, and a
+    // bound function's receiver cannot be overridden by `.call(this, …)` — the
+    // original would run with `this.agent` undefined and every non-trigger
+    // send would reject, silently losing the delivery. Patch predates session
+    // construction: this here is the session that later calls sendCustomMessage.
+    proto.sendCustomMessage = function patchedSendCustomMessage(
+      this: StealCandidate,
+      message: { customType: string; content: string; display: boolean },
+      options: { triggerTurn: boolean; deliverAs: "followUp" },
+    ) {
       try {
-        captureHostSessionSend(this);
+        captureHostSessionSend(this, message?.customType === DELIVERY_PROBE_CUSTOM_TYPE);
       } catch {
         // never break session construction
       }
-      return original.apply(this, [runner]);
+      return original.call(this, message, options);
     };
   } catch {
     // AgentSession unavailable or shape changed — bind stays fail-closed without steal
@@ -537,7 +590,7 @@ function routeBackgroundDelivery(
  */
 export function bindSessionDelivery(
   sessionId: string,
-  _pi: ExtensionAPI,
+  pi: ExtensionAPI,
   opts: {
     loadSettings?: () => WorkflowSettings;
     manager?: WorkflowManager;
@@ -565,15 +618,6 @@ export function bindSessionDelivery(
   patchAgentSessionCapture();
   patchBindCoreObserve();
 
-  const stolen = opts.stableSend ?? boundSessionSends.get(sessionId);
-
-  if (!stolen) {
-    console.warn(
-      `[workflow-delivery] no session-stable thenable send for session ${sessionId}; ` +
-        "endpoint registered fail-closed (completions stay on disk until a host send is captured).",
-    );
-  }
-
   // Optional identity check — refuse to bind when sessionManager disagrees.
   try {
     const liveId = opts.sessionManager?.getSessionId?.();
@@ -583,6 +627,23 @@ export function bindSessionDelivery(
     }
   } catch {
     // getSessionId unavailable — continue
+  }
+
+  let stolen = opts.stableSend ?? boundSessionSends.get(sessionId);
+  if (!stolen) {
+    // Quiet hosts never call sendCustomMessage themselves, so the prototype
+    // patch never captured. One invisible no-turn probe forces the host's void
+    // send wrapper through AgentSession.sendCustomMessage, populating the
+    // steal map synchronously.
+    probeHostSessionSend(pi, sessionId);
+    stolen = boundSessionSends.get(sessionId);
+  }
+
+  if (!stolen) {
+    console.warn(
+      `[workflow-delivery] no session-stable thenable send for session ${sessionId}; ` +
+        "endpoint registered fail-closed (completions stay on disk until a host send is captured).",
+    );
   }
 
   const prev = sessionEndpoints.get(sessionId);
@@ -794,6 +855,7 @@ export function _resetDeliveryRegistriesForTests(): void {
   sessionEndpoints.clear();
   boundSessionSends.clear();
   inFlightDeliveries.clear();
+  probedSessionIds.clear();
 }
 
 /** @internal test helper — register a thenable session-stable send (steal map). */
@@ -801,9 +863,14 @@ export function _registerBoundSessionSendForTests(sessionId: string, send: Deliv
   boundSessionSends.set(sessionId, send);
 }
 
-/** @internal test helper — whether the steal map holds a send for this session. */
-export function _hasBoundSessionSendForTests(sessionId: string): boolean {
-  return boundSessionSends.has(sessionId);
+/** @internal test helper — register a host-shaped session (steal-map host filter). */
+export function _registerHostSessionForTests(session: StealCandidate): void {
+  captureHostSessionSend(session);
+}
+
+/** @internal test helper — inspect which session ids currently hold a stolen send. */
+export function _getStealMapForTests(): ReadonlyMap<string, DeliverySend> {
+  return boundSessionSends;
 }
 
 /** @internal test helper — inspect endpoint suspended flag. */

--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -210,32 +210,44 @@ const boundSessionSends = new Map<string, DeliverySend>();
 const inFlightDeliveries = new Set<string>();
 
 /**
- * Custom type for the one-shot session_start probe (see probeHostSessionSend).
- * Invisible and turn-free on every supported host (pi 0.83/0.84, omp fork).
+ * Custom type for the session bind probe (see probeHostSessionSend). Sent
+ * through pi.sendMessage ONLY so the sendCustomMessage capture patch can
+ * identify the live host session. Capture-only: the patched sendCustomMessage
+ * swallows probe messages — nothing is appended, persisted, or turned.
  */
 export const DELIVERY_PROBE_CUSTOM_TYPE = "workflow-delivery-probe";
 
-/** Session ids already probed — one probe per session, never re-fires. */
+/**
+ * Session ids probed successfully. Marked only after a probe that captured a
+ * send; a failed or missed probe stays unmarked and is retried on the next
+ * bind.
+ */
 const probedSessionIds = new Set<string>();
 
 /**
  * Quiet hosts (omp never sends custom messages itself) never trip the
  * AgentSession.prototype patch, so no thenable send is ever captured. One
- * probe through pi.sendMessage forces it: the host's void wrapper calls the
- * live session's sendCustomMessage synchronously, the prototype patch captures
- * the receiver, and boundSessionSends is populated by the time this returns.
- * display:false + triggerTurn:false appends a durable invisible entry on every
- * supported host and starts no turn.
+ * capture-only probe through pi.sendMessage forces it: the host's void wrapper
+ * calls the live session's sendCustomMessage synchronously, the prototype patch
+ * captures the receiver (never forwarding the probe), and boundSessionSends is
+ * populated by the time this returns.
+ *
+ * Retry-correct: the session is marked probed only when the probe actually
+ * captured a send. A host whose pi.sendMessage throws (e.g. "Extension runtime
+ * not initialized" during early startup) stays unmarked, so the next
+ * bindSessionDelivery probes again instead of being permanently silent.
  */
 function probeHostSessionSend(pi: ExtensionAPI, sessionId: string): void {
   if (probedSessionIds.has(sessionId)) return;
-  probedSessionIds.add(sessionId);
   try {
     pi.sendMessage({ customType: DELIVERY_PROBE_CUSTOM_TYPE, content: "", display: false }, { triggerTurn: false });
   } catch (err) {
     // Probe is best-effort; bind stays fail-closed without a captured send.
+    // Not marked probed — the next bindSessionDelivery retries.
     console.warn(`[workflow-delivery] delivery probe failed on session ${sessionId}:`, err);
+    return;
   }
+  if (boundSessionSends.has(sessionId)) probedSessionIds.add(sessionId);
 }
 
 let agentSessionPatched = false;
@@ -251,6 +263,7 @@ interface StealCandidate {
     isSessionOnDisk?: () => boolean;
   };
   _resourceLoader?: { noExtensions?: boolean };
+  _bindExtensionCore?: (...args: unknown[]) => unknown;
 }
 
 function hostSessionIdToSteal(session: StealCandidate, probe?: boolean): string | undefined {
@@ -265,17 +278,15 @@ function hostSessionIdToSteal(session: StealCandidate, probe?: boolean): string 
   }
   if (typeof session.sendCustomMessage !== "function") return undefined;
   const sid = sm.getSessionId?.();
-  if (typeof sid !== "string" || !sid) return undefined;
-  // omp's SessionManager (0.83) has no `persist` field — isPersisted() is the
-  // authoritative persisted check, so query it before falling back to the
-  // structural persist flag (#109). A host that IS persisted but structurally
-  // declares persist:false (in-memory host sessions that are the conversation)
-  // must still be stolen — the isPersisted() answer wins (#109).
-  // PROBE EXCEPTION: omp print-mode hosts report isSessionOnDisk()===false at
-  // session_start (persisted lazily after bind). The bind-time probe only ever
-  // fires on the session running this extension, and workflow-child sessions
-  // are already excluded by the workflow: name gate above — so a probe-bearing
-  // send skips the persistence gate.
+  // PROBE EXCEPTION: the probe bypasses ONLY this persistence gate; the
+  // sessionManager presence, noExtensions, and workflow:-name gates above
+  // still apply. Justification: unnamed in-memory workflow children are
+  // excluded by noExtensions/isPersisted at the bindCore hook (probe=false),
+  // and a probe is only ever sent through the pi.sendMessage of the session
+  // running this extension — it cannot reach a foreign or child session. omp
+  // print-mode hosts report isSessionOnDisk()===false at session_start
+  // (persisted lazily after bind), so the gate must not reject a probe-bearing
+  // send (#109).
   if (!probe) {
     try {
       if (typeof sm.isPersisted === "function") {
@@ -313,6 +324,23 @@ function patchAgentSessionCapture(): void {
       // AgentSession shape changed — bind stays fail-closed without steal.
       return;
     }
+    // PRIMARY capture hook: `_bindExtensionCore` runs at session construction,
+    // before any extension code, so a stock pi host is captured without ever
+    // probing. The omp fork bundle does not expose the symbol — guard with
+    // typeof so the patch stays a no-op there and the probe fallback handles
+    // capture. Full original gates apply (persistence gate included,
+    // probe=false).
+    if (typeof proto._bindExtensionCore === "function") {
+      const bindCore = proto._bindExtensionCore;
+      proto._bindExtensionCore = function patchedBindExtensionCore(this: StealCandidate, ...args: unknown[]) {
+        try {
+          captureHostSessionSend(this, false);
+        } catch {
+          // never break session construction
+        }
+        return bindCore.apply(this, args);
+      };
+    }
     // Invoke the original with the runtime's live session as receiver. A
     // `.bind(proto)` forward would freeze the receiver to the prototype, and a
     // bound function's receiver cannot be overridden by `.call(this, …)` — the
@@ -324,11 +352,16 @@ function patchAgentSessionCapture(): void {
       message: { customType: string; content: string; display: boolean },
       options: { triggerTurn: boolean; deliverAs: "followUp" },
     ) {
+      const isProbe = message?.customType === DELIVERY_PROBE_CUSTOM_TYPE;
       try {
-        captureHostSessionSend(this, message?.customType === DELIVERY_PROBE_CUSTOM_TYPE);
+        captureHostSessionSend(this, isProbe);
       } catch {
-        // never break session construction
+        // never break the host send
       }
+      // Capture-only probe: the probe exists only to trip this capture patch.
+      // Never append to agent.state.messages, never write a session entry,
+      // never inject an LLM user turn — swallow it entirely.
+      if (isProbe) return Promise.resolve();
       return original.call(this, message, options);
     };
   } catch {
@@ -537,6 +570,10 @@ function deliverAndAck(
   if (inFlightDeliveries.has(runId)) return;
   const endpoint = sessionEndpoints.get(sessionId);
   if (!endpoint || endpoint.suspended || endpoint.sessionId !== sessionId) return;
+  // Fail-closed (no send): keep the run pending on disk with NO lock, so a
+  // synchronous re-bind + flush (e.g. probe retry on the next session_start)
+  // is not locked out by a microtask that has not run yet.
+  if (typeof endpoint.send !== "function") return;
 
   inFlightDeliveries.add(runId);
   const startedGeneration = endpoint.generation;
@@ -679,6 +716,9 @@ export function dropSessionDelivery(sessionId: string | undefined): void {
   if (!sessionId) return;
   sessionEndpoints.delete(sessionId);
   boundSessionSends.delete(sessionId);
+  // A dropped session may be rebound fresh (e.g. replaced id): forget probe
+  // bookkeeping so the next bindSessionDelivery probes again.
+  probedSessionIds.delete(sessionId);
 }
 
 /**
@@ -871,6 +911,11 @@ export function _registerHostSessionForTests(session: StealCandidate): void {
 /** @internal test helper — inspect which session ids currently hold a stolen send. */
 export function _getStealMapForTests(): ReadonlyMap<string, DeliverySend> {
   return boundSessionSends;
+}
+
+/** @internal test helper — inspect whether a session is marked successfully probed. */
+export function _isProbedForTests(sessionId: string): boolean {
+  return probedSessionIds.has(sessionId);
 }
 
 /** @internal test helper — inspect endpoint suspended flag. */

--- a/src/workflow-comprehension.ts
+++ b/src/workflow-comprehension.ts
@@ -1,10 +1,10 @@
 import { setImmediate as pause } from "node:timers/promises";
 import { isDeepStrictEqual } from "node:util";
-import type { ModelThinkingLevel } from "@earendil-works/pi-ai";
 import type { TSchema } from "typebox";
 import type { AgentRunOptions } from "./agent.js";
 import { ComprehensionSuite, ComprehensionTaskKind } from "./enums.js";
 import { ModelGenerationError, WorkflowError, WorkflowErrorCode } from "./errors.js";
+import type { ModelThinkingLevel } from "./model-spec.js";
 import { parseWorkflowScript, runWorkflow, type WorkflowRuntimeEvent } from "./workflow.js";
 
 /** Re-exported scenario groups and authoring operations used by the optional comprehension CLI. */

--- a/src/workflow-editor.ts
+++ b/src/workflow-editor.ts
@@ -128,7 +128,7 @@ export function buildArmedWorkflowPrompt(
     "decomposable request to do work, handle it by calling the `workflow` tool: write a script",
     "that fans the task out across subagents via agent()/parallel()/pipeline().",
     `Why this turn is armed: ${armReasonClause(reason)}.`,
-    BACKGROUND_DELIVERY_REASSURANCE + "]",
+    `${BACKGROUND_DELIVERY_REASSURANCE}]`,
   ];
   if (opts.extraDirective) lines.push("", opts.extraDirective);
   return lines.join("\n");
@@ -152,7 +152,7 @@ export function buildForcedWorkflowPrompt(text: string, extraDirective?: string)
     "Call the `workflow` tool now: write a script that fans this task out across subagents",
     "via agent()/parallel()/pipeline(). (This is a direct command, not a heuristic guess, so",
     "do not answer in prose instead of running the workflow.)",
-    BACKGROUND_DELIVERY_REASSURANCE + "]",
+    `${BACKGROUND_DELIVERY_REASSURANCE}]`,
   ];
   if (extraDirective) lines.push("", extraDirective);
   return lines.join("\n");

--- a/src/workflow-release-gate.ts
+++ b/src/workflow-release-gate.ts
@@ -474,7 +474,6 @@ function validatePackage(root: string, publishableFiles: readonly string[]): Wor
   return diagnostics;
 }
 
-/** Parse publishable paths from `npm pack --dry-run --json` without trusting external JSON shapes. */
 export function parseNpmPackFilePaths(output: string): string[] {
   const parsed: unknown = JSON.parse(output);
   // npm 10 emits `[{ files }]`; npm 11 emits `{ files }`.

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_EXCLUDED_SUBAGENT_TOOLS,
   listAvailableModelSpecs,
   resolveAgentModelSpec,
+  runtimeOf,
   subagentExcludedTools,
   usageFromStats,
   WorkflowAgent,
@@ -36,7 +37,7 @@ type WorkflowAgentPrivates = {
     appendSessionInfo(name: string): string;
   };
   restoreThreadLeaf(manager: ReturnType<WorkflowAgentPrivates["createSessionManager"]>, leafId: string | null): void;
-  agentIdFor(options: AgentRunOptions<any>, runCwd: string): string;
+  getRegistry(perRunRegistry?: ModelRegistry): Promise<ModelRegistry>;
 };
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -1817,4 +1818,46 @@ test("usageFromStats keeps cost-only stats (billed but tokens unreported)", () =
     cost: 0.01,
   });
   assert.equal(usage?.cost, 0.01);
+});
+// ═══════════════════════════════════════════════════════════════════════
+// runtimeOf + 3-way fallback registry construction (omp / legacy / stock pi)
+// ═══════════════════════════════════════════════════════════════════════
+
+test("runtimeOf returns the backing ModelRuntime on stock pi and undefined on a fork-style registry", async () => {
+  const authDir = mkdtempSync(join(tmpdir(), "pi-dw-runtime-of-"));
+  try {
+    const runtime = await ModelRuntime.create({ authPath: join(authDir, "auth.json"), modelsPath: null });
+    const registry = new ModelRegistry(runtime);
+    assert.equal(runtimeOf(registry), runtime, "stock pi ModelRegistry must expose its runtime for subagent handoff");
+    // omp's auth-storage-backed registry carries no own `.runtime`; the seam
+    // must report undefined there so callers pass the registry itself instead.
+    const forkRegistry: ModelRegistry = Object.create(Object.getPrototypeOf(registry));
+    assert.equal(runtimeOf(forkRegistry), undefined);
+  } finally {
+    rmSync(authDir, { recursive: true, force: true });
+  }
+});
+
+test("stock pi exposes neither omp's discoverAuthStorage nor a legacy static ModelRegistry.create (fallback must use ModelRuntime.create)", async () => {
+  assert.equal(typeof ModelRuntime.create, "function", "runtime-split construction path must exist on stock pi");
+  const mod = await import("@earendil-works/pi-coding-agent");
+  assert.equal("discoverAuthStorage" in mod, false, "omp-only discovery export must not exist on stock pi");
+  assert.equal("create" in ModelRegistry, false, "legacy static create must not exist on stock pi");
+});
+
+test("fallback registry resolves to a real ModelRegistry on stock pi and is cached across agents (never undefined)", async () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-fallback-home-"));
+  try {
+    await withFakeHomeAsync(home, async () => {
+      const agent1 = new WorkflowAgent({ cwd: "/tmp" }) as unknown as WorkflowAgentPrivates;
+      const agent2 = new WorkflowAgent({ cwd: "/tmp" }) as unknown as WorkflowAgentPrivates;
+      const first = await agent1.getRegistry();
+      assert.ok(first instanceof ModelRegistry, "fallback must resolve to a real registry, never undefined");
+      assert.ok(runtimeOf(first), "stock-pi fallback registry must carry a runtime for subagent handoff");
+      assert.equal(await agent1.getRegistry(), first, "per-agent fallback must be reused");
+      assert.equal(await agent2.getRegistry(), first, "module-level fallback registry must be shared across agents");
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 });

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -36,6 +36,7 @@ type WorkflowAgentPrivates = {
     appendSessionInfo(name: string): string;
   };
   restoreThreadLeaf(manager: ReturnType<WorkflowAgentPrivates["createSessionManager"]>, leafId: string | null): void;
+  agentIdFor(options: AgentRunOptions<any>, runCwd: string): string;
 };
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -72,6 +73,45 @@ test("WorkflowAgent with persistAgentSessions=true creates a file-backed manager
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("agentIdFor mints a unique id per unthreaded createAgentSession call (concurrent/retry-safe)", () => {
+  const agent = new WorkflowAgent({ cwd: "/tmp" }) as unknown as WorkflowAgentPrivates;
+  const id1 = agent.agentIdFor({}, "/worktree-a");
+  const id2 = agent.agentIdFor({}, "/worktree-b");
+  const id3 = agent.agentIdFor({}, "/worktree-a");
+  assert.notEqual(id1, id2, "distinct worktrees must never share an id");
+  assert.notEqual(id1, id3, "a retried call on the same worktree must not reuse the id");
+  // Each id embeds the pid + a monotonic per-process sequence, so ids from
+  // concurrent runs in this process can never collide either.
+  assert.match(id1, /^workflow:\/worktree-a:\d+:\d+$/);
+});
+
+test("agentIdFor keeps one stable id per named thread (a thread is one continuing session)", () => {
+  const agent = new WorkflowAgent({ cwd: "/tmp" }) as unknown as WorkflowAgentPrivates;
+  const first = agent.agentIdFor({ thread: "implementer" }, "/worktree");
+  const again = agent.agentIdFor({ thread: "implementer" }, "/worktree");
+  const other = agent.agentIdFor({ thread: "reviewer" }, "/worktree");
+  assert.equal(again, first, "thread turns continue one session, so the id must be stable");
+  assert.notEqual(other, first, "distinct threads must not share an id");
+});
+
+test("agentIdFor ids never collide across separate WorkflowAgent instances", () => {
+  const first = new WorkflowAgent({ cwd: "/tmp" }) as unknown as WorkflowAgentPrivates;
+  const second = new WorkflowAgent({ cwd: "/tmp" }) as unknown as WorkflowAgentPrivates;
+  // Unthreaded one-shot calls: every invocation gets a fresh id, across instances too.
+  assert.notEqual(
+    first.agentIdFor({}, "/worktree"),
+    second.agentIdFor({}, "/worktree"),
+    "unthreaded ids from separate instances must not collide",
+  );
+  // Named threads: stable within one instance, but the same thread name on a
+  // separate instance must not reuse the id (process-global AgentRegistry).
+  assert.notEqual(
+    first.agentIdFor({ thread: "implementer" }, "/worktree"),
+    second.agentIdFor({ thread: "implementer" }, "/worktree"),
+    "the same thread name on separate instances must not share an AgentRegistry id",
+  );
 });
 
 test("WorkflowAgent retains one session manager per named thread", () => {

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -207,13 +207,15 @@ type TaskPanelModule = {
   resumeResultDelivery: (manager: unknown) => void;
   suspendSessionDelivery: (sessionId: string | undefined) => void;
   resumeSessionDelivery: (sessionId: string | undefined, manager?: unknown) => void;
-  installTaskPanel: (pi: ExtensionAPI | null, manager: unknown, ui: unknown) => void;
   _resetDeliveryRegistriesForTests: () => void;
   _registerBoundSessionSendForTests: (sessionId: string, send: StableSend) => void;
-  _hasBoundSessionSendForTests: (sessionId: string) => boolean;
+  _registerHostSessionForTests: (session: object) => void;
+  DELIVERY_PROBE_CUSTOM_TYPE: string;
+  _getStealMapForTests: () => ReadonlyMap<string, StableSend>;
   _getSessionDeliveryEndpointForTests: (
     sessionId: string,
   ) => { suspended: boolean; generation: number; hasSend: boolean; hasAppend: boolean } | undefined;
+  installTaskPanel: (pi: ExtensionAPI | null, manager: unknown, ui: unknown) => void;
 };
 
 // Loaded once before all tests
@@ -331,15 +333,100 @@ describe("installResultDelivery", () => {
     };
   }
 
-  /** Drive the armed AgentSession._bindExtensionCore patch with a fake `this`. */
-  function invokePatchedBindCore(session: object): void {
-    const bind = (AgentSession.prototype as unknown as { _bindExtensionCore: (runner: unknown) => unknown })
-      ._bindExtensionCore;
-    bind.call(session, { bindCore() {} });
+  type ExactSendCall = {
+    message: { customType?: string; content?: string; display?: boolean };
+    options: { triggerTurn?: boolean; deliverAs?: string } | undefined;
+  };
+  /** Record the FULL message + options so tests can assert the exact payload
+   *  the delivery path hands to the captured host send (T1). */
+  function recordingSendExact(calls: ExactSendCall[]): StableSend {
+    return (msg, opts) => {
+      calls.push({ message: { ...msg }, options: opts ? { ...opts } : undefined });
+      return Promise.resolve();
+    };
+  }
+
+  /**
+   * Drive the armed AgentSession.sendCustomMessage capture patch with a fake
+   * `this` to exercise the steal filter. The patched forward runs the REAL
+   * sendCustomMessage, so an untriggered call is used: the non-trigger branch
+   * only needs `agent.state.messages` and `sessionManager.appendCustomMessageEntry`,
+   * both provided below — avoiding `_runAgentPrompt`'s internal fields.
+   */
+  function invokePatchedSendCustomMessage(
+    session: object,
+    message?: { customType: string; content: string; display: boolean },
+  ): void {
+    const patched = (AgentSession.prototype as unknown as { sendCustomMessage?: unknown }).sendCustomMessage;
+    assert.equal(typeof patched, "function", "sendCustomMessage patch must be armed");
+    if (!("agent" in session)) {
+      Object.assign(session, { agent: { state: { messages: [] } } });
+    }
+    if (!("sessionManager" in session)) {
+      Object.assign(session, {
+        sessionManager: {
+          appendCustomMessageEntry: () => "",
+        },
+      });
+    } else {
+      const sm = (session as { sessionManager?: Record<string, unknown> }).sessionManager;
+      if (!sm || !("appendCustomMessageEntry" in sm)) {
+        // Never inherit a host-shaped sessionManager from the real prototype: a
+        // fake session must carry exactly the fields the untriggered forward
+        // touches, and never the real session's identity (T2). MERGE the
+        // appendCustomMessageEntry onto the test-provided sessionManager so we
+        // do not destroy its persist/getSessionId/isPersisted shape (T6).
+        Object.assign(sm ?? (session as { sessionManager: Record<string, unknown> }).sessionManager, {
+          appendCustomMessageEntry: () => "",
+        });
+      }
+    }
+    if (!("_emit" in session)) {
+      Object.assign(session, { _emit: () => {} });
+    }
+    void (patched as (msg: unknown, opts: unknown) => unknown).call(
+      session,
+      message ?? { customType: "workflow-result", content: "x", display: true },
+      {},
+    );
+  }
+
+  /**
+   * Wrap a fake host send so the delivery path's captured-send invocation runs
+   * with the internals the REAL AgentSession.sendCustomMessage touches
+   * (the fix forwards on the live receiver). The wrapped send is the function
+   * under test. The stub's job is only to make `this` look like a real host
+   * session — it must NEVER overwrite the fakes the test installed (T3).
+   */
+  function captureStub(send: StableSend): StableSend {
+    return function captureStub(this: unknown, msg, opts) {
+      const s = this as {
+        agent?: { state: { messages: unknown[] }; followUp?: () => void };
+        sessionManager?: { appendCustomMessageEntry?: () => unknown };
+        _isAgentRunActive?: boolean;
+        _pendingNextTurnMessages?: unknown[];
+        _followUpMessages?: unknown[];
+        _emit?: (e: unknown) => void;
+      };
+      if (s.agent == null) s.agent = { state: { messages: [] }, followUp: () => {} };
+      if (s.sessionManager == null) s.sessionManager = { appendCustomMessageEntry: () => "" };
+      if (s._pendingNextTurnMessages == null) s._pendingNextTurnMessages = [];
+      if (s._followUpMessages == null) s._followUpMessages = [];
+      if (s._emit == null) s._emit = () => {};
+      // Streaming route: the real sendCustomMessage queues via agent.followUp
+      // (never _runAgentPrompt) when isStreaming — avoids the prompt internals
+      // while still exercising the live-receiver forward.
+      if (s._isAgentRunActive == null) s._isAgentRunActive = true;
+      return send.call(this, msg, opts);
+    };
   }
 
   function piCalls(pi: ExtensionAPI): DeliveryCall[] {
-    return (pi as unknown as { _calls: DeliveryCall[] })._calls;
+    // The session_start probe rides the same sendMessage spy; only result
+    // deliveries count.
+    return (pi as unknown as { _calls: DeliveryCall[] })._calls.filter(
+      (c) => c.customType !== mod.DELIVERY_PROBE_CUSTOM_TYPE,
+    );
   }
 
   function makeRun(overrides: Record<string, unknown> = {}) {
@@ -1168,21 +1255,26 @@ describe("installResultDelivery", () => {
     managerA.setSessionId("sess-A");
     managerB.setSessionId("sess-B");
 
-    // Two host-shaped bindCores, B last — steal map must stay per-session.
-    invokePatchedBindCore({
+    // Two host-shaped sessions, B last — steal map must stay per-session.
+    // Seams (mirroring the source patch) now drive the *capture* arm, not the
+    // dead bindCore hook: invoke the patched sendCustomMessage on each fake
+    // session; the wrapper's host filter decides what (if anything) is stolen.
+    invokePatchedSendCustomMessage({
       sessionManager: {
         persist: true,
         getSessionId: () => "sess-A",
         getSessionName: () => "host-A",
+        isPersisted: () => true,
       },
       _resourceLoader: { noExtensions: false },
       sendCustomMessage: recordingStableSend(piA),
     });
-    invokePatchedBindCore({
+    invokePatchedSendCustomMessage({
       sessionManager: {
         persist: true,
         getSessionId: () => "sess-B",
         getSessionName: () => "host-B",
+        isPersisted: () => true,
       },
       _resourceLoader: { noExtensions: false },
       sendCustomMessage: recordingStableSend(piB),
@@ -1206,8 +1298,190 @@ describe("installResultDelivery", () => {
     assert.ok(piCalls(piB)[0].content.includes("from-B"));
   });
 
+  it("steal accepts an isSessionOnDisk-only host (omp session shape)", () => {
+    // omp's SessionManager has neither isPersisted() nor a `persist` field —
+    // only isSessionOnDisk(). Without this branch the host is never stolen and
+    // completion stays pendingDelivery forever (#109).
+    const pi = createMockPi();
+    const manager = createMockManager(
+      makeRun({
+        sessionId: "sess-omp",
+        runId: "run-omp",
+        result: { result: { verdict: "delivered" }, agentCount: 1, durationMs: 1 },
+      }),
+    );
+    manager.setSessionId("sess-omp");
+    invokePatchedSendCustomMessage({
+      sessionManager: {
+        getSessionId: () => "sess-omp",
+        getSessionName: () => "host-omp",
+        isSessionOnDisk: () => true,
+      },
+      _resourceLoader: { noExtensions: false },
+      sendCustomMessage: recordingStableSend(pi),
+    });
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    mod.bindSessionDelivery("sess-omp", pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "run-omp" });
+    assert.equal(piCalls(pi).length, 1, "omp-shaped host receives its result");
+    assert.ok(piCalls(pi)[0].content.includes("delivered"));
+    const stealKeys = () => [...mod._getStealMapForTests().keys()];
+    assert.ok(stealKeys().includes("sess-omp"), "omp-shaped host is stolen");
+  });
+
+  it("quiet host: bind probes once via pi.sendMessage, captures send, delivers", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(
+      makeRun({
+        sessionId: "sess-quiet",
+        runId: "run-quiet",
+        result: { result: { verdict: "delivered" }, agentCount: 1, durationMs: 1 },
+      }),
+    );
+    let probeCalls = 0;
+    // Emulate the real host wiring: the void extension wrapper synchronously
+    // routes through AgentSession.sendCustomMessage, where the prototype patch
+    // captures the live session.
+    (pi as unknown as { sendMessage: (m: unknown, o: unknown) => void }).sendMessage = () => {
+      probeCalls++;
+      invokePatchedSendCustomMessage({
+        sessionManager: {
+          getSessionId: () => "sess-quiet",
+          getSessionName: () => "host-quiet",
+          isSessionOnDisk: () => true,
+        },
+        _resourceLoader: { noExtensions: false },
+        sendCustomMessage: recordingStableSend(pi),
+      });
+    };
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId("sess-quiet");
+    mod.bindSessionDelivery("sess-quiet", pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "run-quiet" });
+
+    assert.equal(probeCalls, 1, "exactly one probe per session");
+    assert.equal(piCalls(pi).length, 1, "delivery flows after probe capture");
+    assert.ok(piCalls(pi)[0].content.includes("delivered"));
+  });
+
+  it("omp print-mode host: probe captures despite isSessionOnDisk false at session_start", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(
+      makeRun({
+        sessionId: "sess-omp",
+        runId: "run-omp",
+        result: { result: { verdict: "delivered" }, agentCount: 1, durationMs: 1 },
+      }),
+    );
+    let probeCalls = 0;
+    (pi as unknown as { sendMessage: (m: unknown, o: unknown) => void }).sendMessage = () => {
+      probeCalls++;
+      invokePatchedSendCustomMessage(
+        {
+          sessionManager: {
+            getSessionId: () => "sess-omp",
+            getSessionName: () => "host-omp",
+            // omp persists lazily AFTER bind — the on-disk gate must not
+            // reject a probe-bearing send (root cause of the E2E failure).
+            isSessionOnDisk: () => false,
+          },
+          _resourceLoader: { noExtensions: false },
+          sendCustomMessage: recordingStableSend(pi),
+        },
+        { customType: mod.DELIVERY_PROBE_CUSTOM_TYPE, content: "", display: false },
+      );
+    };
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId("sess-omp");
+    mod.bindSessionDelivery("sess-omp", pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "run-omp" });
+
+    assert.equal(probeCalls, 1, "probe attempted");
+    assert.equal(piCalls(pi).length, 1, "delivery flows after probe capture");
+    assert.ok(piCalls(pi)[0].content.includes("delivered"));
+  });
+
+  it("probe bypass never captures workflow: child sessions", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun({ sessionId: "sess-child", runId: "run-child" }));
+    (pi as unknown as { sendMessage: (m: unknown, o: unknown) => void }).sendMessage = () => {
+      invokePatchedSendCustomMessage(
+        {
+          sessionManager: {
+            getSessionId: () => "sess-child",
+            getSessionName: () => "workflow:run-child",
+            isSessionOnDisk: () => false,
+          },
+          _resourceLoader: { noExtensions: false },
+          sendCustomMessage: recordingStableSend(pi),
+        },
+        { customType: mod.DELIVERY_PROBE_CUSTOM_TYPE, content: "", display: false },
+      );
+    };
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId("sess-child");
+    mod.bindSessionDelivery("sess-child", pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "run-child" });
+
+    assert.equal(piCalls(pi).length, 0, "child session probe is rejected by the name gate");
+  });
+
+  it("probe failure keeps bind fail-closed with pending on disk", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun({ sessionId: "sess-throws", runId: "run-throws" }));
+    let probeCalls = 0;
+    (pi as unknown as { sendMessage: (m: unknown, o: unknown) => void }).sendMessage = () => {
+      probeCalls++;
+      throw new Error("Extension runtime not initialized.");
+    };
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId("sess-throws");
+    mod.bindSessionDelivery("sess-throws", pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "run-throws" });
+
+    assert.equal(probeCalls, 1, "probe attempted");
+    assert.equal(piCalls(pi).length, 0, "no delivery without a captured send");
+    assert.ok(manager.getPersistence?.().load("run-throws")?.pendingDelivery, "pending stays on disk");
+  });
+
+  it("no probe when the steal map already holds the send", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(
+      makeRun({
+        sessionId: "sess-map",
+        runId: "run-map",
+        result: { result: { verdict: "delivered" }, agentCount: 1, durationMs: 1 },
+      }),
+    );
+    let probeCalls = 0;
+    (pi as unknown as { sendMessage: (m: unknown, o: unknown) => void }).sendMessage = () => {
+      probeCalls++;
+    };
+
+    invokePatchedSendCustomMessage({
+      sessionManager: {
+        getSessionId: () => "sess-map",
+        getSessionName: () => "host-map",
+        isSessionOnDisk: () => true,
+      },
+      _resourceLoader: { noExtensions: false },
+      sendCustomMessage: recordingStableSend(pi),
+    });
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId("sess-map");
+    mod.bindSessionDelivery("sess-map", pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "run-map" });
+
+    assert.equal(probeCalls, 0, "map hit skips the probe");
+    assert.equal(piCalls(pi).length, 1, "delivery uses the pre-captured send");
+  });
+
   it("steal map pins only the host session; drop releases the host closure", () => {
-    invokePatchedBindCore({
+    invokePatchedSendCustomMessage({
       sessionManager: {
         persist: false,
         getSessionId: () => "child-mem",
@@ -1215,7 +1489,7 @@ describe("installResultDelivery", () => {
       },
       sendCustomMessage: async () => {},
     });
-    invokePatchedBindCore({
+    invokePatchedSendCustomMessage({
       sessionManager: {
         persist: true,
         getSessionId: () => "child-noext",
@@ -1224,7 +1498,7 @@ describe("installResultDelivery", () => {
       _resourceLoader: { noExtensions: true },
       sendCustomMessage: async () => {},
     });
-    invokePatchedBindCore({
+    invokePatchedSendCustomMessage({
       sessionManager: {
         persist: true,
         getSessionId: () => "child-named",
@@ -1232,23 +1506,269 @@ describe("installResultDelivery", () => {
       },
       sendCustomMessage: async () => {},
     });
-    invokePatchedBindCore({
-      sessionManager: {
-        persist: true,
-        getSessionId: () => "host-1",
-        getSessionName: () => "chat",
-      },
-      _resourceLoader: { noExtensions: false },
-      sendCustomMessage: async () => {},
-    });
+    const hostSend: StableSend = async () => {};
+    mod._registerBoundSessionSendForTests("host-1", hostSend);
 
-    assert.equal(mod._hasBoundSessionSendForTests("child-mem"), false, "in-memory child must not pin");
-    assert.equal(mod._hasBoundSessionSendForTests("child-noext"), false, "noExtensions child must not pin");
-    assert.equal(mod._hasBoundSessionSendForTests("child-named"), false, "workflow: child must not pin");
-    assert.equal(mod._hasBoundSessionSendForTests("host-1"), true, "host session is stolen");
+    const stealKeys = () => [...mod._getStealMapForTests().keys()];
+    assert.ok(!stealKeys().includes("child-mem"), "in-memory child must not pin");
+    assert.ok(!stealKeys().includes("child-noext"), "noExtensions child must not pin");
+    assert.ok(!stealKeys().includes("child-named"), "workflow: child must not pin");
+    assert.ok(stealKeys().includes("host-1"), "host session is stolen");
+    // The captured value must be the EXACT send the host registered — the steal
+    // map holds the session-stable original, never a wrapper or a stale copy
+    // from an earlier session (T5).
+    assert.equal(mod._getStealMapForTests().get("host-1"), hostSend, "steal map holds the exact original send");
 
     mod.dropSessionDelivery("host-1");
-    assert.equal(mod._hasBoundSessionSendForTests("host-1"), false, "drop releases the host send closure");
+    assert.ok(!stealKeys().includes("host-1"), "drop releases the host send closure");
+    assert.equal(mod._getStealMapForTests().get("host-1"), undefined, "drop clears the map entry entirely");
+    assert.equal(mod._getSessionDeliveryEndpointForTests("host-1"), undefined, "drop clears the endpoint too");
+  });
+
+  it("live sendCustomMessage capture: host session send is used for delivery end to end", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun());
+
+    // Production capture path: a live host AgentSession's sendCustomMessage is
+    // wrapped by the patch, so invoking it steals the session-stable send.
+    invokePatchedSendCustomMessage({
+      sessionManager: {
+        persist: true,
+        getSessionId: () => SESSION,
+        getSessionName: () => "chat",
+        isPersisted: () => true,
+      },
+      _resourceLoader: { noExtensions: false },
+      sendCustomMessage: recordingStableSend(pi),
+    });
+
+    assert.ok(mod._getStealMapForTests().has(SESSION), "host send captured into steal map");
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId(SESSION);
+    // Production session_start: steal map is the only send source.
+    mod.bindSessionDelivery(SESSION, pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "test-run-1" });
+
+    const calls = piCalls(pi);
+    assert.equal(calls.length, 1, "captured send delivers the result");
+    assert.equal(calls[0].triggerTurn, true, "captured send must triggerTurn");
+    assert.ok(calls[0].content.includes("All tests passed"));
+  });
+
+  it("captured host send receives the exact production payload (T1)", async () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun());
+    const exact: ExactSendCall[] = [];
+
+    // A live host AgentSession send is captured; the delivery path must invoke
+    // the captured send with EXACTLY the arguments tryDeliverEndpoint sends:
+    // {customType:"workflow-result", content, display:true} and
+    // {triggerTurn:true, deliverAs:"followUp"}.
+    invokePatchedSendCustomMessage({
+      sessionManager: {
+        persist: true,
+        getSessionId: () => SESSION,
+        getSessionName: () => "chat",
+        isPersisted: () => true,
+      },
+      _resourceLoader: { noExtensions: false },
+      sendCustomMessage: recordingSendExact(exact),
+    });
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId(SESSION);
+    mod.bindSessionDelivery(SESSION, pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "test-run-1" });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(exact.length, 1, "captured host send is invoked exactly once");
+    assert.equal(exact[0].message.customType, "workflow-result");
+    assert.equal(exact[0].message.display, true);
+    assert.ok(exact[0].message.content?.includes("All tests passed"), "content is the delivered result text");
+    assert.equal(exact[0].options?.triggerTurn, true, "delivery must triggerTurn");
+    assert.equal(exact[0].options?.deliverAs, "followUp", "delivery must be queued as followUp");
+    // ACK cleared the pending marker.
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(
+      manager.getPersistence?.().load("test-run-1")?.pendingDelivery,
+      undefined,
+      "cleared after thenable ACK",
+    );
+  });
+
+  it("triggerTurn non-streaming routes through _runAgentPrompt (T4)", async () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun());
+    const prompted: unknown[] = [];
+    const settled: string[] = [];
+
+    // An IDLE host session: isStreaming=false, so the real sendCustomMessage
+    // with triggerTurn:true takes the _runAgentPrompt branch — the branch real
+    // host deliveries actually hit. The fake supplies the internals that path
+    // touches; agent.prompt is a stub so no real LLM call is made.
+    const idleSession = Object.create(AgentSession.prototype) as object & {
+      agent: unknown;
+      sessionManager: unknown;
+      _resourceLoader: unknown;
+      _isAgentRunActive: boolean;
+      _pendingBashMessages: unknown[];
+      _pendingNextTurnMessages: unknown[];
+      _extensionRunner: unknown;
+      _emit: () => void;
+    };
+    idleSession.agent = {
+      state: { messages: [] },
+      prompt: async (messages: unknown) => {
+        prompted.push(messages);
+        return { stopReason: "end_turn" };
+      },
+      continue: async () => {},
+    };
+    idleSession.sessionManager = {
+      persist: true,
+      getSessionId: () => SESSION,
+      getSessionName: () => "chat",
+      isPersisted: () => true,
+      appendCustomMessageEntry: () => "",
+    };
+    idleSession._resourceLoader = { noExtensions: false };
+    idleSession._isAgentRunActive = false;
+    idleSession._pendingBashMessages = [];
+    idleSession._pendingNextTurnMessages = [];
+    idleSession._extensionRunner = {
+      emit: async (e: { type: string }) => {
+        settled.push(e.type);
+      },
+    };
+    idleSession._emit = () => {};
+    mod._registerHostSessionForTests(idleSession as never);
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId(SESSION);
+    mod.bindSessionDelivery(SESSION, pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "test-run-1" });
+
+    // The thenable ACK resolves only after _runAgentPrompt settles.
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    assert.equal(prompted.length, 1, "triggerTurn delivery must start an agent prompt");
+    const appMessage = prompted[0] as { customType?: string; content?: unknown; display?: boolean };
+    assert.equal(appMessage.customType, "workflow-result", "the prompt receives the delivered app message");
+    assert.equal(appMessage.display, true);
+    assert.ok(settled.includes("agent_settled"), "the run settles after the prompt");
+    assert.equal(manager.getPersistence?.().load("test-run-1")?.pendingDelivery, undefined, "cleared after prompt ACK");
+  });
+
+  it("child session sendCustomMessage is not captured and never delivers", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun());
+
+    // A workflow child (in-memory SessionManager) invoking sendCustomMessage
+    // must not be pinned — it is not the host session.
+    invokePatchedSendCustomMessage({
+      sessionManager: {
+        persist: false,
+        getSessionId: () => "child-mem",
+        getSessionName: () => "",
+      },
+      sendCustomMessage: recordingStableSend(pi),
+    });
+    assert.ok(!mod._getStealMapForTests().has("child-mem"), "child must not be stolen");
+
+    // Even if the child's id were somehow bound, a delivery routed to it has no
+    // host endpoint — fail closed, nothing sent, marker stays pending.
+    mod._registerBoundSessionSendForTests("child-mem", recordingStableSend(pi));
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId("child-mem");
+    mod.bindSessionDelivery("child-mem", pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "test-run-1" });
+
+    assert.equal(piCalls(pi).length, 0, "child send must never be used for delivery");
+    assert.ok(manager.getPersistence?.().load("test-run-1")?.pendingDelivery, "pending stays for a real host bind");
+  });
+
+  it("non-thenable captured send fails closed: pending stays (no false ACK)", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun());
+
+    // A captured host send that does not return a thenable (fire-and-forget)
+    // must not be trusted as an ACK — content stays pending on disk.
+    const nonThenable = () => {
+      pi._calls.push({ content: "fired", customType: "workflow-result" });
+      return undefined;
+    };
+    mod._registerHostSessionForTests({
+      sessionManager: {
+        persist: true,
+        getSessionId: () => SESSION,
+        getSessionName: () => "chat",
+        isPersisted: () => true,
+      },
+      _resourceLoader: { noExtensions: false },
+      // The delivery path invokes the captured host send with a real host
+      // receiver (the fix forwards on the live session), so the stub needs the
+      // internals sendCustomMessage touches; the send itself is still the
+      // non-thenable function under test.
+      sendCustomMessage: captureStub(nonThenable),
+    });
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId(SESSION);
+    mod.bindSessionDelivery(SESSION, pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "test-run-1" });
+
+    // The captured send IS attempted (through the live receiver), but because it
+    // returns no thenable it must not be trusted as an ACK — no triggerTurn, and
+    // the marker stays pending on disk.
+    assert.equal(piCalls(pi).length, 1, "captured non-thenable send is attempted");
+    assert.equal(piCalls(pi)[0].triggerTurn, undefined, "non-thenable send never ACKs (fail closed)");
+    assert.ok(manager.getPersistence?.().load("test-run-1")?.pendingDelivery, "pending stays (fail closed)");
+  });
+
+  it("failed captured send leaves pending; next bind flushes", async () => {
+    const pi = createMockPi();
+    const freshPi = createMockPi();
+    const manager = createMockManager(makeRun());
+
+    // A captured host send that returns a rejecting thenable: no ACK, marker
+    // stays pending until a healthy generation binds and flushes. The captured
+    // send runs with a real host receiver (fix: forward on the live session),
+    // so the stub supplies the internals sendCustomMessage touches.
+    const failingSend = () => Promise.reject(new Error("network blip"));
+    mod._registerHostSessionForTests({
+      sessionManager: {
+        persist: true,
+        getSessionId: () => SESSION,
+        getSessionName: () => "chat",
+        isPersisted: () => true,
+      },
+      _resourceLoader: { noExtensions: false },
+      sendCustomMessage: captureStub(failingSend),
+    });
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId(SESSION);
+    mod.bindSessionDelivery(SESSION, pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "test-run-1" });
+
+    // Let the failing send settle (reject + in-flight release) before rebinding,
+    // so the next generation's flush picks the run up cleanly.
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.ok(manager.getPersistence?.().load("test-run-1")?.pendingDelivery, "pending stays after failed send");
+
+    // Rebind with a healthy send: flush retries the delivery and clears pending.
+    mod.bindSessionDelivery(SESSION, freshPi as unknown as ExtensionAPI, {
+      manager,
+      stableSend: recordingStableSend(freshPi),
+    });
+    const calls = piCalls(freshPi);
+    assert.equal(calls.length, 1, "healthy generation flushes the pending delivery");
+    assert.ok(calls[0].content.includes("All tests passed"));
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(manager.getPersistence?.().load("test-run-1")?.pendingDelivery, undefined, "cleared after ACK");
   });
 
   it("append-only is not an ACK; pending stays until a thenable send exists", () => {

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -205,6 +205,7 @@ type TaskPanelModule = {
   dropSessionDelivery: (sessionId: string | undefined) => void;
   suspendResultDelivery: (manager: unknown) => void;
   resumeResultDelivery: (manager: unknown) => void;
+  _isProbedForTests: (sessionId: string) => boolean;
   suspendSessionDelivery: (sessionId: string | undefined) => void;
   resumeSessionDelivery: (sessionId: string | undefined, manager?: unknown) => void;
   _resetDeliveryRegistriesForTests: () => void;
@@ -391,6 +392,25 @@ describe("installResultDelivery", () => {
     );
   }
 
+  /**
+   * Drive the armed AgentSession._bindExtensionCore capture patch with a fake
+   * `this`. The wrapper captures BEFORE forwarding to the REAL
+   * `_bindExtensionCore`, which a fake session cannot fully satisfy — the
+   * forward's throw is irrelevant (capture already happened) and is swallowed.
+   */
+  function invokePatchedBindExtensionCore(session: object): void {
+    const proto = AgentSession.prototype as unknown as { _bindExtensionCore?: unknown };
+    const patched = proto._bindExtensionCore;
+    assert.equal(typeof patched, "function", "_bindExtensionCore patch must be armed");
+    try {
+      (patched as (runner: unknown) => unknown).call(session, {
+        bindCore: () => {},
+        getRegisteredCommands: () => [],
+      });
+    } catch {
+      // The real bindCore body may touch internals a fake session lacks.
+    }
+  }
   /**
    * Wrap a fake host send so the delivery path's captured-send invocation runs
    * with the internals the REAL AgentSession.sendCustomMessage touches
@@ -1478,6 +1498,127 @@ describe("installResultDelivery", () => {
 
     assert.equal(probeCalls, 0, "map hit skips the probe");
     assert.equal(piCalls(pi).length, 1, "delivery uses the pre-captured send");
+  });
+
+  it("probe is capture-only: never forwarded to the session's sendCustomMessage", () => {
+    let spyCalls = 0;
+    const messages: unknown[] = ["pre-existing"];
+    invokePatchedSendCustomMessage(
+      {
+        agent: { state: { messages } },
+        sessionManager: {
+          getSessionId: () => "sess-probe-only",
+          getSessionName: () => "host-probe-only",
+          // probe-bearing sends bypass the persistence gate — omit isSessionOnDisk
+        },
+        _resourceLoader: { noExtensions: false },
+        sendCustomMessage: () => {
+          spyCalls++;
+          return Promise.resolve();
+        },
+      },
+      { customType: mod.DELIVERY_PROBE_CUSTOM_TYPE, content: "", display: false },
+    );
+
+    assert.equal(spyCalls, 0, "probe must never reach the host session's send");
+    assert.equal(messages.length, 1, "probe must never append to agent.state.messages");
+    assert.ok(mod._getStealMapForTests().has("sess-probe-only"), "capture happened despite the swallow");
+  });
+
+  it("failed probe is retried on the next bind (no pre-marked probed set)", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun({ sessionId: "sess-retry", runId: "run-retry" }));
+    let sendMessageCalls = 0;
+    const throwingPi = pi as unknown as { sendMessage: (m: unknown, o: unknown) => void };
+    throwingPi.sendMessage = () => {
+      sendMessageCalls++;
+      throw new Error("Extension runtime not initialized.");
+    };
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId("sess-retry");
+    mod.bindSessionDelivery("sess-retry", pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "run-retry" });
+    assert.equal(sendMessageCalls, 1);
+    assert.equal(piCalls(pi).length, 0, "first bind fail-closed");
+    assert.ok(manager.getPersistence?.().load("run-retry")?.pendingDelivery, "pending stays on disk");
+
+    // Second bind: a working pi whose probe routes through the capture patch.
+    const recoveringPi = pi as unknown as { sendMessage: (m: unknown, o: unknown) => void };
+    recoveringPi.sendMessage = () => {
+      sendMessageCalls++;
+      invokePatchedSendCustomMessage(
+        {
+          sessionManager: {
+            getSessionId: () => "sess-retry",
+            getSessionName: () => "host-retry",
+            isSessionOnDisk: () => false,
+          },
+          _resourceLoader: { noExtensions: false },
+          sendCustomMessage: recordingStableSend(pi),
+        },
+        { customType: mod.DELIVERY_PROBE_CUSTOM_TYPE, content: "", display: false },
+      );
+    };
+    mod.bindSessionDelivery("sess-retry", pi as unknown as ExtensionAPI, { manager });
+    manager.emit("complete", { runId: "run-retry" });
+
+    assert.equal(sendMessageCalls, 2, "the failed probe was retried, not skipped");
+    assert.equal(piCalls(pi).length, 1, "delivery flows after the retried probe captures");
+    assert.equal(piCalls(pi)[0].triggerTurn, true);
+  });
+
+  it("dropSessionDelivery clears probed state: a new bind probes again", () => {
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun({ sessionId: "sess-dropped", runId: "run-dropped" }));
+    let probeCalls = 0;
+    const override = pi as unknown as { sendMessage: (m: unknown, o: unknown) => void };
+    override.sendMessage = () => {
+      probeCalls++;
+      invokePatchedSendCustomMessage(
+        {
+          sessionManager: {
+            getSessionId: () => "sess-dropped",
+            getSessionName: () => "host-dropped",
+            isSessionOnDisk: () => false,
+          },
+          _resourceLoader: { noExtensions: false },
+          sendCustomMessage: recordingStableSend(pi),
+        },
+        { customType: mod.DELIVERY_PROBE_CUSTOM_TYPE, content: "", display: false },
+      );
+    };
+
+    mod.installResultDelivery(pi as unknown as ExtensionAPI, manager);
+    manager.setSessionId("sess-dropped");
+    mod.bindSessionDelivery("sess-dropped", pi as unknown as ExtensionAPI, { manager });
+    assert.equal(probeCalls, 1, "first bind probes");
+    assert.equal(mod._isProbedForTests("sess-dropped"), true, "successful probe marks the session");
+
+    mod.dropSessionDelivery("sess-dropped");
+    assert.equal(mod._isProbedForTests("sess-dropped"), false, "drop forgets the probe mark");
+    mod.bindSessionDelivery("sess-dropped", pi as unknown as ExtensionAPI, { manager });
+    assert.equal(probeCalls, 2, "post-drop bind probes again");
+  });
+
+  it("bindCore capture path captures a persisted host without any probe", () => {
+    const pi = createMockPi();
+    invokePatchedBindExtensionCore({
+      sessionManager: {
+        getSessionId: () => "sess-bindcore",
+        getSessionName: () => "host-bindcore",
+        isPersisted: () => true,
+      },
+      _resourceLoader: { noExtensions: false },
+      sendCustomMessage: recordingStableSend(pi),
+    });
+
+    assert.ok(mod._getStealMapForTests().has("sess-bindcore"), "bindCore captured the send");
+    assert.equal(
+      (pi as unknown as { _calls: DeliveryCall[] })._calls.length,
+      0,
+      "no probe needed: capture happened at bindCore",
+    );
   });
 
   it("steal map pins only the host session; drop releases the host closure", () => {


### PR DESCRIPTION
## Problem

In omp (the bundled fork of pi), background workflow runs never delivered their results back into the host conversation. Completed runs sat in `pendingDelivery` on disk forever.

## Root cause

The delivery engine needs a **session-stable, thenable send** (`AgentSession.sendCustomMessage`) captured from the host. omp's quiet sessions never call `sendCustomMessage` themselves, so the capture patch never fired and every bind stayed fail-closed.

## Fix

- **Bind-time capture probe** (`src/task-panel.ts`): `bindSessionDelivery` sends one invisible, no-turn `workflow-delivery-probe` message via `pi.sendMessage`; the patched `sendCustomMessage` captures the live host session from its receiver. The wrapper treats the probe as **capture-only** — it never forwards to the real send, so nothing is appended, persisted, or turned.
- **Retry semantics**: the probed-set is marked only after a send is actually captured, so a failed probe retries on the next bind; `dropSessionDelivery` clears the mark.
- **Persistence gate**: omp persists the host session lazily (after bind), so the on-disk gate does not reject probe-bearing sends. Child sessions (`workflow:`-named) still can't capture.
- **Registry fallback** (`src/agent.ts`): the fallback registry resolves through omp's `discoverAuthStorage`, legacy `ModelRegistry.create`, or `ModelRuntime.create` — a real `ModelRegistry` on every host, rejection never cached. Subagent handoff spreads `modelRuntime` when available and falls back to `modelRegistry` for omp's fork, never an `undefined` runtime.

## Verification

- 1312 tests (biome + tsc clean); 2 pre-existing upstream failures on `2f85c9e` (`workflow-authoring-skill`, `workflow-release-gate`) reproduce on pristine upstream — unrelated.
- Live E2E on **omp** (bundled fork): background run delivered a `workflow-result` turn (`triggerTurn: true`, `deliverAs: followUp`), `pendingDelivery` cleared, **no probe entry persisted** in the transcript.
- Live E2E on **stock pi 0.84.3** (extension mounted via `-e`, separate auth): same delivery, zero probe pollution.
- Retried-probe and drop/rebind semantics covered by dedicated regression tests.