### PR TITLE
feat: overlay project model-tiers.json on the global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ The [full documentation](https://quintinshaw.github.io/pi-dynamic-workflows/) co
 <details>
 <summary><strong>Model tiers and run controls</strong></summary>
 
-Model tiers live at `~/.pi/workflows/model-tiers.json` and accept Pi CLI-style thinking suffixes:
+Model tiers live at `~/.pi/workflows/model-tiers.json`. A project file at `~/.pi/workflows/projects/<project>/model-tiers.json` overlays the global map (project keys win). They accept Pi CLI-style thinking suffixes:
 
 ```json
 {
@@ -231,7 +231,7 @@ Model tiers live at `~/.pi/workflows/model-tiers.json` and accept Pi CLI-style t
 }
 ```
 
-Use `/workflows-models` to edit them interactively. Without a config, the extension ranks authenticated models by capability hints and assigns distinct models when possible.
+Use `/workflows-models` to edit them interactively; it is cwd-aware and can save to the project or global file. A project save writes the resolved map, including keys currently inherited from global. Without a config, the extension ranks authenticated models by capability hints and assigns distinct models when possible.
 
 Omitted `tokenBudget` and `agentTimeoutMs` values use configured `defaultTokenBudget` and `defaultAgentTimeoutMs` settings; without them, runs are unlimited and have no hard per-agent timeout. Add per-run or per-agent values when you need explicit gates. `concurrency` is clamped to 16; `agentRetries` retries only recoverable failures. Defaults live in `~/.pi/workflows/settings.json`; `defaultTokenBudget` is a soft pre-call gate, and a project-level override of `null` cancels a global budget.
 
@@ -247,7 +247,7 @@ Pausing and resuming a run keeps the limits it started with — `maxAgents`, `ag
 Extension state lives outside the repository under `~/.pi/workflows`:
 
 - global settings and tiers: `~/.pi/workflows/settings.json` and `model-tiers.json`
-- project runs, journals, locks, and saved overrides: `~/.pi/workflows/projects/<project>/`
+- project runs, journals, locks, saved overrides, and optional tier overlay: `~/.pi/workflows/projects/<project>/`
 - older project-local `.pi/workflows/runs` and `.pi/workflows/saved` remain readable as fallbacks
 
 Subagents are in-memory by default. Set `persistAgentSessions: true` to retain full transcripts in Pi's standard session directory. This creates one file per unthreaded call or named thread and may store sensitive material that an agent read, so enable it deliberately.

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -185,7 +185,8 @@ export async function resolveStructuredOutput<T>(
  *      user customizes tiers via /workflows-models.
  * Returns undefined when nothing applies, so the session default is used.
  *
- * `loadConfig` is injectable for testing; it defaults to reading from disk.
+ * `loadConfig` is injectable for testing; it defaults to the global file.
+ * WorkflowAgent passes a cwd-aware overlay loader so project tiers win.
  */
 export function resolveAgentModelSpec(
   options: { model?: string; tier?: string },
@@ -711,7 +712,7 @@ export class WorkflowAgent {
   }
 
   /**
-   * Read+parse ~/.pi/workflows/model-tiers.json at most once for this
+   * Read+parse the cwd-aware model-tiers overlay at most once for this
    * instance's lifetime, instead of on every run() call. `resolveAgentModelSpec`
    * previously received `loadModelTierConfig` directly (sync existsSync +
    * readFileSync + JSON.parse from disk), which it calls unconditionally for
@@ -735,9 +736,10 @@ export class WorkflowAgent {
    * only ever consulted once, on the first call, regardless of what is passed
    * on later calls.
    */
-  private loadTierConfig(loader: () => ModelTierConfig | null = loadModelTierConfig): ModelTierConfig | null {
+  private loadTierConfig(loader?: () => ModelTierConfig | null): ModelTierConfig | null {
     if (!this.tierConfigBox) {
-      this.tierConfigBox = { value: loader() };
+      const read = loader ?? (() => loadModelTierConfig({ cwd: this.cwd }));
+      this.tierConfigBox = { value: read() };
     }
     return this.tierConfigBox.value;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,11 +56,12 @@ export {
   splitModelSpecThinking,
   THINKING_LEVELS,
 } from "./model-spec.js";
-export type { ModelTierConfig, RankableModel } from "./model-tier-config.js";
+export type { ModelTierConfig, ModelTierConfigOptions, RankableModel } from "./model-tier-config.js";
 export {
   buildDefaultTierConfig,
   formatTierFallbackNotice,
   getModelTierConfigPath,
+  getProjectModelTierConfigPath,
   loadModelTierConfig,
   resolveTierModel,
   saveModelTierConfig,

--- a/src/model-tier-config.ts
+++ b/src/model-tier-config.ts
@@ -18,6 +18,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { listAvailableModels } from "./agent.js";
 import { MODEL_TIERS_FILE } from "./config.js";
+import { workflowProjectPaths } from "./workflow-paths.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -30,6 +31,16 @@ import { MODEL_TIERS_FILE } from "./config.js";
  */
 export interface ModelTierConfig {
   tiers: Record<string, string>;
+}
+
+/** Options for loading the global file, a project overlay, or an explicit test path. */
+export interface ModelTierConfigOptions {
+  /** Explicit global (or single-file) path; primarily for tests. */
+  configPath?: string;
+  /** Project cwd whose project-level tiers overlay the global file. */
+  cwd?: string;
+  /** Explicit project tiers path; primarily for tests. */
+  projectConfigPath?: string;
 }
 
 /**
@@ -55,6 +66,11 @@ export interface RankableModel {
 /** Path to the model tiers JSON config file (~/.pi/workflows/model-tiers.json). */
 export function getModelTierConfigPath(): string {
   return join(homedir(), MODEL_TIERS_FILE);
+}
+
+/** Path to this project's optional model-tiers overlay. */
+export function getProjectModelTierConfigPath(cwd: string): string {
+  return workflowProjectPaths(cwd).modelTiersPath;
 }
 
 // ---------------------------------------------------------------------------
@@ -236,22 +252,47 @@ function isValidTiersMap(value: unknown): value is Record<string, string> {
   return entries.every(([key, val]) => key.trim().length > 0 && typeof val === "string" && val.trim().length > 0);
 }
 
-/**
- * Load the model tier config from disk. Returns null if the file does not
- * exist or is unparseable (callers fall back to a default).
- */
-export function loadModelTierConfig(configPath?: string): ModelTierConfig | null {
-  const path = configPath ?? getModelTierConfigPath();
+function readTierConfig(path: string): ModelTierConfig | null {
   if (!existsSync(path)) return null;
   try {
     const raw = readFileSync(path, "utf-8");
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object") return null;
-    if (!isValidTiersMap(parsed.tiers)) return null;
+    if (!isValidTiersMap((parsed as { tiers?: unknown }).tiers)) return null;
     return parsed as ModelTierConfig;
   } catch {
     return null;
   }
+}
+
+function normalizeLoadOptions(configPathOrOptions?: string | ModelTierConfigOptions): ModelTierConfigOptions {
+  return typeof configPathOrOptions === "string" ? { configPath: configPathOrOptions } : (configPathOrOptions ?? {});
+}
+
+/**
+ * Load the model tier config from disk. Returns null if the file does not
+ * exist or is unparseable (callers fall back to a default).
+ *
+ * A string path (or `{ configPath }` without a project) reads that single
+ * file — the historical global-only behavior.
+ * `{ cwd }` overlays `~/.pi/workflows/projects/<key>/model-tiers.json` on the
+ * global file; project keys win. Missing project file = global-only.
+ */
+export function loadModelTierConfig(configPathOrOptions?: string | ModelTierConfigOptions): ModelTierConfig | null {
+  const options = normalizeLoadOptions(configPathOrOptions);
+  const globalPath = options.configPath ?? getModelTierConfigPath();
+  const global = readTierConfig(globalPath);
+  const overlayRequested = options.cwd !== undefined || options.projectConfigPath !== undefined;
+  if (!overlayRequested) return global;
+
+  const projectPath =
+    options.projectConfigPath ?? (options.cwd ? getProjectModelTierConfigPath(options.cwd) : undefined);
+  if (!projectPath) return global;
+  const project = readTierConfig(projectPath);
+  if (!project) return global;
+  if (!global) return project;
+  const merged = { tiers: { ...global.tiers, ...project.tiers } };
+  return isValidTiersMap(merged.tiers) ? merged : null;
 }
 
 /**

--- a/src/workflow-paths.ts
+++ b/src/workflow-paths.ts
@@ -20,6 +20,7 @@ export interface WorkflowProjectPaths {
   runsDir: string;
   savedDir: string;
   settingsPath: string;
+  modelTiersPath: string;
   legacyRunsDir: string;
   legacySavedDir: string;
 }
@@ -48,6 +49,7 @@ export function workflowProjectPaths(cwd: string): WorkflowProjectPaths {
     runsDir: join(rootDir, "runs"),
     savedDir: join(rootDir, "saved"),
     settingsPath: join(rootDir, "settings.json"),
+    modelTiersPath: join(rootDir, "model-tiers.json"),
     legacyRunsDir: resolve(cwd, WORKFLOW_RUNS_DIR),
     legacySavedDir: resolve(cwd, WORKFLOW_SAVED_DIR),
   };

--- a/src/workflows-models-command.ts
+++ b/src/workflows-models-command.ts
@@ -13,6 +13,7 @@
  * When editing a tier, users pick a model, then an optional thinking level.
  */
 
+import { existsSync } from "node:fs";
 import type { ExtensionAPI, ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent";
 import {
   Container,
@@ -32,7 +33,10 @@ import {
 } from "./model-spec.js";
 import {
   buildDefaultTierConfig,
+  getModelTierConfigPath,
+  getProjectModelTierConfigPath,
   loadModelTierConfig,
+  type ModelTierConfig,
   saveModelTierConfig,
   sortedTierNames,
 } from "./model-tier-config.js";
@@ -52,9 +56,19 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
       // registry explicitly: since pi 0.80.8 the no-registry fallback inside
       // listAvailableModels() initializes asynchronously and reports [] on the
       // first call, which would rank defaults from an empty model list.
+      const cwd = ctx.cwd || process.cwd();
+      const globalPath = getModelTierConfigPath();
+      const projectPath = getProjectModelTierConfigPath(cwd);
+      let scope: "global" | "project" = existsSync(projectPath) ? "project" : "global";
       const currentModel = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
-      let config =
-        loadModelTierConfig() ?? buildDefaultTierConfig(currentModel, listAvailableModels(ctx.modelRegistry));
+      const defaults = () => buildDefaultTierConfig(currentModel, listAvailableModels(ctx.modelRegistry));
+      const loadForScope = (next: "global" | "project"): ModelTierConfig => {
+        if (next === "project") {
+          return loadModelTierConfig({ cwd }) ?? defaults();
+        }
+        return loadModelTierConfig(globalPath) ?? defaults();
+      };
+      let config = loadForScope(scope);
       let dirty = false;
 
       const ensureFresh = (cfg: typeof config) => {
@@ -67,6 +81,7 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
         const tiers = sortedTierNames(config);
         const menuOptions: string[] = [];
 
+        menuOptions.push(`Editing ${scope} tiers`);
         menuOptions.push("─".repeat(30));
         for (const name of tiers) {
           const model = config.tiers[name];
@@ -74,12 +89,17 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
         }
         menuOptions.push("─".repeat(30));
 
+        menuOptions.push(scope === "project" ? "Switch to global" : "Switch to project");
         menuOptions.push("Reset to defaults");
         menuOptions.push(dirty ? "Save and exit" : "Exit");
 
-        const choice = await ctx.ui.select("Model tier configuration", menuOptions);
+        const choice = await ctx.ui.select(`Model tier configuration (${scope})`, menuOptions);
 
         if (!choice) break;
+
+        if (choice === "Editing global tiers" || choice === "Editing project tiers") {
+          continue;
+        }
 
         // Handle "<tier> → [model]" selections
         for (const name of tiers) {
@@ -90,6 +110,19 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
             }
             break;
           }
+        }
+
+        if (choice === "Switch to global" || choice === "Switch to project") {
+          const nextScope = choice === "Switch to project" ? "project" : "global";
+          if (nextScope === scope) continue;
+          if (dirty) {
+            const confirmed = await ctx.ui.confirm("Switch scope", "Unsaved changes will be discarded. Continue?");
+            if (!confirmed) continue;
+          }
+          scope = nextScope;
+          config = loadForScope(scope);
+          dirty = false;
+          continue;
         }
 
         if (choice === "Reset to defaults") {
@@ -105,8 +138,8 @@ export function registerWorkflowModelsCommand(pi: ExtensionAPI): void {
 
         if (choice === "Save and exit" || choice === "Exit") {
           if (choice === "Save and exit") {
-            saveModelTierConfig(config);
-            ctx.ui.notify("Model tiers saved.", "info");
+            saveModelTierConfig(config, scope === "project" ? projectPath : globalPath);
+            ctx.ui.notify(scope === "project" ? "Project model tiers saved." : "Model tiers saved.", "info");
           }
           break;
         }

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -17,7 +17,11 @@ import {
 } from "../src/agent.js";
 import { WorkflowError, WorkflowErrorCode } from "../src/errors.js";
 import { resolveModelSpecWithThinking } from "../src/model-spec.js";
-import type { ModelTierConfig } from "../src/model-tier-config.js";
+import {
+  getModelTierConfigPath,
+  getProjectModelTierConfigPath,
+  type ModelTierConfig,
+} from "../src/model-tier-config.js";
 import { type JournalEntry, runWorkflow } from "../src/workflow.js";
 import { withFakeHome, withFakeHomeAsync } from "./helpers/fake-home.js";
 
@@ -305,6 +309,28 @@ test("WorkflowAgent#loadTierConfig: memoization is per-instance (two agents, two
     a.loadTierConfig(() => cfgB),
     cfgA,
   );
+});
+
+test("WorkflowAgent#loadTierConfig: default loader overlays project tiers over global", () => {
+  const home = mkdtempSync(join(tmpdir(), "pi-dw-tier-overlay-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "pi-dw-tier-overlay-cwd-"));
+  try {
+    withFakeHome(home, () => {
+      const globalPath = getModelTierConfigPath();
+      const projectPath = getProjectModelTierConfigPath(cwd);
+      mkdirSync(join(globalPath, ".."), { recursive: true });
+      mkdirSync(join(projectPath, ".."), { recursive: true });
+      writeFileSync(globalPath, JSON.stringify({ tiers: { small: "global/small", medium: "global/medium" } }));
+      writeFileSync(projectPath, JSON.stringify({ tiers: { small: "project/small" } }));
+
+      const agent = new WorkflowAgent({ cwd }) as unknown as WorkflowAgentTierPrivates;
+      const loaded = agent.loadTierConfig();
+      assert.deepEqual(loaded, { tiers: { small: "project/small", medium: "global/medium" } });
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
 });
 
 test("WorkflowAgent.run(): tier routing resolves correctly through the real (non-injected) disk loader, read only once across two run() calls", async () => {

--- a/tests/model-tier-config.test.ts
+++ b/tests/model-tier-config.test.ts
@@ -14,10 +14,11 @@
  */
 
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
+import { withFakeHome } from "./helpers/fake-home.js";
 
 async function loadModule() {
   return await import("../src/model-tier-config.js");
@@ -503,6 +504,78 @@ describe("model-tier-config", () => {
       const result = loadModelTierConfig(cfgPath);
       assert.deepEqual(result, { tiers: { small: "openai/gpt-4.1-mini" } });
       rmSync(tmpDir, { recursive: true, force: true });
+    });
+  });
+
+  describe("project overlay ({ cwd })", () => {
+    function withOverlayHome(fn: (home: string, cwd: string) => void): void {
+      const home = mkdtempSync(join(tmpdir(), "mtc-overlay-home-"));
+      const cwd = mkdtempSync(join(tmpdir(), "mtc-overlay-cwd-"));
+      try {
+        withFakeHome(home, () => fn(home, cwd));
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    }
+
+    it("overlays project keys over global when a project file exists", async () => {
+      const { loadModelTierConfig, getModelTierConfigPath, getProjectModelTierConfigPath } = await loadModule();
+      withOverlayHome((_home, cwd) => {
+        const globalPath = getModelTierConfigPath();
+        const projectPath = getProjectModelTierConfigPath(cwd);
+        mkdirSync(join(globalPath, ".."), { recursive: true });
+        mkdirSync(join(projectPath, ".."), { recursive: true });
+        writeFileSync(
+          globalPath,
+          JSON.stringify({
+            tiers: { small: "global/small", medium: "global/medium", big: "global/big" },
+          }),
+        );
+        writeFileSync(projectPath, JSON.stringify({ tiers: { small: "project/small", big: "project/big" } }));
+
+        const overlay = loadModelTierConfig({ cwd });
+        assert.deepEqual(overlay, {
+          tiers: { small: "project/small", medium: "global/medium", big: "project/big" },
+        });
+        assert.deepEqual(loadModelTierConfig(), {
+          tiers: { small: "global/small", medium: "global/medium", big: "global/big" },
+        });
+      });
+    });
+
+    it("matches current global-only resolution when no project file exists", async () => {
+      const { loadModelTierConfig, getModelTierConfigPath } = await loadModule();
+      withOverlayHome((_home, cwd) => {
+        const globalPath = getModelTierConfigPath();
+        mkdirSync(join(globalPath, ".."), { recursive: true });
+        writeFileSync(globalPath, JSON.stringify({ tiers: { medium: "global/medium" } }));
+
+        const overlay = loadModelTierConfig({ cwd });
+        const globalOnly = loadModelTierConfig();
+        assert.deepEqual(overlay, { tiers: { medium: "global/medium" } });
+        assert.deepEqual(overlay, globalOnly);
+      });
+    });
+
+    it("uses the project file alone when there is no global file", async () => {
+      const { loadModelTierConfig, getProjectModelTierConfigPath } = await loadModule();
+      withOverlayHome((_home, cwd) => {
+        const projectPath = getProjectModelTierConfigPath(cwd);
+        mkdirSync(join(projectPath, ".."), { recursive: true });
+        writeFileSync(projectPath, JSON.stringify({ tiers: { small: "project/only" } }));
+
+        assert.deepEqual(loadModelTierConfig({ cwd }), { tiers: { small: "project/only" } });
+        assert.equal(loadModelTierConfig(), null);
+      });
+    });
+
+    it("returns null when neither file exists", async () => {
+      const { loadModelTierConfig } = await loadModule();
+      withOverlayHome((_home, cwd) => {
+        assert.equal(loadModelTierConfig({ cwd }), null);
+        assert.equal(loadModelTierConfig(), null);
+      });
     });
   });
 

--- a/tests/workflow-paths.test.ts
+++ b/tests/workflow-paths.test.ts
@@ -48,6 +48,7 @@ describe("workflow paths", () => {
       assert.equal(paths.runsDir, join(paths.rootDir, "runs"));
       assert.equal(paths.savedDir, join(paths.rootDir, "saved"));
       assert.equal(paths.settingsPath, join(paths.rootDir, "settings.json"));
+      assert.equal(paths.modelTiersPath, join(paths.rootDir, "model-tiers.json"));
       assert.equal(paths.legacyRunsDir, normalize(join(cwd, ".pi/workflows/runs")));
       assert.equal(paths.legacySavedDir, normalize(join(cwd, ".pi/workflows/saved")));
     });

--- a/tests/workflows-models-command.test.ts
+++ b/tests/workflows-models-command.test.ts
@@ -10,10 +10,11 @@
  */
 
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, mock } from "node:test";
+import { getModelTierConfigPath, getProjectModelTierConfigPath } from "../src/model-tier-config.js";
 import { withFakeHomeAsync } from "./helpers/fake-home.js";
 
 async function loadCommand() {
@@ -244,6 +245,155 @@ describe("workflows-models-command", () => {
         menu.includes("mockvendor/cheap-model"),
         `default tiers must rank from the host registry's models; menu was:\n${menu}`,
       );
