### PR TITLE
fix: persist abort/fail agent status and run cause

### DIFF
--- a/src/run-persistence.ts
+++ b/src/run-persistence.ts
@@ -5,7 +5,7 @@
 import { join } from "node:path";
 import type { AgentUsage } from "./agent.js";
 import type { AgentHistoryEntry } from "./agent-history.js";
-import type { WorkflowErrorCode } from "./errors.js";
+import { WorkflowErrorCode } from "./errors.js";
 import {
   ensureDir as ensureDirFs,
   listJsonFilesSafe,
@@ -64,6 +64,16 @@ export interface PersistedRunState {
    * the navigator shows only the current session's runs (undefined = legacy/global). */
   sessionId?: string;
   status: RunStatus;
+  /**
+   * Terminal failure/abort message. Written for `failed` and `aborted` runs;
+   * absent on running/paused/completed and on records persisted before this field.
+   */
+  error?: string;
+  /**
+   * Classified terminal cause. Written with `error` for `failed` and `aborted`
+   * runs; absent on running/paused/completed and on legacy records.
+   */
+  errorCode?: WorkflowErrorCode;
   /** Why a paused run is paused (e.g. "usage_limit" when a provider quota was hit). */
   pauseReason?: string;
   /** Provider reset hint for a usage-limit pause, e.g. "Resets in ~3h" (verbatim). */
@@ -214,7 +224,72 @@ export type FsLayer = PersistenceFsLayer;
  */
 export const DEFAULT_MAX_TERMINAL_RUNS_ON_DISK = 300;
 
-const TERMINAL_RUN_STATUSES: ReadonlySet<RunStatus> = new Set(["completed", "failed", "aborted"]);
+export const TERMINAL_RUN_STATUSES: ReadonlySet<RunStatus> = new Set(["completed", "failed", "aborted"]);
+
+const NON_TERMINAL_AGENT_STATUSES = new Set(["queued", "running"]);
+
+/** Cause stamped onto leftover agents when a live execution is gone but the run is still paused. */
+export const INTERRUPTED_AGENT_CAUSE: { error: string; errorCode: WorkflowErrorCode } = {
+  error: "interrupted",
+  errorCode: WorkflowErrorCode.WORKFLOW_ABORTED,
+};
+
+export function agentHasNonTerminalStatus(status: PersistedAgentState["status"]): boolean {
+  return NON_TERMINAL_AGENT_STATUSES.has(status);
+}
+
+/** Cause stamped onto leftover in-flight agents when a run reaches a terminal status. */
+export function terminalRunInterruptCause(
+  status: RunStatus,
+  error?: { message?: string; code?: WorkflowErrorCode },
+): { error: string; errorCode?: WorkflowErrorCode } {
+  if (status === "aborted") {
+    return { error: "aborted", errorCode: error?.code ?? WorkflowErrorCode.WORKFLOW_ABORTED };
+  }
+  if (status === "failed") {
+    return {
+      error: error?.message ?? "run failed",
+      errorCode: error?.code ?? WorkflowErrorCode.UNKNOWN,
+    };
+  }
+  return { error: "run completed" };
+}
+
+/**
+ * Rewrite leftover queued/running agents to skipped. Replay ignores
+ * `agents[].status` (journal-keyed), so this is display-only.
+ */
+export function settleInterruptedPersistedAgents(
+  agents: PersistedAgentState[],
+  cause: { error: string; errorCode?: WorkflowErrorCode },
+  endedAt: string,
+): PersistedAgentState[] {
+  return agents.map((agent) => {
+    if (!NON_TERMINAL_AGENT_STATUSES.has(agent.status)) return agent;
+    return {
+      ...agent,
+      status: "skipped",
+      error: cause.error,
+      errorCode: cause.errorCode,
+      recoverable: false,
+      endedAt: agent.endedAt ?? endedAt,
+    };
+  });
+}
+
+/**
+ * Fail-closed rewrite of leftover queued/running agents on a terminal run.
+ * Completed/failed/aborted must never persist a still-`running` agent.
+ */
+export function settleNonTerminalPersistedAgents(
+  agents: PersistedAgentState[],
+  status: RunStatus,
+  error: { message?: string; code?: WorkflowErrorCode } | undefined,
+  endedAt: string,
+): PersistedAgentState[] {
+  if (!TERMINAL_RUN_STATUSES.has(status)) return agents;
+  return settleInterruptedPersistedAgents(agents, terminalRunInterruptCause(status, error), endedAt);
+}
 
 export interface RunPersistenceOptions {
   /** Override DEFAULT_MAX_TERMINAL_RUNS_ON_DISK (tests; advanced tuning). */

--- a/src/workflow-manager.ts
+++ b/src/workflow-manager.ts
@@ -7,16 +7,21 @@ import type { ModelRegistry, ToolDefinition } from "@earendil-works/pi-coding-ag
 import type { WorkflowAgent } from "./agent.js";
 import { type AgentUsage, createEmptyAgentUsage, sumAgentUsage } from "./agent-usage.js";
 import { MAX_AGENTS_PER_RUN } from "./config.js";
-import { preview, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
+import { preview, recomputeWorkflowSnapshot, type WorkflowAgentSnapshot, type WorkflowSnapshot } from "./display.js";
 import { isProviderUsageLimit, WorkflowError, WorkflowErrorCode } from "./errors.js";
 import {
+  agentHasNonTerminalStatus,
   createRunPersistence,
   generateRunId,
+  INTERRUPTED_AGENT_CAUSE,
   type PendingDeliveryMarker,
   type PersistedRunState,
   type RunLease,
   type RunPersistence,
   type RunStatus,
+  settleInterruptedPersistedAgents,
+  settleNonTerminalPersistedAgents,
+  terminalRunInterruptCause,
 } from "./run-persistence.js";
 import { type JournalEntry, parseWorkflowScript, runWorkflow, type WorkflowRunResult } from "./workflow.js";
 
@@ -496,14 +501,23 @@ export class WorkflowManager extends EventEmitter {
   private recoverStaleRuns(): void {
     try {
       for (const p of this.listAllRuns()) {
-        if (p.status === "running" && !this.runs.has(p.runId)) {
-          const lease = this.persistence.acquireRunLease(p.runId);
-          if (!lease) continue;
-          try {
-            this.persistence.save({ ...p, status: "paused" });
-          } finally {
-            this.persistence.releaseRunLease(lease);
-          }
+        if (this.runs.has(p.runId)) continue;
+        const staleRunning = p.status === "running";
+        const pausedWithGhostAgents =
+          p.status === "paused" && p.agents.some((agent) => agentHasNonTerminalStatus(agent.status));
+        if (!staleRunning && !pausedWithGhostAgents) continue;
+        const lease = this.persistence.acquireRunLease(p.runId);
+        if (!lease) continue;
+        try {
+          const endedAt = new Date().toISOString();
+          this.persistence.save({
+            ...p,
+            status: "paused",
+            updatedAt: endedAt,
+            agents: settleInterruptedPersistedAgents(p.agents, INTERRUPTED_AGENT_CAUSE, endedAt),
+          });
+        } finally {
+          this.persistence.releaseRunLease(lease);
         }
       }
     } catch {
@@ -1050,7 +1064,12 @@ export class WorkflowManager extends EventEmitter {
       }
 
       // Persist final state (see the success-path comment above for the
-      // isCurrent() rationale — same guard, same reason).
+      // isCurrent() rationale — same guard, same reason). Drain has finished,
+      // so leftover queued/running agents are no longer in flight even when
+      // pause() kept the run resumable.
+      if (managed.status === "paused") {
+        this.settleManagedInterruptedAgents(managed, INTERRUPTED_AGENT_CAUSE, new Date());
+      }
       this.persistRun(managed);
       if (this.isCurrent(managed)) {
         this.releaseRunLease(managed);
@@ -1218,6 +1237,41 @@ export class WorkflowManager extends EventEmitter {
   }
 
   /**
+   * Fail-closed: leftover queued/running agents are display-only after the
+   * execution that owned them has gone. Replay is journal-keyed.
+   */
+  private settleManagedInterruptedAgents(
+    managed: ManagedRun,
+    cause: { error: string; errorCode?: WorkflowErrorCode },
+    endedAt: Date,
+  ): void {
+    const endedAtIso = endedAt.toISOString();
+    for (const agent of managed.snapshot.agents) {
+      if (agent.status !== "running" && agent.status !== "queued") continue;
+      agent.status = "skipped";
+      agent.error = cause.error;
+      agent.errorCode = cause.errorCode;
+      agent.recoverable = false;
+      const ts = managed.agentTimestamps.get(agent.id);
+      if (ts) ts.endedAt ??= endedAtIso;
+      else managed.agentTimestamps.set(agent.id, { startedAt: endedAtIso, endedAt: endedAtIso });
+    }
+    managed.snapshot = recomputeWorkflowSnapshot(managed.snapshot);
+  }
+
+  private settleManagedAgentsForTerminalRun(managed: ManagedRun, endedAt: Date): void {
+    if (!IN_MEMORY_TERMINAL_STATUSES.has(managed.status)) return;
+    this.settleManagedInterruptedAgents(
+      managed,
+      terminalRunInterruptCause(managed.status, {
+        message: managed.error?.message,
+        code: managed.error?.code,
+      }),
+      endedAt,
+    );
+  }
+
+  /**
    * Persist immediately and synchronously. Cancels any pending throttled write
    * for this run first, so the write that lands is always the caller's current
    * (final) state — never superseded by a stale deferred write. Use this for
@@ -1267,10 +1321,14 @@ export class WorkflowManager extends EventEmitter {
     // gate) reintroduces a producer for it.
     if (!this.isCurrent(managed)) return;
     try {
+      const now = new Date();
+      const terminal = IN_MEMORY_TERMINAL_STATUSES.has(managed.status);
+      if (terminal) this.settleManagedAgentsForTerminalRun(managed, now);
       // Resumable states need their journal; completed/aborted states need rich
       // agent details. Persist exactly one full copy of each agent result instead
       // of writing it to both agents[].result and journal[].result.
       const keepsResumeJournal = managed.status !== "completed" && managed.status !== "aborted";
+      const persistError = terminal && managed.status !== "completed" ? managed.error : undefined;
       this.persistence.save({
         runId: managed.runId,
         workflowName: managed.snapshot.name,
@@ -1286,6 +1344,8 @@ export class WorkflowManager extends EventEmitter {
         pendingDelivery: managed.pendingDelivery,
         journal: keepsResumeJournal ? managed.journal : undefined,
         status: managed.status,
+        error: persistError?.message,
+        errorCode: persistError?.code,
         // Persisted every write (not just at pause) so a stale read during the
         // "paused" event race (see UsageLimitScheduler) is still correct — this
         // is fixed at run-start and doesn't change over the run's lifetime.
@@ -1307,7 +1367,8 @@ export class WorkflowManager extends EventEmitter {
         currentPhase: managed.snapshot.currentPhase,
         // Real per-agent timestamps only (see agentTimestamps) — never the run's
         // own startedAt or "now" stamped onto every agent on every write. A
-        // still-running agent is persisted with no endedAt.
+        // still-running agent on a live/paused run is persisted with no endedAt;
+        // terminal persist stamps leftover in-flight agents first.
         agents: managed.snapshot.agents.map((a) => {
           const { result, ...summary } = a;
           const ts = managed.agentTimestamps.get(a.id);
@@ -1333,9 +1394,9 @@ export class WorkflowManager extends EventEmitter {
             }
           : undefined,
         startedAt: managed.startedAt.toISOString(),
-        updatedAt: new Date().toISOString(),
-        completedAt: managed.status === "completed" ? new Date().toISOString() : undefined,
-        durationMs: managed.result?.durationMs,
+        updatedAt: now.toISOString(),
+        completedAt: terminal ? now.toISOString() : undefined,
+        durationMs: managed.result?.durationMs ?? (terminal ? now.getTime() - managed.startedAt.getTime() : undefined),
       });
     } catch (err) {
       // Persistence is best-effort: the run is still healthy in memory.
@@ -1585,6 +1646,9 @@ export class WorkflowManager extends EventEmitter {
       // small leak in exactly the class this manager otherwise bounds.
       const hadNoPendingSettle = managed.status === "paused";
       managed.status = "aborted";
+      managed.error ??= new WorkflowError("workflow aborted", WorkflowErrorCode.WORKFLOW_ABORTED, {
+        recoverable: true,
+      });
       this.abortForLifecycleControl(managed, "stop");
       this.emit("stopped", { runId });
       this.persistRun(managed);
@@ -1598,7 +1662,23 @@ export class WorkflowManager extends EventEmitter {
     const lease = this.persistence.acquireRunLease(runId);
     if (!lease) return false;
     try {
-      this.persistence.save({ ...persisted, status: "aborted", updatedAt: new Date().toISOString() });
+      const endedAt = new Date().toISOString();
+      const errorMessage = persisted.error ?? "workflow aborted";
+      const errorCode = persisted.errorCode ?? WorkflowErrorCode.WORKFLOW_ABORTED;
+      this.persistence.save({
+        ...persisted,
+        status: "aborted",
+        updatedAt: endedAt,
+        completedAt: persisted.completedAt ?? endedAt,
+        error: errorMessage,
+        errorCode,
+        agents: settleNonTerminalPersistedAgents(
+          persisted.agents,
+          "aborted",
+          { message: errorMessage, code: errorCode },
+          endedAt,
+        ),
+      });
     } finally {
       this.persistence.releaseRunLease(lease);
     }

--- a/tests/run-persistence.test.ts
+++ b/tests/run-persistence.test.ts
@@ -13,7 +13,16 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { WORKFLOW_RUNS_DIR } from "../src/config.js";
-import { createRunPersistence, generateRunId, type PersistedRunState } from "../src/run-persistence.js";
+import { WorkflowErrorCode } from "../src/errors.js";
+import {
+  createRunPersistence,
+  generateRunId,
+  INTERRUPTED_AGENT_CAUSE,
+  type PersistedAgentState,
+  type PersistedRunState,
+  settleInterruptedPersistedAgents,
+  settleNonTerminalPersistedAgents,
+} from "../src/run-persistence.js";
 import { WorkflowManager } from "../src/workflow-manager.js";
 import { workflowProjectPaths } from "../src/workflow-paths.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
@@ -375,6 +384,67 @@ test(
     assert.equal(loaded?.durationMs, 60000);
   }),
 );
+
+test(
+  "createRunPersistence save and load preserves terminal error and errorCode",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    rp.save({
+      runId: "failed-cause",
+      workflowName: "wf",
+      script: "export const meta = { name: 'w', description: 'w' }",
+      status: "failed",
+      error: "script failed",
+      errorCode: WorkflowErrorCode.AGENT_EXECUTION_ERROR,
+      phases: [],
+      agents: [],
+      logs: [],
+      startedAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    });
+    const loaded = rp.load("failed-cause");
+    assert.equal(loaded?.error, "script failed");
+    assert.equal(loaded?.errorCode, WorkflowErrorCode.AGENT_EXECUTION_ERROR);
+  }),
+);
+
+test("settleNonTerminalPersistedAgents skips leftover running/queued agents on abort", () => {
+  const agents: PersistedAgentState[] = [
+    { id: 1, label: "done", prompt: "a", status: "done", endedAt: "2024-01-01T00:00:01.000Z" },
+    { id: 2, label: "hang", prompt: "b", status: "running", startedAt: "2024-01-01T00:00:02.000Z" },
+    { id: 3, label: "wait", prompt: "c", status: "queued" },
+    { id: 4, label: "err", prompt: "d", status: "error", error: "boom" },
+  ];
+  const settled = settleNonTerminalPersistedAgents(
+    agents,
+    "aborted",
+    { message: "workflow aborted", code: WorkflowErrorCode.WORKFLOW_ABORTED },
+    "2024-01-01T00:00:10.000Z",
+  );
+  assert.equal(settled[0]?.status, "done");
+  assert.equal(settled[1]?.status, "skipped");
+  assert.equal(settled[1]?.error, "aborted");
+  assert.equal(settled[1]?.errorCode, WorkflowErrorCode.WORKFLOW_ABORTED);
+  assert.equal(settled[1]?.endedAt, "2024-01-01T00:00:10.000Z");
+  assert.equal(settled[2]?.status, "skipped");
+  assert.equal(settled[3]?.status, "error");
+  assert.equal(settled[3]?.error, "boom");
+});
+
+test("settleNonTerminalPersistedAgents is a no-op for paused runs", () => {
+  const agents: PersistedAgentState[] = [{ id: 1, label: "hang", prompt: "b", status: "running" }];
+  const settled = settleNonTerminalPersistedAgents(agents, "paused", undefined, "2024-01-01T00:00:10.000Z");
+  assert.equal(settled[0]?.status, "running");
+  assert.equal(settled[0]?.error, undefined);
+});
+
+test("settleInterruptedPersistedAgents skips leftover agents regardless of run status", () => {
+  const agents: PersistedAgentState[] = [{ id: 1, label: "hang", prompt: "b", status: "running" }];
+  const settled = settleInterruptedPersistedAgents(agents, INTERRUPTED_AGENT_CAUSE, "2024-01-01T00:00:10.000Z");
+  assert.equal(settled[0]?.status, "skipped");
+  assert.equal(settled[0]?.error, "interrupted");
+  assert.equal(settled[0]?.endedAt, "2024-01-01T00:00:10.000Z");
+});
 
 test("generateRunId returns a string with timestamp and random parts", () => {
   const id = generateRunId();
@@ -997,12 +1067,40 @@ test(
       status: "running",
       script: "export const meta = { name: 'w', description: 'd' }\nawait agent('x',{label:'x'})\nreturn 1",
       phases: [],
-      agents: [],
+      agents: [{ id: 1, label: "x", prompt: "x", status: "running" }],
       logs: [],
     } as PersistedRunState);
     // A fresh manager (the previous process died) should recover the orphan.
     new WorkflowManager({ cwd });
-    assert.equal(rp.load("stale")?.status, "paused", "stale running -> paused (journal preserved for resume)");
+    const recovered = rp.load("stale");
+    assert.equal(recovered?.status, "paused", "stale running -> paused (journal preserved for resume)");
+    assert.equal(recovered?.agents[0]?.status, "skipped", "orphaned in-flight agents cannot still be running");
+    assert.equal(recovered?.agents[0]?.error, "interrupted");
+  }),
+);
+
+test(
+  "WorkflowManager settles leftover running agents on an orphaned paused run",
+  withTempCwd(async (cwd) => {
+    const rp = createRunPersistence(cwd);
+    rp.save({
+      runId: "paused-ghost",
+      workflowName: "w",
+      status: "paused",
+      script: "export const meta = { name: 'w', description: 'd' }\nawait agent('x',{label:'x'})\nreturn 1",
+      phases: [],
+      agents: [{ id: 1, label: "x", prompt: "x", status: "running" }],
+      logs: ["still going"],
+      startedAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    });
+    new WorkflowManager({ cwd });
+    const recovered = rp.load("paused-ghost");
+    assert.equal(recovered?.status, "paused");
+    assert.equal(recovered?.agents[0]?.status, "skipped");
+    assert.equal(recovered?.agents[0]?.error, "interrupted");
+    assert.ok(recovered?.agents[0]?.endedAt);
+    assert.deepEqual(recovered?.logs, ["still going"]);
   }),
 );
 

--- a/tests/workflow-manager.test.ts
+++ b/tests/workflow-manager.test.ts
@@ -2262,9 +2262,34 @@ test(
     const agentA = persisted?.agents.find((a) => a.label === "a");
     assert.equal(agentA?.status, "done", "the already-completed agent's state is flushed synchronously too");
     assert.ok(agentA?.endedAt, "flushed agent state carries its real endedAt, not stale/missing data");
+    const agentB = persisted?.agents.find((a) => a.label === "b");
+    assert.equal(agentB?.status, "running", "pause is resumable and must not skip in-flight agents");
+    assert.equal(agentB?.endedAt, undefined);
+    assert.equal(persisted?.error, undefined);
 
     // 'second' never resolves on its own; don't await it, just avoid an unhandled rejection.
     promise.catch(() => {});
+  }),
+);
+
+test(
+  "pause drain persist skips leftover agents once the execution has settled",
+  withTempCwd(async (cwd) => {
+    const da = deferredAgent();
+    const manager = new WorkflowManager({ cwd, agent: da.runner });
+    manager.on("error", () => {});
+    const { runId, promise } = manager.startInBackground(oneAgentScript);
+    for (let i = 0; i < 200 && manager.getRun(runId)?.snapshot.agents[0]?.status !== "running"; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(manager.pause(runId), true);
+    await promise.catch(() => {});
+
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.equal(persisted?.status, "paused");
+    assert.equal(persisted?.agents[0]?.status, "skipped");
+    assert.equal(persisted?.agents[0]?.error, "interrupted");
+    assert.ok(persisted?.agents[0]?.endedAt);
   }),
 );
 
@@ -2288,9 +2313,59 @@ test(
     const agentA = persisted?.agents.find((a) => a.label === "a");
     assert.equal(agentA?.status, "done");
     assert.ok(agentA?.endedAt, "flushed agent state carries its real endedAt, not stale/missing data");
+    const agentB = persisted?.agents.find((a) => a.label === "b");
+    assert.equal(agentB?.status, "skipped", "in-flight agents must not stay running on an aborted persist");
+    assert.equal(agentB?.error, "aborted");
+    assert.equal(agentB?.errorCode, WorkflowErrorCode.WORKFLOW_ABORTED);
+    assert.ok(agentB?.endedAt, "skipped leftover agents get endedAt from the terminal persist");
+    assert.equal(persisted?.error, "workflow aborted");
+    assert.equal(persisted?.errorCode, WorkflowErrorCode.WORKFLOW_ABORTED);
+    assert.ok(persisted?.completedAt, "aborted runs record a completion timestamp");
+    assert.ok((persisted?.durationMs ?? 0) >= 0);
 
     // 'second' never resolves on its own; don't await it, just avoid an unhandled rejection.
     promise.catch(() => {});
+  }),
+);
+
+test(
+  "failed persist settles leftover running siblings and records the cause",
+  withTempCwd(async (cwd) => {
+    const agent = {
+      async run(prompt: string, options?: { signal?: AbortSignal }) {
+        if (prompt === "failer") {
+          throw new WorkflowError("boom", WorkflowErrorCode.AGENT_EXECUTION_ERROR, { recoverable: false });
+        }
+        return new Promise((_resolve, reject) => {
+          const onAbort = () => reject(new Error("deferred agent aborted"));
+          if (options?.signal?.aborted) onAbort();
+          else options?.signal?.addEventListener("abort", onAbort, { once: true });
+        });
+      },
+    };
+    const manager = new WorkflowManager({ cwd, agent });
+    manager.on("error", () => {});
+    const script = `export const meta = { name: 'fail_sibling', description: 'fail with in-flight sibling' }
+const xs = await parallel([
+  () => agent('failer', { label: 'failer' }),
+  () => agent('hang', { label: 'hang' }),
+])
+return xs`;
+    const { runId, promise } = manager.startInBackground(script);
+    await promise.catch(() => {});
+
+    const persisted = manager.listRuns().find((r) => r.runId === runId);
+    assert.equal(persisted?.status, "failed");
+    assert.match(persisted?.error ?? "", /boom/);
+    assert.equal(persisted?.errorCode, WorkflowErrorCode.AGENT_EXECUTION_ERROR);
+    const failer = persisted?.agents.find((a) => a.label === "failer");
+    const hang = persisted?.agents.find((a) => a.label === "hang");
+    assert.equal(failer?.status, "error");
+    assert.equal(hang?.status, "skipped", "run-fatal abort must not leave siblings running on disk");
+    assert.equal(hang?.error, "boom", "leftover agents carry the run's failure cause");
+    assert.equal(hang?.errorCode, WorkflowErrorCode.AGENT_EXECUTION_ERROR);
+    assert.ok(hang?.endedAt);
+    assert.ok(persisted?.completedAt);
   }),
 );
 
@@ -2554,8 +2629,16 @@ test(
       args: undefined,
       status: "running",
       phases: [],
-      agents: [],
-      logs: [],
+      agents: [
+        {
+          id: 1,
+          label: "hang",
+          prompt: "do it",
+          status: "running",
+          startedAt: new Date().toISOString(),
+        },
+      ],
+      logs: ["still going"],
       startedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });
@@ -2565,6 +2648,12 @@ test(
 
     const persisted = manager.listRuns().find((r) => r.runId === runId);
     assert.equal(persisted?.status, "aborted", "persisted status should become aborted");
+    assert.equal(persisted?.error, "workflow aborted");
+    assert.equal(persisted?.errorCode, WorkflowErrorCode.WORKFLOW_ABORTED);
+    assert.equal(persisted?.agents[0]?.status, "skipped");
+    assert.equal(persisted?.agents[0]?.error, "aborted");
+    assert.ok(persisted?.agents[0]?.endedAt);
+    assert.deepEqual(persisted?.logs, ["still going"], "cold-start stop must keep already-persisted logs");
   }),
 );
 


### PR DESCRIPTION
## Why

Aborted and failed runs were persisting leftover agents as `running` with no top-level cause. A local census of 73 run files on 3.9.0 showed the split exactly: 0/48 completed runs had stranded agents; 13/13 aborted+failed runs did. `/workflows` then treated those agents as live, and the records were not diagnosable.

## What

- On every terminal persist (`completed` / `failed` / `aborted`), rewrite leftover `queued`/`running` agents to `skipped` with `endedAt` and a cause. Replay stays journal-keyed, so this is display-only.
- Persist `error` and `errorCode` on failed/aborted runs.
- A live `pause()` still keeps in-flight agents `running` (resumable). Once that execution has drained, leftover agents become `interrupted`.
- `recoverStaleRuns()` now does the same for orphaned `running` records and for paused records that still show ghost `running` agents after a killed drain.

## Verify

- `npm test` (1290 tests)
- New coverage: abort/fail persist, cold-start stop, recoverStaleRuns, pause-immediate vs pause-after-drain

Fixes #171
