### PR TITLE
fix(delivery): ownership-token in-flight lock prevents stale finally double-delivery

### DIFF
--- a/src/task-panel.ts
+++ b/src/task-panel.ts
@@ -206,8 +206,9 @@ const sessionEndpoints = new Map<string, SessionDeliveryEndpoint>();
  */
 const boundSessionSends = new Map<string, DeliverySend>();
 
-/** runIds with an in-flight deliver-and-ack so bind flush does not double-send. */
-const inFlightDeliveries = new Set<string>();
+/** runId → token of the deliver-and-ack that owns the lock, so bind flush does not double-send. Ownership prevents a stale finally from releasing a newer send's lock. */
+const inFlightDeliveries = new Map<string, number>();
+let inFlightSeq = 0;
 
 /**
  * Custom type for the session bind probe (see probeHostSessionSend). Sent
@@ -585,9 +586,15 @@ function deliverAndAck(
   // synchronous re-bind + flush (e.g. probe retry on the next session_start)
   // is not locked out by a microtask that has not run yet.
   if (typeof endpoint.send !== "function") return;
-
-  inFlightDeliveries.add(runId);
+  // Ownership token: a stale finally (from a superseded send) must never
+  // release the lock held by a newer delivery — that would let a third
+  // caller double-deliver the same result mid-flight.
+  const lockToken = ++inFlightSeq;
+  inFlightDeliveries.set(runId, lockToken);
   const startedGeneration = endpoint.generation;
+  const release = () => {
+    if (inFlightDeliveries.get(runId) === lockToken) inFlightDeliveries.delete(runId);
+  };
   void tryDeliverEndpoint(endpoint, content)
     .then((ok) => {
       if (ok) {
@@ -595,16 +602,15 @@ function deliverAndAck(
         return;
       }
       // Release the in-flight lock before a generation-change retry so flush
-      // can actually pick this run back up.
-      inFlightDeliveries.delete(runId);
+      // can actually pick this run back up. If the retry re-arms the lock with
+      // a new token before this handler's release runs, the release is a no-op.
+      release();
       const current = sessionEndpoints.get(sessionId);
       if (current && !current.suspended && current.generation !== startedGeneration && current.manager) {
         flushSessionDiskPending(current.manager, sessionId, current);
       }
     })
-    .finally(() => {
-      inFlightDeliveries.delete(runId);
-    });
+    .finally(release);
 }
 
 function routeBackgroundDelivery(

--- a/tests/task-panel.test.ts
+++ b/tests/task-panel.test.ts
@@ -912,6 +912,36 @@ describe("installResultDelivery", () => {
     assert.ok(calls[0].content.includes("test-workflow"));
   });
 
+  it("a failed send overlapping a re-bind cannot double-deliver", async () => {
+    // Generation N's send fails; the generation-change retry re-arms the lock
+    // (new token) and starts send 2. N's stale .finally must NOT release the
+    // lock T2 holds — otherwise a third caller could start a duplicate send.
+    const resolvers: Array<(err: Error) => void> = [];
+    let sends = 0;
+    const pi = createMockPi();
+    const manager = createMockManager(makeRun({ sessionId: SESSION, runId: "run-double" }));
+    const stableSend: StableSend = () => {
+      sends++;
+      return new Promise<never>((_resolve, reject) => {
+        resolvers.push(reject);
+      });
+    };
+    setup(pi, manager, SESSION, { stableSend });
+    manager.emit("complete", { runId: "run-double" });
+    assert.equal(sends, 1, "first in-flight send");
+
+    mod.bindSessionDelivery(SESSION, pi, { manager, stableSend }); // generation bump
+    resolvers[0](new Error("send failed")); // fail send 1 → release + generation retry
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(sends, 2, "generation-change flush retries the send exactly once");
+
+    manager.emit("complete", { runId: "run-double" });
+    assert.equal(sends, 2, "the retried send keeps its lock — no third delivery");
+    resolvers[1]?.(new Error("test cleanup"));
+  });
+
   it("never silently drops pending deliveries when the queue grows past the soft cap", () => {
     const pi1 = createMockPi();
     const pi2 = createMockPi();


### PR DESCRIPTION
Fixes #175.

`deliverAndAck`'s in-flight lock (`Set<runId>`) could be released twice for one run: the failed send's `.then` releases it, the generation-change retry re-acquires it for the next send, and the original `.finally` deletes it again — leaving the retry send unprotected so a third caller (bind flush / duplicate `complete`) can double-deliver the same `workflow-result` turn.

**Change:** the lock becomes `Map<runId, token>`. Each deliver-and-ack captures its own token at acquisition; both `.then` and `.finally` release via `release()`, which deletes only if the stored token still matches. A superseded chain can no longer drop a newer send's lock.

**Verification:**
- New regression test `a failed send overlapping a re-bind cannot double-deliver` — fails on the old `Set` lock (retry released mid-flight), passes with the token lock.
- Full suite: 1331/1333 — the 2 failures (`workflow-authoring-skill`, `workflow-release-gate`) fail on pristine `main` too (pack-shape/environment, pre-existing).
- biome + tsc clean; live omp E2E on this tree: workflow launched in background, `workflow-result` delivered with `pendingDelivery` cleared, zero probe entries.