+    });
+  });
+
+  describe("project vs global scope", () => {
+    async function registeredHandler() {
+      const { registerWorkflowModelsCommand } = await loadCommand();
+      let handler: ((args: unknown, ctx: unknown) => Promise<void>) | undefined;
+      const mockPi = {
+        registerCommand: mock.fn(
+          (_name: string, opts: { handler?: (args: unknown, ctx: unknown) => Promise<void> }) => {
+            handler = opts.handler;
+          },
+        ),
+      };
+      registerWorkflowModelsCommand(mockPi as never);
+      assert.ok(handler, "handler should be registered");
+      return handler;
+    }
+
+    function cheapRegistry() {
+      const cheap = {
+        provider: "mockvendor",
+        id: "cheap-model",
+        cost: { input: 0, output: 1, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 100000,
+      };
+      return { getAvailable: () => [cheap], getAll: () => [cheap], find: () => cheap };
+    }
+
+    it("defaults to global scope and leaves behavior unchanged when no project file exists", async () => {
+      const handler = await registeredHandler();
+      const titles: string[] = [];
+      const selectCalls: string[][] = [];
+      const home = mkdtempSync(join(tmpdir(), "pi-dw-wmc-home-"));
+      const cwd = mkdtempSync(join(tmpdir(), "pi-dw-wmc-cwd-"));
+      try {
+        await withFakeHomeAsync(home, async () => {
+          const globalPath = getModelTierConfigPath();
+          mkdirSync(join(globalPath, ".."), { recursive: true });
+          writeFileSync(globalPath, JSON.stringify({ tiers: { small: "global/small" } }));
+          const ctx = {
+            cwd,
+            waitForIdle: async () => {},
+            model: undefined,
+            modelRegistry: cheapRegistry(),
+            ui: {
+              select: mock.fn(async (title: string, options: string[]) => {
+                titles.push(title);
+                selectCalls.push(options);
+                return "Exit";
+              }),
+              notify: mock.fn(),
+              confirm: mock.fn(async () => false),
+              custom: mock.fn(async () => null),
+            },
+          };
+          await handler(undefined, ctx);
+        });
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+        rmSync(cwd, { recursive: true, force: true });
+      }
+
+      assert.ok(titles[0]?.includes("global"), `title should indicate global scope: ${titles[0]}`);
+      const menu = selectCalls[0]?.join("\n") ?? "";
+      assert.ok(menu.includes("Editing global tiers"), `menu was:\n${menu}`);
+      assert.ok(menu.includes("small tier → global/small"), `menu was:\n${menu}`);
+      assert.ok(menu.includes("Switch to project"), `menu was:\n${menu}`);
+    });
+
+    it("defaults to project scope and shows overlay-winning models when a project file exists", async () => {
+      const handler = await registeredHandler();
+      const titles: string[] = [];
+      const selectCalls: string[][] = [];
+      const home = mkdtempSync(join(tmpdir(), "pi-dw-wmc-home-"));
+      const cwd = mkdtempSync(join(tmpdir(), "pi-dw-wmc-cwd-"));
+      try {
+        await withFakeHomeAsync(home, async () => {
+          const globalPath = getModelTierConfigPath();
+          const projectPath = getProjectModelTierConfigPath(cwd);
+          mkdirSync(join(globalPath, ".."), { recursive: true });
+          mkdirSync(join(projectPath, ".."), { recursive: true });
+          writeFileSync(globalPath, JSON.stringify({ tiers: { small: "global/small", medium: "global/medium" } }));
+          writeFileSync(projectPath, JSON.stringify({ tiers: { small: "project/small" } }));
+          const ctx = {
+            cwd,
+            waitForIdle: async () => {},
+            model: undefined,
+            modelRegistry: cheapRegistry(),
+            ui: {
+              select: mock.fn(async (title: string, options: string[]) => {
+                titles.push(title);
+                selectCalls.push(options);
+                return "Exit";
+              }),
+              notify: mock.fn(),
+              confirm: mock.fn(async () => false),
+              custom: mock.fn(async () => null),
+            },
+          };
+          await handler(undefined, ctx);
+        });
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+        rmSync(cwd, { recursive: true, force: true });
+      }
+
+      assert.ok(titles[0]?.includes("project"), `title should indicate project scope: ${titles[0]}`);
+      const menu = selectCalls[0]?.join("\n") ?? "";
+      assert.ok(menu.includes("Editing project tiers"), `menu was:\n${menu}`);
+      assert.ok(menu.includes("small tier → project/small"), `menu was:\n${menu}`);
+      assert.ok(menu.includes("medium tier → global/medium"), `menu was:\n${menu}`);
+      assert.ok(menu.includes("Switch to global"), `menu was:\n${menu}`);
+    });
+
+    it("saves the working config to the project file after switching scope", async () => {
+      const handler = await registeredHandler();
+      const home = mkdtempSync(join(tmpdir(), "pi-dw-wmc-home-"));
+      const cwd = mkdtempSync(join(tmpdir(), "pi-dw-wmc-cwd-"));
+      try {
+        await withFakeHomeAsync(home, async () => {
+          const globalPath = getModelTierConfigPath();
+          const projectPath = getProjectModelTierConfigPath(cwd);
+          mkdirSync(join(globalPath, ".."), { recursive: true });
+          writeFileSync(globalPath, JSON.stringify({ tiers: { small: "global/small" } }));
+          const actions = ["Switch to project", "Reset to defaults", "Save and exit"];
+          const ctx = {
+            cwd,
+            waitForIdle: async () => {},
+            model: undefined,
+            modelRegistry: cheapRegistry(),
+            ui: {
+              select: mock.fn(async () => actions.shift() ?? "Exit"),
+              notify: mock.fn(),
+              confirm: mock.fn(async () => true),
+              custom: mock.fn(async () => null),
+            },
+          };
+          await handler(undefined, ctx);
+          assert.equal(existsSync(projectPath), true, "project file should be written");
+          const saved = JSON.parse(readFileSync(projectPath, "utf-8"));
+          assert.equal(saved.tiers.small, "mockvendor/cheap-model");
+          const global = JSON.parse(readFileSync(globalPath, "utf-8"));
+          assert.equal(global.tiers.small, "global/small", "global file must stay untouched");
+        });
+      } finally {
+        rmSync(home, { recursive: true, force: true });
+        rmSync(cwd, { recursive: true, force: true });
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Model tiers were global-only. A project `~/.pi/workflows/projects/<key>/model-tiers.json` now overlays the global map, with project keys winning. `/workflows-models` is cwd-aware and can edit or save either the project or the global file. When no project file exists, resolution and the command stay on the global file.

Fixes #159.

## How to verify

- `npm test`
- With a fake home and a project cwd, a project overlay wins over global; with only the global file, behavior matches today's global-only resolution.
- `/workflows-models` defaults to project scope when that file exists, otherwise global. Switch scope and Save write the chosen file.